### PR TITLE
Update Grid Track and Trace to use sawtooth-sdk = 0.2

### DIFF
--- a/contracts/track_and_trace/Cargo.toml
+++ b/contracts/track_and_trace/Cargo.toml
@@ -20,7 +20,7 @@ description = "Grid Track and Trace Transaction Processor"
 homepage = "https://grid.hyperledger.org"
 
 [dependencies]
-sawtooth-sdk = "^0.1"
+sawtooth-sdk = "^0.2"
 rust-crypto = "0.2.36"
 rustc-serialize = "0.3.22"
 sawtooth-zmq = "0.8.2-dev5"


### PR DESCRIPTION
Signed-off-by: Andrea Gunderson <agunde@bitwise.io>