### PR TITLE
Update and expand README.md for grid repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,55 @@
-Hyperledger Grid
-----------------
+# Hyperledger Grid
 
-Hyperledger Grid is a project for building supply chain solutions. It includes
-a set of libraries, data models, and SDKs to accelerate development for supply
-chain smart contracts and client interfaces.
+Hyperledger Grid is a platform for building supply chain solutions that include
+distributed ledger components. It provides a growing set of tools that
+accelerate development for supply chain smart contracts and client interfaces.
 
-Documentation
--------------
+This project is not an implementation of a distributed ledger or a client
+application. Instead, Hyperledger Grid provides supply-chain-focused libraries,
+data models, and software development kits (SDKs) as modular, reusable
+components.
 
-Information on how to run and extend Hyperledger Grid is available at
-https://grid.hyperledger.org/docs/.
+The Hyperledger Grid project includes several repositories:
 
-Project Status
---------------
+- [This repository](https://github.com/hyperledger/grid) contains core
+  components such as supply-chain-centric data types and smart permissioning
+  code.
 
-This Hyperledger project is in _incubation_. It was proposed to the community
-and documented in this [Hyperledger Grid
-Proposal](https://docs.google.com/document/d/1b6ES0bKUK30E2iZizy3vjVEhPn7IvsW5buDo7nFXBE0/edit).
-Information on what _incubation_ means can be found in the [Hyperledger
-Project Lifecycle
-document](https://wiki.hyperledger.org/community/project-lifecycle).
+- The [grid-contrib](https://github.com/hyperledger/grid-contrib) repository
+  contains example domain models and reference implementations for smart
+  contracts (also called "transaction families").
+
+- The [grid-rfcs](https://github.com/hyperledger/grid-rfcs) repository
+  contains RFCs (requests for comments) for proposed and approved changes to
+  Hyperledger Grid.
+
+
+## Project Status
+
+Hyperledger Grid is currently in the
+[incubation](https://wiki.hyperledger.org/display/HYP/Project+Lifecycle#ProjectLifecycle-incubation)
+stage of the Hyperledger product lifecycle.
+The [Hyperledger Grid
+proposal](https://docs.google.com/document/d/1b6ES0bKUK30E2iZizy3vjVEhPn7IvsW5buDo7nFXBE0/)
+was accepted in December, 2018.
+
+
+## How to Participate
+
+We welcome contributors, both organizations and individuals, to help shape
+project direction, contribute ideas, provide use cases, and work on specific
+tools and examples. Please [join the
+discussion](https://grid.hyperledger.org/community/join_the_discussion/).
+
+
+## More Information
+
+- [Hyperledger Grid website](https://grid.hyperledger.org)
+- [Documentation](https://grid.hyperledger.org/docs/grid/nightly/master/)
+- [Hyperledger Grid mailing list](https://lists.hyperledger.org/g/grid)
+- [#grid discussion channel](https://chat.hyperledger.org/channel/grid)
+- [Hyperledger Grid project overview](https://www.hyperledger.org/projects/grid)
+  at [hyperledger.org](https://www.hyperledger.org)
 
 
 ## License
@@ -28,5 +58,6 @@ Hyperledger Grid software is licensed under the [Apache License Version
 2.0](LICENSE) software license.
 
 The Hyperledger Grid documentation in the [docs](docs) subdirectory is licensed
-under a Creative Commons Attribution 4.0 International License.  You may obtain
-a copy of the license at: http://creativecommons.org/licenses/by/4.0/.
+under a Creative Commons Attribution 4.0 International License (CC BY 4.0).
+You may obtain a copy of the license at
+<http://creativecommons.org/licenses/by/4.0/>.


### PR DESCRIPTION
- Update repo description to explain the Hyperledger Grid project and goals

- Summarize the three main grid repos (didn't include grid-website, because it's
  not about the Grid software)

- Add "How to Participate" section with information intended to encourage
  high-level contributions: ideas, use case, and examples

- Remove the "Documentation" section because "how to run and extend Hyperledger
  Grid" distracts from the focus on shaping the project direction

- Add "More Information" section with links

- Clean up the "License" section

Signed-off-by: Anne Chenette <chenette@bitwise.io>