### PR TITLE
Fix Grid T+T doc link in indexcontent.html

### DIFF
--- a/docs/source/_templates/indexcontent.html
+++ b/docs/source/_templates/indexcontent.html
@@ -4,7 +4,7 @@
 
   <h1>Hyperledger Grid documentation</h1>
 
-  <p class="biglink"><a class="biglink" href="{{ pathto("family_specification") }}">{% trans %}Grid Track and Trace Transaction Family Specification{% endtrans %}</a><br/>
+  <p class="biglink"><a class="biglink" href="{{ pathto("grid_track_and_trace_family_specification") }}">{% trans %}Grid Track and Trace Transaction Family Specification{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}learn about Grid Track and Trace{% endtrans %}</span></p>
 
   <p class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{% trans %}Table of Contents{% endtrans %}</a><br/>


### PR DESCRIPTION
A previous commit changed the file name for the Grid Track and Trace Family
Specification, but did not change the "pathto" name in the landing page.
This commit fixes the problem.

Signed-off-by: Anne Chenette <chenette@bitwise.io>