### PR TITLE
Add initial Grid Schema Protos

### DIFF
--- a/contracts/track_and_trace/src/handler.rs
+++ b/contracts/track_and_trace/src/handler.rs
@@ -20,9 +20,9 @@ use std::collections::HashMap;
 
 use grid_sdk::protos::track_and_trace_agent::{Agent, AgentContainer};
 use grid_sdk::protos::track_and_trace_payload::{
-    AnswerProposalAction, AnswerProposalAction_Response, CreateAgentAction,
-    CreateProposalAction, CreateRecordAction, CreateRecordTypeAction, FinalizeRecordAction,
-    RevokeReporterAction, SCPayload, UpdatePropertiesAction, SCPayload_Action
+    AnswerProposalAction, AnswerProposalAction_Response, CreateAgentAction, CreateProposalAction,
+    CreateRecordAction, CreateRecordTypeAction, FinalizeRecordAction, RevokeReporterAction,
+    SCPayload, SCPayload_Action, UpdatePropertiesAction,
 };
 use grid_sdk::protos::track_and_trace_property::{
     Property, PropertyContainer, PropertyPage, PropertyPageContainer, PropertyPage_ReportedValue,
@@ -308,15 +308,14 @@ impl<'a> SupplyChainState<'a> {
         let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
-                let agents: AgentContainer =
-                    match protobuf::parse_from_bytes(packed.as_slice()) {
-                        Ok(agents) => agents,
-                        Err(_) => {
-                            return Err(ApplyError::InternalError(String::from(
-                                "Cannot deserialize agent container",
-                            )));
-                        }
-                    };
+                let agents: AgentContainer = match protobuf::parse_from_bytes(packed.as_slice()) {
+                    Ok(agents) => agents,
+                    Err(_) => {
+                        return Err(ApplyError::InternalError(String::from(
+                            "Cannot deserialize agent container",
+                        )));
+                    }
+                };
 
                 for agent in agents.get_entries() {
                     if agent.public_key == agent_id {

--- a/contracts/track_and_trace/src/handler.rs
+++ b/contracts/track_and_trace/src/handler.rs
@@ -25,9 +25,8 @@ use grid_sdk::protos::track_and_trace_payload::{
     RevokeReporterAction, SCPayload, UpdatePropertiesAction, SCPayload_Action
 };
 use grid_sdk::protos::track_and_trace_property::{
-    Property, PropertyContainer, PropertyPage, PropertyPageContainer,
-    PropertyPage_ReportedValue, PropertySchema, PropertySchema_DataType, PropertyValue,
-    Property_Reporter,
+    Property, PropertyContainer, PropertyPage, PropertyPageContainer, PropertyPage_ReportedValue,
+    PropertySchema, PropertySchema_DataType, Property_Reporter, TrackAndTracePropertyValue,
 };
 use grid_sdk::protos::track_and_trace_proposal::{
     Proposal, ProposalContainer, Proposal_Role, Proposal_Status,
@@ -670,7 +669,7 @@ impl SupplyChainTransactionHandler {
 
         let mut type_schemata: HashMap<&str, PropertySchema> = HashMap::new();
         let mut required_properties: HashMap<&str, PropertySchema> = HashMap::new();
-        let mut provided_properties: HashMap<&str, PropertyValue> = HashMap::new();
+        let mut provided_properties: HashMap<&str, TrackAndTracePropertyValue> = HashMap::new();
         for property in record_type.get_properties() {
             type_schemata.insert(property.get_name(), property.clone());
             if property.get_required() {
@@ -1505,7 +1504,7 @@ impl SupplyChainTransactionHandler {
         &self,
         reporter_index: u32,
         timestamp: u64,
-        value: &PropertyValue,
+        value: &TrackAndTracePropertyValue,
         property: &Property,
     ) -> Result<PropertyPage_ReportedValue, ApplyError> {
         let mut reported_value = PropertyPage_ReportedValue::new();
@@ -1567,7 +1566,7 @@ impl SupplyChainTransactionHandler {
 
     fn _validate_struct_values(
         &self,
-        struct_values: &RepeatedField<PropertyValue>,
+        struct_values: &RepeatedField<TrackAndTracePropertyValue>,
         schema_values: &RepeatedField<PropertySchema>,
     ) -> Result<(), ApplyError> {
         if struct_values.len() != schema_values.len() {

--- a/sdk/protos/schema_payload.proto
+++ b/sdk/protos/schema_payload.proto
@@ -1,0 +1,55 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "schema_state.proto";
+
+// SchemaPayload contains an action enum and the associated action payload.
+message SchemaPayload {
+    enum Action {
+        UNSET_ACTION = 0;
+        SCHEMA_CREATE = 1;
+        SCHEMA_UPDATE = 2;
+    }
+
+    Action action = 1;
+
+    // The smart contract will read from just one of these fields
+    // according to the Action. Only one of these should be set and must match
+    // the corresponding Action.
+    SchemaCreateAction schema_create = 2;
+    SchemaUpdateAction schema_update = 3;
+}
+
+// SchemaCreateAction adds a new Schema to state.
+message SchemaCreateAction {
+    // The name of the Schema.  This is also the unique identifier for the
+    // new Schema.
+    string schema_name = 1;
+     // An optional description of the schema.
+    string description = 2;
+    // The property definitions that make up the Schema; must not be empty.
+    repeated PropertyDefinition properties = 10;
+}
+
+// SchemaUpdateAction updates an existing Schema. The new properties will
+// be added to the Schema definitions.
+message SchemaUpdateAction {
+    // The name of the Schema to be updated.
+    string schema_name = 1;
+    // The property definitions to be added to the Schema; must not be empty.
+    repeated PropertyDefinition properties = 2;
+}

--- a/sdk/protos/schema_state.proto
+++ b/sdk/protos/schema_state.proto
@@ -1,0 +1,73 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message PropertyDefinition {
+    enum DataType {
+        UNSET_DATA_TYPE = 0;
+        BYTES = 1;
+        BOOLEAN = 2;
+        NUMBER = 3;
+        STRING = 4;
+        ENUM = 5;
+        STRUCT = 6;
+    }
+    // The name of the property
+    string name = 1;
+    // The data type of the value; must not be set to UNSET_DATA_TYPE.
+    DataType data_type = 2;
+    // Indicates that this is a required property in the Schema
+    bool required = 3;
+    // An optional description of the field.
+    string description = 4;
+    // The exponent for a NUMBER property
+    sint32 number_exponent = 10;
+    // The list of values for an ENUM property; must not be empty/ for
+    // properties of that type.
+    repeated string enum_options = 11;
+    // The list of property definitions for a STRUCT property; must  not be
+    // empty for properties of that type.
+    repeated PropertyDefinition struct_properties = 12;
+}
+
+message Schema {
+    // The name of the Schema.  This is also the unique identifier for the
+    // Schema.
+    string name = 1;
+    // An optional description of the schema.
+    string description = 2;
+    // The Pike organization that has rights to modify the schema.
+    string owner = 3;
+    // The property definitions that make up the Schema; must not be empty.
+    repeated PropertyDefinition properties = 10;
+}
+
+message PropertyValue {
+    // The name of the property value.  Used to validate the property against a
+    // Schema.
+    string name = 1;
+    // The data type of the property.  Indicates which value field the actual
+    // value may be found.  Must not be set to `UNSET_DATA_TYPE`.
+    PropertyDefinition.DataType data_type = 2;
+    // The value fields for the possible data types.  Only one of these will
+    // contain a value, determined by the value of `data_type`
+    bytes bytes_value = 10;
+    bool boolean_value = 11;
+    sint64 number_value = 12;
+    string string_value = 13;
+    uint32 enum_value = 14;
+    repeated PropertyValue struct_values = 15;
+}

--- a/sdk/protos/track_and_trace_payload.proto
+++ b/sdk/protos/track_and_trace_payload.proto
@@ -64,7 +64,7 @@ message CreateRecordAction {
   // The name of the RecordType this Record belongs to
   string record_type = 2;
 
-  repeated PropertyValue properties = 3;
+  repeated TrackAndTracePropertyValue properties = 3;
 }
 
 
@@ -85,7 +85,7 @@ message UpdatePropertiesAction {
   // The natural key of the Record
   string record_id = 1;
 
-  repeated PropertyValue properties = 2;
+  repeated TrackAndTracePropertyValue properties = 2;
 }
 
 

--- a/sdk/protos/track_and_trace_property.proto
+++ b/sdk/protos/track_and_trace_property.proto
@@ -129,7 +129,7 @@ message PropertySchema {
 }
 
 
-message PropertyValue {
+message TrackAndTracePropertyValue {
   // The name of the property being set
   string name = 1;
 
@@ -144,7 +144,7 @@ message PropertyValue {
   sint64 number_value = 13;
   string string_value = 14;
   string enum_value = 15;
-  repeated PropertyValue struct_values = 16;
+  repeated TrackAndTracePropertyValue struct_values = 16;
   Location location_value = 17;
 }
 
@@ -165,7 +165,7 @@ message PropertyPage {
     sint64 number_value = 13;
     string string_value = 14;
     uint32 enum_value = 15;
-    repeated PropertyValue struct_values = 16;
+    repeated TrackAndTracePropertyValue struct_values = 16;
     Location location_value = 17;
   }
 


### PR DESCRIPTION
This required temporarily renaming Track and Trace's PropertyValue to TrackAndTracePropertyValue because protobuf would not build two instances of PropertyValue. We plan to update Track And Trace to use Grid Schema once it has been completed. 