### PR TITLE
Add protocol module to Grid SDK

### DIFF
--- a/sdk/src/protocol/mod.rs
+++ b/sdk/src/protocol/mod.rs
@@ -12,5 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod protocol;
-pub mod protos;
+pub mod schema;

--- a/sdk/src/protocol/schema/mod.rs
+++ b/sdk/src/protocol/schema/mod.rs
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod protocol;
-pub mod protos;
+pub mod payload;
+pub mod state;

--- a/sdk/src/protocol/schema/payload.rs
+++ b/sdk/src/protocol/schema/payload.rs
@@ -1,0 +1,570 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use protobuf::RepeatedField;
+
+use std::error::Error as StdError;
+
+use crate::protocol::schema::state::PropertyDefinition;
+use crate::protos;
+use crate::protos::{FromNative, FromProto, IntoNative, IntoProto, ProtoConversionError};
+
+/// Native implementation for SchemaPayload_Action
+#[derive(Debug, Clone, PartialEq)]
+pub enum Action {
+    SchemaCreate,
+    SchemaUpdate,
+}
+
+impl FromProto<protos::schema_payload::SchemaPayload_Action> for Action {
+    fn from_proto(
+        actions: protos::schema_payload::SchemaPayload_Action,
+    ) -> Result<Self, ProtoConversionError> {
+        match actions {
+            protos::schema_payload::SchemaPayload_Action::SCHEMA_CREATE => Ok(Action::SchemaCreate),
+            protos::schema_payload::SchemaPayload_Action::SCHEMA_UPDATE => Ok(Action::SchemaUpdate),
+            protos::schema_payload::SchemaPayload_Action::UNSET_ACTION => {
+                Err(ProtoConversionError::InvalidTypeError(
+                    "Cannot convert SchemaPayload_Action with type unset.".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+impl FromNative<Action> for protos::schema_payload::SchemaPayload_Action {
+    fn from_native(action: Action) -> Result<Self, ProtoConversionError> {
+        match action {
+            Action::SchemaCreate => Ok(protos::schema_payload::SchemaPayload_Action::SCHEMA_CREATE),
+            Action::SchemaUpdate => Ok(protos::schema_payload::SchemaPayload_Action::SCHEMA_UPDATE),
+        }
+    }
+}
+
+impl IntoProto<protos::schema_payload::SchemaPayload_Action> for Action {}
+impl IntoNative<Action> for protos::schema_payload::SchemaPayload_Action {}
+
+/// Native implementation for SchemaPayload
+#[derive(Debug, Clone, PartialEq)]
+pub struct SchemaPayload {
+    action: Action,
+    schema_create: SchemaCreateAction,
+    schema_update: SchemaUpdateAction,
+}
+
+impl SchemaPayload {
+    pub fn action(&self) -> &Action {
+        &self.action
+    }
+
+    pub fn schema_create(&self) -> &SchemaCreateAction {
+        &self.schema_create
+    }
+
+    pub fn schema_update(&self) -> &SchemaUpdateAction {
+        &self.schema_update
+    }
+}
+
+impl FromProto<protos::schema_payload::SchemaPayload> for SchemaPayload {
+    fn from_proto(
+        payload: protos::schema_payload::SchemaPayload,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(SchemaPayload {
+            action: Action::from_proto(payload.get_action())?,
+            schema_create: SchemaCreateAction::from_proto(payload.get_schema_create().clone())?,
+            schema_update: SchemaUpdateAction::from_proto(payload.get_schema_update().clone())?,
+        })
+    }
+}
+
+impl FromNative<SchemaPayload> for protos::schema_payload::SchemaPayload {
+    fn from_native(payload: SchemaPayload) -> Result<Self, ProtoConversionError> {
+        let mut proto_payload = protos::schema_payload::SchemaPayload::new();
+
+        proto_payload.set_action(payload.action().clone().into_proto()?);
+        proto_payload.set_schema_create(payload.schema_create().clone().into_proto()?);
+        proto_payload.set_schema_update(payload.schema_update().clone().into_proto()?);
+        Ok(proto_payload)
+    }
+}
+
+impl IntoProto<protos::schema_payload::SchemaPayload> for SchemaPayload {}
+impl IntoNative<SchemaPayload> for protos::schema_payload::SchemaPayload {}
+
+#[derive(Debug)]
+pub enum SchemaPayloadBuildError {
+    MissingField(String),
+}
+
+impl StdError for SchemaPayloadBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            SchemaPayloadBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            SchemaPayloadBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for SchemaPayloadBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            SchemaPayloadBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+/// Builder used to create a SchemaPayload
+#[derive(Default, Clone)]
+pub struct SchemaPayloadBuilder {
+    action: Option<Action>,
+    schema_create: Option<SchemaCreateAction>,
+    schema_update: Option<SchemaUpdateAction>,
+}
+
+impl SchemaPayloadBuilder {
+    pub fn new() -> Self {
+        SchemaPayloadBuilder::default()
+    }
+
+    pub fn with_action(mut self, action: Action) -> SchemaPayloadBuilder {
+        self.action = Some(action);
+        self
+    }
+
+    pub fn with_schema_create(mut self, create: SchemaCreateAction) -> SchemaPayloadBuilder {
+        self.schema_create = Some(create);
+        self
+    }
+
+    pub fn with_schema_update(mut self, update: SchemaUpdateAction) -> SchemaPayloadBuilder {
+        self.schema_update = Some(update);
+        self
+    }
+
+    pub fn build(self) -> Result<SchemaPayload, SchemaPayloadBuildError> {
+        let action = self.action.ok_or_else(|| {
+            SchemaPayloadBuildError::MissingField("'action' field is required".to_string())
+        })?;
+
+        let schema_create = {
+            if action == Action::SchemaCreate {
+                self.schema_create.ok_or_else(|| {
+                    SchemaPayloadBuildError::MissingField(
+                        "'schema_create' field is required".to_string(),
+                    )
+                })?
+            } else {
+                SchemaCreateAction::default()
+            }
+        };
+
+        let schema_update = {
+            if action == Action::SchemaUpdate {
+                self.schema_update.ok_or_else(|| {
+                    SchemaPayloadBuildError::MissingField(
+                        "'schema_update' field is required".to_string(),
+                    )
+                })?
+            } else {
+                SchemaUpdateAction::default()
+            }
+        };
+
+        Ok(SchemaPayload {
+            action,
+            schema_create,
+            schema_update,
+        })
+    }
+}
+
+/// Native implementation for SchemaCreateAction
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SchemaCreateAction {
+    schema_name: String,
+    description: String,
+    properties: Vec<PropertyDefinition>,
+}
+
+impl SchemaCreateAction {
+    pub fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn properties(&self) -> &[PropertyDefinition] {
+        &self.properties
+    }
+}
+
+impl FromProto<protos::schema_payload::SchemaCreateAction> for SchemaCreateAction {
+    fn from_proto(
+        schema_create: protos::schema_payload::SchemaCreateAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(SchemaCreateAction {
+            schema_name: schema_create.get_schema_name().to_string(),
+            description: schema_create.get_description().to_string(),
+            properties: schema_create
+                .get_properties()
+                .to_vec()
+                .into_iter()
+                .map(PropertyDefinition::from_proto)
+                .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<SchemaCreateAction> for protos::schema_payload::SchemaCreateAction {
+    fn from_native(schema_create: SchemaCreateAction) -> Result<Self, ProtoConversionError> {
+        let mut proto_schema_create = protos::schema_payload::SchemaCreateAction::new();
+
+        proto_schema_create.set_schema_name(schema_create.schema_name().to_string());
+        proto_schema_create.set_description(schema_create.description().to_string());
+        proto_schema_create.set_properties(
+            RepeatedField::from_vec(
+            schema_create.properties().to_vec().into_iter()
+            .map(PropertyDefinition::into_proto)
+            .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
+
+        Ok(proto_schema_create)
+    }
+}
+
+impl IntoProto<protos::schema_payload::SchemaCreateAction> for SchemaCreateAction {}
+impl IntoNative<SchemaCreateAction> for protos::schema_payload::SchemaCreateAction {}
+
+#[derive(Debug)]
+pub enum SchemaCreateBuildError {
+    MissingField(String),
+}
+
+impl StdError for SchemaCreateBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            SchemaCreateBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            SchemaCreateBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for SchemaCreateBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            SchemaCreateBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+/// Builder used to create a SchemaPayload
+#[derive(Default, Clone)]
+pub struct SchemaCreateBuilder {
+    schema_name: Option<String>,
+    description: Option<String>,
+    properties: Vec<PropertyDefinition>,
+}
+
+impl SchemaCreateBuilder {
+    pub fn new() -> Self {
+        SchemaCreateBuilder::default()
+    }
+
+    pub fn with_schema_name(mut self, schema_name: String) -> SchemaCreateBuilder {
+        self.schema_name = Some(schema_name);
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> SchemaCreateBuilder {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_properties(mut self, properties: Vec<PropertyDefinition>) -> SchemaCreateBuilder {
+        self.properties = properties;
+        self
+    }
+
+    pub fn build(self) -> Result<SchemaCreateAction, SchemaCreateBuildError> {
+        let schema_name = self.schema_name.ok_or_else(|| {
+            SchemaCreateBuildError::MissingField("'schema_name' field is required".to_string())
+        })?;
+
+        let description = self.description.unwrap_or_default();
+
+        let properties = {
+            if self.properties.len() > 0 {
+                self.properties
+            } else {
+                return Err(SchemaCreateBuildError::MissingField(
+                    "'properties' field is required".to_string(),
+                ));
+            }
+        };
+
+        Ok(SchemaCreateAction {
+            schema_name,
+            description,
+            properties,
+        })
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SchemaUpdateAction {
+    schema_name: String,
+    properties: Vec<PropertyDefinition>,
+}
+
+/// Native implementation for SchemaUpdateAction
+impl SchemaUpdateAction {
+    pub fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
+
+    pub fn properties(&self) -> &[PropertyDefinition] {
+        &self.properties
+    }
+}
+
+impl FromProto<protos::schema_payload::SchemaUpdateAction> for SchemaUpdateAction {
+    fn from_proto(
+        schema_update: protos::schema_payload::SchemaUpdateAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(SchemaUpdateAction {
+            schema_name: schema_update.get_schema_name().to_string(),
+            properties: schema_update
+                .get_properties()
+                .to_vec()
+                .into_iter()
+                .map(PropertyDefinition::from_proto)
+                .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<SchemaUpdateAction> for protos::schema_payload::SchemaUpdateAction {
+    fn from_native(schema_update: SchemaUpdateAction) -> Result<Self, ProtoConversionError> {
+        let mut proto_schema_update = protos::schema_payload::SchemaUpdateAction::new();
+
+        proto_schema_update.set_schema_name(schema_update.schema_name().to_string());
+        proto_schema_update.set_properties(
+            RepeatedField::from_vec(
+            schema_update.properties().to_vec().into_iter()
+            .map(PropertyDefinition::into_proto)
+            .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
+
+        Ok(proto_schema_update)
+    }
+}
+
+impl IntoProto<protos::schema_payload::SchemaUpdateAction> for SchemaUpdateAction {}
+impl IntoNative<SchemaUpdateAction> for protos::schema_payload::SchemaUpdateAction {}
+
+#[derive(Debug)]
+pub enum SchemaUpdateBuildError {
+    MissingField(String),
+}
+
+impl StdError for SchemaUpdateBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            SchemaUpdateBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            SchemaUpdateBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for SchemaUpdateBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            SchemaUpdateBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+/// Builder used to create a SchemaPayload
+#[derive(Default, Clone)]
+pub struct SchemaUpdateBuilder {
+    schema_name: Option<String>,
+    description: Option<String>,
+    properties: Vec<PropertyDefinition>,
+}
+
+impl SchemaUpdateBuilder {
+    pub fn new() -> Self {
+        SchemaUpdateBuilder::default()
+    }
+
+    pub fn with_schema_name(mut self, schema_name: String) -> SchemaUpdateBuilder {
+        self.schema_name = Some(schema_name);
+        self
+    }
+
+    pub fn with_properties(mut self, properties: Vec<PropertyDefinition>) -> SchemaUpdateBuilder {
+        self.properties = properties;
+        self
+    }
+
+    pub fn build(self) -> Result<SchemaUpdateAction, SchemaUpdateBuildError> {
+        let schema_name = self.schema_name.ok_or_else(|| {
+            SchemaUpdateBuildError::MissingField("'schema field is required".to_string())
+        })?;
+
+        let properties = {
+            if self.properties.len() > 0 {
+                self.properties
+            } else {
+                return Err(SchemaUpdateBuildError::MissingField(
+                    "'properties' field is required".to_string(),
+                ));
+            }
+        };
+
+        Ok(SchemaUpdateAction {
+            schema_name,
+            properties,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::schema::state::{DataType, PropertyDefinitionBuilder};
+
+    #[test]
+    // check that a schema create action is built correctly
+    fn check_schema_create_action() {
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaCreateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_description("Test Schema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        assert_eq!(action.schema_name, "TestSchema");
+        assert_eq!(action.description, "Test Schema");
+        assert_eq!(action.properties, vec![property_definition]);
+    }
+
+    #[test]
+    // check that a schema update action is built correctly
+    fn check_schema_update_action() {
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaUpdateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        assert_eq!(action.schema_name, "TestSchema");
+        assert_eq!(action.properties, vec![property_definition]);
+    }
+
+    #[test]
+    // check that a schema payload with create action is built correctly
+    fn check_schema_create_action_payload() {
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaCreateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_description("Test Schema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        let builder = SchemaPayloadBuilder::new();
+        let payload = builder
+            .with_action(Action::SchemaCreate)
+            .with_schema_create(action.clone())
+            .build()
+            .unwrap();
+
+        assert_eq!(payload.action, Action::SchemaCreate);
+        assert_eq!(payload.schema_create, action);
+        assert_eq!(payload.schema_update, SchemaUpdateAction::default());
+    }
+
+    #[test]
+    // check that a schema payload with update action is built correctly
+    fn check_schema_update_action_payload() {
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaUpdateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        let builder = SchemaPayloadBuilder::new();
+        let payload = builder
+            .with_action(Action::SchemaUpdate)
+            .with_schema_update(action.clone())
+            .build()
+            .unwrap();
+
+        assert_eq!(payload.action, Action::SchemaUpdate);
+        assert_eq!(payload.schema_create, SchemaCreateAction::default());
+        assert_eq!(payload.schema_update, action);
+    }
+}

--- a/sdk/src/protocol/schema/state.rs
+++ b/sdk/src/protocol/schema/state.rs
@@ -1,0 +1,883 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use protobuf::RepeatedField;
+
+use std::error::Error as StdError;
+
+use crate::protos;
+use crate::protos::{FromNative, FromProto, IntoNative, IntoProto, ProtoConversionError};
+
+/// Native implementation of DataType enum
+#[derive(Debug, Clone, PartialEq)]
+pub enum DataType {
+    Bytes,
+    Boolean,
+    Number,
+    String,
+    Enum,
+    Struct,
+}
+
+impl FromProto<protos::schema_state::PropertyDefinition_DataType> for DataType {
+    fn from_proto(
+        data_type: protos::schema_state::PropertyDefinition_DataType,
+    ) -> Result<Self, ProtoConversionError> {
+        match data_type {
+            protos::schema_state::PropertyDefinition_DataType::BYTES => Ok(DataType::Bytes),
+            protos::schema_state::PropertyDefinition_DataType::BOOLEAN => Ok(DataType::Boolean),
+            protos::schema_state::PropertyDefinition_DataType::NUMBER => Ok(DataType::Number),
+            protos::schema_state::PropertyDefinition_DataType::STRING => Ok(DataType::String),
+            protos::schema_state::PropertyDefinition_DataType::ENUM => Ok(DataType::Enum),
+            protos::schema_state::PropertyDefinition_DataType::STRUCT => Ok(DataType::Struct),
+            protos::schema_state::PropertyDefinition_DataType::UNSET_DATA_TYPE => {
+                Err(ProtoConversionError::InvalidTypeError(
+                    "Cannot convert PropertyDefinition_DataType with type unset.".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+impl FromNative<DataType> for protos::schema_state::PropertyDefinition_DataType {
+    fn from_native(data_type: DataType) -> Result<Self, ProtoConversionError> {
+        match data_type {
+            DataType::Bytes => Ok(protos::schema_state::PropertyDefinition_DataType::BYTES),
+            DataType::Boolean => Ok(protos::schema_state::PropertyDefinition_DataType::BOOLEAN),
+            DataType::Number => Ok(protos::schema_state::PropertyDefinition_DataType::NUMBER),
+            DataType::String => Ok(protos::schema_state::PropertyDefinition_DataType::STRING),
+            DataType::Enum => Ok(protos::schema_state::PropertyDefinition_DataType::ENUM),
+            DataType::Struct => Ok(protos::schema_state::PropertyDefinition_DataType::STRUCT),
+        }
+    }
+}
+
+impl IntoProto<protos::schema_state::PropertyDefinition_DataType> for DataType {}
+impl IntoNative<DataType> for protos::schema_state::PropertyDefinition_DataType {}
+
+/// Native implementation of PropertyDefinition
+#[derive(Debug, Clone, PartialEq)]
+pub struct PropertyDefinition {
+    name: String,
+    data_type: DataType,
+    required: bool,
+    description: String,
+    number_exponent: i32,
+    enum_options: Vec<String>,
+    struct_properties: Vec<PropertyDefinition>,
+}
+
+impl PropertyDefinition {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    pub fn required(&self) -> &bool {
+        &self.required
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn number_exponent(&self) -> &i32 {
+        &self.number_exponent
+    }
+
+    pub fn enum_options(&self) -> &[String] {
+        &self.enum_options
+    }
+
+    pub fn struct_properties(&self) -> &[PropertyDefinition] {
+        &self.struct_properties
+    }
+}
+
+impl FromProto<protos::schema_state::PropertyDefinition> for PropertyDefinition {
+    fn from_proto(
+        property_definition: protos::schema_state::PropertyDefinition,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(PropertyDefinition {
+            name: property_definition.get_name().to_string(),
+            data_type: DataType::from_proto(property_definition.get_data_type())?,
+            required: property_definition.get_required(),
+            description: property_definition.get_description().to_string(),
+            number_exponent: property_definition.get_number_exponent(),
+            enum_options: property_definition.get_enum_options().to_vec(),
+            struct_properties: property_definition
+                .get_struct_properties()
+                .to_vec()
+                .into_iter()
+                .map(PropertyDefinition::from_proto)
+                .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<PropertyDefinition> for protos::schema_state::PropertyDefinition {
+    fn from_native(property_definition: PropertyDefinition) -> Result<Self, ProtoConversionError> {
+        let mut proto_property_definition = protos::schema_state::PropertyDefinition::new();
+        proto_property_definition.set_name(property_definition.name().to_string());
+        proto_property_definition
+            .set_data_type(property_definition.data_type().clone().into_proto()?);
+        proto_property_definition.set_required(property_definition.required().clone());
+        proto_property_definition.set_description(property_definition.description().to_string());
+        proto_property_definition
+            .set_number_exponent(property_definition.number_exponent().clone());
+        proto_property_definition.set_enum_options(RepeatedField::from_vec(
+            property_definition.enum_options().to_vec(),
+        ));
+        proto_property_definition.set_struct_properties(
+            RepeatedField::from_vec(
+            property_definition.struct_properties().to_vec().into_iter()
+            .map(PropertyDefinition::into_proto)
+            .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
+        Ok(proto_property_definition)
+    }
+}
+
+impl IntoProto<protos::schema_state::PropertyDefinition> for PropertyDefinition {}
+impl IntoNative<PropertyDefinition> for protos::schema_state::PropertyDefinition {}
+
+#[derive(Debug)]
+pub enum PropertyDefinitionBuildError {
+    MissingField(String),
+    EmptyVec(String),
+}
+
+impl StdError for PropertyDefinitionBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            PropertyDefinitionBuildError::MissingField(ref msg) => msg,
+            PropertyDefinitionBuildError::EmptyVec(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            PropertyDefinitionBuildError::MissingField(_) => None,
+            PropertyDefinitionBuildError::EmptyVec(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for PropertyDefinitionBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            PropertyDefinitionBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+            PropertyDefinitionBuildError::EmptyVec(ref s) => write!(f, "EmptyVec: {}", s),
+        }
+    }
+}
+
+/// Builder used to create a PropertyDefinition
+#[derive(Default, Clone, PartialEq)]
+pub struct PropertyDefinitionBuilder {
+    pub name: Option<String>,
+    pub data_type: Option<DataType>,
+    pub required: Option<bool>,
+    pub description: Option<String>,
+    pub number_exponent: Option<i32>,
+    pub enum_options: Vec<String>,
+    pub struct_properties: Vec<PropertyDefinition>,
+}
+
+impl PropertyDefinitionBuilder {
+    pub fn new() -> Self {
+        PropertyDefinitionBuilder::default()
+    }
+
+    pub fn with_name(mut self, name: String) -> PropertyDefinitionBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_data_type(mut self, data_type: DataType) -> PropertyDefinitionBuilder {
+        self.data_type = Some(data_type);
+        self
+    }
+
+    pub fn with_required(mut self, required: bool) -> PropertyDefinitionBuilder {
+        self.required = Some(required);
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> PropertyDefinitionBuilder {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_number_exponent(mut self, number_exponent: i32) -> PropertyDefinitionBuilder {
+        self.number_exponent = Some(number_exponent);
+        self
+    }
+
+    pub fn with_enum_options(mut self, enum_options: Vec<String>) -> PropertyDefinitionBuilder {
+        self.enum_options = enum_options;
+        self
+    }
+
+    pub fn with_struct_properties(
+        mut self,
+        struct_properties: Vec<PropertyDefinition>,
+    ) -> PropertyDefinitionBuilder {
+        self.struct_properties = struct_properties;
+        self
+    }
+
+    pub fn build(self) -> Result<PropertyDefinition, PropertyDefinitionBuildError> {
+        let name = self.name.ok_or_else(|| {
+            PropertyDefinitionBuildError::MissingField("'name' field is required".to_string())
+        })?;
+
+        let data_type = self.data_type.ok_or_else(|| {
+            PropertyDefinitionBuildError::MissingField("'data_type' field is required".to_string())
+        })?;
+
+        let required = self.required.unwrap_or_else(|| false);
+        let description = self.description.unwrap_or_default();
+
+        let number_exponent = {
+            if data_type == DataType::Number {
+                self.number_exponent.ok_or_else(|| {
+                    PropertyDefinitionBuildError::MissingField(
+                        "'number_exponent' field is required".to_string(),
+                    )
+                })?
+            } else {
+                0 as i32
+            }
+        };
+
+        let enum_options = {
+            if data_type == DataType::Enum {
+                if self.enum_options.len() > 0 {
+                    self.enum_options
+                } else {
+                    return Err(PropertyDefinitionBuildError::EmptyVec(
+                        "'enum_options' cannot be empty".to_string(),
+                    ));
+                }
+            } else {
+                self.enum_options
+            }
+        };
+
+        let struct_properties = {
+            if data_type == DataType::Struct {
+                if self.struct_properties.len() > 0 {
+                    self.struct_properties
+                } else {
+                    return Err(PropertyDefinitionBuildError::EmptyVec(
+                        "'struct_properties' cannot be empty".to_string(),
+                    ));
+                }
+            } else {
+                self.struct_properties
+            }
+        };
+
+        Ok(PropertyDefinition {
+            name,
+            data_type,
+            required,
+            description,
+            number_exponent,
+            enum_options,
+            struct_properties,
+        })
+    }
+}
+
+/// Native implementation of Schema
+#[derive(Debug, Clone, PartialEq)]
+pub struct Schema {
+    name: String,
+    description: String,
+    owner: String,
+    properties: Vec<PropertyDefinition>,
+}
+
+impl Schema {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    pub fn properties(&self) -> &[PropertyDefinition] {
+        &self.properties
+    }
+}
+
+impl FromProto<protos::schema_state::Schema> for Schema {
+    fn from_proto(schema: protos::schema_state::Schema) -> Result<Self, ProtoConversionError> {
+        Ok(Schema {
+            name: schema.get_name().to_string(),
+            description: schema.get_description().to_string(),
+            owner: schema.get_owner().to_string(),
+            properties: schema
+                .get_properties()
+                .to_vec()
+                .into_iter()
+                .map(PropertyDefinition::from_proto)
+                .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<Schema> for protos::schema_state::Schema {
+    fn from_native(schema: Schema) -> Result<Self, ProtoConversionError> {
+        let mut proto_schema = protos::schema_state::Schema::new();
+        proto_schema.set_name(schema.name().to_string());
+        proto_schema.set_description(schema.description().to_string());
+        proto_schema.set_owner(schema.owner().to_string());
+        proto_schema.set_properties(RepeatedField::from_vec(
+            schema
+                .properties()
+                .to_vec()
+                .into_iter()
+                .map(PropertyDefinition::into_proto)
+                .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,
+        ));
+        Ok(proto_schema)
+    }
+}
+
+impl IntoProto<protos::schema_state::Schema> for Schema {}
+impl IntoNative<Schema> for protos::schema_state::Schema {}
+
+#[derive(Debug)]
+pub enum SchemaBuildError {
+    MissingField(String),
+}
+
+impl StdError for SchemaBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            SchemaBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            SchemaBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for SchemaBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            SchemaBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+/// Builder used to create a Schema
+#[derive(Default, Clone)]
+pub struct SchemaBuilder {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub owner: Option<String>,
+    pub properties: Vec<PropertyDefinition>,
+}
+
+impl SchemaBuilder {
+    pub fn new() -> Self {
+        SchemaBuilder::default()
+    }
+
+    pub fn with_name(mut self, name: String) -> SchemaBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> SchemaBuilder {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_owner(mut self, owner: String) -> SchemaBuilder {
+        self.owner = Some(owner);
+        self
+    }
+
+    pub fn with_properties(mut self, properties: Vec<PropertyDefinition>) -> SchemaBuilder {
+        self.properties = properties;
+        self
+    }
+
+    pub fn build(self) -> Result<Schema, SchemaBuildError> {
+        let name = self.name.ok_or_else(|| {
+            SchemaBuildError::MissingField("'name' field is required".to_string())
+        })?;
+
+        let owner = self.owner.ok_or_else(|| {
+            SchemaBuildError::MissingField("'owner' field is required".to_string())
+        })?;
+
+        let description = self.description.unwrap_or_else(|| "".to_string());
+        let properties = {
+            if self.properties.len() > 0 {
+                self.properties
+            } else {
+                return Err(SchemaBuildError::MissingField(
+                    "'properties' field is required".to_string(),
+                ));
+            }
+        };
+
+        Ok(Schema {
+            name,
+            description,
+            owner,
+            properties,
+        })
+    }
+}
+
+/// Native implementation of PropertyValue
+#[derive(Debug, Clone, PartialEq)]
+pub struct PropertyValue {
+    name: String,
+    data_type: DataType,
+    bytes_value: Vec<u8>,
+    boolean_value: bool,
+    number_value: i64,
+    string_value: String,
+    enum_value: u32,
+    struct_values: Vec<PropertyValue>,
+}
+
+impl PropertyValue {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    pub fn bytes_value(&self) -> &[u8] {
+        &self.bytes_value
+    }
+
+    pub fn boolean_value(&self) -> &bool {
+        &self.boolean_value
+    }
+
+    pub fn number_value(&self) -> &i64 {
+        &self.number_value
+    }
+
+    pub fn string_value(&self) -> &str {
+        &self.string_value
+    }
+
+    pub fn enum_value(&self) -> &u32 {
+        &self.enum_value
+    }
+
+    pub fn struct_values(&self) -> &[PropertyValue] {
+        &self.struct_values
+    }
+}
+
+impl FromProto<protos::schema_state::PropertyValue> for PropertyValue {
+    fn from_proto(
+        property_value: protos::schema_state::PropertyValue,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(PropertyValue {
+            name: property_value.get_name().to_string(),
+            data_type: DataType::from_proto(property_value.get_data_type())?,
+            bytes_value: property_value.get_bytes_value().to_vec(),
+            boolean_value: property_value.get_boolean_value().clone(),
+            number_value: property_value.get_number_value().clone(),
+            string_value: property_value.get_string_value().to_string(),
+            enum_value: property_value.get_enum_value().clone(),
+            struct_values: property_value
+                .get_struct_values()
+                .to_vec()
+                .into_iter()
+                .map(PropertyValue::from_proto)
+                .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<PropertyValue> for protos::schema_state::PropertyValue {
+    fn from_native(property_value: PropertyValue) -> Result<Self, ProtoConversionError> {
+        let mut proto_property_value = protos::schema_state::PropertyValue::new();
+        proto_property_value.set_name(property_value.name().to_string());
+        proto_property_value.set_data_type(property_value.data_type().clone().into_proto()?);
+        proto_property_value.set_bytes_value(property_value.bytes_value().to_vec());
+        proto_property_value.set_boolean_value(property_value.boolean_value().clone());
+        proto_property_value.set_number_value(property_value.number_value().clone());
+        proto_property_value.set_string_value(property_value.string_value().to_string());
+        proto_property_value.set_enum_value(property_value.enum_value().clone());
+        proto_property_value.set_struct_values(RepeatedField::from_vec(
+            property_value
+                .struct_values()
+                .to_vec()
+                .into_iter()
+                .map(PropertyValue::into_proto)
+                .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
+                )?,
+        ));
+        Ok(proto_property_value)
+    }
+}
+
+impl IntoProto<protos::schema_state::PropertyValue> for PropertyValue {}
+impl IntoNative<PropertyValue> for protos::schema_state::PropertyValue {}
+
+#[derive(Debug)]
+pub enum PropertyValueBuildError {
+    MissingField(String),
+}
+
+impl StdError for PropertyValueBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            PropertyValueBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            PropertyValueBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for PropertyValueBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            PropertyValueBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+/// Builder used to create a PropertyValue
+#[derive(Default, Clone)]
+pub struct PropertyValueBuilder {
+    pub name: Option<String>,
+    pub data_type: Option<DataType>,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<u32>,
+    pub struct_values: Vec<PropertyValue>,
+}
+
+impl PropertyValueBuilder {
+    pub fn new() -> Self {
+        PropertyValueBuilder::default()
+    }
+
+    pub fn with_name(mut self, name: String) -> PropertyValueBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_data_type(mut self, data_type: DataType) -> PropertyValueBuilder {
+        self.data_type = Some(data_type);
+        self
+    }
+
+    pub fn with_bytes_value(mut self, bytes: Vec<u8>) -> PropertyValueBuilder {
+        self.bytes_value = Some(bytes);
+        self
+    }
+
+    pub fn with_boolean_value(mut self, boolean: bool) -> PropertyValueBuilder {
+        self.boolean_value = Some(boolean);
+        self
+    }
+
+    pub fn with_number_value(mut self, number: i64) -> PropertyValueBuilder {
+        self.number_value = Some(number);
+        self
+    }
+
+    pub fn with_enum_value(mut self, enum_value: u32) -> PropertyValueBuilder {
+        self.enum_value = Some(enum_value);
+        self
+    }
+
+    pub fn with_string_value(mut self, string: String) -> PropertyValueBuilder {
+        self.string_value = Some(string);
+        self
+    }
+
+    pub fn with_struct_values(mut self, struct_values: Vec<PropertyValue>) -> PropertyValueBuilder {
+        self.struct_values = struct_values;
+        self
+    }
+
+    pub fn build(self) -> Result<PropertyValue, PropertyValueBuildError> {
+        let name = self.name.ok_or_else(|| {
+            PropertyValueBuildError::MissingField("'name' field is required".to_string())
+        })?;
+
+        let data_type = self.data_type.ok_or_else(|| {
+            PropertyValueBuildError::MissingField("'data_type' field is required".to_string())
+        })?;
+
+        let bytes_value = {
+            if data_type == DataType::Bytes {
+                self.bytes_value.ok_or_else(|| {
+                    PropertyValueBuildError::MissingField(
+                        "'bytes_value' field is required".to_string(),
+                    )
+                })?
+            } else {
+                vec![]
+            }
+        };
+
+        let boolean_value = {
+            if data_type == DataType::Boolean {
+                self.boolean_value.ok_or_else(|| {
+                    PropertyValueBuildError::MissingField(
+                        "'boolean_value' field is required".to_string(),
+                    )
+                })?
+            } else {
+                false
+            }
+        };
+
+        let number_value = {
+            if data_type == DataType::Number {
+                self.number_value.ok_or_else(|| {
+                    PropertyValueBuildError::MissingField(
+                        "'number_value' field is required".to_string(),
+                    )
+                })?
+            } else {
+                0 as i64
+            }
+        };
+
+        let string_value = {
+            if data_type == DataType::String {
+                self.string_value.ok_or_else(|| {
+                    PropertyValueBuildError::MissingField(
+                        "'string_value' field is required".to_string(),
+                    )
+                })?
+            } else {
+                "".to_string()
+            }
+        };
+
+        let enum_value = {
+            if data_type == DataType::Enum {
+                self.enum_value.ok_or_else(|| {
+                    PropertyValueBuildError::MissingField(
+                        "'enum_value' field is required".to_string(),
+                    )
+                })?
+            } else {
+                0 as u32
+            }
+        };
+
+        let struct_values = {
+            if data_type == DataType::Struct {
+                if self.struct_values.len() > 0 {
+                    self.struct_values
+                } else {
+                    return Err(PropertyValueBuildError::MissingField(
+                        "'struct_values' cannot be empty".to_string(),
+                    ));
+                }
+            } else {
+                self.struct_values
+            }
+        };
+
+        Ok(PropertyValue {
+            name,
+            data_type,
+            bytes_value,
+            boolean_value,
+            number_value,
+            string_value,
+            enum_value,
+            struct_values,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    // check that a property definition with a string data type is built correctly
+    fn check_property_definition_builder_string() {
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        assert_eq!(property_definition.name, "TEST");
+        assert_eq!(property_definition.data_type, DataType::String);
+        assert_eq!(property_definition.description, "Optional");
+    }
+
+    #[test]
+    // check that a property definition with a enum data type is built correctly
+    fn check_property_definition_builder_enum() {
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::Enum)
+            .with_description("Optional".to_string())
+            .with_enum_options(vec![
+                "One".to_string(),
+                "Two".to_string(),
+                "Three".to_string(),
+            ])
+            .build()
+            .unwrap();
+
+        assert_eq!(property_definition.name, "TEST");
+        assert_eq!(property_definition.data_type, DataType::Enum);
+        assert_eq!(property_definition.description, "Optional");
+        assert_eq!(
+            property_definition.enum_options,
+            vec!["One".to_string(), "Two".to_string(), "Three".to_string()]
+        );
+    }
+
+    #[test]
+    // check that a property definitionwith a struct data type is built correctly
+    fn check_property_definition_builder_struct() {
+        let builder = PropertyDefinitionBuilder::new();
+        let struct_string = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::Enum)
+            .with_description("Optional".to_string())
+            .with_enum_options(vec![
+                "One".to_string(),
+                "Two".to_string(),
+                "Three".to_string(),
+            ])
+            .build()
+            .unwrap();
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST_STRUCT".to_string())
+            .with_data_type(DataType::Struct)
+            .with_description("Optional".to_string())
+            .with_struct_properties(vec![struct_string.clone()])
+            .build()
+            .unwrap();
+
+        assert_eq!(property_definition.name, "TEST_STRUCT");
+        assert_eq!(property_definition.data_type, DataType::Struct);
+        assert_eq!(property_definition.description, "Optional");
+        assert_eq!(property_definition.struct_properties, vec![struct_string]);
+    }
+
+    #[test]
+    // check that a schema with a enum property is built correctly
+    fn check_schema_builder() {
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::Enum)
+            .with_description("Optional".to_string())
+            .with_enum_options(vec![
+                "One".to_string(),
+                "Two".to_string(),
+                "Three".to_string(),
+            ])
+            .build()
+            .unwrap();
+
+        let builder = SchemaBuilder::new();
+        let schema = builder
+            .with_name("TestSchema".to_string())
+            .with_description("Test Schema".to_string())
+            .with_owner("owner".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        assert_eq!(schema.name, "TestSchema");
+        assert_eq!(schema.description, "Test Schema");
+        assert_eq!(schema.owner, "owner");
+        assert_eq!(schema.properties, vec![property_definition]);
+    }
+
+    #[test]
+    // check that a property value with a string data type is built correctly
+    fn check_property_value_builder_string() {
+        let builder = PropertyValueBuilder::new();
+        let property_value = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_string_value("String value".to_string())
+            .build()
+            .unwrap();
+
+        assert_eq!(property_value.name, "TEST");
+        assert_eq!(property_value.data_type, DataType::String);
+        assert_eq!(property_value.string_value, "String value");
+    }
+
+    #[test]
+    // check that a property value with a struct data type is built correctly
+    fn check_property_value_builder_struct() {
+        let builder = PropertyValueBuilder::new();
+        let string_value = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_string_value("String value".to_string())
+            .build()
+            .unwrap();
+
+        let builder = PropertyValueBuilder::new();
+        let property_value = builder
+            .with_name("TEST_STRUCT".to_string())
+            .with_data_type(DataType::Struct)
+            .with_struct_values(vec![string_value.clone()])
+            .build()
+            .unwrap();
+
+        assert_eq!(property_value.name, "TEST_STRUCT");
+        assert_eq!(property_value.data_type, DataType::Struct);
+        assert_eq!(property_value.struct_values, vec![string_value]);
+    }
+}


### PR DESCRIPTION
This module will be used by componets that do not
wish to use the protobuf directly. This commit
includes the protocol definations for the Grid Schema
payload and state protos.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>