### PR TITLE
Add IntoBytes and FromBytes to protocol

### DIFF
--- a/sdk/src/protos.rs
+++ b/sdk/src/protos.rs
@@ -55,6 +55,14 @@ pub trait FromNative<N>: Sized {
     fn from_native(other: N) -> Result<Self, ProtoConversionError>;
 }
 
+pub trait FromBytes<N>: Sized {
+    fn from_bytes(bytes: &[u8]) -> Result<N, ProtoConversionError>;
+}
+
+pub trait IntoBytes: Sized {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError>;
+}
+
 pub trait IntoNative<T>: Sized
 where
     T: FromProto<Self>,


### PR DESCRIPTION
This allows a developer to go directly from bytes to
the native implementation and from the native
implementation to the bytes. This will be useful
when writing smart contracts.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>