### PR TITLE
Add initial Rest API

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -19,6 +19,8 @@ authors = ["Contributors to Hyperledger Grid"]
 edition = "2018"
 
 [dependencies]
+actix = "0.7"
+actix-web = "0.7"
 clap = "2"
 log = "0.4"
 simple_logger = "1.0"

--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -18,10 +18,13 @@ use std::fmt;
 
 use log;
 
+use crate::rest_api::RestApiError;
+
 #[derive(Debug)]
 pub enum DaemonError {
     LoggingInitializationError(Box<log::SetLoggerError>),
     ConfigurationError(Box<ConfigurationError>),
+    RestApiError(RestApiError),
 }
 
 impl Error for DaemonError {
@@ -29,6 +32,7 @@ impl Error for DaemonError {
         match self {
             DaemonError::LoggingInitializationError(err) => Some(err),
             DaemonError::ConfigurationError(err) => Some(err),
+            DaemonError::RestApiError(err) => Some(err),
         }
     }
 }
@@ -40,6 +44,7 @@ impl fmt::Display for DaemonError {
                 write!(f, "Logging initialization error: {}", e)
             }
             DaemonError::ConfigurationError(e) => write!(f, "Configuration error: {}", e),
+            DaemonError::RestApiError(e) => write!(f, "Rest API error: {}", e),
         }
     }
 }
@@ -70,5 +75,11 @@ impl fmt::Display for ConfigurationError {
 impl From<ConfigurationError> for DaemonError {
     fn from(err: ConfigurationError) -> Self {
         DaemonError::ConfigurationError(Box::new(err))
+    }
+}
+
+impl From<RestApiError> for DaemonError {
+    fn from(err: RestApiError) -> DaemonError {
+        DaemonError::RestApiError(err)
     }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -22,6 +22,7 @@ extern crate log;
 
 mod config;
 mod error;
+mod rest_api;
 
 use simple_logger;
 
@@ -49,6 +50,8 @@ fn run() -> Result<(), DaemonError> {
     simple_logger::init_with_level(config.log_level())?;
 
     info!("Connecting to validator at {}", config.validator_endpoint());
+
+    let _ = rest_api::run()?;
 
     Ok(())
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -40,6 +40,7 @@ fn run() -> Result<(), DaemonError> {
         (about: "Daemon Package for Hyperledger Grid")
         (@arg connect: -C --connect +takes_value "connection endpoint for validator")
         (@arg verbose: -v +multiple "Log verbosely")
+        (@arg bind: -b --bind +takes_value "connection endpoint for rest API")
     )
     .get_matches();
 
@@ -51,7 +52,8 @@ fn run() -> Result<(), DaemonError> {
 
     info!("Connecting to validator at {}", config.validator_endpoint());
 
-    let _ = rest_api::run()?;
+    let _ = rest_api::run(config.rest_api_endpoint())?;
+    info!("Starting Rest API at {}", config.rest_api_endpoint());
 
     Ok(())
 }

--- a/daemon/src/rest_api/error.rs
+++ b/daemon/src/rest_api/error.rs
@@ -1,0 +1,43 @@
+// Copyright 2019 Bitwise IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum RestApiError {
+    StdError(std::io::Error),
+}
+
+impl Error for RestApiError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            RestApiError::StdError(err) => Some(err),
+        }
+    }
+}
+
+impl fmt::Display for RestApiError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RestApiError::StdError(e) => write!(f, "Std Error: {}", e),
+        }
+    }
+}
+
+impl From<std::io::Error> for RestApiError {
+    fn from(err: std::io::Error) -> RestApiError {
+        RestApiError::StdError(err)
+    }
+}

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -1,0 +1,54 @@
+// Copyright 2019 Bitwise IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod error;
+mod route_handler;
+
+use actix_web::{http::Method, server, App};
+
+pub use crate::rest_api::error::RestApiError;
+use crate::rest_api::route_handler::index;
+
+fn create_app() -> App {
+    App::new().resource("/", |r| r.method(Method::GET).f(index))
+}
+
+pub fn run() -> Result<i32, RestApiError> {
+    let sys = actix::System::new("Grid-Rest-API");
+
+    server::new(create_app).bind("127.0.0.1:8080")?.start();
+
+    Ok(sys.run())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use actix_web::test::TestServer;
+    use actix_web::HttpMessage;
+    use std::str;
+
+    #[test]
+    fn index_test() {
+        let mut srv = TestServer::new(|app| app.handler(index));
+
+        let req = srv.get().finish().unwrap();
+        let resp = srv.execute(req.send()).unwrap();
+        assert!(resp.status().is_success());
+
+        let body_bytes = srv.execute(resp.body()).unwrap();
+        let body_str = str::from_utf8(&body_bytes).unwrap();
+        assert_eq!(body_str, "Hello world!");
+    }
+}

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -24,10 +24,10 @@ fn create_app() -> App {
     App::new().resource("/", |r| r.method(Method::GET).f(index))
 }
 
-pub fn run() -> Result<i32, RestApiError> {
+pub fn run(bind_url: &str) -> Result<i32, RestApiError> {
     let sys = actix::System::new("Grid-Rest-API");
 
-    server::new(create_app).bind("127.0.0.1:8080")?.start();
+    server::new(create_app).bind(bind_url)?.start();
 
     Ok(sys.run())
 }

--- a/daemon/src/rest_api/route_handler.rs
+++ b/daemon/src/rest_api/route_handler.rs
@@ -1,0 +1,19 @@
+// Copyright 2019 Bitwise IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use actix_web::{HttpRequest, HttpResponse};
+
+pub fn index(_req: &HttpRequest) -> HttpResponse {
+    HttpResponse::Ok().body("Hello world!")
+}


### PR DESCRIPTION
Adds initial setup for Rest API which adds a basic Hello World
route and begins a server using Actix.

There is currently a test in place which uses a TestServer to access the index route currently in place. However, you can also test this initial route directly by running `cargo run` from the `daemon` folder. Then, run the command `curl http://localhost:8080` in a terminal, or access `http://localhost:8080` from a web browser and you should see the message "Hello world!" in the response. Use Ctrl+C to shut down this process. 

Signed-off-by: Shannyn Telander <telander@bitwise.io>