### PR TITLE
Change default validator and rest_api addresses

### DIFF
--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -48,9 +48,9 @@ pub struct GridConfigBuilder {
 impl Default for GridConfigBuilder {
     fn default() -> Self {
         Self {
-            validator_endpoint: Some("localhost:4004".to_owned()),
+            validator_endpoint: Some("127.0.0.1:4004".to_owned()),
             log_level: Some(Level::Warn),
-            rest_api_endpoint: Some("localhost:8080".to_owned()),
+            rest_api_endpoint: Some("127.0.0.1:8080".to_owned()),
         }
     }
 }
@@ -131,7 +131,7 @@ mod test {
             .build()
             .expect("Unable to build configuration");
 
-        assert_eq!("localhost:4004", config.validator_endpoint());
-        assert_eq!("localhost:8080", config.rest_api_endpoint());
+        assert_eq!("127.0.0.1:4004", config.validator_endpoint());
+        assert_eq!("127.0.0.1:8080", config.rest_api_endpoint());
     }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -102,4 +102,8 @@ services:
     build:
       context: .
       dockerfile: daemon/Dockerfile
-    entrypoint: "/gridd -v"
+    expose:
+      - 8080
+    ports:
+      - '8080:8080'
+    entrypoint: "/gridd -v -b gridd:8080


### PR DESCRIPTION
To use `localhost` as part of an address does not work with Actix. It compiles but when you try to send a request, there's no response. I found no documentation on this problem, but all Actix examples use `127.0.0.1` rather than localhost. This PR updates updates the default validator
and REST API endpoints to use `127.0.0.1` instead of `localhost`.

