### PR TITLE
Gracefully shutdown the REST API

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2018"
 actix = "0.7"
 actix-web = "0.7"
 clap = "2"
+ctrlc = "3.0"
 log = "0.4"
 simple_logger = "1.0"
 

--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -25,6 +25,7 @@ pub enum DaemonError {
     LoggingInitializationError(Box<log::SetLoggerError>),
     ConfigurationError(Box<ConfigurationError>),
     RestApiError(RestApiError),
+    StartUpError(Box<dyn Error>),
 }
 
 impl Error for DaemonError {
@@ -33,6 +34,7 @@ impl Error for DaemonError {
             DaemonError::LoggingInitializationError(err) => Some(err),
             DaemonError::ConfigurationError(err) => Some(err),
             DaemonError::RestApiError(err) => Some(err),
+            DaemonError::StartUpError(err) => Some(&**err),
         }
     }
 }
@@ -45,6 +47,7 @@ impl fmt::Display for DaemonError {
             }
             DaemonError::ConfigurationError(e) => write!(f, "Configuration error: {}", e),
             DaemonError::RestApiError(e) => write!(f, "Rest API error: {}", e),
+            DaemonError::StartUpError(e) => write!(f, "Start-up error: {}", e),
         }
     }
 }

--- a/daemon/src/rest_api/error.rs
+++ b/daemon/src/rest_api/error.rs
@@ -17,12 +17,14 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum RestApiError {
+    StartUpError(String),
     StdError(std::io::Error),
 }
 
 impl Error for RestApiError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            RestApiError::StartUpError(_) => None,
             RestApiError::StdError(err) => Some(err),
         }
     }
@@ -31,6 +33,7 @@ impl Error for RestApiError {
 impl fmt::Display for RestApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            RestApiError::StartUpError(e) => write!(f, "Start-up Error: {}", e),
             RestApiError::StdError(e) => write!(f, "Std Error: {}", e),
         }
     }


### PR DESCRIPTION
This PR adds the `ctrlc` dependency, and creates a shutdown handle, join handle tuple to be used by the main method. 

It runs the rest api on its own thread, which allows other activities (the future event processor for example) to also be started.