### PR TITLE
Add Grid Schema Smart contract  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ cli/target
 contracts/track_and_trace/Cargo.lock
 contracts/track_and_trace/bin/
 contracts/track_and_trace/target/
-contracts/track_and_trace/src/messages/
+
+contracts/schema/Cargo.lock
+contracts/schema/target/
 
 daemon/Cargo.lock
 daemon/target

--- a/contracts/schema/Cargo.toml
+++ b/contracts/schema/Cargo.toml
@@ -1,0 +1,39 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "grid-schema-tp"
+version = "0.1.0"
+authors = ["Contributors to Hyperledger Grid"]
+description = "Grid Schema Smart Contract"
+homepage = "https://grid.hyperledger.org"
+edition = "2018"
+
+[dependencies]
+clap = "2"
+grid-sdk = { path = "../../sdk" }
+cfg-if = "0.1"
+hex = "0.3.1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
+sabre-sdk = {git = "https://github.com/hyperledger/sawtooth-sabre"}
+
+[target.'cfg(unix)'.dependencies]
+rust-crypto = "0.2.36"
+sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
+rustc-serialize = "0.3.22"
+log = "0.3.0"
+log4rs = "0.7.0"
+sawtooth-zmq = "0.8.2-dev5"

--- a/contracts/schema/Dockerfile
+++ b/contracts/schema/Dockerfile
@@ -1,0 +1,74 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:bionic as GRID-SCHEMA-BUILDER
+
+# Install base dependencies
+RUN apt-get update \
+    && apt-get install -y -q \
+        build-essential \
+        curl \
+        gcc \
+        g++ \
+        libpq-dev \
+        libssl-dev \
+        libsasl2-dev \
+        libzmq3-dev \
+        openssl \
+        pkg-config \
+        unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
+ && chmod +x /usr/bin/rustup-init \
+ && rustup-init -y
+
+# For Building Protobufs
+RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
+    && unzip -o protoc-3.5.1-linux-x86_64.zip -d /usr/local \
+    && rm protoc-3.5.1-linux-x86_64.zip
+
+ENV PATH=$PATH:/protoc3/bin:/root/.cargo/bin
+
+COPY ./sdk /sdk
+
+RUN USER=root cargo new --bin contracts/schema
+WORKDIR /contracts/schema
+
+# Build TP with dummy source in order to cache dependencies in Docker image.
+COPY ./contracts/schema/Cargo.toml ./Cargo.toml
+RUN cargo build --release
+
+COPY contracts/schema/Cargo.toml contracts/schema/Cargo.lock* ./
+RUN cargo build
+
+RUN rm src/*.rs
+COPY ./contracts/schema/src ./src
+
+RUN rm ./target/release/grid-schema-tp* ./target/release/deps/grid_schema*
+RUN cargo build --release
+
+# Create the stand-alone stage
+FROM ubuntu:bionic
+
+RUN apt-get update \
+ && apt-get install -y libssl1.1 libzmq5 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=GRID-SCHEMA-BUILDER /contracts/schema/target/release/grid-schema-tp /
+
+CMD ["/grid-schema-tp"]

--- a/contracts/schema/Dockerfile-installed
+++ b/contracts/schema/Dockerfile-installed
@@ -1,0 +1,53 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -------------=== grid-schema-tp-builder ===-------------
+FROM ubuntu:bionic as grid-schema-builder
+
+ENV VERSION=AUTO_STRICT
+
+RUN apt-get update \
+ && apt-get install -y \
+ curl \
+ gcc \
+ libssl-dev \
+ libzmq3-dev \
+ pkg-config \
+ unzip
+
+# For Building Protobufs
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
+ && curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
+ && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \
+ && rm protoc-3.5.1-linux-x86_64.zip
+
+ENV PATH=$PATH:/protoc3/bin
+RUN /root/.cargo/bin/cargo install cargo-deb
+
+COPY . /project
+
+WORKDIR /project/contracts/schema
+
+RUN /root/.cargo/bin/cargo deb
+
+# -------------=== grid-schema-tp docker build ===-------------
+FROM ubuntu:bionic
+
+COPY --from=grid-schema-builder /project/contracts/schema/target/debian/grid-schema-tp*.deb /tmp
+
+RUN apt-get update \
+ && dpkg -i /tmp/grid-schema-tp*.deb || true \
+ && apt-get -f -y install
+
+CMD ["grid-schema-tp", "-vv"]

--- a/contracts/schema/src/handler.rs
+++ b/contracts/schema/src/handler.rs
@@ -1,0 +1,700 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        use sabre_sdk::ApplyError;
+        use sabre_sdk::TransactionContext;
+        use sabre_sdk::TransactionHandler;
+        use sabre_sdk::TpProcessRequest;
+        use sabre_sdk::{WasmPtr, execute_entrypoint};
+    } else {
+        use sawtooth_sdk::processor::handler::ApplyError;
+        use sawtooth_sdk::processor::handler::TransactionContext;
+        use sawtooth_sdk::processor::handler::TransactionHandler;
+        use sawtooth_sdk::messages::processor::TpProcessRequest;
+    }
+}
+
+use grid_sdk::protocol::schema::payload::{
+    Action, SchemaCreateAction, SchemaPayload, SchemaUpdateAction,
+};
+use grid_sdk::protocol::schema::state::SchemaBuilder;
+use grid_sdk::protos::FromBytes;
+
+use crate::payload::validate_payload;
+use crate::state::GridSchemaState;
+
+pub const GRID_NAMESPACE: &str = "621dee";
+pub const PIKE_NAMESPACE: &str = "cad11d";
+
+#[cfg(target_arch = "wasm32")]
+// Sabre apply must return a bool
+fn apply(request: &TpProcessRequest, context: &mut TransactionContext) -> Result<bool, ApplyError> {
+    let handler = GridSchemaTransactionHandler::new();
+    match handler.apply(request, context) {
+        Ok(_) => Ok(true),
+        Err(err) => Err(err),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub unsafe fn entrypoint(payload: WasmPtr, signer: WasmPtr, signature: WasmPtr) -> i32 {
+    execute_entrypoint(payload, signer, signature, apply)
+}
+
+#[derive(Default)]
+pub struct GridSchemaTransactionHandler {
+    family_name: String,
+    family_versions: Vec<String>,
+    namespaces: Vec<String>,
+}
+
+impl GridSchemaTransactionHandler {
+    pub fn new() -> Self {
+        GridSchemaTransactionHandler {
+            family_name: "grid_schema".to_string(),
+            family_versions: vec!["1.0".to_string()],
+            namespaces: vec![GRID_NAMESPACE.to_string()],
+        }
+    }
+}
+
+impl TransactionHandler for GridSchemaTransactionHandler {
+    fn family_name(&self) -> String {
+        self.family_name.clone()
+    }
+
+    fn family_versions(&self) -> Vec<String> {
+        self.family_versions.clone()
+    }
+
+    fn namespaces(&self) -> Vec<String> {
+        self.namespaces.clone()
+    }
+
+    fn apply(
+        &self,
+        request: &TpProcessRequest,
+        context: &mut TransactionContext,
+    ) -> Result<(), ApplyError> {
+        let payload = SchemaPayload::from_bytes(request.get_payload()).map_err(|err| {
+            ApplyError::InvalidTransaction(format!("Cannot build schema payload: {}", err))
+        })?;
+
+        validate_payload(&payload)?;
+
+        let signer = request.get_header().get_signer_public_key();
+        let mut state = GridSchemaState::new(context);
+
+        #[cfg(not(target_arch = "wasm32"))]
+        info!(
+            "{:?} {:?} {:?}",
+            payload.action(),
+            request.get_header().get_inputs(),
+            request.get_header().get_outputs()
+        );
+
+        match payload.action() {
+            Action::SchemaCreate => schema_create(payload.schema_create(), signer, &mut state),
+            Action::SchemaUpdate => schema_update(payload.schema_update(), signer, &mut state),
+        }
+    }
+}
+
+fn schema_create(
+    payload: &SchemaCreateAction,
+    signer: &str,
+    state: &mut GridSchemaState,
+) -> Result<(), ApplyError> {
+    let schema_name = payload.schema_name();
+    let description = payload.description();
+    let properties = payload.properties();
+
+    if state.get_schema(schema_name)?.is_some() {
+        return Err(ApplyError::InvalidTransaction(format!(
+            "Schema with name {} already exists",
+            schema_name
+        )));
+    }
+
+    let agent = match state.get_agent(signer)? {
+        Some(agent) => agent,
+        None => {
+            return Err(ApplyError::InvalidTransaction(format!(
+                "The signer is not an Agent: {}",
+                signer
+            )));
+        }
+    };
+
+    if !agent.active() {
+        return Err(ApplyError::InvalidTransaction(format!(
+            "The signer is not an active Agent: {}",
+            signer
+        )));
+    }
+
+    let schema = SchemaBuilder::new()
+        .with_name(schema_name.into())
+        .with_description(description.into())
+        .with_owner(agent.org_id().into())
+        .with_properties(properties.to_vec())
+        .build()
+        .map_err(|err| ApplyError::InvalidTransaction(format!("Cannot build schema: {}", err)))?;
+
+    state.set_schema(schema_name, schema)
+}
+
+fn schema_update(
+    payload: &SchemaUpdateAction,
+    signer: &str,
+    state: &mut GridSchemaState,
+) -> Result<(), ApplyError> {
+    let schema_name = payload.schema_name();
+    let mut new_properties = payload.properties().to_vec();
+
+    let schema = match state.get_schema(schema_name)? {
+        Some(schema) => schema,
+        None => {
+            return Err(ApplyError::InvalidTransaction(format!(
+                "Schema with name {} does not exist",
+                schema_name
+            )));
+        }
+    };
+
+    let agent = match state.get_agent(signer)? {
+        Some(agent) => agent,
+        None => {
+            return Err(ApplyError::InvalidTransaction(format!(
+                "The signer is not an Agent: {}",
+                signer
+            )));
+        }
+    };
+
+    if !agent.active() {
+        return Err(ApplyError::InvalidTransaction(format!(
+            "The signer is not an active Agent: {}",
+            signer
+        )));
+    }
+
+    if agent.org_id() != schema.owner() {
+        return Err(ApplyError::InvalidTransaction(format!(
+            "The signer does not belong to the correct organization: {} != {}",
+            agent.org_id(),
+            schema.owner()
+        )));
+    }
+
+    let mut properties = schema.properties().to_vec();
+    properties.sort_by_key(|p| p.name().to_string());
+
+    for property in new_properties.iter() {
+        if properties
+            .binary_search_by_key(&property.name().to_string(), |p| p.name().to_string())
+            .is_ok()
+        {
+            return Err(ApplyError::InvalidTransaction(format!(
+                "Schema already has PropertyDefination with name {}",
+                property.name()
+            )));
+        }
+    }
+    properties.append(&mut new_properties);
+
+    let schema = SchemaBuilder::new()
+        .with_name(schema.name().into())
+        .with_description(schema.description().into())
+        .with_owner(schema.owner().into())
+        .with_properties(properties)
+        .build()
+        .map_err(|err| ApplyError::InvalidTransaction(format!("Cannot build schema: {}", err)))?;
+
+    state.set_schema(schema_name, schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    use grid_sdk::protocol::pike::state::{AgentBuilder, AgentListBuilder};
+    use grid_sdk::protocol::schema::payload::{SchemaCreateBuilder, SchemaUpdateBuilder};
+    use grid_sdk::protocol::schema::state::{
+        DataType, PropertyDefinitionBuilder, SchemaBuilder, SchemaListBuilder,
+    };
+    use grid_sdk::protos::IntoBytes;
+    use sawtooth_sdk::processor::handler::ApplyError;
+    use sawtooth_sdk::processor::handler::{ContextError, TransactionContext};
+
+    use crate::state::{compute_agent_address, compute_schema_address};
+
+    #[derive(Default)]
+    /// A MockTransactionContext that can be used to test GridSchemaState
+    struct MockTransactionContext {
+        state: RefCell<HashMap<String, Vec<u8>>>,
+    }
+
+    impl TransactionContext for MockTransactionContext {
+        fn get_state_entries(
+            &self,
+            addresses: &[String],
+        ) -> Result<Vec<(String, Vec<u8>)>, ContextError> {
+            let mut results = Vec::new();
+            for addr in addresses {
+                let data = match self.state.borrow().get(addr) {
+                    Some(data) => data.clone(),
+                    None => Vec::new(),
+                };
+                results.push((addr.to_string(), data));
+            }
+            Ok(results)
+        }
+
+        fn set_state_entries(&self, entries: Vec<(String, Vec<u8>)>) -> Result<(), ContextError> {
+            for (addr, data) in entries {
+                self.state.borrow_mut().insert(addr, data);
+            }
+            Ok(())
+        }
+
+        /// this is not needed for these tests
+        fn delete_state_entries(&self, _addresses: &[String]) -> Result<Vec<String>, ContextError> {
+            unimplemented!()
+        }
+
+        /// this is not needed for these tests
+        fn add_receipt_data(&self, _data: &[u8]) -> Result<(), ContextError> {
+            unimplemented!()
+        }
+
+        /// this is not needed for these tests
+        fn add_event(
+            &self,
+            _event_type: String,
+            _attributes: Vec<(String, String)>,
+            _data: &[u8],
+        ) -> Result<(), ContextError> {
+            unimplemented!()
+        }
+    }
+
+    impl MockTransactionContext {
+        fn add_agent(&self) {
+            let builder = AgentBuilder::new();
+            let agent = builder
+                .with_org_id("test_org".to_string())
+                .with_public_key("agent_public_key".to_string())
+                .with_active(true)
+                .with_roles(vec!["Role".to_string()])
+                .build()
+                .unwrap();
+
+            let builder = AgentListBuilder::new();
+            let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
+            let agent_bytes = agent_list.into_bytes().unwrap();
+            let agent_address = compute_agent_address("agent_public_key");
+            self.set_state_entry(agent_address, agent_bytes).unwrap();
+        }
+
+        fn add_agent_inactive(&self) {
+            let builder = AgentBuilder::new();
+            let agent = builder
+                .with_org_id("test_org".to_string())
+                .with_public_key("agent_public_key".to_string())
+                .with_active(false)
+                .with_roles(vec!["Role".to_string()])
+                .build()
+                .unwrap();
+
+            let builder = AgentListBuilder::new();
+            let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
+            let agent_bytes = agent_list.into_bytes().unwrap();
+            let agent_address = compute_agent_address("agent_public_key");
+            self.set_state_entry(agent_address, agent_bytes).unwrap();
+        }
+
+        fn add_agent_wrong_organization(&self) {
+            let builder = AgentBuilder::new();
+            let agent = builder
+                .with_org_id("wrong_org".to_string())
+                .with_public_key("agent_public_key".to_string())
+                .with_active(true)
+                .with_roles(vec!["Role".to_string()])
+                .build()
+                .unwrap();
+
+            let builder = AgentListBuilder::new();
+            let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
+            let agent_bytes = agent_list.into_bytes().unwrap();
+            let agent_address = compute_agent_address("agent_public_key");
+            self.set_state_entry(agent_address, agent_bytes).unwrap();
+        }
+
+        fn add_schema(&self) {
+            let builder = PropertyDefinitionBuilder::new();
+            let property_definition = builder
+                .with_name("TEST".to_string())
+                .with_data_type(DataType::Enum)
+                .with_description("Optional".to_string())
+                .with_enum_options(vec![
+                    "One".to_string(),
+                    "Two".to_string(),
+                    "Three".to_string(),
+                ])
+                .build()
+                .unwrap();
+
+            let builder = SchemaBuilder::new();
+            let schema = builder
+                .with_name("TestSchema".to_string())
+                .with_description("Test Schema".to_string())
+                .with_owner("test_org".to_string())
+                .with_properties(vec![property_definition.clone()])
+                .build()
+                .unwrap();
+
+            let builder = SchemaListBuilder::new();
+            let schema_list = builder.with_schemas(vec![schema]).build().unwrap();
+            let schema_bytes = schema_list.into_bytes().unwrap();
+            let schema_address = compute_schema_address("TestSchema");
+            self.set_state_entry(schema_address, schema_bytes).unwrap();
+        }
+    }
+
+    #[test]
+    // Test that if a schema with the same name already exists in state an InvalidTransaction
+    // is returned
+    fn test_create_schema_handler_schema_already_exists() {
+        let mut transaction_context = MockTransactionContext::default();
+        transaction_context.add_schema();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+        let signer = "agent_public_key";
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaCreateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_description("Test Schema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        match schema_create(&action, signer, &mut state) {
+            Ok(()) => panic!("Schema already exists, InvalidTransaction should be returned"),
+            Err(ApplyError::InvalidTransaction(err)) => {
+                assert!(err.contains("Schema with name TestSchema already exists"));
+            }
+            Err(err) => panic!("Should have gotten invalid error but got {}", err),
+        }
+    }
+
+    #[test]
+    // Test that if the transaction signer is not an agent an InvalidTransaction
+    // is returned
+    fn test_create_schema_handler_agent_does_not_exist() {
+        let mut transaction_context = MockTransactionContext::default();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+        let signer = "agent_public_key";
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaCreateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_description("Test Schema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        match schema_create(&action, signer, &mut state) {
+            Ok(()) => panic!("Agent does not exist, InvalidTransaction should be returned"),
+            Err(ApplyError::InvalidTransaction(err)) => {
+                assert!(err.contains("The signer is not an Agent: agent_public_key"));
+            }
+            Err(err) => panic!("Should have gotten invalid error but got {}", err),
+        }
+    }
+
+    #[test]
+    // Test that if the agent is inactive an InvalidTransaction
+    // is returned
+    fn test_create_schema_handler_inactive_agent() {
+        let mut transaction_context = MockTransactionContext::default();
+        transaction_context.add_agent_inactive();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+        let signer = "agent_public_key";
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaCreateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_description("Test Schema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        match schema_create(&action, signer, &mut state) {
+            Ok(()) => panic!("Agent does not exist, InvalidTransaction should be returned"),
+            Err(ApplyError::InvalidTransaction(err)) => {
+                assert!(err.contains("The signer is not an active Agent: agent_public_key"));
+            }
+            Err(err) => panic!("Should have gotten invalid error but got {}", err),
+        }
+    }
+
+    #[test]
+    // Test that if the SchemaCreateAction is valid OK is returned
+    fn test_create_schema_handler_valid() {
+        let mut transaction_context = MockTransactionContext::default();
+        transaction_context.add_agent();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+        let signer = "agent_public_key";
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaCreateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_description("Test Schema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        assert!(schema_create(&action, signer, &mut state).is_ok());
+    }
+
+    #[test]
+    // Test that if the schema does not exist in state an InvalidTransaction is returned
+    fn test_update_schema_handler_schema_does_not_exists() {
+        let mut transaction_context = MockTransactionContext::default();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+        let signer = "agent_public_key";
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaUpdateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        match schema_update(&action, signer, &mut state) {
+            Ok(()) => panic!("Schema already exists, InvalidTransaction should be returned"),
+            Err(ApplyError::InvalidTransaction(err)) => {
+                assert!(err.contains("Schema with name TestSchema does not exist"));
+            }
+            Err(err) => panic!("Should have gotten invalid error but got {}", err),
+        }
+    }
+
+    #[test]
+    // Test that if the signer is not an agent an InvalidTransaction is returned
+    fn test_update_schema_handler_agent_does_not_exist() {
+        let mut transaction_context = MockTransactionContext::default();
+        transaction_context.add_schema();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+        let signer = "agent_public_key";
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaUpdateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        match schema_update(&action, signer, &mut state) {
+            Ok(()) => panic!("Agent does not exist, InvalidTransaction should be returned"),
+            Err(ApplyError::InvalidTransaction(err)) => {
+                assert!(err.contains("The signer is not an Agent: agent_public_key"));
+            }
+            Err(err) => panic!("Should have gotten invalid error but got {}", err),
+        }
+    }
+
+    #[test]
+    // Test that if the agent is inactive an InvalidTransaction is returned
+    fn test_update_schema_handler_inactive_agent() {
+        let mut transaction_context = MockTransactionContext::default();
+        transaction_context.add_schema();
+        transaction_context.add_agent_inactive();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+        let signer = "agent_public_key";
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaUpdateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        match schema_update(&action, signer, &mut state) {
+            Ok(()) => panic!("Agent does not exist, InvalidTransaction should be returned"),
+            Err(ApplyError::InvalidTransaction(err)) => {
+                assert!(err.contains("The signer is not an active Agent: agent_public_key"));
+            }
+            Err(err) => panic!("Should have gotten invalid error but got {}", err),
+        }
+    }
+
+    #[test]
+    // Test that if the agent belongs to the wrong organization an InvalidTransaction is returned
+    fn test_update_schema_handler_agent_wrong_org() {
+        let mut transaction_context = MockTransactionContext::default();
+        transaction_context.add_schema();
+        transaction_context.add_agent_wrong_organization();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+        let signer = "agent_public_key";
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaUpdateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        match schema_update(&action, signer, &mut state) {
+            Ok(()) => panic!("Agent does not exist, InvalidTransaction should be returned"),
+            Err(ApplyError::InvalidTransaction(err)) => {
+                assert!(err.contains(
+                    "The signer does not belong to the correct organization: wrong_org != test_org"
+                ));
+            }
+            Err(err) => panic!("Should have gotten invalid error but got {}", err),
+        }
+    }
+
+    #[test]
+    // Test that if a property already exists in that schema an InvalidTransaction is returned
+    fn test_update_schema_handler_duplicate_property() {
+        let mut transaction_context = MockTransactionContext::default();
+        transaction_context.add_schema();
+        transaction_context.add_agent();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+        let signer = "agent_public_key";
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaUpdateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        match schema_update(&action, signer, &mut state) {
+            Ok(()) => panic!("Agent does not exist, InvalidTransaction should be returned"),
+            Err(ApplyError::InvalidTransaction(err)) => {
+                assert!(err.contains("Schema already has PropertyDefination with name TEST"));
+            }
+            Err(err) => panic!("Should have gotten invalid error but got {}", err),
+        }
+    }
+
+    #[test]
+    // Test that if the SchemaUpdateAction is valid an OK is returned
+    fn test_update_schema_handler_valid() {
+        let mut transaction_context = MockTransactionContext::default();
+        transaction_context.add_schema();
+        transaction_context.add_agent();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+        let signer = "agent_public_key";
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("NEW".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaUpdateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        assert!(schema_update(&action, signer, &mut state).is_ok());
+    }
+}

--- a/contracts/schema/src/main.rs
+++ b/contracts/schema/src/main.rs
@@ -1,0 +1,88 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[macro_use]
+extern crate cfg_if;
+cfg_if! {
+    if #[cfg(not(target_arch = "wasm32"))] {
+        #[macro_use]
+        extern crate clap;
+        #[macro_use]
+        extern crate log;
+        use std::process;
+        use log::LogLevelFilter;
+        use log4rs::append::console::ConsoleAppender;
+        use log4rs::config::{Appender, Config, Root};
+        use log4rs::encode::pattern::PatternEncoder;
+        use sawtooth_sdk::processor::TransactionProcessor;
+        use handler::GridSchemaTransactionHandler;
+    }
+}
+
+pub mod handler;
+mod payload;
+mod state;
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+    let matches = clap_app!(intkey =>
+        (version: crate_version!())
+        (about: "Grid Schema Processor (Rust)")
+        (@arg connect: -C --connect +takes_value
+         "connection endpoint for validator")
+        (@arg verbose: -v --verbose +multiple
+         "increase output verbosity"))
+    .get_matches();
+
+    let endpoint = matches
+        .value_of("connect")
+        .unwrap_or("tcp://localhost:4004");
+
+    let console_log_level;
+    match matches.occurrences_of("verbose") {
+        0 => console_log_level = LogLevelFilter::Warn,
+        1 => console_log_level = LogLevelFilter::Info,
+        2 => console_log_level = LogLevelFilter::Debug,
+        3 | _ => console_log_level = LogLevelFilter::Trace,
+    }
+
+    let stdout = ConsoleAppender::builder()
+        .encoder(Box::new(PatternEncoder::new(
+            "{h({l:5.5})} | {({M}:{L}):20.20} | {m}{n}",
+        )))
+        .build();
+
+    let config = match Config::builder()
+        .appender(Appender::builder().build("stdout", Box::new(stdout)))
+        .build(Root::builder().appender("stdout").build(console_log_level))
+    {
+        Ok(x) => x,
+        Err(_) => process::exit(1),
+    };
+
+    match log4rs::init_config(config) {
+        Ok(_) => (),
+        Err(_) => process::exit(1),
+    }
+
+    let handler = GridSchemaTransactionHandler::new();
+    let mut processor = TransactionProcessor::new(endpoint);
+
+    info!("Console logging level: {}", console_log_level);
+
+    processor.add_handler(&handler);
+    processor.start();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/contracts/schema/src/payload.rs
+++ b/contracts/schema/src/payload.rs
@@ -1,0 +1,210 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        use sabre_sdk::ApplyError;
+    } else {
+        use sawtooth_sdk::processor::handler::ApplyError;
+    }
+}
+
+use grid_sdk::protocol::schema::payload::{
+    Action, SchemaCreateAction, SchemaPayload, SchemaUpdateAction,
+};
+
+pub fn validate_payload(payload: &SchemaPayload) -> Result<(), ApplyError> {
+    match payload.action() {
+        Action::SchemaCreate => validate_schema_create_action(payload.schema_create()),
+        Action::SchemaUpdate => validate_schema_update_action(payload.schema_update()),
+    }
+}
+
+fn validate_schema_create_action(create_action: &SchemaCreateAction) -> Result<(), ApplyError> {
+    if create_action.schema_name().is_empty() {
+        return Err(ApplyError::InvalidTransaction(String::from(
+            "Schema name must be set",
+        )));
+    }
+
+    if create_action.properties().is_empty() {
+        return Err(ApplyError::InvalidTransaction(String::from(
+            "Properties must not be empty",
+        )));
+    }
+    Ok(())
+}
+
+fn validate_schema_update_action(update_action: &SchemaUpdateAction) -> Result<(), ApplyError> {
+    if update_action.schema_name().is_empty() {
+        return Err(ApplyError::InvalidTransaction(String::from(
+            "Schema name must be set",
+        )));
+    }
+
+    if update_action.properties().is_empty() {
+        return Err(ApplyError::InvalidTransaction(String::from(
+            "Properties must not be empty",
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use grid_sdk::protocol::schema::payload::{
+        Action, SchemaCreateBuilder, SchemaPayloadBuilder, SchemaUpdateBuilder,
+    };
+    use grid_sdk::protocol::schema::state::{DataType, PropertyDefinitionBuilder};
+    use grid_sdk::protos;
+    use grid_sdk::protos::IntoNative;
+
+    #[test]
+    // Test a payload with a schema create action is properly validated. This test needs to use
+    // the proto directly originally to be able to mimic the scenarios possbile from creating
+    // a SchemaPayload from bytes. This is because the SchemaPayloadBuilder protects from building
+    // a certain invalid payloads.
+    fn test_validate_schema_create_action() {
+        let mut payload_proto = protos::schema_payload::SchemaPayload::new();
+        assert!(
+            payload_proto.clone().into_native().is_err(),
+            "Cannot convert SchemaPayload_Action with type unset."
+        );
+
+        // create payload with no create SchemaCreateAction
+        payload_proto.set_action(protos::schema_payload::SchemaPayload_Action::SCHEMA_CREATE);
+        let payload = payload_proto.clone().into_native().unwrap();
+        assert!(
+            validate_payload(&payload).is_err(),
+            "Empty SchemaCreateAction should not be valid"
+        );
+
+        let mut action = protos::schema_payload::SchemaCreateAction::new();
+
+        // create payload with empty create SchemaCreateAction
+        payload_proto.set_schema_create(action.clone());
+        let payload = payload_proto.clone().into_native().unwrap();
+        assert!(
+            validate_payload(&payload).is_err(),
+            "Schema name must be set"
+        );
+
+        // create payload with SchemaCreateAction without any properites,
+        action.set_schema_name("test_schema".into());
+        payload_proto.set_schema_create(action.clone());
+        let payload = payload_proto.clone().into_native().unwrap();
+        assert!(
+            validate_payload(&payload).is_err(),
+            "Properties must not be empty"
+        );
+
+        // create payload with full payload
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaCreateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        let builder = SchemaPayloadBuilder::new();
+        let payload = builder
+            .with_action(Action::SchemaCreate)
+            .with_schema_create(action.clone())
+            .build()
+            .unwrap();
+
+        assert!(
+            validate_payload(&payload).is_ok(),
+            "Payload should be valid"
+        );
+    }
+
+    #[test]
+    // Test a payload with a schema update action is properly validated. This test needs to use
+    // the proto directly originally to be able to mimic the scenarios possbile from creating
+    // a SchemaPayload from bytes. This is because the SchemaPayloadBuilder protects from building
+    // a certain invalid payloads.
+    fn test_validate_schema_update_action() {
+        let mut payload_proto = protos::schema_payload::SchemaPayload::new();
+        assert!(
+            payload_proto.clone().into_native().is_err(),
+            "Cannot convert SchemaPayload_Action with type unset."
+        );
+
+        // create payload with no create SchemaCreateAction
+        payload_proto.set_action(protos::schema_payload::SchemaPayload_Action::SCHEMA_UPDATE);
+        let payload = payload_proto.clone().into_native().unwrap();
+        assert!(
+            validate_payload(&payload).is_err(),
+            "Empty SchemaUpdateAction should not be valid"
+        );
+
+        let mut action = protos::schema_payload::SchemaUpdateAction::new();
+
+        // create payload with empty create SchemaCreateAction
+        payload_proto.set_schema_update(action.clone());
+        let payload = payload_proto.clone().into_native().unwrap();
+        assert!(
+            validate_payload(&payload).is_err(),
+            "Schema name must be set"
+        );
+
+        // create payload with SchemaCreateAction without any properites,
+        action.set_schema_name("test_schema".into());
+        payload_proto.set_schema_update(action.clone());
+        let payload = payload_proto.clone().into_native().unwrap();
+        assert!(
+            validate_payload(&payload).is_err(),
+            "Properties must not be empty"
+        );
+
+        // create payload with full payload
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::String)
+            .with_description("Optional".to_string())
+            .build()
+            .unwrap();
+
+        let builder = SchemaUpdateBuilder::new();
+        let action = builder
+            .with_schema_name("TestSchema".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        let builder = SchemaPayloadBuilder::new();
+        let payload = builder
+            .with_action(Action::SchemaUpdate)
+            .with_schema_update(action.clone())
+            .build()
+            .unwrap();
+
+        assert!(
+            validate_payload(&payload).is_ok(),
+            "Payload should be valid"
+        );
+    }
+}

--- a/contracts/schema/src/state.rs
+++ b/contracts/schema/src/state.rs
@@ -1,0 +1,419 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crypto::digest::Digest;
+use crypto::sha2::Sha512;
+use grid_sdk::protocol::pike::state::{Agent, AgentList, Organization, OrganizationList};
+use grid_sdk::protocol::schema::state::{Schema, SchemaList, SchemaListBuilder};
+use grid_sdk::protos::{FromBytes, IntoBytes};
+
+cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        use sabre_sdk::ApplyError;
+        use sabre_sdk::TransactionContext;
+    } else {
+        use sawtooth_sdk::processor::handler::ApplyError;
+        use sawtooth_sdk::processor::handler::TransactionContext;
+    }
+}
+
+pub const GRID_NAMESPACE: &str = "621dee";
+pub const GRID_SCHEMA_NAMESPACE: &str = "01";
+
+pub const PIKE_NAMESPACE: &str = "cad11d";
+pub const PIKE_AGENT_NAMESPACE: &str = "00";
+pub const PIKE_ORG_NAMESPACE: &str = "01";
+
+/// Computes the address a Pike Agent is stored at based on its public_key
+pub fn compute_agent_address(public_key: &str) -> String {
+    let mut sha = Sha512::new();
+    sha.input(public_key.as_bytes());
+
+    String::from(PIKE_NAMESPACE) + PIKE_AGENT_NAMESPACE + &sha.result_str()[..62].to_string()
+}
+
+/// Computes the address a Pike Organization is stored at based on its name
+pub fn compute_org_address(name: &str) -> String {
+    let mut sha = Sha512::new();
+    sha.input(name.as_bytes());
+
+    String::from(PIKE_NAMESPACE) + PIKE_ORG_NAMESPACE + &sha.result_str()[..62].to_string()
+}
+
+/// Computes the address a Grid Schema is stored at based on its name
+pub fn compute_schema_address(name: &str) -> String {
+    let mut sha = Sha512::new();
+    sha.input(name.as_bytes());
+
+    String::from(GRID_NAMESPACE) + GRID_SCHEMA_NAMESPACE + &sha.result_str()[..62].to_string()
+}
+
+/// GridSchemaState is in charge of handling getting and setting state.
+pub struct GridSchemaState<'a> {
+    context: &'a mut dyn TransactionContext,
+}
+
+impl<'a> GridSchemaState<'a> {
+    pub fn new(context: &'a mut dyn TransactionContext) -> GridSchemaState {
+        GridSchemaState { context }
+    }
+
+    /// Gets a Pike Agent. Handles retrieving the correct agent from an AgentList.
+    pub fn get_agent(&mut self, public_key: &str) -> Result<Option<Agent>, ApplyError> {
+        let address = compute_agent_address(public_key);
+        let d = self.context.get_state_entry(&address)?;
+        match d {
+            Some(packed) => {
+                let agents: AgentList = match AgentList::from_bytes(packed.as_slice()) {
+                    Ok(agents) => agents,
+                    Err(err) => {
+                        return Err(ApplyError::InvalidTransaction(format!(
+                            "Cannot deserialize agent list: {:?}",
+                            err,
+                        )));
+                    }
+                };
+
+                // find the agent with the correct public_key
+                for agent in agents.agents() {
+                    if agent.public_key() == public_key {
+                        return Ok(Some(agent.clone()));
+                    }
+                }
+                Ok(None)
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Gets a Pike Organization. Handles retrieving the correct organization from an
+    /// OrganizationList.
+    pub fn get_organization(&mut self, id: &str) -> Result<Option<Organization>, ApplyError> {
+        let address = compute_org_address(id);
+        let d = self.context.get_state_entry(&address)?;
+        match d {
+            Some(packed) => {
+                let orgs: OrganizationList = match OrganizationList::from_bytes(packed.as_slice()) {
+                    Ok(orgs) => orgs,
+                    Err(err) => {
+                        return Err(ApplyError::InvalidTransaction(format!(
+                            "Cannot deserialize organization list: {:?}",
+                            err,
+                        )));
+                    }
+                };
+
+                // find the organization with the correct org id
+                for org in orgs.organizations() {
+                    if org.org_id() == id {
+                        return Ok(Some(org.clone()));
+                    }
+                }
+                Ok(None)
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Gets a Grid Schema. Handles retrieving the correct Schema from a SchemaList
+    pub fn get_schema(&mut self, name: &str) -> Result<Option<Schema>, ApplyError> {
+        let address = compute_schema_address(name);
+        let d = self.context.get_state_entry(&address)?;
+        match d {
+            Some(packed) => {
+                let schemas: SchemaList = match SchemaList::from_bytes(packed.as_slice()) {
+                    Ok(schemas) => schemas,
+                    Err(err) => {
+                        return Err(ApplyError::InvalidTransaction(format!(
+                            "Cannot deserialize organization list: {:?}",
+                            err,
+                        )));
+                    }
+                };
+
+                // find the schema with the correct name
+                for schema in schemas.schemas() {
+                    if schema.name() == name {
+                        return Ok(Some(schema.clone()));
+                    }
+                }
+                Ok(None)
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Sets a Grid Schema in state. Handles creating a SchemaList if one does not already exist
+    /// at the address the schema will be stored. If a SchemaList does already exist, there has
+    /// been a hash collision. The Schema is stored in the SchemaList, sorted by the Schema name,
+    /// and set in state.
+    pub fn set_schema(&mut self, name: &str, new_schema: Schema) -> Result<(), ApplyError> {
+        let address = compute_schema_address(name);
+        let d = self.context.get_state_entry(&address)?;
+        // get list of existing schemas, or an empty vec if none
+        let mut schemas = match d {
+            Some(packed) => match SchemaList::from_bytes(packed.as_slice()) {
+                Ok(schema_list) => schema_list.schemas().to_vec(),
+                Err(err) => {
+                    return Err(ApplyError::InvalidTransaction(format!(
+                        "Cannot deserialize schema list: {}",
+                        err,
+                    )));
+                }
+            },
+            None => vec![],
+        };
+
+        // remove old schema if it exists and sort the schemas by name
+        let mut index = None;
+        for (count, schema) in schemas.iter().enumerate() {
+            if schema.name() == name {
+                index = Some(count);
+                break;
+            }
+        }
+
+        if let Some(x) = index {
+            schemas.remove(x);
+        }
+        schemas.push(new_schema);
+        schemas.sort_by_key(|s| s.name().to_string());
+
+        // build new SchemaList and set in state
+        let schema_list = SchemaListBuilder::new()
+            .with_schemas(schemas)
+            .build()
+            .map_err(|_| {
+                ApplyError::InvalidTransaction(String::from("Cannot build schema list"))
+            })?;
+
+        let serialized = match schema_list.into_bytes() {
+            Ok(serialized) => serialized,
+            Err(_) => {
+                return Err(ApplyError::InvalidTransaction(String::from(
+                    "Cannot serialize schema list",
+                )));
+            }
+        };
+        self.context
+            .set_state_entry(address, serialized)
+            .map_err(|err| ApplyError::InvalidTransaction(format!("{}", err)))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    use grid_sdk::protocol::pike::state::{
+        AgentBuilder, AgentListBuilder, OrganizationBuilder, OrganizationListBuilder,
+    };
+    use grid_sdk::protocol::schema::state::{DataType, PropertyDefinitionBuilder, SchemaBuilder};
+    use sawtooth_sdk::processor::handler::{ContextError, TransactionContext};
+
+    #[derive(Default)]
+    /// A MockTransactionContext that can be used to test GridSchemaState
+    struct MockTransactionContext {
+        state: RefCell<HashMap<String, Vec<u8>>>,
+    }
+
+    impl TransactionContext for MockTransactionContext {
+        fn get_state_entries(
+            &self,
+            addresses: &[String],
+        ) -> Result<Vec<(String, Vec<u8>)>, ContextError> {
+            let mut results = Vec::new();
+            for addr in addresses {
+                let data = match self.state.borrow().get(addr) {
+                    Some(data) => data.clone(),
+                    None => Vec::new(),
+                };
+                results.push((addr.to_string(), data));
+            }
+            Ok(results)
+        }
+
+        fn set_state_entries(&self, entries: Vec<(String, Vec<u8>)>) -> Result<(), ContextError> {
+            for (addr, data) in entries {
+                self.state.borrow_mut().insert(addr, data);
+            }
+            Ok(())
+        }
+
+        /// this is not needed for these tests
+        fn delete_state_entries(&self, _addresses: &[String]) -> Result<Vec<String>, ContextError> {
+            unimplemented!()
+        }
+
+        /// this is not needed for these tests
+        fn add_receipt_data(&self, _data: &[u8]) -> Result<(), ContextError> {
+            unimplemented!()
+        }
+
+        /// this is not needed for these tests
+        fn add_event(
+            &self,
+            _event_type: String,
+            _attributes: Vec<(String, String)>,
+            _data: &[u8],
+        ) -> Result<(), ContextError> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    // Test that if an agent does not exist in state, None is returned
+    fn test_get_agent_none() {
+        let mut transaction_context = MockTransactionContext::default();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+
+        let result = state.get_agent("agent_public_key").unwrap();
+        assert!(result.is_none())
+    }
+
+    #[test]
+    // Test that if an agent does exists in state, Some(Agent) is returned;
+    fn test_get_agent_some() {
+        let mut transaction_context = MockTransactionContext::default();
+
+        let builder = AgentBuilder::new();
+        let agent = builder
+            .with_org_id("organization".to_string())
+            .with_public_key("agent_public_key".to_string())
+            .with_active(true)
+            .with_roles(vec!["Role".to_string()])
+            .build()
+            .unwrap();
+
+        let builder = AgentListBuilder::new();
+        let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
+        let agent_bytes = agent_list.into_bytes().unwrap();
+        let agent_address = compute_agent_address("agent_public_key");
+        transaction_context
+            .set_state_entry(agent_address, agent_bytes)
+            .unwrap();
+
+        let mut state = GridSchemaState::new(&mut transaction_context);
+
+        let result = state.get_agent("agent_public_key").unwrap();
+        assert!(result.is_some());
+        let agent = result.unwrap();
+
+        assert_eq!(agent.public_key(), "agent_public_key");
+    }
+
+    #[test]
+    // Test that if an org does not exist in state, None is returned
+    fn test_get_organization_none() {
+        let mut transaction_context = MockTransactionContext::default();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+
+        let result = state.get_organization("test_org").unwrap();
+        assert!(result.is_none())
+    }
+
+    #[test]
+    // Test that if an org does exists in state, Some(Organization) is returned
+    fn test_get_organization_some() {
+        let mut transaction_context = MockTransactionContext::default();
+
+        let builder = OrganizationBuilder::new();
+        let organization = builder
+            .with_org_id("test_org".to_string())
+            .with_name("name".to_string())
+            .with_address("address".to_string())
+            .build()
+            .unwrap();
+
+        let builder = OrganizationListBuilder::new();
+        let organization_list = builder
+            .with_organizations(vec![organization.clone()])
+            .build()
+            .unwrap();
+        let org_bytes = organization_list.into_bytes().unwrap();
+        let org_address = compute_org_address("test_org");
+        transaction_context
+            .set_state_entry(org_address, org_bytes)
+            .unwrap();
+
+        let mut state = GridSchemaState::new(&mut transaction_context);
+
+        let result = state.get_organization("test_org").unwrap();
+        assert!(result.is_some());
+        let organization = result.unwrap();
+
+        assert_eq!(organization.org_id(), "test_org");
+    }
+
+    #[test]
+    // 1. Test that if a schema is not in state a None is returned.
+    // 2. Test that a schema can be added to state using set_state.
+    // 3. Test that if a schema is in state it will be returned as Some(Schema).
+    // 4. Test that a schema can be replaced
+    fn test_grid_schema_state() {
+        let mut transaction_context = MockTransactionContext::default();
+        let mut state = GridSchemaState::new(&mut transaction_context);
+
+        let result = state.get_schema("TestSchema").unwrap();
+        assert!(result.is_none());
+
+        let builder = PropertyDefinitionBuilder::new();
+        let property_definition = builder
+            .with_name("TEST".to_string())
+            .with_data_type(DataType::Enum)
+            .with_description("Optional".to_string())
+            .with_enum_options(vec![
+                "One".to_string(),
+                "Two".to_string(),
+                "Three".to_string(),
+            ])
+            .build()
+            .unwrap();
+
+        let builder = SchemaBuilder::new();
+        let schema = builder
+            .with_name("TestSchema".to_string())
+            .with_description("Test Schema".to_string())
+            .with_owner("owner".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        assert!(state.set_schema("TestSchema", schema).is_ok());
+        let schema_result = state.get_schema("TestSchema").unwrap();
+        assert!(schema_result.is_some());
+        let schema = schema_result.unwrap();
+        assert_eq!(schema.description(), "Test Schema");
+
+        let builder = SchemaBuilder::new();
+        let schema = builder
+            .with_name("TestSchema".to_string())
+            .with_description("New Description".to_string())
+            .with_owner("owner".to_string())
+            .with_properties(vec![property_definition.clone()])
+            .build()
+            .unwrap();
+
+        assert!(state.set_schema("TestSchema", schema).is_ok());
+        let schema_result = state.get_schema("TestSchema").unwrap();
+        assert!(schema_result.is_some());
+        let schema = schema_result.unwrap();
+        assert_eq!(schema.description(), "New Description");
+    }
+
+}

--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -31,6 +31,16 @@ services:
       - validator
     entrypoint: grid-track-and-trace-tp -C tcp://validator:4004 -v
 
+  schema:
+    image: grid-schema-tp-installed:${ISOLATION_ID}
+    container_name: grid-schema-tp-installed
+    build:
+      context: .
+      dockerfile: contracts/schema/Dockerfile-installed
+    depends_on:
+      - validator
+    entrypoint: grid-schema-tp -C tcp://validator:4004 -v
+
   validator:
     image: hyperledger/sawtooth-validator:1.1
     container_name: grid-sawtooth-validator

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,17 @@ services:
         grid-track-and-trace-tp -v -C tcp://validator:4004
       "
 
+  schema:
+    image: grid-schema-tp
+    container_name: grid-schema-tp
+    build:
+      context: .
+      dockerfile: contracts/schema/Dockerfile
+    entrypoint: |
+      bash -c "
+        /grid-schema-tp -v -C tcp://validator:4004
+      "
+
   validator:
     image: hyperledger/sawtooth-validator:1.1
     container_name: grid-sawtooth-validator

--- a/sdk/protos/schema_state.proto
+++ b/sdk/protos/schema_state.proto
@@ -55,6 +55,11 @@ message Schema {
     repeated PropertyDefinition properties = 10;
 }
 
+message SchemaList {
+  // Schemas are stored in a list to handle any hash collisions
+  repeated Schema schemas = 1;
+}
+
 message PropertyValue {
     // The name of the property value.  Used to validate the property against a
     // Schema.

--- a/sdk/src/protocol/schema/payload.rs
+++ b/sdk/src/protocol/schema/payload.rs
@@ -367,7 +367,7 @@ impl SchemaCreateBuilder {
         let description = self.description.unwrap_or_default();
 
         let properties = {
-            if self.properties.len() > 0 {
+            if !self.properties.is_empty() {
                 self.properties
             } else {
                 return Err(SchemaCreateBuildError::MissingField(
@@ -515,7 +515,7 @@ impl SchemaUpdateBuilder {
         })?;
 
         let properties = {
-            if self.properties.len() > 0 {
+            if !self.properties.is_empty() {
                 self.properties
             } else {
                 return Err(SchemaUpdateBuildError::MissingField(

--- a/sdk/src/protocol/schema/state.rs
+++ b/sdk/src/protocol/schema/state.rs
@@ -293,7 +293,7 @@ impl PropertyDefinitionBuilder {
 
         let enum_options = {
             if data_type == DataType::Enum {
-                if self.enum_options.len() > 0 {
+                if !self.enum_options.is_empty() {
                     self.enum_options
                 } else {
                     return Err(PropertyDefinitionBuildError::EmptyVec(
@@ -307,7 +307,7 @@ impl PropertyDefinitionBuilder {
 
         let struct_properties = {
             if data_type == DataType::Struct {
-                if self.struct_properties.len() > 0 {
+                if !self.struct_properties.is_empty() {
                     self.struct_properties
                 } else {
                     return Err(PropertyDefinitionBuildError::EmptyVec(
@@ -489,7 +489,7 @@ impl SchemaBuilder {
 
         let description = self.description.unwrap_or_else(|| "".to_string());
         let properties = {
-            if self.properties.len() > 0 {
+            if !self.properties.is_empty() {
                 self.properties
             } else {
                 return Err(SchemaBuildError::MissingField(
@@ -689,10 +689,10 @@ impl FromProto<protos::schema_state::PropertyValue> for PropertyValue {
             name: property_value.get_name().to_string(),
             data_type: DataType::from_proto(property_value.get_data_type())?,
             bytes_value: property_value.get_bytes_value().to_vec(),
-            boolean_value: property_value.get_boolean_value().clone(),
-            number_value: property_value.get_number_value().clone(),
+            boolean_value: property_value.get_boolean_value(),
+            number_value: property_value.get_number_value(),
             string_value: property_value.get_string_value().to_string(),
-            enum_value: property_value.get_enum_value().clone(),
+            enum_value: property_value.get_enum_value(),
             struct_values: property_value
                 .get_struct_values()
                 .to_vec()
@@ -909,7 +909,7 @@ impl PropertyValueBuilder {
 
         let struct_values = {
             if data_type == DataType::Struct {
-                if self.struct_values.len() > 0 {
+                if !self.struct_values.is_empty() {
                     self.struct_values
                 } else {
                     return Err(PropertyValueBuildError::MissingField(


### PR DESCRIPTION
This PR implements the Smart contract described in
the Grid Primitives RFC
hyperledger/grid-rfcs#4

Note this does not include the permission check of if
the agent has the permission can_create_schema for the
organization. This we will be added in a separate PR
after the implementation of Permission checker in the
Grid SDK.