### PR TITLE
Connect rest API to database & get_agents route

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -37,6 +37,9 @@ uuid = { version = "0.6", features = ["v4"] }
 url = "1.7.1"
 base64 = "0.10"
 
+[features]
+test-api = []
+
 [[bin]]
 name = "gridd"
 path = "src/main.rs"

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -178,6 +178,36 @@ paths:
           description: API is unable to reach the database
           schema:
             $ref: "#/definitions/Error"
+  /agent:
+    get:
+      tags:
+        - "agents"
+      summary: "Get a list of Agents"
+      description: "Fetches a list of agents from the reporting database"
+      operationId: "list_agents"
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: "List of Agents"
+          schema:
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: "#/definitions/Agents"
+        400:
+          $ref: "#/responses/400BadRequest"
+        429:
+          $ref: "#/responses/429TooManyRequests"
+        500:
+          description: Something went wrong within the database
+          schema:
+            $ref: "#/definitions/Error"
+        503:
+          description: API is unable to reach the database
+          schema:
+            $ref: "#/definitions/Error"
 
 responses:
   400BadRequest:
@@ -390,3 +420,30 @@ definitions:
         - ENUM
         - STRUCT
         - LOCATION
+
+  Agent:
+    properties:
+      public_key:
+        type: string
+        example: 038bba5708acc262464c9fe30d3de9e905a9a5fa30cedd151dd9cd09ea26d46d00
+      org_id:
+        type: string
+        example: 03c360a46457a284793153e09840c322bee1dcc34445d7d49e19e60abd18fd0758
+      active:
+        type: boolean
+      roles:
+        type: array
+        items:
+          type: string
+      metadata:
+        type: array
+        items:
+          $ref: '#definitions/Metadata'
+
+  Metadata:
+    type: object
+    properties:
+      key:
+        type: string
+      value:
+        type: string

--- a/daemon/src/database/helpers/agents.rs
+++ b/daemon/src/database/helpers/agents.rs
@@ -15,7 +15,7 @@
  * -----------------------------------------------------------------------------
  */
 
-use super::models::NewAgent;
+use super::models::{Agent, NewAgent};
 use super::schema::agent;
 use super::MAX_BLOCK_NUM;
 
@@ -51,4 +51,11 @@ fn update_agent_end_block_num(
         .set(agent::end_block_num.eq(current_block_num))
         .execute(conn)
         .map(|_| ())
+}
+
+pub fn get_agents(conn: &PgConnection) -> QueryResult<Vec<Agent>> {
+    agent::table
+        .select(agent::all_columns)
+        .filter(agent::end_block_num.eq(MAX_BLOCK_NUM))
+        .load::<Agent>(conn)
 }

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -56,9 +56,4 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(
-    agent,
-    block,
-    chain_record,
-    organization,
-);
+allow_tables_to_appear_in_same_query!(agent, block, chain_record, organization,);

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -18,13 +18,13 @@
 table! {
     agent (id) {
         id -> Int8,
-        start_block_num -> Int8,
-        end_block_num -> Int8,
         public_key -> Varchar,
         org_id -> Varchar,
         active -> Bool,
         roles -> Array<Varchar>,
         metadata -> Array<Json>,
+        start_block_num -> Int8,
+        end_block_num -> Int8,
     }
 }
 

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -21,7 +21,7 @@ use std::thread;
 use crate::database::ConnectionPool;
 pub use crate::rest_api::error::RestApiServerError;
 use crate::rest_api::route_handler::{
-    get_batch_statuses, submit_batches, DbExecutor, SawtoothMessageSender,
+    get_batch_statuses, list_agents, submit_batches, DbExecutor, SawtoothMessageSender,
 };
 use actix::{Actor, Addr, Context, SyncArbiter};
 use actix_web::{http::Method, server, App};
@@ -57,6 +57,7 @@ fn create_app(
         r.name("batch_statuses");
         r.method(Method::GET).with_async(get_batch_statuses)
     })
+    .resource("/agent", |r| r.method(Method::GET).with_async(list_agents))
 }
 
 pub fn run(

--- a/daemon/src/rest_api/route_handler.rs
+++ b/daemon/src/rest_api/route_handler.rs
@@ -407,6 +407,20 @@ impl Handler<ListAgents> for DbExecutor {
     }
 }
 
+pub fn list_agents(
+    req: HttpRequest<AppState>,
+) -> Box<Future<Item = HttpResponse, Error = RestApiResponseError>> {
+    req.state()
+        .database_connection
+        .send(ListAgents)
+        .from_err()
+        .and_then(move |res| match res {
+            Ok(agents) => Ok(HttpResponse::Ok().json(agents)),
+            Err(err) => Err(err),
+        })
+        .responder()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/daemon/src/rest_api/route_handler.rs
+++ b/daemon/src/rest_api/route_handler.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::database::ConnectionPool;
 use crate::rest_api::{error::RestApiResponseError, AppState};
-use actix::{Actor, Context, Handler, Message};
+use actix::{Actor, Context, Handler, Message, SyncContext};
 use actix_web::{AsyncResponder, HttpMessage, HttpRequest, HttpResponse, Query, State};
 use futures::future;
 use futures::future::Future;
@@ -32,6 +33,20 @@ use url::Url;
 use uuid::Uuid;
 
 const DEFAULT_TIME_OUT: u32 = 300; // Max timeout 300 seconds == 5 minutes
+
+pub struct DbExecutor {
+    connection_pool: ConnectionPool,
+}
+
+impl Actor for DbExecutor {
+    type Context = SyncContext<Self>;
+}
+
+impl DbExecutor {
+    pub fn new(connection_pool: ConnectionPool) -> DbExecutor {
+        DbExecutor { connection_pool }
+    }
+}
 
 pub struct SawtoothMessageSender {
     sender: Box<dyn MessageSender>,

--- a/daemon/src/rest_api/route_handler.rs
+++ b/daemon/src/rest_api/route_handler.rs
@@ -421,7 +421,7 @@ pub fn list_agents(
         .responder()
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "test-api", test))]
 mod test {
     use super::*;
     use crate::database;

--- a/daemon/src/rest_api/route_handler.rs
+++ b/daemon/src/rest_api/route_handler.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::database::ConnectionPool;
+use crate::database::{models::Agent, ConnectionPool};
 use crate::rest_api::{error::RestApiResponseError, AppState};
 use actix::{Actor, Context, Handler, Message, SyncContext};
 use actix_web::{AsyncResponder, HttpMessage, HttpRequest, HttpResponse, Query, State};
@@ -27,6 +27,7 @@ use sawtooth_sdk::messages::client_batch_submit::{
 use sawtooth_sdk::messages::validator::Message_MessageType;
 use sawtooth_sdk::messaging::stream::MessageSender;
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::time::Duration;
 use url::Url;
@@ -364,6 +365,27 @@ fn process_batch_status_response(
         _ => Err(RestApiResponseError::SawtoothValidatorResponseError(
             format!("Validator responded with error {:?}", status),
         )),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct AgentSlice {
+    public_key: String,
+    org_id: String,
+    active: bool,
+    roles: Vec<String>,
+    metadata: Vec<JsonValue>,
+}
+
+impl AgentSlice {
+    pub fn from_agent(agent: Agent) -> Self {
+        Self {
+            public_key: agent.public_key,
+            org_id: agent.org_id,
+            active: agent.active,
+            roles: agent.roles,
+            metadata: agent.metadata,
+        }
     }
 }
 

--- a/daemon/test/docker-compose.yaml
+++ b/daemon/test/docker-compose.yaml
@@ -1,0 +1,27 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: '2.1'
+
+services:
+    test_server:
+        image: postgres
+        restart: always
+        ports:
+            - '5433:5432'
+        environment:
+            POSTGRES_USER: grid_test
+            POSTGRES_PASSWORD: grid_test
+            POSTGRES_DB: grid_test


### PR DESCRIPTION
Adds a connection for the rest API to the database created in pr #32. 

This pr is now dependent on #43 which adds the necessary agents table for this api route.

For testing, run `docker-compose.yaml` in the `daemon/test` directory. Then, run `cargo test --features test-api`