### PR TITLE
Batch statuses endpoint

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "0.6", features = ["v4"] }
 url = "1.7.1"
-
+base64 = "0.10"
 
 [[bin]]
 name = "gridd"


### PR DESCRIPTION
Implement GET batch_statuses endpoint as defined in [openapi spec documentation](https://github.com/hyperledger/grid/blob/440d3b4e0b59d215063cdabd2342f7f32fe47c21/daemon/openapi.yaml#L66). 