### PR TITLE
Add Latitude/Longitude to PropertyDefinition 

### DIFF
--- a/cli/src/actions/schemas.rs
+++ b/cli/src/actions/schemas.rs
@@ -249,6 +249,7 @@ fn parse_data_type(data_type: &str) -> Result<DataType, CliError> {
         "number" => Ok(DataType::Number),
         "enum" => Ok(DataType::Enum),
         "struct" => Ok(DataType::Struct),
+        "lat_long" => Ok(DataType::LatLong),
         _ => Err(CliError::InvalidYamlError(format!(
             "Invalid data type for PropertyDefinition: {}",
             data_type
@@ -382,7 +383,7 @@ mod test {
               data_type: STRING
               description: "RGB value" "##;
 
-    static PHONE_YAML_EXAMPLE: &[u8; 492] = br##"
+    static PHONE_YAML_EXAMPLE: &[u8; 630] = br##"
 - name: "Phone"
   description: "Example phone schema"
   properties:
@@ -398,7 +399,10 @@ mod test {
       - name: "price"
         data_type: NUMBER
         description: "Price of phone rounded to the nearest dollar"
-        number_exponent: 0"##;
+        number_exponent: 0
+      - name: "manufacturer_location"
+        data_type: lat_long
+        description: "Location where manufacturer is headquarted.""##;
 
     ///
     /// Verifies parse_yaml returns a valid SchemaPayload with SchemaCreateAction set from a yaml
@@ -496,6 +500,7 @@ mod test {
         assert_eq!(parse_data_type("NUMBER").unwrap(), DataType::Number);
         assert_eq!(parse_data_type("enum").unwrap(), DataType::Enum);
         assert_eq!(parse_data_type("Struct").unwrap(), DataType::Struct);
+        assert_eq!(parse_data_type("lat_long").unwrap(), DataType::LatLong);
 
         // Check the method returns an error for an invalid input
         assert!(parse_data_type("not_a_valid_type").is_err());
@@ -742,6 +747,11 @@ mod test {
                 false,
                 "Price of phone rounded to the nearest dollar",
             ),
+            make_lat_long_property_definition(
+                "manufacturer_location",
+                false,
+                "Location where manufacturer is headquarted.",
+            ),
         ]
     }
 
@@ -801,6 +811,20 @@ mod test {
         PropertyDefinitionBuilder::new()
             .with_name(name.to_string())
             .with_data_type(DataType::String)
+            .with_required(required)
+            .with_description(description.to_string())
+            .build()
+            .unwrap()
+    }
+
+    fn make_lat_long_property_definition(
+        name: &str,
+        required: bool,
+        description: &str,
+    ) -> PropertyDefinition {
+        PropertyDefinitionBuilder::new()
+            .with_name(name.to_string())
+            .with_data_type(DataType::LatLong)
             .with_required(required)
             .with_description(description.to_string())
             .build()

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -36,6 +36,7 @@ serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "0.6", features = ["v4"] }
 url = "1.7.1"
 base64 = "0.10"
+byteorder = "1"
 
 [features]
 test-api = []

--- a/daemon/migrations/2019-04-19-191743_create_grid_schema_tables/down.sql
+++ b/daemon/migrations/2019-04-19-191743_create_grid_schema_tables/down.sql
@@ -21,3 +21,4 @@ DROP INDEX IF EXISTS grid_property_definition_name_block_num_idx;
 
 DROP TABLE IF EXISTS grid_property_value;
 DROP INDEX IF EXISTS grid_property_value_name_block_num_idx;
+DROP TYPE IF EXISTS latlong;

--- a/daemon/migrations/2019-04-19-191743_create_grid_schema_tables/up.sql
+++ b/daemon/migrations/2019-04-19-191743_create_grid_schema_tables/up.sql
@@ -38,6 +38,18 @@ CREATE TABLE IF NOT EXISTS grid_property_definition (
 CREATE INDEX IF NOT EXISTS grid_property_definition_name_block_num_idx
     ON grid_property_definition (name, end_block_num);
 
+
+-- Create the latlong type if it does not already exists;
+DO $$
+BEGIN
+  CREATE TYPE latlong as (
+   latitude BIGINT,
+   longitude BIGINT
+);
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
 CREATE TABLE IF NOT EXISTS grid_property_value (
     id BIGSERIAL PRIMARY KEY,
     name TEXT NOT NULL,
@@ -47,7 +59,8 @@ CREATE TABLE IF NOT EXISTS grid_property_value (
     number_value BIGINT,
     string_value TEXT,
     enum_value INTEGER,
-    struct_values TEXT []
+    struct_values TEXT [],
+    lat_long_value latlong
 ) INHERITS (chain_record);
 
 CREATE INDEX IF NOT EXISTS grid_property_value_name_block_num_idx

--- a/daemon/src/database/models.rs
+++ b/daemon/src/database/models.rs
@@ -168,7 +168,7 @@ pub struct GridPropertyValue {
     pub boolean_value: Option<bool>,
     pub number_value: Option<i64>,
     pub string_value: Option<String>,
-    pub enum_value: Option<i64>,
+    pub enum_value: Option<i32>,
     pub struct_values: Option<Vec<String>>,
     pub lat_long_value: Option<LatLongValue>,
 }

--- a/daemon/src/database/models.rs
+++ b/daemon/src/database/models.rs
@@ -15,7 +15,13 @@
  * -----------------------------------------------------------------------------
  */
 
+use byteorder::{NetworkEndian, ReadBytesExt};
+use diesel::deserialize::{self, FromSql};
+use diesel::pg::Pg;
+use diesel::serialize::{self, Output, ToSql, WriteTuple};
+use diesel::sql_types;
 use serde_json::Value as JsonValue;
+use std::io::Write;
 
 use super::schema::{
     agent, block, grid_property_definition, grid_property_value, grid_schema, organization,
@@ -148,6 +154,7 @@ pub struct NewGridPropertyValue {
     pub string_value: Option<String>,
     pub enum_value: Option<i32>,
     pub struct_values: Option<Vec<String>>,
+    pub lat_long_value: Option<LatLongValue>,
 }
 
 #[derive(Queryable, Debug)]
@@ -163,4 +170,51 @@ pub struct GridPropertyValue {
     pub string_value: Option<String>,
     pub enum_value: Option<i64>,
     pub struct_values: Option<Vec<String>>,
+    pub lat_long_value: Option<LatLongValue>,
+}
+
+#[derive(SqlType, QueryId, Debug, Clone, Copy)]
+#[postgres(type_name = "latlong")]
+pub struct LatLong;
+
+#[derive(Debug, PartialEq, FromSqlRow, AsExpression)]
+#[sql_type = "LatLong"]
+pub struct LatLongValue(pub i64, pub i64);
+
+impl ToSql<LatLong, Pg> for LatLongValue {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+        WriteTuple::<(sql_types::BigInt, sql_types::BigInt)>::write_tuple(&(self.0, self.1), out)
+    }
+}
+
+impl FromSql<LatLong, Pg> for LatLongValue {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+        let mut bytes = not_none!(bytes);
+        let num_elements = bytes.read_i32::<NetworkEndian>()?;
+        if num_elements != 2 {
+            return Err(format!("Expected a tuple of 2 elements, got {}", num_elements,).into());
+        }
+        let (_, mut bytes) = bytes.split_at(std::mem::size_of::<i32>() * 2);
+        let lat = bytes.read_i64::<NetworkEndian>()?;
+        let (_, mut bytes) = bytes.split_at(std::mem::size_of::<i32>() * 2);
+        let long = bytes.read_i64::<NetworkEndian>()?;
+        Ok(LatLongValue(lat, long))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserializing_lat_long_value_from_bytes() {
+        let lat_long_bytes = [
+            0, 0, 0, 2, 0, 0, 0, 20, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 8,
+            255, 255, 255, 255, 255, 255, 255, 255,
+        ];
+        let lat_long = LatLongValue::from_sql(Some(&lat_long_bytes))
+            .expect("Failed to deserialize LatLongValue");
+
+        assert_eq!(lat_long, LatLongValue(0, -1));
+    }
 }

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -15,6 +15,8 @@
  * -----------------------------------------------------------------------------
  */
 
+use crate::database::models::LatLong;
+
 table! {
     agent (id) {
         id -> Int8,
@@ -61,6 +63,8 @@ table! {
 }
 
 table! {
+    use diesel::sql_types::*;
+    use super::LatLong;
     grid_property_value (id) {
         id -> Int8,
         start_block_num -> Int8,
@@ -73,6 +77,7 @@ table! {
         string_value -> Nullable<Text>,
         enum_value -> Nullable<Int4>,
         struct_values -> Nullable<Array<Text>>,
+        lat_long_value -> Nullable<LatLong>,
     }
 }
 

--- a/docs/source/transaction_family_specifications/grid_schema_family_specification.rst
+++ b/docs/source/transaction_family_specifications/grid_schema_family_specification.rst
@@ -47,6 +47,7 @@ following:
           STRING = 4;
           ENUM = 5;
           STRUCT = 6;
+          LAT_LONG = 7;
       }
 
       // The name of the property
@@ -74,7 +75,7 @@ PropertyValue
 A property value is defined using a ``PropertyValue`` which includes the
 following:
 
-- Data type (one of: BYTES, BOOLEAN, NUMBER, STRING, ENUM, STRUCT)
+- Data type (one of: BYTES, BOOLEAN, NUMBER, STRING, ENUM, STRUCT, LAT_LONG)
 - Name
 - Corresponding value of data type
 
@@ -96,6 +97,7 @@ following:
       string string_value = 13;
       uint32 enum_value = 14;
       repeated PropertyValue struct_values = 15;
+      LatLong lat_long_value = 16;
   }
 
 Data Types
@@ -334,6 +336,39 @@ Structs
   property definition, or it is invalid.  The defaults for the struct values
   themselves depend on their data types and/or the smart-contract implementer
   validation rules.
+
+Latitude/Longitude
+  Latitude/Longitude (Lat/Long) values are represented as a predefined struct
+  made up of a latitude, longitude pair.  Both latitude and longitude are
+  represented as signed integers indicating millionths of degrees.
+
+  A latitude/longitude (lat/long) value would be represented as follows:
+
+  .. code-block:: python
+
+    PropertyDefintion(
+        name='origin',
+        data_type=PropertyDefinition.DataType.LAT_LONG,
+        required=True
+    )
+
+
+  A lat/long instance would be as follows:
+
+  .. code-block:: python
+
+    PropertyValue(
+        name='origin',
+        data_type=PropertyDefinition.DataType.LAT_LONG,
+        lat_long_value=LatLong(
+            latitude=44977753,
+            longitude=-93265015)
+    )
+
+
+  Due to the use of protobuf, the default values for `LatLong` would be `(0, 0)`.
+  While this is a valid lat/long, it could be used to indicate an error, depending
+  on the choice of the smart-contract implementer.
 
 Schemas
 -------

--- a/docs/source/transaction_family_specifications/grid_schema_family_specification.rst
+++ b/docs/source/transaction_family_specifications/grid_schema_family_specification.rst
@@ -78,7 +78,7 @@ following:
 - Name
 - Corresponding value of data type
 
-.. code-block:: python
+.. code-block:: protobuf
 
   message PropertyValue {
       // The name of the property value.  Used to validate the property against
@@ -430,7 +430,7 @@ fields in a schema may be optional.
 
 We can define a data structure that uses this schema for validation as follows:
 
-.. code-block:: python
+.. code-block:: protobuf
 
   message Lightbulb {
       string id = 1;

--- a/sdk/protos/schema_state.proto
+++ b/sdk/protos/schema_state.proto
@@ -24,6 +24,7 @@ message PropertyDefinition {
         STRING = 4;
         ENUM = 5;
         STRUCT = 6;
+        LAT_LONG = 7;
     }
     // The name of the property
     string name = 1;
@@ -56,8 +57,14 @@ message Schema {
 }
 
 message SchemaList {
-  // Schemas are stored in a list to handle any hash collisions
-  repeated Schema schemas = 1;
+    // Schemas are stored in a list to handle any hash collisions
+    repeated Schema schemas = 1;
+}
+
+message LatLong {
+    // Coordinates are expected to be in millionths of a degree
+    sint64 latitude = 1;
+    sint64 longitude = 2;
 }
 
 message PropertyValue {
@@ -75,4 +82,5 @@ message PropertyValue {
     string string_value = 13;
     uint32 enum_value = 14;
     repeated PropertyValue struct_values = 15;
+    LatLong lat_long_value = 16;
 }

--- a/sdk/src/protocol/pike/payload.rs
+++ b/sdk/src/protocol/pike/payload.rs
@@ -605,7 +605,10 @@ impl CreateOrganizationActionBuilder {
         self
     }
 
-    pub fn with_metadata(mut self, metadata: Vec<KeyValueEntry>) -> CreateOrganizationActionBuilder {
+    pub fn with_metadata(
+        mut self,
+        metadata: Vec<KeyValueEntry>,
+    ) -> CreateOrganizationActionBuilder {
         self.metadata = metadata;
         self
     }
@@ -698,7 +701,7 @@ impl FromNative<UpdateOrganizationAction> for protos::pike_payload::UpdateOrgani
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
-            ));
+        ));
 
         Ok(proto_update_org)
     }
@@ -789,7 +792,10 @@ impl UpdateOrganizationActionBuilder {
         self
     }
 
-    pub fn with_metadata(mut self, metadata: Vec<KeyValueEntry>) -> UpdateOrganizationActionBuilder {
+    pub fn with_metadata(
+        mut self,
+        metadata: Vec<KeyValueEntry>,
+    ) -> UpdateOrganizationActionBuilder {
         self.metadata = metadata;
         self
     }

--- a/sdk/src/protocol/pike/state.rs
+++ b/sdk/src/protocol/pike/state.rs
@@ -512,8 +512,7 @@ impl FromNative<Organization> for protos::pike_state::Organization {
         org_proto.set_name(org.name().to_string());
         org_proto.set_address(org.address().to_string());
         org_proto.set_metadata(RepeatedField::from_vec(
-            org
-                .metadata()
+            org.metadata()
                 .to_vec()
                 .into_iter()
                 .map(KeyValueEntry::into_proto)

--- a/sdk/src/protocol/schema/state.rs
+++ b/sdk/src/protocol/schema/state.rs
@@ -31,6 +31,7 @@ pub enum DataType {
     String,
     Enum,
     Struct,
+    LatLong,
 }
 
 impl FromProto<protos::schema_state::PropertyDefinition_DataType> for DataType {
@@ -44,6 +45,7 @@ impl FromProto<protos::schema_state::PropertyDefinition_DataType> for DataType {
             protos::schema_state::PropertyDefinition_DataType::STRING => Ok(DataType::String),
             protos::schema_state::PropertyDefinition_DataType::ENUM => Ok(DataType::Enum),
             protos::schema_state::PropertyDefinition_DataType::STRUCT => Ok(DataType::Struct),
+            protos::schema_state::PropertyDefinition_DataType::LAT_LONG => Ok(DataType::LatLong),
             protos::schema_state::PropertyDefinition_DataType::UNSET_DATA_TYPE => {
                 Err(ProtoConversionError::InvalidTypeError(
                     "Cannot convert PropertyDefinition_DataType with type unset.".to_string(),
@@ -62,6 +64,7 @@ impl FromNative<DataType> for protos::schema_state::PropertyDefinition_DataType 
             DataType::String => Ok(protos::schema_state::PropertyDefinition_DataType::STRING),
             DataType::Enum => Ok(protos::schema_state::PropertyDefinition_DataType::ENUM),
             DataType::Struct => Ok(protos::schema_state::PropertyDefinition_DataType::STRUCT),
+            DataType::LatLong => Ok(protos::schema_state::PropertyDefinition_DataType::LAT_LONG),
         }
     }
 }

--- a/sdk/src/protocol/schema/state.rs
+++ b/sdk/src/protocol/schema/state.rs
@@ -72,6 +72,42 @@ impl FromNative<DataType> for protos::schema_state::PropertyDefinition_DataType 
 impl IntoProto<protos::schema_state::PropertyDefinition_DataType> for DataType {}
 impl IntoNative<DataType> for protos::schema_state::PropertyDefinition_DataType {}
 
+pub struct LatLong {
+    latitude: i64,
+    longitude: i64,
+}
+
+impl LatLong {
+    pub fn latitude(&self) -> &i64 {
+        &self.latitude
+    }
+
+    pub fn longitude(&self) -> &i64 {
+        &self.longitude
+    }
+}
+
+impl FromProto<protos::schema_state::LatLong> for LatLong {
+    fn from_proto(lat_long: protos::schema_state::LatLong) -> Result<Self, ProtoConversionError> {
+        Ok(LatLong {
+            latitude: lat_long.get_latitude(),
+            longitude: lat_long.get_longitude(),
+        })
+    }
+}
+
+impl FromNative<LatLong> for protos::schema_state::LatLong {
+    fn from_native(lat_long: LatLong) -> Result<Self, ProtoConversionError> {
+        let mut proto_lat_long = protos::schema_state::LatLong::new();
+        proto_lat_long.set_latitude(lat_long.latitude().clone());
+        proto_lat_long.set_longitude(lat_long.longitude().clone());
+        Ok(proto_lat_long)
+    }
+}
+
+impl IntoProto<protos::schema_state::LatLong> for LatLong {}
+impl IntoNative<LatLong> for protos::schema_state::LatLong {}
+
 /// Native implementation of PropertyDefinition
 #[derive(Debug, Clone, PartialEq)]
 pub struct PropertyDefinition {

--- a/sdk/src/protocol/schema/state.rs
+++ b/sdk/src/protocol/schema/state.rs
@@ -447,7 +447,7 @@ impl IntoBytes for Schema {
     fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
         let proto = self.into_proto()?;
         let bytes = proto.write_to_bytes().map_err(|_| {
-            ProtoConversionError::SerializationError("Unable to get bytes from Scheman".to_string())
+            ProtoConversionError::SerializationError("Unable to get bytes from Schema".to_string())
         })?;
         Ok(bytes)
     }

--- a/sdk/src/protocol/schema/state.rs
+++ b/sdk/src/protocol/schema/state.rs
@@ -559,7 +559,9 @@ impl SchemaList {
 }
 
 impl FromProto<protos::schema_state::SchemaList> for SchemaList {
-    fn from_proto(schema_list: protos::schema_state::SchemaList) -> Result<Self, ProtoConversionError> {
+    fn from_proto(
+        schema_list: protos::schema_state::SchemaList,
+    ) -> Result<Self, ProtoConversionError> {
         Ok(SchemaList {
             schemas: schema_list
                 .get_schemas()


### PR DESCRIPTION
This PR: 
- Adds LatLong as a DataType for a PropertyDefinition as defined in  hyperledger/grid-rfcs#4.
- Adds a new proto message definition for LatLong and implement a native version of it.
- Fixes a couple of formatting issues and typos.
- Updates the Grid schema family specification document to include information about the LatLong data type. 

~This PR might need to be updated if other changes get merged first, such as #46 and #52.~ Updated!