### PR TITLE
Replace unix with not wasm32 in platform-specific dependencies

### DIFF
--- a/contracts/pike/Cargo.toml
+++ b/contracts/pike/Cargo.toml
@@ -27,7 +27,7 @@ grid-sdk = {path = "../../sdk"}
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
 sabre-sdk = "0.2"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
 log = "0.3.8"
 log4rs = "0.7.0"

--- a/contracts/schema/Cargo.toml
+++ b/contracts/schema/Cargo.toml
@@ -30,7 +30,7 @@ hex = "0.3.1"
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
 sabre-sdk = "0.2"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rust-crypto = "0.2.36"
 sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
 rustc-serialize = "0.3.22"

--- a/contracts/track_and_trace/Cargo.toml
+++ b/contracts/track_and_trace/Cargo.toml
@@ -31,7 +31,7 @@ protobuf = "2"
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
 sabre-sdk = "0.2"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rust-crypto = "0.2.36"
 sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
 rustc-serialize = "0.3.22"


### PR DESCRIPTION
This will allow sabre smart contracts to be compiled on more
platforms when not compiling into wasm.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>