### PR TITLE
Add organization endpoints

### DIFF
--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -237,6 +237,42 @@ paths:
           description: API is unable to reach the database
           schema:
             $ref: "#/definitions/Error"
+
+  /organization/{id}:
+    get:
+      tags:
+        - "organization"
+      operationId: "fetch_organization"
+      produces:
+        - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "Id of the organization to return"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: Successful operation
+          schema:
+            properties:
+              link:
+                $ref: "#/definitions/Organization"
+        400:
+          $ref: "#/responses/400BadRequest"
+        404:
+          $ref: "#/responses/404NotFound"
+        429:
+          $ref: "#/responses/429TooManyRequests"
+        500:
+          description: Something went wrong within the database
+          schema:
+            $ref: "#/definitions/Error"
+        503:
+          description: API is unable to reach the database
+          schema:
+            $ref: "#/definitions/Error"
+
 responses:
   400BadRequest:
     description: Request was malformed

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -209,6 +209,34 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /organization:
+    get:
+      tags:
+        - "organization"
+      operationId: "list_organizations"
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: "Retrieve list of organizations"
+          schema:
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: "#/definitions/Organization"
+        400:
+          $ref: "#/responses/400BadRequest"
+        429:
+          $ref: "#/responses/429TooManyRequests"
+        500:
+          description: Something went wrong within the database
+          schema:
+            $ref: "#/definitions/Error"
+        503:
+          description: API is unable to reach the database
+          schema:
+            $ref: "#/definitions/Error"
 responses:
   400BadRequest:
     description: Request was malformed
@@ -437,6 +465,23 @@ definitions:
         items:
           type: string
           example: "admin"
+      metadata:
+        type: array
+        items:
+          $ref: '#/definitions/Metadata'
+
+  Organization:
+    type: object
+    properties:
+      id:
+        type: string
+        example: "philips001"
+      name:
+        type: string
+        example: "Philips"
+      address:
+        type: string
+        example: "Amstelplein 2 1096 BC Amsterdam The Netherlands"
       metadata:
         type: array
         items:

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -120,7 +120,7 @@ paths:
       produces:
       - "application/json"
       responses:
-        202:
+        200:
           description: "List of schemas"
           schema:
             properties:
@@ -158,7 +158,7 @@ paths:
         required: true
         type: "string"
       responses:
-        202:
+        200:
           description: Successful operation
           schema:
             properties:
@@ -181,7 +181,7 @@ paths:
   /agent:
     get:
       tags:
-        - "agents"
+        - "agent"
       summary: "Get a list of Agents"
       description: "Fetches a list of agents from the reporting database"
       operationId: "list_agents"
@@ -195,7 +195,7 @@ paths:
               data:
                 type: array
                 items:
-                  $ref: "#/definitions/Agents"
+                  $ref: "#/definitions/Agent"
         400:
           $ref: "#/responses/400BadRequest"
         429:
@@ -438,7 +438,7 @@ definitions:
       metadata:
         type: array
         items:
-          $ref: '#definitions/Metadata'
+          $ref: '#/definitions/Metadata'
 
   Metadata:
     type: object

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -431,10 +431,12 @@ definitions:
         example: 03c360a46457a284793153e09840c322bee1dcc34445d7d49e19e60abd18fd0758
       active:
         type: boolean
+        example: "true"
       roles:
         type: array
         items:
           type: string
+          example: "admin"
       metadata:
         type: array
         items:
@@ -445,5 +447,7 @@ definitions:
     properties:
       key:
         type: string
+        example: "industry"
       value:
         type: string
+        example: "eletronics"

--- a/daemon/src/database/helpers/organizations.rs
+++ b/daemon/src/database/helpers/organizations.rs
@@ -15,7 +15,7 @@
  * -----------------------------------------------------------------------------
  */
 
-use super::models::NewOrganization;
+use super::models::{NewOrganization, Organization};
 use super::schema::organization;
 use super::MAX_BLOCK_NUM;
 
@@ -54,4 +54,11 @@ fn update_org_end_block_num(
         .set(organization::end_block_num.eq(current_block_num))
         .execute(conn)
         .map(|_| ())
+}
+
+pub fn list_organizations(conn: &PgConnection) -> QueryResult<Vec<Organization>> {
+    organization::table
+        .select(organization::all_columns)
+        .filter(organization::end_block_num.eq(MAX_BLOCK_NUM))
+        .load::<Organization>(conn)
 }

--- a/daemon/src/database/helpers/organizations.rs
+++ b/daemon/src/database/helpers/organizations.rs
@@ -23,6 +23,7 @@ use diesel::{
     dsl::{insert_into, update},
     pg::PgConnection,
     prelude::*,
+    result::Error::NotFound,
     QueryResult,
 };
 
@@ -61,4 +62,20 @@ pub fn list_organizations(conn: &PgConnection) -> QueryResult<Vec<Organization>>
         .select(organization::all_columns)
         .filter(organization::end_block_num.eq(MAX_BLOCK_NUM))
         .load::<Organization>(conn)
+}
+
+pub fn fetch_organization(
+    conn: &PgConnection,
+    organization_id: &str,
+) -> QueryResult<Option<Organization>> {
+    organization::table
+        .select(organization::all_columns)
+        .filter(
+            organization::org_id
+                .eq(organization_id)
+                .and(organization::end_block_num.eq(MAX_BLOCK_NUM)),
+        )
+        .first(conn)
+        .map(Some)
+        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
 }

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -90,12 +90,12 @@ table! {
 table! {
     organization (id) {
         id -> Int8,
-        start_block_num -> Int8,
-        end_block_num -> Int8,
         org_id -> Varchar,
         name -> Varchar,
         address -> Varchar,
         metadata -> Array<Json>,
+        start_block_num -> Int8,
+        end_block_num -> Int8,
     }
 }
 

--- a/daemon/src/rest_api/error.rs
+++ b/daemon/src/rest_api/error.rs
@@ -59,6 +59,7 @@ pub enum RestApiResponseError {
     SawtoothValidatorResponseError(String),
     RequestHandlerError(String),
     DatabaseError(String),
+    NotFoundError(String),
 }
 
 impl Error for RestApiResponseError {
@@ -69,6 +70,7 @@ impl Error for RestApiResponseError {
             RestApiResponseError::SawtoothValidatorResponseError(_) => None,
             RestApiResponseError::RequestHandlerError(_) => None,
             RestApiResponseError::DatabaseError(_) => None,
+            RestApiResponseError::NotFoundError(_) => None,
         }
     }
 }
@@ -86,6 +88,7 @@ impl fmt::Display for RestApiResponseError {
             RestApiResponseError::RequestHandlerError(ref s) => {
                 write!(f, "Sawtooth Validator Response Error: {}", s)
             }
+            RestApiResponseError::NotFoundError(ref s) => write!(f, "Not Found Error: {}", s),
             RestApiResponseError::DatabaseError(ref s) => write!(f, "Database Error: {}", s),
         }
     }
@@ -103,6 +106,9 @@ impl ResponseError for RestApiResponseError {
             }
             RestApiResponseError::DatabaseError(ref message) => {
                 HttpResponse::ServiceUnavailable().json(message)
+            }
+            RestApiResponseError::NotFoundError(ref message) => {
+                HttpResponse::NotFound().json(message)
             }
             _ => HttpResponse::InternalServerError().json("Internal Server Error"),
         }

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -20,7 +20,9 @@ use std::thread;
 
 use crate::database::ConnectionPool;
 pub use crate::rest_api::error::RestApiServerError;
-use crate::rest_api::routes::{get_batch_statuses, list_agents, submit_batches};
+use crate::rest_api::routes::{
+    get_batch_statuses, list_agents, list_organizations, submit_batches,
+};
 use crate::rest_api::routes::{DbExecutor, SawtoothMessageSender};
 use actix::{Actor, Addr, Context, SyncArbiter};
 use actix_web::{http::Method, server, App};
@@ -57,6 +59,9 @@ fn create_app(
         r.method(Method::GET).with_async(get_batch_statuses)
     })
     .resource("/agent", |r| r.method(Method::GET).with_async(list_agents))
+    .resource("/organization", |r| {
+        r.method(Method::GET).with_async(list_organizations)
+    })
 }
 
 pub fn run(

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -21,7 +21,7 @@ use std::thread;
 use crate::database::ConnectionPool;
 pub use crate::rest_api::error::RestApiServerError;
 use crate::rest_api::routes::{
-    get_batch_statuses, list_agents, list_organizations, submit_batches,
+    fetch_organization, get_batch_statuses, list_agents, list_organizations, submit_batches,
 };
 use crate::rest_api::routes::{DbExecutor, SawtoothMessageSender};
 use actix::{Actor, Addr, Context, SyncArbiter};
@@ -61,6 +61,9 @@ fn create_app(
     .resource("/agent", |r| r.method(Method::GET).with_async(list_agents))
     .resource("/organization", |r| {
         r.method(Method::GET).with_async(list_organizations)
+    })
+    .resource("/organization/{id}", |r| {
+        r.method(Method::GET).with_async(fetch_organization)
     })
 }
 

--- a/daemon/src/rest_api/routes/organizations.rs
+++ b/daemon/src/rest_api/routes/organizations.rs
@@ -1,0 +1,72 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::database::{helpers as db, models::Organization};
+use crate::rest_api::{error::RestApiResponseError, routes::DbExecutor, AppState};
+
+use actix::{Handler, Message, SyncContext};
+use actix_web::{HttpRequest, HttpResponse, Path};
+use futures::Future;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OrganizationSlice {
+    pub org_id: String,
+    pub name: String,
+    pub address: String,
+    pub metadata: Vec<JsonValue>,
+}
+
+impl OrganizationSlice {
+    pub fn from_organization(organization: &Organization) -> Self {
+        Self {
+            org_id: organization.org_id.clone(),
+            name: organization.name.clone(),
+            address: organization.address.clone(),
+            metadata: organization.metadata.clone(),
+        }
+    }
+}
+
+struct ListOrganizations;
+
+impl Message for ListOrganizations {
+    type Result = Result<Vec<OrganizationSlice>, RestApiResponseError>;
+}
+
+impl Handler<ListOrganizations> for DbExecutor {
+    type Result = Result<Vec<OrganizationSlice>, RestApiResponseError>;
+
+    fn handle(&mut self, _msg: ListOrganizations, _: &mut SyncContext<Self>) -> Self::Result {
+        let fetched_organizations = db::list_organizations(&*self.connection_pool.get()?)?
+            .iter()
+            .map(|organization| OrganizationSlice::from_organization(organization))
+            .collect();
+        Ok(fetched_organizations)
+    }
+}
+
+pub fn list_organizations(
+    req: HttpRequest<AppState>,
+) -> impl Future<Item = HttpResponse, Error = RestApiResponseError> {
+    req.state()
+        .database_connection
+        .send(ListOrganizations)
+        .from_err()
+        .and_then(move |res| match res {
+            Ok(organizations) => Ok(HttpResponse::Ok().json(organizations)),
+            Err(err) => Err(err),
+        })
+}


### PR DESCRIPTION
This PR implements the endpoints GET /organization and GET/organization/{id}.  It includes tests and updates to the REST API spec doc. 

To run the tests:
`cargo test --features test-api --  --test-threads=1 `

~Based on #56.~