### PR TITLE
Add /agent/{public_key} route

### DIFF
--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -189,7 +189,7 @@ paths:
         - "application/json"
       responses:
         200:
-          description: "List of Agents"
+          description: Successful operation
           schema:
             properties:
               data:
@@ -272,6 +272,46 @@ paths:
           description: API is unable to reach the database
           schema:
             $ref: "#/definitions/Error"
+
+  /agent/{public_key}:
+    get:
+      tags:
+        - "agent"
+      summary: "Find agent by public key"
+      description: "Returns a single agent from reporting database"
+      operationId: "fetch_agent"
+      produces:
+        - "application/json"
+      parameters:
+        - "public_key"
+        in: "path"
+        description: "Public key of the agent to return"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: Successful operation
+          schema:
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: "#/definitions/Agent"
+        400:
+          $ref: "#/responses/400BadRequest"
+        404:
+          $ref: "#/responses/404NotFound"
+        429:
+          $ref: "#/responses/429TooManyRequests"
+        500:
+          description: Something went wrong within the database
+          schema:
+            $ref: "#/definitions/Error"
+        503:
+          description: API is unable to reach the database
+          schema:
+            $ref: "#/definitions/Error"
+
 
 responses:
   400BadRequest:

--- a/daemon/src/database/helpers/agents.rs
+++ b/daemon/src/database/helpers/agents.rs
@@ -23,6 +23,7 @@ use diesel::{
     dsl::{insert_into, update},
     pg::PgConnection,
     prelude::*,
+    result::Error::NotFound,
     QueryResult,
 };
 
@@ -58,4 +59,17 @@ pub fn get_agents(conn: &PgConnection) -> QueryResult<Vec<Agent>> {
         .select(agent::all_columns)
         .filter(agent::end_block_num.eq(MAX_BLOCK_NUM))
         .load::<Agent>(conn)
+}
+
+pub fn get_agent(conn: &PgConnection, public_key: &str) -> QueryResult<Option<Agent>> {
+    agent::table
+        .select(agent::all_columns)
+        .filter(
+            agent::public_key
+                .eq(public_key)
+                .and(agent::end_block_num.eq(MAX_BLOCK_NUM)),
+        )
+        .first(conn)
+        .map(Some)
+        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
 }

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -21,7 +21,8 @@ use std::thread;
 use crate::database::ConnectionPool;
 pub use crate::rest_api::error::RestApiServerError;
 use crate::rest_api::routes::{
-    fetch_organization, get_batch_statuses, list_agents, list_organizations, submit_batches,
+    fetch_agent, fetch_organization, get_batch_statuses, list_agents, list_organizations,
+    submit_batches,
 };
 use crate::rest_api::routes::{DbExecutor, SawtoothMessageSender};
 use actix::{Actor, Addr, Context, SyncArbiter};
@@ -59,6 +60,9 @@ fn create_app(
         r.method(Method::GET).with_async(get_batch_statuses)
     })
     .resource("/agent", |r| r.method(Method::GET).with_async(list_agents))
+    .resource("/agent/{public_key}", |r| {
+        r.method(Method::GET).with_async(fetch_agent)
+    })
     .resource("/organization", |r| {
         r.method(Method::GET).with_async(list_organizations)
     })


### PR DESCRIPTION
Finishes the agents route with the /agent/{public_key} route which allows the rest API to fetch an agent based on the public key. 

Test with: `cargo test --features test-api --test-threads=1`