### PR TITLE
Track and Trace Protocol for SDK

### DIFF
--- a/contracts/track_and_trace/src/handler.rs
+++ b/contracts/track_and_trace/src/handler.rs
@@ -32,20 +32,32 @@ cfg_if! {
     }
 }
 
-use grid_sdk::protos::track_and_trace_agent::TrackAndTraceAgent as Agent;
-use grid_sdk::protos::track_and_trace_payload::CreateTrackAndTraceAgentAction as CreateAgentAction;
-use grid_sdk::protos::track_and_trace_payload::{
-    AnswerProposalAction, AnswerProposalAction_Response, CreateProposalAction, CreateRecordAction,
-    CreateRecordTypeAction, FinalizeRecordAction, RevokeReporterAction, UpdatePropertiesAction,
+use grid_sdk::protos::deprecated_track_and_trace_payload::DeprecatedCreateTrackAndTraceAgentAction as CreateAgentAction;
+use grid_sdk::protos::deprecated_track_and_trace_payload::{
+    DeprecatedAnswerProposalAction as AnswerProposalAction,
+    DeprecatedAnswerProposalAction_Response as AnswerProposalAction_Response,
+    DeprecatedCreateProposalAction as CreateProposalAction,
+    DeprecatedCreateRecordAction as CreateRecordAction,
+    DeprecatedCreateRecordTypeAction as CreateRecordTypeAction,
+    DeprecatedFinalizeRecordAction as FinalizeRecordAction,
+    DeprecatedRevokeReporterAction as RevokeReporterAction,
+    DeprecatedUpdatePropertiesAction as UpdatePropertiesAction,
 };
+use grid_sdk::protos::track_and_trace_agent::TrackAndTraceAgent as Agent;
 use grid_sdk::protos::track_and_trace_property::{
-    Property, PropertyPage, PropertyPage_ReportedValue, PropertySchema, PropertySchema_DataType,
-    Property_Reporter, TrackAndTracePropertyValue,
+    DeprecatedProperty as Property, DeprecatedPropertyPage as PropertyPage,
+    DeprecatedPropertyPage_ReportedValue as PropertyPage_ReportedValue,
+    DeprecatedProperty_Reporter as Property_Reporter, PropertySchema, PropertySchema_DataType,
+    TrackAndTracePropertyValue,
 };
 use grid_sdk::protos::track_and_trace_proposal::{
-    Proposal, ProposalContainer, Proposal_Role, Proposal_Status,
+    DeprecatedProposal as Proposal, DeprecatedProposalContainer as ProposalContainer,
+    DeprecatedProposal_Role as Proposal_Role, DeprecatedProposal_Status as Proposal_Status,
 };
-use grid_sdk::protos::track_and_trace_record::{Record, RecordType, Record_AssociatedAgent};
+use grid_sdk::protos::track_and_trace_record::{
+    DeprecatedRecord as Record, DeprecatedRecord_AssociatedAgent as Record_AssociatedAgent,
+    RecordType,
+};
 
 use crate::addressing::*;
 use crate::payload::{Action, SupplyChainPayload};

--- a/contracts/track_and_trace/src/payload.rs
+++ b/contracts/track_and_trace/src/payload.rs
@@ -20,11 +20,15 @@ cfg_if! {
     }
 }
 
-use grid_sdk::protos::track_and_trace_payload::CreateTrackAndTraceAgentAction as CreateAgentAction;
-use grid_sdk::protos::track_and_trace_payload::{
-    AnswerProposalAction, CreateProposalAction, CreateRecordAction, CreateRecordTypeAction,
-    FinalizeRecordAction, RevokeReporterAction, SCPayload, SCPayload_Action,
-    UpdatePropertiesAction,
+use grid_sdk::protos::deprecated_track_and_trace_payload::DeprecatedCreateTrackAndTraceAgentAction as CreateAgentAction;
+use grid_sdk::protos::deprecated_track_and_trace_payload::{
+    DeprecatedAnswerProposalAction as AnswerProposalAction,
+    DeprecatedCreateProposalAction as CreateProposalAction,
+    DeprecatedCreateRecordAction as CreateRecordAction,
+    DeprecatedCreateRecordTypeAction as CreateRecordTypeAction,
+    DeprecatedFinalizeRecordAction as FinalizeRecordAction,
+    DeprecatedRevokeReporterAction as RevokeReporterAction,
+    DeprecatedUpdatePropertiesAction as UpdatePropertiesAction, SCPayload, SCPayload_Action,
 };
 
 #[derive(Debug, Clone)]

--- a/contracts/track_and_trace/src/state.rs
+++ b/contracts/track_and_trace/src/state.rs
@@ -25,11 +25,14 @@ cfg_if! {
 use grid_sdk::protos::track_and_trace_agent::TrackAndTraceAgent as Agent;
 use grid_sdk::protos::track_and_trace_agent::TrackAndTraceAgentContainer as AgentContainer;
 use grid_sdk::protos::track_and_trace_property::{
-    Property, PropertyContainer, PropertyPage, PropertyPageContainer,
+    DeprecatedProperty as Property, DeprecatedPropertyContainer as PropertyContainer,
+    DeprecatedPropertyPage as PropertyPage,
+    DeprecatedPropertyPageContainer as PropertyPageContainer,
 };
-use grid_sdk::protos::track_and_trace_proposal::ProposalContainer;
+use grid_sdk::protos::track_and_trace_proposal::DeprecatedProposalContainer as ProposalContainer;
 use grid_sdk::protos::track_and_trace_record::{
-    Record, RecordContainer, RecordType, RecordTypeContainer,
+    DeprecatedRecord as Record, DeprecatedRecordContainer as RecordContainer, RecordType,
+    RecordTypeContainer,
 };
 use protobuf::Message;
 

--- a/sdk/protos/deprecated_track_and_trace_payload.proto
+++ b/sdk/protos/deprecated_track_and_trace_payload.proto
@@ -1,0 +1,137 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "track_and_trace_property.proto";
+import "track_and_trace_proposal.proto";
+
+
+message SCPayload {
+  enum Action {
+    CREATE_AGENT = 0;
+    CREATE_RECORD = 1;
+    FINALIZE_RECORD = 2;
+    CREATE_RECORD_TYPE = 3;
+    UPDATE_PROPERTIES = 4;
+    CREATE_PROPOSAL = 5;
+    ANSWER_PROPOSAL = 6;
+    REVOKE_REPORTER = 7;
+  }
+
+  Action action = 1;
+
+  // Approximately when transaction was submitted, as a Unix UTC
+  // timestamp
+  uint64 timestamp = 2;
+
+  // The transaction handler will read from just one of these fields
+  // according to the Action.
+  DeprecatedCreateTrackAndTraceAgentAction create_agent = 3;
+  DeprecatedCreateRecordAction create_record = 4;
+  DeprecatedFinalizeRecordAction finalize_record = 5;
+  DeprecatedCreateRecordTypeAction create_record_type = 6;
+  DeprecatedUpdatePropertiesAction update_properties = 7;
+  DeprecatedCreateProposalAction create_proposal = 8;
+  DeprecatedAnswerProposalAction answer_proposal = 9;
+  DeprecatedRevokeReporterAction revoke_reporter = 10;
+}
+
+
+message DeprecatedCreateTrackAndTraceAgentAction {
+  // The human-readable name of the Agent. This does not need to be
+  // unique.
+  string name = 1;
+}
+
+
+message DeprecatedCreateRecordAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  // The name of the RecordType this Record belongs to
+  string record_type = 2;
+
+  repeated TrackAndTracePropertyValue properties = 3;
+}
+
+
+message DeprecatedFinalizeRecordAction {
+  // The natural key of the Record
+  string record_id = 1;
+}
+
+
+message DeprecatedCreateRecordTypeAction {
+  string name = 1;
+
+  repeated PropertySchema properties = 2;
+}
+
+
+message DeprecatedUpdatePropertiesAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  repeated TrackAndTracePropertyValue properties = 2;
+}
+
+
+message DeprecatedCreateProposalAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  // the public key of the Agent to whom the Proposal is sent
+  // (must be different from the Agent creating the Proposal)
+  string receiving_agent = 2;
+
+  DeprecatedProposal.Role role = 3;
+
+  repeated string properties = 4;
+}
+
+
+message DeprecatedAnswerProposalAction {
+  enum Response {
+    ACCEPT = 0;
+    REJECT = 1;
+    CANCEL = 2;
+  }
+
+  // The natural key of the Record
+  string record_id = 1;
+
+  // The public key of the Agent to whom the proposal is sent
+  string receiving_agent = 2;
+
+  // The role being proposed (owner, custodian, or reporter)
+  DeprecatedProposal.Role role = 3;
+
+  // The respose to the Proposal (accept, reject, or cancel)
+  Response response = 4;
+}
+
+
+message DeprecatedRevokeReporterAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  // The reporter's public key
+  string reporter_id = 2;
+
+  // The names of the Properties for which the reporter's
+  // authorization is revoked
+  repeated string properties = 3;
+}

--- a/sdk/protos/track_and_trace_payload.proto
+++ b/sdk/protos/track_and_trace_payload.proto
@@ -15,20 +15,18 @@
 
 syntax = "proto3";
 
-import "track_and_trace_property.proto";
-import "track_and_trace_proposal.proto";
+import "track_and_trace_state.proto";
+import "schema_state.proto";
 
-
-message SCPayload {
+message TrackAndTracePayload {
   enum Action {
-    CREATE_AGENT = 0;
+    UNSET_ACTION = 0;
     CREATE_RECORD = 1;
     FINALIZE_RECORD = 2;
-    CREATE_RECORD_TYPE = 3;
-    UPDATE_PROPERTIES = 4;
-    CREATE_PROPOSAL = 5;
-    ANSWER_PROPOSAL = 6;
-    REVOKE_REPORTER = 7;
+    UPDATE_PROPERTIES = 3;
+    CREATE_PROPOSAL = 4;
+    ANSWER_PROPOSAL = 5;
+    REVOKE_REPORTER = 6;
   }
 
   Action action = 1;
@@ -39,32 +37,22 @@ message SCPayload {
 
   // The transaction handler will read from just one of these fields
   // according to the Action.
-  CreateTrackAndTraceAgentAction create_agent = 3;
-  CreateRecordAction create_record = 4;
-  FinalizeRecordAction finalize_record = 5;
-  CreateRecordTypeAction create_record_type = 6;
-  UpdatePropertiesAction update_properties = 7;
-  CreateProposalAction create_proposal = 8;
-  AnswerProposalAction answer_proposal = 9;
-  RevokeReporterAction revoke_reporter = 10;
+  CreateRecordAction create_record = 3;
+  FinalizeRecordAction finalize_record = 4;
+  UpdatePropertiesAction update_properties = 6;
+  CreateProposalAction create_proposal = 7;
+  AnswerProposalAction answer_proposal = 8;
+  RevokeReporterAction revoke_reporter = 9;
 }
-
-
-message CreateTrackAndTraceAgentAction {
-  // The human-readable name of the Agent. This does not need to be
-  // unique.
-  string name = 1;
-}
-
 
 message CreateRecordAction {
   // The natural key of the Record
   string record_id = 1;
 
-  // The name of the RecordType this Record belongs to
-  string record_type = 2;
+  // The name of the Schema this Record belongs to
+  string schema = 2;
 
-  repeated TrackAndTracePropertyValue properties = 3;
+  repeated PropertyValue properties = 3;
 }
 
 
@@ -73,19 +61,11 @@ message FinalizeRecordAction {
   string record_id = 1;
 }
 
-
-message CreateRecordTypeAction {
-  string name = 1;
-
-  repeated PropertySchema properties = 2;
-}
-
-
 message UpdatePropertiesAction {
   // The natural key of the Record
   string record_id = 1;
 
-  repeated TrackAndTracePropertyValue properties = 2;
+  repeated PropertyValue properties = 2;
 }
 
 

--- a/sdk/protos/track_and_trace_property.proto
+++ b/sdk/protos/track_and_trace_property.proto
@@ -16,7 +16,7 @@
 syntax = "proto3";
 
 
-message Property {
+message DeprecatedProperty {
   message Reporter {
     // The public key of the Agent authorized to report updates.
     string public_key = 1;
@@ -77,8 +77,8 @@ message Property {
 }
 
 
-message PropertyContainer {
-  repeated Property entries = 1;
+message DeprecatedPropertyContainer {
+  repeated DeprecatedProperty entries = 1;
 }
 
 
@@ -149,7 +149,7 @@ message TrackAndTracePropertyValue {
 }
 
 
-message PropertyPage {
+message DeprecatedPropertyPage {
   message ReportedValue {
     // The index of the reporter id in reporters field
     uint32 reporter_index = 1;
@@ -181,8 +181,8 @@ message PropertyPage {
 }
 
 
-message PropertyPageContainer {
-  repeated PropertyPage entries = 1;
+message DeprecatedPropertyPageContainer {
+  repeated DeprecatedPropertyPage entries = 1;
 }
 
 

--- a/sdk/protos/track_and_trace_proposal.proto
+++ b/sdk/protos/track_and_trace_proposal.proto
@@ -16,7 +16,7 @@
 syntax = "proto3";
 
 
-message Proposal {
+message DeprecatedProposal {
   enum Role {
     OWNER = 0;
     CUSTODIAN = 1;
@@ -61,6 +61,6 @@ message Proposal {
 }
 
 
-message ProposalContainer {
-  repeated Proposal entries = 1;
+message DeprecatedProposalContainer {
+  repeated DeprecatedProposal entries = 1;
 }

--- a/sdk/protos/track_and_trace_record.proto
+++ b/sdk/protos/track_and_trace_record.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 import "track_and_trace_property.proto";
 
 
-message Record {
+message DeprecatedRecord {
   message AssociatedAgent {
     string agent_id = 1;
     uint64 timestamp = 2;
@@ -41,8 +41,8 @@ message Record {
 }
 
 
-message RecordContainer {
-  repeated Record entries = 1;
+message DeprecatedRecordContainer {
+  repeated DeprecatedRecord entries = 1;
 }
 
 

--- a/sdk/protos/track_and_trace_state.proto
+++ b/sdk/protos/track_and_trace_state.proto
@@ -1,0 +1,165 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "schema_state.proto";
+
+message Property {
+  message Reporter {
+    // The public key of the Agent authorized to report updates.
+    string public_key = 1;
+    bool authorized = 2;
+    // An update must be stored with some way of identifying which
+    // Agent sent it. Storing a full public key for each update would
+    // be wasteful, so instead Reporters are identified by their index
+    // in the `reporters` field.
+    uint32 index = 3;
+  }
+
+  // The name of the Property, e.g. "temperature". This must be unique
+  // among Properties.
+  string name = 1;
+
+  // The natural key of the Property's associated Record.
+  string record_id = 2;
+
+  PropertyDefinition property_definition = 3;
+
+  // The Reporters authorized to send updates, sorted by index. New
+  // Reporters should be given an index equal to the number of
+  // Reporters already authorized.
+  repeated Reporter reporters = 4;
+
+  // The page to which new updates are added. This number represents
+  // the last 4 hex characters of the page's address. Consequently,
+  // it should not exceed 16^4 = 65536.
+  uint32 current_page = 5;
+
+  // A flag indicating whether the first 16^4 pages have been filled.
+  // This is used to calculate the last four hex characters of the
+  // address of the page containing the earliest updates. When it is
+  // false, the earliest page's address will end in "0001". When it is
+  // true, the earliest page's address will be one more than the
+  // current_page, or "0001" if the current_page is "ffff".
+  bool wrapped = 6;
+}
+
+message PropertyList {
+  repeated Property entries = 1;
+}
+
+message PropertyPage {
+  message ReportedValue {
+    // The index of the reporter id in reporters field
+    uint32 reporter_index = 1;
+    // Approximately when this value was reported, as a Unix UTC
+    // timestamp
+    uint64 timestamp = 2;
+
+    PropertyValue value = 3;
+  }
+
+  // The name of the page's associated Property and the record_id of
+  // its associated Record. These are required to distinguish pages
+  // with colliding addresses.
+  string name = 1;
+  string record_id = 2;
+
+  // ReportedValues are sorted first by timestamp, then by
+  // reporter_index
+  repeated ReportedValue reported_values = 3;
+}
+
+
+message PropertyPageList {
+  repeated PropertyPage entries = 1;
+}
+
+message Proposal {
+  enum Role {
+    OWNER = 0;
+    CUSTODIAN = 1;
+    REPORTER = 2;
+  }
+
+  enum Status {
+    OPEN = 0;
+    ACCEPTED = 1;
+    REJECTED = 2;
+    CANCELED = 3;
+  }
+
+  string record_id = 1;
+
+  // The time at which the Proposal was created
+  uint64 timestamp = 2;
+
+  // The public key of the Agent sending the Proposal. This Agent must
+  // be the owner of the Record (or the custodian, if the Proposal is
+  // to transfer custodianship).
+  string issuing_agent = 3;
+
+  // The public key of the Agent to whom the Proposal is sent.
+  string receiving_agent = 4;
+
+  // What the Proposal is for -- transferring ownership, transferring
+  // custodianship, or authorizing a reporter.
+  Role role = 5;
+
+  // The names of properties for which the reporter is being authorized
+  // (empty for owner or custodian transfers)
+  repeated string properties = 6;
+
+  // The status of the Proposal. For a given Record and receiving
+  // Agent, there can be only one open Proposal at a time for each
+  // role.
+  Status status = 7;
+
+  // The human-readable terms of transfer.
+  string terms = 8;
+}
+
+
+message ProposalList {
+  repeated Proposal entries = 1;
+}
+
+message Record {
+  message AssociatedAgent {
+    string agent_id = 1;
+    uint64 timestamp = 2;
+  }
+
+  // The user-defined natural key which identifies the object in the
+  // real world (for example a serial number)
+  string record_id = 1;
+
+  // Name of the schema used by the record
+  string schema = 2;
+
+  // Ordered oldest to newest by timestamp
+  repeated AssociatedAgent owners = 3;
+  repeated AssociatedAgent custodians = 4;
+
+  // Flag indicating whether the Record can be updated. If it is set
+  // to true, then the record has been finalized and no further
+  // changes can be made to it or its Properties.
+  bool final = 5;
+}
+
+message RecordList {
+  repeated Record entries = 1;
+}

--- a/sdk/src/protocol/errors.rs
+++ b/sdk/src/protocol/errors.rs
@@ -1,0 +1,12 @@
+#[derive(Debug)]
+pub enum BuilderError {
+    MissingField(String),
+}
+
+impl std::fmt::Display for BuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            BuilderError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}

--- a/sdk/src/protocol/mod.rs
+++ b/sdk/src/protocol/mod.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod errors;
 pub mod pike;
 pub mod schema;

--- a/sdk/src/protocol/track_and_trace/mod.rs
+++ b/sdk/src/protocol/track_and_trace/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod errors;
-pub mod pike;
-pub mod schema;
-pub mod track_and_trace;
+use super::errors;
+
+pub mod payload;
+pub mod state;

--- a/sdk/src/protocol/track_and_trace/payload.rs
+++ b/sdk/src/protocol/track_and_trace/payload.rs
@@ -1,0 +1,1120 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use protobuf::Message;
+use protobuf::RepeatedField;
+
+use std::default::Default;
+
+use super::errors::BuilderError;
+use crate::protocol::{schema::state::PropertyValue, track_and_trace::state::Role};
+use crate::protos;
+use crate::protos::{
+    track_and_trace_payload, track_and_trace_payload::TrackAndTracePayload_Action,
+};
+use crate::protos::{
+    FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateRecordAction {
+    record_id: String,
+    schema: String,
+    properties: Vec<PropertyValue>,
+}
+
+impl CreateRecordAction {
+    pub fn record_id(&self) -> &str {
+        &self.record_id
+    }
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+    pub fn properties(&self) -> &[PropertyValue] {
+        &self.properties
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct CreateRecordActionBuilder {
+    record_id: Option<String>,
+    schema: Option<String>,
+    properties: Option<Vec<PropertyValue>>,
+}
+
+impl CreateRecordActionBuilder {
+    pub fn new() -> Self {
+        CreateRecordActionBuilder::default()
+    }
+    pub fn with_record_id(mut self, value: String) -> Self {
+        self.record_id = Some(value);
+        self
+    }
+    pub fn with_schema(mut self, value: String) -> Self {
+        self.schema = Some(value);
+        self
+    }
+    pub fn with_properties(mut self, value: Vec<PropertyValue>) -> Self {
+        self.properties = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<CreateRecordAction, BuilderError> {
+        let record_id = self
+            .record_id
+            .ok_or_else(|| BuilderError::MissingField("record_id".into()))?;
+        let schema = self
+            .schema
+            .ok_or_else(|| BuilderError::MissingField("schema".into()))?;
+        let properties = self
+            .properties
+            .ok_or_else(|| BuilderError::MissingField("properties".into()))?;
+        Ok(CreateRecordAction {
+            record_id,
+            schema,
+            properties,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_payload::CreateRecordAction> for CreateRecordAction {
+    fn from_proto(
+        proto: track_and_trace_payload::CreateRecordAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(CreateRecordAction {
+            record_id: proto.get_record_id().to_string(),
+            schema: proto.get_schema().to_string(),
+            properties: proto
+                .get_properties()
+                .to_vec()
+                .into_iter()
+                .map(PropertyValue::from_proto)
+                .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<CreateRecordAction> for track_and_trace_payload::CreateRecordAction {
+    fn from_native(create_record_action: CreateRecordAction) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_payload::CreateRecordAction::new();
+        proto.set_record_id(create_record_action.record_id().to_string());
+        proto.set_schema(create_record_action.schema().to_string());
+        proto.set_properties(RepeatedField::from_vec(
+            create_record_action
+                .properties()
+                .to_vec()
+                .into_iter()
+                .map(PropertyValue::into_proto)
+                .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
+                )?,
+        ));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<CreateRecordAction> for CreateRecordAction {
+    fn from_bytes(bytes: &[u8]) -> Result<CreateRecordAction, ProtoConversionError> {
+        let proto: track_and_trace_payload::CreateRecordAction = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get CreateRecordAction from bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for CreateRecordAction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get CreateRecordAction from bytes".into(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_payload::CreateRecordAction> for CreateRecordAction {}
+impl IntoNative<CreateRecordAction> for track_and_trace_payload::CreateRecordAction {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FinalizeRecordAction {
+    record_id: String,
+}
+
+impl FinalizeRecordAction {
+    pub fn record_id(&self) -> &str {
+        &self.record_id
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct FinalizeRecordActionBuilder {
+    record_id: Option<String>,
+}
+
+impl FinalizeRecordActionBuilder {
+    pub fn new() -> Self {
+        FinalizeRecordActionBuilder::default()
+    }
+    pub fn with_record_id(mut self, value: String) -> Self {
+        self.record_id = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<FinalizeRecordAction, BuilderError> {
+        let record_id = self
+            .record_id
+            .ok_or_else(|| BuilderError::MissingField("record_id".into()))?;
+        Ok(FinalizeRecordAction { record_id })
+    }
+}
+
+impl FromProto<track_and_trace_payload::FinalizeRecordAction> for FinalizeRecordAction {
+    fn from_proto(
+        proto: track_and_trace_payload::FinalizeRecordAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(FinalizeRecordAction {
+            record_id: proto.get_record_id().to_string(),
+        })
+    }
+}
+
+impl FromNative<FinalizeRecordAction> for track_and_trace_payload::FinalizeRecordAction {
+    fn from_native(native: FinalizeRecordAction) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_payload::FinalizeRecordAction::new();
+        proto.set_record_id(native.record_id().to_string());
+        Ok(proto)
+    }
+}
+
+impl FromBytes<FinalizeRecordAction> for FinalizeRecordAction {
+    fn from_bytes(bytes: &[u8]) -> Result<FinalizeRecordAction, ProtoConversionError> {
+        let proto: track_and_trace_payload::FinalizeRecordAction =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get CreateFinalizeAction from bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for FinalizeRecordAction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get CreateFinalizeAction from bytes".into(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_payload::FinalizeRecordAction> for FinalizeRecordAction {}
+impl IntoNative<FinalizeRecordAction> for track_and_trace_payload::FinalizeRecordAction {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UpdatePropertiesAction {
+    record_id: String,
+    properties: Vec<PropertyValue>,
+}
+
+impl UpdatePropertiesAction {
+    pub fn record_id(&self) -> &str {
+        &self.record_id
+    }
+    pub fn properties(&self) -> &[PropertyValue] {
+        &self.properties
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct UpdatePropertiesActionBuilder {
+    record_id: Option<String>,
+    properties: Option<Vec<PropertyValue>>,
+}
+
+impl UpdatePropertiesActionBuilder {
+    pub fn new() -> Self {
+        UpdatePropertiesActionBuilder::default()
+    }
+    pub fn with_record_id(mut self, value: String) -> Self {
+        self.record_id = Some(value);
+        self
+    }
+    pub fn with_properties(mut self, value: Vec<PropertyValue>) -> Self {
+        self.properties = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<UpdatePropertiesAction, BuilderError> {
+        let record_id = self
+            .record_id
+            .ok_or_else(|| BuilderError::MissingField("record_id".into()))?;
+        let properties = self
+            .properties
+            .ok_or_else(|| BuilderError::MissingField("properties".into()))?;
+        Ok(UpdatePropertiesAction {
+            record_id,
+            properties,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_payload::UpdatePropertiesAction> for UpdatePropertiesAction {
+    fn from_proto(
+        proto: track_and_trace_payload::UpdatePropertiesAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(UpdatePropertiesAction {
+            record_id: proto.get_record_id().to_string(),
+            properties: proto
+                .get_properties()
+                .to_vec()
+                .into_iter()
+                .map(PropertyValue::from_proto)
+                .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<UpdatePropertiesAction> for track_and_trace_payload::UpdatePropertiesAction {
+    fn from_native(native: UpdatePropertiesAction) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_payload::UpdatePropertiesAction::new();
+        proto.set_record_id(native.record_id().to_string());
+        proto.set_properties(RepeatedField::from_vec(
+            native
+                .properties()
+                .to_vec()
+                .into_iter()
+                .map(PropertyValue::into_proto)
+                .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
+                )?,
+        ));
+        Ok(proto)
+    }
+}
+
+impl FromBytes<UpdatePropertiesAction> for UpdatePropertiesAction {
+    fn from_bytes(bytes: &[u8]) -> Result<UpdatePropertiesAction, ProtoConversionError> {
+        let proto: track_and_trace_payload::UpdatePropertiesAction =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get UpdatePropertiesAction from bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for UpdatePropertiesAction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get UpdatePropertiesAction from bytes".into(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_payload::UpdatePropertiesAction> for UpdatePropertiesAction {}
+impl IntoNative<UpdatePropertiesAction> for track_and_trace_payload::UpdatePropertiesAction {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateProposalAction {
+    record_id: String,
+    receiving_agent: String,
+    role: Role,
+    properties: Vec<String>,
+}
+
+impl CreateProposalAction {
+    pub fn record_id(&self) -> &str {
+        &self.record_id
+    }
+    pub fn receiving_agent(&self) -> &str {
+        &self.receiving_agent
+    }
+    pub fn role(&self) -> &Role {
+        &self.role
+    }
+    pub fn properties(&self) -> &[String] {
+        &self.properties
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct CreateProposalActionBuilder {
+    record_id: Option<String>,
+    receiving_agent: Option<String>,
+    role: Option<Role>,
+    properties: Option<Vec<String>>,
+}
+
+impl CreateProposalActionBuilder {
+    pub fn new() -> Self {
+        CreateProposalActionBuilder::default()
+    }
+    pub fn with_record_id(mut self, value: String) -> Self {
+        self.record_id = Some(value);
+        self
+    }
+    pub fn with_receiving_agent(mut self, value: String) -> Self {
+        self.receiving_agent = Some(value);
+        self
+    }
+    pub fn with_role(mut self, value: Role) -> Self {
+        self.role = Some(value);
+        self
+    }
+    pub fn with_properties(mut self, value: Vec<String>) -> Self {
+        self.properties = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<CreateProposalAction, BuilderError> {
+        let record_id = self
+            .record_id
+            .ok_or_else(|| BuilderError::MissingField("record_id".into()))?;
+        let receiving_agent = self
+            .receiving_agent
+            .ok_or_else(|| BuilderError::MissingField("receiving_agent".into()))?;
+        let role = self
+            .role
+            .ok_or_else(|| BuilderError::MissingField("role".into()))?;
+        let properties = self
+            .properties
+            .ok_or_else(|| BuilderError::MissingField("properties".into()))?;
+        Ok(CreateProposalAction {
+            record_id,
+            receiving_agent,
+            role,
+            properties,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_payload::CreateProposalAction> for CreateProposalAction {
+    fn from_proto(
+        proto: track_and_trace_payload::CreateProposalAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(CreateProposalAction {
+            record_id: proto.get_record_id().to_string(),
+            receiving_agent: proto.get_receiving_agent().to_string(),
+            role: Role::from_proto(proto.get_role())?,
+            properties: proto
+                .get_properties()
+                .to_vec()
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        })
+    }
+}
+
+impl FromNative<CreateProposalAction> for track_and_trace_payload::CreateProposalAction {
+    fn from_native(native: CreateProposalAction) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_payload::CreateProposalAction::new();
+        proto.set_record_id(native.record_id().to_string());
+        proto.set_receiving_agent(native.receiving_agent().to_string());
+        proto.set_role(native.role().clone().into_proto()?);
+        proto.set_properties(RepeatedField::from_vec(native.properties().to_vec()));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<CreateProposalAction> for CreateProposalAction {
+    fn from_bytes(bytes: &[u8]) -> Result<CreateProposalAction, ProtoConversionError> {
+        let proto: track_and_trace_payload::CreateProposalAction =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get CreateProposalAction from bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for CreateProposalAction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get CreateProposalAction from bytes".into(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_payload::CreateProposalAction> for CreateProposalAction {}
+impl IntoNative<CreateProposalAction> for track_and_trace_payload::CreateProposalAction {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Response {
+    Accept,
+    Reject,
+    Cancel,
+}
+
+impl Default for Response {
+    fn default() -> Response {
+        Response::Accept
+    }
+}
+
+impl FromProto<track_and_trace_payload::AnswerProposalAction_Response> for Response {
+    fn from_proto(
+        responses: track_and_trace_payload::AnswerProposalAction_Response,
+    ) -> Result<Self, ProtoConversionError> {
+        match responses {
+            track_and_trace_payload::AnswerProposalAction_Response::ACCEPT => Ok(Response::Accept),
+            track_and_trace_payload::AnswerProposalAction_Response::REJECT => Ok(Response::Reject),
+            track_and_trace_payload::AnswerProposalAction_Response::CANCEL => Ok(Response::Cancel),
+        }
+    }
+}
+
+impl FromNative<Response> for track_and_trace_payload::AnswerProposalAction_Response {
+    fn from_native(responses: Response) -> Result<Self, ProtoConversionError> {
+        match responses {
+            Response::Accept => Ok(track_and_trace_payload::AnswerProposalAction_Response::ACCEPT),
+            Response::Reject => Ok(track_and_trace_payload::AnswerProposalAction_Response::REJECT),
+            Response::Cancel => Ok(track_and_trace_payload::AnswerProposalAction_Response::CANCEL),
+        }
+    }
+}
+
+impl IntoProto<track_and_trace_payload::AnswerProposalAction_Response> for Response {}
+impl IntoNative<Response> for track_and_trace_payload::AnswerProposalAction_Response {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnswerProposalAction {
+    record_id: String,
+    receiving_agent: String,
+    role: Role,
+    response: Response,
+}
+
+impl AnswerProposalAction {
+    pub fn record_id(&self) -> &str {
+        &self.record_id
+    }
+    pub fn receiving_agent(&self) -> &str {
+        &self.receiving_agent
+    }
+    pub fn role(&self) -> &Role {
+        &self.role
+    }
+    pub fn response(&self) -> &Response {
+        &self.response
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct AnswerProposalActionBuilder {
+    record_id: Option<String>,
+    receiving_agent: Option<String>,
+    role: Option<Role>,
+    response: Option<Response>,
+}
+
+impl AnswerProposalActionBuilder {
+    pub fn new() -> Self {
+        AnswerProposalActionBuilder::default()
+    }
+    pub fn with_record_id(mut self, value: String) -> Self {
+        self.record_id = Some(value);
+        self
+    }
+    pub fn with_receiving_agent(mut self, value: String) -> Self {
+        self.receiving_agent = Some(value);
+        self
+    }
+    pub fn with_role(mut self, value: Role) -> Self {
+        self.role = Some(value);
+        self
+    }
+    pub fn with_response(mut self, value: Response) -> Self {
+        self.response = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<AnswerProposalAction, BuilderError> {
+        let record_id = self
+            .record_id
+            .ok_or_else(|| BuilderError::MissingField("record_id".into()))?;
+        let receiving_agent = self
+            .receiving_agent
+            .ok_or_else(|| BuilderError::MissingField("receiving_agent".into()))?;
+        let role = self
+            .role
+            .ok_or_else(|| BuilderError::MissingField("role".into()))?;
+        let response = self
+            .response
+            .ok_or_else(|| BuilderError::MissingField("response".into()))?;
+        Ok(AnswerProposalAction {
+            record_id,
+            receiving_agent,
+            role,
+            response,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_payload::AnswerProposalAction> for AnswerProposalAction {
+    fn from_proto(
+        proto: track_and_trace_payload::AnswerProposalAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(AnswerProposalAction {
+            record_id: proto.get_record_id().to_string(),
+            receiving_agent: proto.get_receiving_agent().to_string(),
+            role: Role::from_proto(proto.get_role())?,
+            response: Response::from_proto(proto.get_response())?,
+        })
+    }
+}
+
+impl FromNative<AnswerProposalAction> for track_and_trace_payload::AnswerProposalAction {
+    fn from_native(native: AnswerProposalAction) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_payload::AnswerProposalAction::new();
+        proto.set_record_id(native.record_id().to_string());
+        proto.set_receiving_agent(native.receiving_agent().to_string());
+        proto.set_role(native.role().clone().into_proto()?);
+        proto.set_response(native.response().clone().into_proto()?);
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<AnswerProposalAction> for AnswerProposalAction {
+    fn from_bytes(bytes: &[u8]) -> Result<AnswerProposalAction, ProtoConversionError> {
+        let proto: track_and_trace_payload::AnswerProposalAction =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get AnswerProposalAction from bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for AnswerProposalAction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get AnswerProposalAction from bytes".into(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_payload::AnswerProposalAction> for AnswerProposalAction {}
+impl IntoNative<AnswerProposalAction> for track_and_trace_payload::AnswerProposalAction {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RevokeReporterAction {
+    record_id: String,
+    reporter_id: String,
+    properties: Vec<String>,
+}
+
+impl RevokeReporterAction {
+    pub fn record_id(&self) -> &str {
+        &self.record_id
+    }
+    pub fn reporter_id(&self) -> &str {
+        &self.reporter_id
+    }
+    pub fn properties(&self) -> &[String] {
+        &self.properties
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct RevokeReporterActionBuilder {
+    record_id: Option<String>,
+    reporter_id: Option<String>,
+    properties: Option<Vec<String>>,
+}
+
+impl RevokeReporterActionBuilder {
+    pub fn new() -> Self {
+        RevokeReporterActionBuilder::default()
+    }
+    pub fn with_record_id(mut self, value: String) -> Self {
+        self.record_id = Some(value);
+        self
+    }
+    pub fn with_reporter_id(mut self, value: String) -> Self {
+        self.reporter_id = Some(value);
+        self
+    }
+    pub fn with_properties(mut self, value: Vec<String>) -> Self {
+        self.properties = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<RevokeReporterAction, BuilderError> {
+        let record_id = self
+            .record_id
+            .ok_or_else(|| BuilderError::MissingField("record_id".into()))?;
+        let reporter_id = self
+            .reporter_id
+            .ok_or_else(|| BuilderError::MissingField("reporter_id".into()))?;
+        let properties = self
+            .properties
+            .ok_or_else(|| BuilderError::MissingField("properties".into()))?;
+        Ok(RevokeReporterAction {
+            record_id,
+            reporter_id,
+            properties,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_payload::RevokeReporterAction> for RevokeReporterAction {
+    fn from_proto(
+        proto: track_and_trace_payload::RevokeReporterAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(RevokeReporterAction {
+            record_id: proto.get_record_id().to_string(),
+            reporter_id: proto.get_reporter_id().to_string(),
+            properties: proto
+                .get_properties()
+                .to_vec()
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        })
+    }
+}
+
+impl FromNative<RevokeReporterAction> for track_and_trace_payload::RevokeReporterAction {
+    fn from_native(native: RevokeReporterAction) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_payload::RevokeReporterAction::new();
+        proto.set_record_id(native.record_id().to_string());
+        proto.set_reporter_id(native.reporter_id().to_string());
+        proto.set_properties(RepeatedField::from_vec(native.properties().to_vec()));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<RevokeReporterAction> for RevokeReporterAction {
+    fn from_bytes(bytes: &[u8]) -> Result<RevokeReporterAction, ProtoConversionError> {
+        let proto: track_and_trace_payload::RevokeReporterAction =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get RevokeReporterAction from bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for RevokeReporterAction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get RevokeReporterAction from bytes".into(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_payload::RevokeReporterAction> for RevokeReporterAction {}
+impl IntoNative<RevokeReporterAction> for track_and_trace_payload::RevokeReporterAction {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Action {
+    CreateRecord(CreateRecordAction),
+    FinalizeRecord(FinalizeRecordAction),
+    UpdateProperties(UpdatePropertiesAction),
+    CreateProposal(CreateProposalAction),
+    AnswerProposal(AnswerProposalAction),
+    RevokeReporter(RevokeReporterAction),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrackAndTracePayload {
+    action: Action,
+    timestamp: u64,
+}
+
+impl TrackAndTracePayload {
+    pub fn action(&self) -> &Action {
+        &self.action
+    }
+    pub fn timestamp(&self) -> &u64 {
+        &self.timestamp
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct TrackAndTracePayloadBuilder {
+    action: Option<Action>,
+    timestamp: Option<u64>,
+}
+
+impl TrackAndTracePayloadBuilder {
+    pub fn new() -> Self {
+        TrackAndTracePayloadBuilder::default()
+    }
+    pub fn with_action(mut self, value: Action) -> Self {
+        self.action = Some(value);
+        self
+    }
+    pub fn with_timestamp(mut self, value: u64) -> Self {
+        self.timestamp = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<TrackAndTracePayload, BuilderError> {
+        let action = self
+            .action
+            .ok_or_else(|| BuilderError::MissingField("action".into()))?;
+        let timestamp = self
+            .timestamp
+            .ok_or_else(|| BuilderError::MissingField("timestamp".into()))?;
+        Ok(TrackAndTracePayload { action, timestamp })
+    }
+}
+
+impl FromProto<track_and_trace_payload::TrackAndTracePayload> for TrackAndTracePayload {
+    fn from_proto(
+        proto: track_and_trace_payload::TrackAndTracePayload,
+    ) -> Result<Self, ProtoConversionError> {
+        let action = match proto.get_action() {
+            TrackAndTracePayload_Action::CREATE_RECORD => Action::CreateRecord(
+                CreateRecordAction::from_proto(proto.get_create_record().clone())?,
+            ),
+            TrackAndTracePayload_Action::FINALIZE_RECORD => Action::FinalizeRecord(
+                FinalizeRecordAction::from_proto(proto.get_finalize_record().clone())?,
+            ),
+            TrackAndTracePayload_Action::UPDATE_PROPERTIES => Action::UpdateProperties(
+                UpdatePropertiesAction::from_proto(proto.get_update_properties().clone())?,
+            ),
+            TrackAndTracePayload_Action::CREATE_PROPOSAL => Action::CreateProposal(
+                CreateProposalAction::from_proto(proto.get_create_proposal().clone())?,
+            ),
+            TrackAndTracePayload_Action::ANSWER_PROPOSAL => Action::AnswerProposal(
+                AnswerProposalAction::from_proto(proto.get_answer_proposal().clone())?,
+            ),
+            TrackAndTracePayload_Action::REVOKE_REPORTER => Action::RevokeReporter(
+                RevokeReporterAction::from_proto(proto.get_revoke_reporter().clone())?,
+            ),
+            TrackAndTracePayload_Action::UNSET_ACTION => {
+                return Err(ProtoConversionError::InvalidTypeError(
+                    "Cannot convert TrackAndTracePayload_Action with type unset.".to_string(),
+                ));
+            }
+        };
+
+        Ok(TrackAndTracePayload {
+            action,
+            timestamp: proto.get_timestamp(),
+        })
+    }
+}
+
+impl FromNative<TrackAndTracePayload> for track_and_trace_payload::TrackAndTracePayload {
+    fn from_native(native: TrackAndTracePayload) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_payload::TrackAndTracePayload::new();
+
+        proto.set_timestamp(*native.timestamp());
+
+        match native.action() {
+            Action::CreateRecord(payload) => {
+                proto.set_action(TrackAndTracePayload_Action::CREATE_RECORD);
+                proto.set_create_record(payload.clone().into_proto()?);
+            }
+            Action::FinalizeRecord(payload) => {
+                proto.set_action(TrackAndTracePayload_Action::FINALIZE_RECORD);
+                proto.set_finalize_record(payload.clone().into_proto()?);
+            }
+            Action::UpdateProperties(payload) => {
+                proto.set_action(TrackAndTracePayload_Action::UPDATE_PROPERTIES);
+                proto.set_update_properties(payload.clone().into_proto()?);
+            }
+            Action::CreateProposal(payload) => {
+                proto.set_action(TrackAndTracePayload_Action::CREATE_PROPOSAL);
+                proto.set_create_proposal(payload.clone().into_proto()?);
+            }
+            Action::AnswerProposal(payload) => {
+                proto.set_action(TrackAndTracePayload_Action::ANSWER_PROPOSAL);
+                proto.set_answer_proposal(payload.clone().into_proto()?);
+            }
+            Action::RevokeReporter(payload) => {
+                proto.set_action(TrackAndTracePayload_Action::REVOKE_REPORTER);
+                proto.set_revoke_reporter(payload.clone().into_proto()?);
+            }
+        }
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<TrackAndTracePayload> for TrackAndTracePayload {
+    fn from_bytes(bytes: &[u8]) -> Result<TrackAndTracePayload, ProtoConversionError> {
+        let proto: track_and_trace_payload::TrackAndTracePayload =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get TrackAndTracePaylaod from bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for TrackAndTracePayload {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get TrackAndTracePaylaod from bytes".into(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_payload::TrackAndTracePayload> for TrackAndTracePayload {}
+impl IntoNative<TrackAndTracePayload> for track_and_trace_payload::TrackAndTracePayload {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::schema::state::{DataType, PropertyValueBuilder};
+    use std::fmt::Debug;
+
+    fn test_from_bytes<T: FromBytes<T> + Clone + PartialEq + IntoBytes + Debug, F>(
+        under_test: T,
+        from_bytes: F,
+    ) where
+        F: Fn(&[u8]) -> Result<T, ProtoConversionError>,
+    {
+        let bytes = under_test.clone().into_bytes().unwrap();
+        let created_from_bytes = from_bytes(&bytes).unwrap();
+        assert_eq!(under_test, created_from_bytes);
+    }
+
+    #[test]
+    fn test_create_record_builder() {
+        let property_value = PropertyValueBuilder::new()
+            .with_name("egg".into())
+            .with_data_type(DataType::Number)
+            .with_number_value(42)
+            .build()
+            .unwrap();
+
+        let action = CreateRecordActionBuilder::new()
+            .with_record_id("32".into())
+            .with_schema("schema".into())
+            .with_properties(vec![property_value.clone()])
+            .build()
+            .unwrap();
+
+        assert_eq!(action.record_id(), "32");
+        assert_eq!(action.schema(), "schema");
+        assert!(action.properties().iter().any(|x| *x == property_value));
+    }
+
+    #[test]
+    fn test_create_record_bytes() {
+        let property_value = PropertyValueBuilder::new()
+            .with_name("egg".into())
+            .with_data_type(DataType::Number)
+            .with_number_value(42)
+            .build()
+            .unwrap();
+
+        let action = CreateRecordActionBuilder::new()
+            .with_record_id("32".into())
+            .with_schema("schema".into())
+            .with_properties(vec![property_value.clone()])
+            .build()
+            .unwrap();
+
+        test_from_bytes(action, CreateRecordAction::from_bytes);
+    }
+
+    #[test]
+    fn test_finalize_record_action_builder() {
+        let action = FinalizeRecordActionBuilder::new()
+            .with_record_id("32".into())
+            .build()
+            .unwrap();
+
+        assert_eq!(action.record_id(), "32");
+    }
+
+    #[test]
+    fn test_finalize_record_action_bytes() {
+        let action = FinalizeRecordActionBuilder::new()
+            .with_record_id("32".into())
+            .build()
+            .unwrap();
+
+        test_from_bytes(action, FinalizeRecordAction::from_bytes);
+    }
+
+    #[test]
+    fn test_update_properties_action() {
+        let property_value = PropertyValueBuilder::new()
+            .with_name("egg".into())
+            .with_data_type(DataType::Number)
+            .with_number_value(42)
+            .build()
+            .unwrap();
+
+        let action = UpdatePropertiesActionBuilder::new()
+            .with_record_id("32".into())
+            .with_properties(vec![property_value.clone()])
+            .build()
+            .unwrap();
+
+        assert_eq!(action.record_id(), "32");
+        assert!(action.properties().iter().any(|x| *x == property_value));
+    }
+
+    #[test]
+    fn test_update_properties_action_bytes() {
+        let property_value = PropertyValueBuilder::new()
+            .with_name("egg".into())
+            .with_data_type(DataType::Number)
+            .with_number_value(42)
+            .build()
+            .unwrap();
+
+        let action = UpdatePropertiesActionBuilder::new()
+            .with_record_id("32".into())
+            .with_properties(vec![property_value.clone()])
+            .build()
+            .unwrap();
+
+        test_from_bytes(action, UpdatePropertiesAction::from_bytes);
+    }
+
+    #[test]
+    fn test_create_proposal_action_builder() {
+        let action = CreateProposalActionBuilder::new()
+            .with_record_id("32".into())
+            .with_receiving_agent("jim".into())
+            .with_role(Role::Custodian)
+            .with_properties(vec!["egg".into()])
+            .build()
+            .unwrap();
+
+        assert_eq!(action.record_id(), "32");
+        assert_eq!(action.receiving_agent(), "jim");
+        assert_eq!(*action.role(), Role::Custodian);
+        assert!(action.properties().iter().any(|x| x == "egg"));
+    }
+
+    #[test]
+    fn test_create_proposal_action_bytes() {
+        let action = CreateProposalActionBuilder::new()
+            .with_record_id("32".into())
+            .with_receiving_agent("jim".into())
+            .with_role(Role::Custodian)
+            .with_properties(vec!["egg".into()])
+            .build()
+            .unwrap();
+
+        test_from_bytes(action, CreateProposalAction::from_bytes);
+    }
+
+    #[test]
+    fn test_answer_proposal_action_builder() {
+        let action = AnswerProposalActionBuilder::new()
+            .with_record_id("32".into())
+            .with_receiving_agent("jim".into())
+            .with_role(Role::Custodian)
+            .with_response(Response::Accept)
+            .build()
+            .unwrap();
+
+        assert_eq!(action.record_id(), "32");
+        assert_eq!(action.receiving_agent(), "jim");
+        assert_eq!(*action.role(), Role::Custodian);
+        assert_eq!(*action.response(), Response::Accept);
+    }
+
+    #[test]
+    fn test_answer_proposal_action_bytes() {
+        let action = AnswerProposalActionBuilder::new()
+            .with_record_id("32".into())
+            .with_receiving_agent("jim".into())
+            .with_role(Role::Custodian)
+            .with_response(Response::Accept)
+            .build()
+            .unwrap();
+
+        test_from_bytes(action, AnswerProposalAction::from_bytes);
+    }
+
+    #[test]
+    fn test_revoke_reporter_action_builder() {
+        let action = RevokeReporterActionBuilder::new()
+            .with_record_id("32".into())
+            .with_reporter_id("jim".into())
+            .with_properties(vec!["egg".into()])
+            .build()
+            .unwrap();
+
+        assert_eq!(action.record_id(), "32");
+        assert_eq!(action.reporter_id(), "jim");
+        assert!(action.properties().iter().any(|x| x == "egg"));
+    }
+
+    #[test]
+    fn test_revoke_reporter_action_bytes() {
+        let action = RevokeReporterActionBuilder::new()
+            .with_record_id("32".into())
+            .with_reporter_id("jim".into())
+            .with_properties(vec!["egg".into()])
+            .build()
+            .unwrap();
+
+        test_from_bytes(action, RevokeReporterAction::from_bytes);
+    }
+
+    #[test]
+    fn test_payload_builder() {
+        let action = RevokeReporterActionBuilder::new()
+            .with_record_id("32".into())
+            .with_reporter_id("jim".into())
+            .with_properties(vec!["egg".into()])
+            .build()
+            .unwrap();
+
+        let payload = TrackAndTracePayloadBuilder::new()
+            .with_action(Action::RevokeReporter(action.clone()))
+            .with_timestamp(0)
+            .build()
+            .unwrap();
+
+        assert_eq!(*payload.action(), Action::RevokeReporter(action));
+        assert_eq!(*payload.timestamp(), 0);
+    }
+
+    #[test]
+    fn test_payload_bytes() {
+        let action = RevokeReporterActionBuilder::new()
+            .with_record_id("32".into())
+            .with_reporter_id("jim".into())
+            .with_properties(vec!["egg".into()])
+            .build()
+            .unwrap();
+
+        let payload = TrackAndTracePayloadBuilder::new()
+            .with_action(Action::RevokeReporter(action.clone()))
+            .with_timestamp(0)
+            .build()
+            .unwrap();
+
+        test_from_bytes(payload, TrackAndTracePayload::from_bytes);
+    }
+}

--- a/sdk/src/protocol/track_and_trace/state.rs
+++ b/sdk/src/protocol/track_and_trace/state.rs
@@ -1,0 +1,1869 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::errors::BuilderError;
+use crate::protocol::schema::state::{PropertyDefinition, PropertyValue};
+use crate::protos::track_and_trace_state;
+use crate::protos::{
+    FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+};
+use protobuf::Message;
+use protobuf::RepeatedField;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Reporter {
+    public_key: String,
+    authorized: bool,
+    index: u32,
+}
+
+impl Reporter {
+    pub fn public_key(&self) -> &str {
+        &self.public_key
+    }
+    pub fn authorized(&self) -> &bool {
+        &self.authorized
+    }
+    pub fn index(&self) -> &u32 {
+        &self.index
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct ReporterBuilder {
+    public_key: Option<String>,
+    authorized: Option<bool>,
+    index: Option<u32>,
+}
+
+impl ReporterBuilder {
+    pub fn new() -> Self {
+        ReporterBuilder::default()
+    }
+    pub fn with_public_key(mut self, value: String) -> Self {
+        self.public_key = Some(value);
+        self
+    }
+    pub fn with_authorized(mut self, value: bool) -> Self {
+        self.authorized = Some(value);
+        self
+    }
+    pub fn with_index(mut self, value: u32) -> Self {
+        self.index = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<Reporter, BuilderError> {
+        let public_key = self
+            .public_key
+            .ok_or_else(|| BuilderError::MissingField("public_key".into()))?;
+        let authorized = self
+            .authorized
+            .ok_or_else(|| BuilderError::MissingField("authorized".into()))?;
+        let index = self
+            .index
+            .ok_or_else(|| BuilderError::MissingField("index".into()))?;
+        Ok(Reporter {
+            public_key,
+            authorized,
+            index,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_state::Property_Reporter> for Reporter {
+    fn from_proto(
+        proto: track_and_trace_state::Property_Reporter,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(Reporter {
+            public_key: proto.get_public_key().to_string(),
+            authorized: proto.get_authorized(),
+            index: proto.get_index(),
+        })
+    }
+}
+
+impl FromNative<Reporter> for track_and_trace_state::Property_Reporter {
+    fn from_native(native: Reporter) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_state::Property_Reporter::new();
+        proto.set_public_key(native.public_key().to_string());
+        proto.set_authorized(*native.authorized());
+        proto.set_index(*native.index());
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<Reporter> for Reporter {
+    fn from_bytes(bytes: &[u8]) -> Result<Reporter, ProtoConversionError> {
+        let proto: track_and_trace_state::Property_Reporter = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError("Unable to get Reporter from bytes".into())
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for Reporter {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get Reporter from bytes".into())
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_state::Property_Reporter> for Reporter {}
+impl IntoNative<Reporter> for track_and_trace_state::Property_Reporter {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Property {
+    name: String,
+    record_id: String,
+    property_definition: PropertyDefinition,
+    reporters: Vec<Reporter>,
+    current_page: u32,
+    wrapped: bool,
+}
+
+impl Property {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn record_id(&self) -> &str {
+        &self.record_id
+    }
+    pub fn property_definition(&self) -> &PropertyDefinition {
+        &self.property_definition
+    }
+    pub fn reporters(&self) -> &[Reporter] {
+        &self.reporters
+    }
+    pub fn current_page(&self) -> &u32 {
+        &self.current_page
+    }
+    pub fn wrapped(&self) -> &bool {
+        &self.wrapped
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct PropertyBuilder {
+    name: Option<String>,
+    record_id: Option<String>,
+    property_definition: Option<PropertyDefinition>,
+    reporters: Option<Vec<Reporter>>,
+    current_page: Option<u32>,
+    wrapped: Option<bool>,
+}
+
+impl PropertyBuilder {
+    pub fn new() -> Self {
+        PropertyBuilder::default()
+    }
+    pub fn with_name(mut self, value: String) -> Self {
+        self.name = Some(value);
+        self
+    }
+    pub fn with_record_id(mut self, value: String) -> Self {
+        self.record_id = Some(value);
+        self
+    }
+    pub fn with_property_definition(mut self, value: PropertyDefinition) -> Self {
+        self.property_definition = Some(value);
+        self
+    }
+    pub fn with_reporters(mut self, value: Vec<Reporter>) -> Self {
+        self.reporters = Some(value);
+        self
+    }
+    pub fn with_current_page(mut self, value: u32) -> Self {
+        self.current_page = Some(value);
+        self
+    }
+    pub fn with_wrapped(mut self, value: bool) -> Self {
+        self.wrapped = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<Property, BuilderError> {
+        let name = self
+            .name
+            .ok_or_else(|| BuilderError::MissingField("name".into()))?;
+        let record_id = self
+            .record_id
+            .ok_or_else(|| BuilderError::MissingField("record_id".into()))?;
+        let property_definition = self
+            .property_definition
+            .ok_or_else(|| BuilderError::MissingField("property_definition".into()))?;
+        let reporters = self
+            .reporters
+            .ok_or_else(|| BuilderError::MissingField("reporters".into()))?;
+        let current_page = self
+            .current_page
+            .ok_or_else(|| BuilderError::MissingField("current_page".into()))?;
+        let wrapped = self
+            .wrapped
+            .ok_or_else(|| BuilderError::MissingField("wrapped".into()))?;
+        Ok(Property {
+            name,
+            record_id,
+            property_definition,
+            reporters,
+            current_page,
+            wrapped,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_state::Property> for Property {
+    fn from_proto(proto: track_and_trace_state::Property) -> Result<Self, ProtoConversionError> {
+        Ok(Property {
+            name: proto.get_name().to_string(),
+            record_id: proto.get_record_id().to_string(),
+            property_definition: PropertyDefinition::from_proto(
+                proto.get_property_definition().clone(),
+            )?,
+            reporters: proto
+                .get_reporters()
+                .to_vec()
+                .into_iter()
+                .map(Reporter::from_proto)
+                .collect::<Result<Vec<Reporter>, ProtoConversionError>>()?,
+            current_page: proto.get_current_page(),
+            wrapped: proto.get_wrapped(),
+        })
+    }
+}
+
+impl FromNative<Property> for track_and_trace_state::Property {
+    fn from_native(native: Property) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_state::Property::new();
+        proto.set_name(native.name().to_string());
+        proto.set_record_id(native.record_id().to_string());
+        proto.set_property_definition(native.property_definition().clone().into_proto()?);
+        proto.set_reporters(RepeatedField::from_vec(
+            native.reporters()
+            .to_vec()
+            .into_iter()
+            .map(Reporter::into_proto)
+            .collect::<Result<Vec<track_and_trace_state::Property_Reporter>, ProtoConversionError>>()?));
+        proto.set_current_page(*native.current_page());
+        proto.set_wrapped(*native.wrapped());
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<Property> for Property {
+    fn from_bytes(bytes: &[u8]) -> Result<Property, ProtoConversionError> {
+        let proto: track_and_trace_state::Property =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError("Unable to get Property from bytes".into())
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for Property {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get Property from bytes".into())
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_state::Property> for Property {}
+impl IntoNative<Property> for track_and_trace_state::Property {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PropertyList {
+    properties: Vec<Property>,
+}
+
+impl PropertyList {
+    pub fn properties(&self) -> &[Property] {
+        &self.properties
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct PropertyListBuilder {
+    properties: Option<Vec<Property>>,
+}
+
+impl PropertyListBuilder {
+    pub fn new() -> Self {
+        PropertyListBuilder::default()
+    }
+    pub fn with_properties(mut self, value: Vec<Property>) -> Self {
+        self.properties = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<PropertyList, BuilderError> {
+        let properties = self
+            .properties
+            .ok_or_else(|| BuilderError::MissingField("properties".into()))?;
+        Ok(PropertyList { properties })
+    }
+}
+
+impl FromProto<track_and_trace_state::PropertyList> for PropertyList {
+    fn from_proto(
+        proto: track_and_trace_state::PropertyList,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(PropertyList {
+            properties: proto
+                .get_entries()
+                .to_vec()
+                .into_iter()
+                .map(Property::from_proto)
+                .collect::<Result<Vec<Property>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<PropertyList> for track_and_trace_state::PropertyList {
+    fn from_native(native: PropertyList) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_state::PropertyList::new();
+        proto.set_entries(RepeatedField::from_vec(
+            native
+                .properties()
+                .to_vec()
+                .into_iter()
+                .map(Property::into_proto)
+                .collect::<Result<Vec<track_and_trace_state::Property>, ProtoConversionError>>()?,
+        ));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<PropertyList> for PropertyList {
+    fn from_bytes(bytes: &[u8]) -> Result<PropertyList, ProtoConversionError> {
+        let proto: track_and_trace_state::PropertyList = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get PropertyList from Bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for PropertyList {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get PropertyList from Bytes".into())
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_state::PropertyList> for PropertyList {}
+impl IntoNative<PropertyList> for track_and_trace_state::PropertyList {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReportedValue {
+    reporter_index: u32,
+    timestamp: u64,
+    value: PropertyValue,
+}
+
+impl ReportedValue {
+    pub fn reporter_index(&self) -> &u32 {
+        &self.reporter_index
+    }
+    pub fn timestamp(&self) -> &u64 {
+        &self.timestamp
+    }
+    pub fn value(&self) -> &PropertyValue {
+        &self.value
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct ReportedValueBuilder {
+    reporter_index: Option<u32>,
+    timestamp: Option<u64>,
+    value: Option<PropertyValue>,
+}
+
+impl ReportedValueBuilder {
+    pub fn new() -> Self {
+        ReportedValueBuilder::default()
+    }
+    pub fn with_reporter_index(mut self, value: u32) -> Self {
+        self.reporter_index = Some(value);
+        self
+    }
+    pub fn with_timestamp(mut self, value: u64) -> Self {
+        self.timestamp = Some(value);
+        self
+    }
+    pub fn with_value(mut self, value: PropertyValue) -> Self {
+        self.value = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<ReportedValue, BuilderError> {
+        let reporter_index = self
+            .reporter_index
+            .ok_or_else(|| BuilderError::MissingField("reporter_index".into()))?;
+        let timestamp = self
+            .timestamp
+            .ok_or_else(|| BuilderError::MissingField("timestamp".into()))?;
+        let value = self
+            .value
+            .ok_or_else(|| BuilderError::MissingField("value".into()))?;
+        Ok(ReportedValue {
+            reporter_index,
+            timestamp,
+            value,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_state::PropertyPage_ReportedValue> for ReportedValue {
+    fn from_proto(
+        proto: track_and_trace_state::PropertyPage_ReportedValue,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(ReportedValue {
+            reporter_index: proto.get_reporter_index(),
+            timestamp: proto.get_timestamp(),
+            value: PropertyValue::from_proto(proto.get_value().clone())?,
+        })
+    }
+}
+
+impl FromNative<ReportedValue> for track_and_trace_state::PropertyPage_ReportedValue {
+    fn from_native(native: ReportedValue) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_state::PropertyPage_ReportedValue::new();
+        proto.set_reporter_index(*native.reporter_index());
+        proto.set_timestamp(*native.timestamp());
+        proto.set_value(native.value().clone().into_proto()?);
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<ReportedValue> for ReportedValue {
+    fn from_bytes(bytes: &[u8]) -> Result<ReportedValue, ProtoConversionError> {
+        let proto: track_and_trace_state::PropertyPage_ReportedValue =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get ReportedValue from bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for ReportedValue {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get ReportedValue from bytes".into(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_state::PropertyPage_ReportedValue> for ReportedValue {}
+impl IntoNative<ReportedValue> for track_and_trace_state::PropertyPage_ReportedValue {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PropertyPage {
+    name: String,
+    record_id: String,
+    reported_values: Vec<ReportedValue>,
+}
+
+impl PropertyPage {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn record_id(&self) -> &str {
+        &self.record_id
+    }
+    pub fn reported_values(&self) -> &[ReportedValue] {
+        &self.reported_values
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct PropertyPageBuilder {
+    name: Option<String>,
+    record_id: Option<String>,
+    reported_values: Option<Vec<ReportedValue>>,
+}
+
+impl PropertyPageBuilder {
+    pub fn new() -> Self {
+        PropertyPageBuilder::default()
+    }
+    pub fn with_name(mut self, value: String) -> Self {
+        self.name = Some(value);
+        self
+    }
+    pub fn with_record_id(mut self, value: String) -> Self {
+        self.record_id = Some(value);
+        self
+    }
+    pub fn with_reported_values(mut self, value: Vec<ReportedValue>) -> Self {
+        self.reported_values = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<PropertyPage, BuilderError> {
+        let name = self
+            .name
+            .ok_or_else(|| BuilderError::MissingField("name".into()))?;
+        let record_id = self
+            .record_id
+            .ok_or_else(|| BuilderError::MissingField("record_id".into()))?;
+        let reported_values = self
+            .reported_values
+            .ok_or_else(|| BuilderError::MissingField("reported_values".into()))?;
+        Ok(PropertyPage {
+            name,
+            record_id,
+            reported_values,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_state::PropertyPage> for PropertyPage {
+    fn from_proto(
+        proto: track_and_trace_state::PropertyPage,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(PropertyPage {
+            name: proto.get_name().to_string(),
+            record_id: proto.get_record_id().to_string(),
+            reported_values: proto
+                .get_reported_values()
+                .to_vec()
+                .into_iter()
+                .map(ReportedValue::from_proto)
+                .collect::<Result<Vec<ReportedValue>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<PropertyPage> for track_and_trace_state::PropertyPage {
+    fn from_native(native: PropertyPage) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_state::PropertyPage::new();
+        proto.set_name(native.name().to_string());
+        proto.set_record_id(native.record_id().to_string());
+        proto.set_reported_values(RepeatedField::from_vec(
+            native
+                .reported_values()
+                .to_vec()
+                .into_iter()
+                .map(ReportedValue::into_proto)
+                .collect::<Result<
+                    Vec<track_and_trace_state::PropertyPage_ReportedValue>,
+                    ProtoConversionError,
+                >>()?,
+        ));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<PropertyPage> for PropertyPage {
+    fn from_bytes(bytes: &[u8]) -> Result<PropertyPage, ProtoConversionError> {
+        let proto: track_and_trace_state::PropertyPage = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Undable to get PropertyPage from bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for PropertyPage {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Undable to get PropertyPage from bytes".into(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_state::PropertyPage> for PropertyPage {}
+impl IntoNative<PropertyPage> for track_and_trace_state::PropertyPage {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PropertyPageList {
+    property_pages: Vec<PropertyPage>,
+}
+
+impl PropertyPageList {
+    pub fn property_pages(&self) -> &[PropertyPage] {
+        &self.property_pages
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct PropertyPageListBuilder {
+    property_pages: Option<Vec<PropertyPage>>,
+}
+
+impl PropertyPageListBuilder {
+    pub fn new() -> Self {
+        PropertyPageListBuilder::default()
+    }
+    pub fn with_property_pages(mut self, value: Vec<PropertyPage>) -> Self {
+        self.property_pages = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<PropertyPageList, BuilderError> {
+        let property_pages = self
+            .property_pages
+            .ok_or_else(|| BuilderError::MissingField("property_pages".into()))?;
+        Ok(PropertyPageList { property_pages })
+    }
+}
+
+impl FromProto<track_and_trace_state::PropertyPageList> for PropertyPageList {
+    fn from_proto(
+        proto: track_and_trace_state::PropertyPageList,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(PropertyPageList {
+            property_pages: proto
+                .get_entries()
+                .to_vec()
+                .into_iter()
+                .map(PropertyPage::from_proto)
+                .collect::<Result<Vec<PropertyPage>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<PropertyPageList> for track_and_trace_state::PropertyPageList {
+    fn from_native(native: PropertyPageList) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_state::PropertyPageList::new();
+        proto.set_entries(RepeatedField::from_vec(
+            native
+                .property_pages()
+                .to_vec()
+                .into_iter()
+                .map(PropertyPage::into_proto)
+                .collect::<Result<Vec<track_and_trace_state::PropertyPage>, ProtoConversionError>>(
+                )?,
+        ));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<PropertyPageList> for PropertyPageList {
+    fn from_bytes(bytes: &[u8]) -> Result<PropertyPageList, ProtoConversionError> {
+        let proto: track_and_trace_state::PropertyPageList = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get PropertyPageList from Bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for PropertyPageList {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get PropertyPageList from Bytes".into(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_state::PropertyPageList> for PropertyPageList {}
+impl IntoNative<PropertyPageList> for track_and_trace_state::PropertyPageList {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Role {
+    Owner,
+    Custodian,
+    Reporter,
+}
+
+impl Default for Role {
+    fn default() -> Role {
+        Role::Owner
+    }
+}
+
+impl FromProto<track_and_trace_state::Proposal_Role> for Role {
+    fn from_proto(
+        roles: track_and_trace_state::Proposal_Role,
+    ) -> Result<Self, ProtoConversionError> {
+        match roles {
+            track_and_trace_state::Proposal_Role::OWNER => Ok(Role::Owner),
+            track_and_trace_state::Proposal_Role::CUSTODIAN => Ok(Role::Custodian),
+            track_and_trace_state::Proposal_Role::REPORTER => Ok(Role::Reporter),
+        }
+    }
+}
+
+impl FromNative<Role> for track_and_trace_state::Proposal_Role {
+    fn from_native(roles: Role) -> Result<Self, ProtoConversionError> {
+        match roles {
+            Role::Owner => Ok(track_and_trace_state::Proposal_Role::OWNER),
+            Role::Custodian => Ok(track_and_trace_state::Proposal_Role::CUSTODIAN),
+            Role::Reporter => Ok(track_and_trace_state::Proposal_Role::REPORTER),
+        }
+    }
+}
+
+impl IntoProto<track_and_trace_state::Proposal_Role> for Role {}
+impl IntoNative<Role> for track_and_trace_state::Proposal_Role {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Status {
+    Open,
+    Accepted,
+    Rejected,
+    Canceled,
+}
+
+impl Default for Status {
+    fn default() -> Status {
+        Status::Open
+    }
+}
+
+impl FromProto<track_and_trace_state::Proposal_Status> for Status {
+    fn from_proto(
+        statuses: track_and_trace_state::Proposal_Status,
+    ) -> Result<Self, ProtoConversionError> {
+        match statuses {
+            track_and_trace_state::Proposal_Status::OPEN => Ok(Status::Open),
+            track_and_trace_state::Proposal_Status::ACCEPTED => Ok(Status::Accepted),
+            track_and_trace_state::Proposal_Status::REJECTED => Ok(Status::Rejected),
+            track_and_trace_state::Proposal_Status::CANCELED => Ok(Status::Canceled),
+        }
+    }
+}
+
+impl FromNative<Status> for track_and_trace_state::Proposal_Status {
+    fn from_native(statuses: Status) -> Result<Self, ProtoConversionError> {
+        match statuses {
+            Status::Open => Ok(track_and_trace_state::Proposal_Status::OPEN),
+            Status::Accepted => Ok(track_and_trace_state::Proposal_Status::ACCEPTED),
+            Status::Rejected => Ok(track_and_trace_state::Proposal_Status::REJECTED),
+            Status::Canceled => Ok(track_and_trace_state::Proposal_Status::CANCELED),
+        }
+    }
+}
+
+impl IntoProto<track_and_trace_state::Proposal_Status> for Status {}
+impl IntoNative<Status> for track_and_trace_state::Proposal_Status {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Proposal {
+    record_id: String,
+    timestamp: u64,
+    issuing_agent: String,
+    receiving_agent: String,
+    role: Role,
+    properties: Vec<String>,
+    status: Status,
+    terms: String,
+}
+
+impl Proposal {
+    pub fn record_id(&self) -> &str {
+        &self.record_id
+    }
+    pub fn timestamp(&self) -> &u64 {
+        &self.timestamp
+    }
+    pub fn issuing_agent(&self) -> &str {
+        &self.issuing_agent
+    }
+    pub fn receiving_agent(&self) -> &str {
+        &self.receiving_agent
+    }
+    pub fn role(&self) -> &Role {
+        &self.role
+    }
+    pub fn properties(&self) -> &[String] {
+        &self.properties
+    }
+    pub fn status(&self) -> &Status {
+        &self.status
+    }
+    pub fn terms(&self) -> &str {
+        &self.terms
+    }
+}
+#[derive(Default, Debug)]
+pub struct ProposalBuilder {
+    record_id: Option<String>,
+    timestamp: Option<u64>,
+    issuing_agent: Option<String>,
+    receiving_agent: Option<String>,
+    role: Option<Role>,
+    properties: Option<Vec<String>>,
+    status: Option<Status>,
+    terms: Option<String>,
+}
+
+impl ProposalBuilder {
+    pub fn new() -> Self {
+        ProposalBuilder::default()
+    }
+    pub fn with_record_id(mut self, value: String) -> Self {
+        self.record_id = Some(value);
+        self
+    }
+    pub fn with_timestamp(mut self, value: u64) -> Self {
+        self.timestamp = Some(value);
+        self
+    }
+    pub fn with_issuing_agent(mut self, value: String) -> Self {
+        self.issuing_agent = Some(value);
+        self
+    }
+    pub fn with_receiving_agent(mut self, value: String) -> Self {
+        self.receiving_agent = Some(value);
+        self
+    }
+    pub fn with_role(mut self, value: Role) -> Self {
+        self.role = Some(value);
+        self
+    }
+    pub fn with_properties(mut self, value: Vec<String>) -> Self {
+        self.properties = Some(value);
+        self
+    }
+    pub fn with_status(mut self, value: Status) -> Self {
+        self.status = Some(value);
+        self
+    }
+    pub fn with_terms(mut self, value: String) -> Self {
+        self.terms = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<Proposal, BuilderError> {
+        let record_id = self
+            .record_id
+            .ok_or_else(|| BuilderError::MissingField("record_id".into()))?;
+        let timestamp = self
+            .timestamp
+            .ok_or_else(|| BuilderError::MissingField("timestamp".into()))?;
+        let issuing_agent = self
+            .issuing_agent
+            .ok_or_else(|| BuilderError::MissingField("issuing_agent".into()))?;
+        let receiving_agent = self
+            .receiving_agent
+            .ok_or_else(|| BuilderError::MissingField("receiving_agent".into()))?;
+        let role = self
+            .role
+            .ok_or_else(|| BuilderError::MissingField("role".into()))?;
+        let properties = self
+            .properties
+            .ok_or_else(|| BuilderError::MissingField("properties".into()))?;
+        let status = self
+            .status
+            .ok_or_else(|| BuilderError::MissingField("status".into()))?;
+        let terms = self
+            .terms
+            .ok_or_else(|| BuilderError::MissingField("terms".into()))?;
+        Ok(Proposal {
+            record_id,
+            timestamp,
+            issuing_agent,
+            receiving_agent,
+            role,
+            properties,
+            status,
+            terms,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_state::Proposal> for Proposal {
+    fn from_proto(proto: track_and_trace_state::Proposal) -> Result<Self, ProtoConversionError> {
+        Ok(Proposal {
+            record_id: proto.get_record_id().to_string(),
+            timestamp: proto.get_timestamp(),
+            issuing_agent: proto.get_issuing_agent().to_string(),
+            receiving_agent: proto.get_receiving_agent().to_string(),
+            role: Role::from_proto(proto.get_role())?,
+            properties: proto
+                .get_properties()
+                .to_vec()
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            status: Status::from_proto(proto.get_status())?,
+            terms: proto.get_terms().to_string(),
+        })
+    }
+}
+
+impl FromNative<Proposal> for track_and_trace_state::Proposal {
+    fn from_native(native: Proposal) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_state::Proposal::new();
+
+        proto.set_record_id(native.record_id().to_string());
+        proto.set_timestamp(*native.timestamp());
+        proto.set_issuing_agent(native.issuing_agent().to_string());
+        proto.set_receiving_agent(native.receiving_agent().to_string());
+        proto.set_role(native.role().clone().into_proto()?);
+        proto.set_properties(RepeatedField::from_vec(native.properties().to_vec()));
+        proto.set_status(native.status().clone().into_proto()?);
+        proto.set_terms(native.terms().to_string());
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<Proposal> for Proposal {
+    fn from_bytes(bytes: &[u8]) -> Result<Proposal, ProtoConversionError> {
+        let proto: track_and_trace_state::Proposal =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError("Unable to get Proposal from bytes".into())
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for Proposal {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get Proposal from bytes".into())
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_state::Proposal> for Proposal {}
+impl IntoNative<Proposal> for track_and_trace_state::Proposal {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProposalList {
+    proposals: Vec<Proposal>,
+}
+
+impl ProposalList {
+    pub fn proposals(&self) -> &[Proposal] {
+        &self.proposals
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct ProposalListBuilder {
+    proposals: Option<Vec<Proposal>>,
+}
+
+impl ProposalListBuilder {
+    pub fn new() -> Self {
+        ProposalListBuilder::default()
+    }
+    pub fn with_proposals(mut self, value: Vec<Proposal>) -> Self {
+        self.proposals = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<ProposalList, BuilderError> {
+        let proposals = self
+            .proposals
+            .ok_or_else(|| BuilderError::MissingField("proposals".into()))?;
+        Ok(ProposalList { proposals })
+    }
+}
+
+impl FromProto<track_and_trace_state::ProposalList> for ProposalList {
+    fn from_proto(
+        proto: track_and_trace_state::ProposalList,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(ProposalList {
+            proposals: proto
+                .get_entries()
+                .to_vec()
+                .into_iter()
+                .map(Proposal::from_proto)
+                .collect::<Result<Vec<Proposal>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<ProposalList> for track_and_trace_state::ProposalList {
+    fn from_native(native: ProposalList) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_state::ProposalList::new();
+        proto.set_entries(RepeatedField::from_vec(
+            native
+                .proposals()
+                .to_vec()
+                .into_iter()
+                .map(Proposal::into_proto)
+                .collect::<Result<Vec<track_and_trace_state::Proposal>, ProtoConversionError>>()?,
+        ));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<ProposalList> for ProposalList {
+    fn from_bytes(bytes: &[u8]) -> Result<ProposalList, ProtoConversionError> {
+        let proto: track_and_trace_state::ProposalList = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get ProposalList from bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for ProposalList {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get ProposalList from bytes".into())
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<track_and_trace_state::ProposalList> for ProposalList {}
+impl IntoNative<ProposalList> for track_and_trace_state::ProposalList {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AssociatedAgent {
+    agent_id: String,
+    timestamp: u64,
+}
+
+impl AssociatedAgent {
+    pub fn agent_id(&self) -> &str {
+        &self.agent_id
+    }
+    pub fn timestamp(&self) -> &u64 {
+        &self.timestamp
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct AssociatedAgentBuilder {
+    agent_id: Option<String>,
+    timestamp: Option<u64>,
+}
+
+impl AssociatedAgentBuilder {
+    pub fn new() -> Self {
+        AssociatedAgentBuilder::default()
+    }
+    pub fn with_agent_id(mut self, value: String) -> Self {
+        self.agent_id = Some(value);
+        self
+    }
+    pub fn with_timestamp(mut self, value: u64) -> Self {
+        self.timestamp = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<AssociatedAgent, BuilderError> {
+        let agent_id = self
+            .agent_id
+            .ok_or_else(|| BuilderError::MissingField("agent_id".into()))?;
+        let timestamp = self
+            .timestamp
+            .ok_or_else(|| BuilderError::MissingField("timestamp".into()))?;
+        Ok(AssociatedAgent {
+            agent_id,
+            timestamp,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_state::Record_AssociatedAgent> for AssociatedAgent {
+    fn from_proto(
+        proto: track_and_trace_state::Record_AssociatedAgent,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(AssociatedAgent {
+            agent_id: proto.get_agent_id().to_string(),
+            timestamp: proto.get_timestamp(),
+        })
+    }
+}
+
+impl FromNative<AssociatedAgent> for track_and_trace_state::Record_AssociatedAgent {
+    fn from_native(native: AssociatedAgent) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_state::Record_AssociatedAgent::new();
+
+        proto.set_agent_id(native.agent_id().to_string());
+        proto.set_timestamp(*native.timestamp());
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<AssociatedAgent> for AssociatedAgent {
+    fn from_bytes(bytes: &[u8]) -> Result<AssociatedAgent, ProtoConversionError> {
+        let proto: track_and_trace_state::Record_AssociatedAgent =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get AssociatedAgent from bytes".into(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for AssociatedAgent {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get AssociatedAgent from bytes".into(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_state::Record_AssociatedAgent> for AssociatedAgent {}
+impl IntoNative<AssociatedAgent> for track_and_trace_state::Record_AssociatedAgent {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Record {
+    record_id: String,
+    schema: String,
+    owners: Vec<AssociatedAgent>,
+    custodians: Vec<AssociatedAgent>,
+    field_final: bool,
+}
+
+impl Record {
+    pub fn record_id(&self) -> &str {
+        &self.record_id
+    }
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+    pub fn owners(&self) -> &[AssociatedAgent] {
+        &self.owners
+    }
+    pub fn custodians(&self) -> &[AssociatedAgent] {
+        &self.custodians
+    }
+    pub fn field_final(&self) -> &bool {
+        &self.field_final
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct RecordBuilder {
+    record_id: Option<String>,
+    schema: Option<String>,
+    owners: Option<Vec<AssociatedAgent>>,
+    custodians: Option<Vec<AssociatedAgent>>,
+    field_final: Option<bool>,
+}
+
+impl RecordBuilder {
+    pub fn new() -> Self {
+        RecordBuilder::default()
+    }
+    pub fn with_record_id(mut self, value: String) -> Self {
+        self.record_id = Some(value);
+        self
+    }
+    pub fn with_schema(mut self, value: String) -> Self {
+        self.schema = Some(value);
+        self
+    }
+    pub fn with_owners(mut self, value: Vec<AssociatedAgent>) -> Self {
+        self.owners = Some(value);
+        self
+    }
+    pub fn with_custodians(mut self, value: Vec<AssociatedAgent>) -> Self {
+        self.custodians = Some(value);
+        self
+    }
+    pub fn with_field_final(mut self, value: bool) -> Self {
+        self.field_final = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<Record, BuilderError> {
+        let record_id = self
+            .record_id
+            .ok_or_else(|| BuilderError::MissingField("record_id".into()))?;
+        let schema = self
+            .schema
+            .ok_or_else(|| BuilderError::MissingField("schema".into()))?;
+        let owners = self
+            .owners
+            .ok_or_else(|| BuilderError::MissingField("owners".into()))?;
+        let custodians = self
+            .custodians
+            .ok_or_else(|| BuilderError::MissingField("custodians".into()))?;
+        let field_final = self
+            .field_final
+            .ok_or_else(|| BuilderError::MissingField("field_final".into()))?;
+        Ok(Record {
+            record_id,
+            schema,
+            owners,
+            custodians,
+            field_final,
+        })
+    }
+}
+
+impl FromProto<track_and_trace_state::Record> for Record {
+    fn from_proto(proto: track_and_trace_state::Record) -> Result<Self, ProtoConversionError> {
+        Ok(Record {
+            record_id: proto.get_record_id().to_string(),
+            schema: proto.get_schema().to_string(),
+            owners: proto
+                .get_owners()
+                .to_vec()
+                .into_iter()
+                .map(AssociatedAgent::from_proto)
+                .collect::<Result<Vec<AssociatedAgent>, ProtoConversionError>>()?,
+            custodians: proto
+                .get_custodians()
+                .to_vec()
+                .into_iter()
+                .map(AssociatedAgent::from_proto)
+                .collect::<Result<Vec<AssociatedAgent>, ProtoConversionError>>()?,
+            field_final: proto.get_field_final(),
+        })
+    }
+}
+
+impl FromNative<Record> for track_and_trace_state::Record {
+    fn from_native(native: Record) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_state::Record::new();
+        proto.set_record_id(native.record_id().to_string());
+        proto.set_schema(native.schema().to_string());
+        proto.set_owners(
+            RepeatedField::from_vec(
+                native
+                    .owners()
+                    .to_vec()
+                    .into_iter()
+                    .map(AssociatedAgent::into_proto)
+                    .collect::<Result<
+                        Vec<track_and_trace_state::Record_AssociatedAgent>,
+                        ProtoConversionError,
+                    >>()?,
+            ),
+        );
+        proto.set_custodians(
+            RepeatedField::from_vec(
+                native
+                    .custodians()
+                    .to_vec()
+                    .into_iter()
+                    .map(AssociatedAgent::into_proto)
+                    .collect::<Result<
+                        Vec<track_and_trace_state::Record_AssociatedAgent>,
+                        ProtoConversionError,
+                    >>()?,
+            ),
+        );
+        proto.set_field_final(*native.field_final());
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<Record> for Record {
+    fn from_bytes(bytes: &[u8]) -> Result<Record, ProtoConversionError> {
+        let proto: track_and_trace_state::Record =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError("Unable to get Record from bytes".into())
+            })?;
+        proto.into_native()
+    }
+}
+impl IntoBytes for Record {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get Record from bytes".into())
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_state::Record> for Record {}
+impl IntoNative<Record> for track_and_trace_state::Record {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecordList {
+    records: Vec<Record>,
+}
+
+impl RecordList {
+    pub fn records(&self) -> &[Record] {
+        &self.records
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct RecordListBuilder {
+    records: Option<Vec<Record>>,
+}
+
+impl RecordListBuilder {
+    pub fn new() -> Self {
+        RecordListBuilder::default()
+    }
+    pub fn with_records(mut self, value: Vec<Record>) -> Self {
+        self.records = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<RecordList, BuilderError> {
+        let records = self
+            .records
+            .ok_or_else(|| BuilderError::MissingField("records".into()))?;
+        Ok(RecordList { records })
+    }
+}
+
+impl FromProto<track_and_trace_state::RecordList> for RecordList {
+    fn from_proto(proto: track_and_trace_state::RecordList) -> Result<Self, ProtoConversionError> {
+        Ok(RecordList {
+            records: proto
+                .get_entries()
+                .to_vec()
+                .into_iter()
+                .map(Record::from_proto)
+                .collect::<Result<Vec<Record>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<RecordList> for track_and_trace_state::RecordList {
+    fn from_native(native: RecordList) -> Result<Self, ProtoConversionError> {
+        let mut proto = track_and_trace_state::RecordList::new();
+        proto.set_entries(RepeatedField::from_vec(
+            native
+                .records()
+                .to_vec()
+                .into_iter()
+                .map(Record::into_proto)
+                .collect::<Result<Vec<track_and_trace_state::Record>, ProtoConversionError>>()?,
+        ));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<RecordList> for RecordList {
+    fn from_bytes(bytes: &[u8]) -> Result<RecordList, ProtoConversionError> {
+        let proto: track_and_trace_state::RecordList =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError("Unable to get Record from bytes".into())
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for RecordList {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get Record from bytes".into())
+        })?;
+        Ok(bytes)
+    }
+}
+impl IntoProto<track_and_trace_state::RecordList> for RecordList {}
+impl IntoNative<RecordList> for track_and_trace_state::RecordList {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::schema::state::{
+        DataType, PropertyDefinitionBuilder, PropertyValueBuilder,
+    };
+    use std::fmt::Debug;
+
+    fn test_from_bytes<T: FromBytes<T> + Clone + PartialEq + IntoBytes + Debug, F>(
+        under_test: T,
+        from_bytes: F,
+    ) where
+        F: Fn(&[u8]) -> Result<T, ProtoConversionError>,
+    {
+        let bytes = under_test.clone().into_bytes().unwrap();
+        let created_from_bytes = from_bytes(&bytes).unwrap();
+        assert_eq!(under_test, created_from_bytes);
+    }
+
+    #[test]
+    fn test_reporter_builder() {
+        let builder = ReporterBuilder::new();
+        let reporter = builder
+            .with_public_key("1234".to_string())
+            .with_authorized(true)
+            .with_index(0)
+            .build()
+            .unwrap();
+
+        assert_eq!(reporter.public_key(), "1234");
+        assert_eq!(*reporter.authorized(), true);
+        assert_eq!(*reporter.index(), 0);
+    }
+
+    #[test]
+    fn test_reporter_bytes() {
+        let builder = ReporterBuilder::new();
+        let original = builder
+            .with_public_key("1234".to_string())
+            .with_authorized(true)
+            .with_index(0)
+            .build()
+            .unwrap();
+
+        test_from_bytes(original, Reporter::from_bytes);
+    }
+
+    #[test]
+    fn test_property_builder() {
+        let property_definition = PropertyDefinitionBuilder::new()
+            .with_name("i dunno".into())
+            .with_data_type(DataType::String)
+            .with_required(true)
+            .with_description("test".into())
+            .build()
+            .unwrap();
+
+        let reporter = ReporterBuilder::new()
+            .with_public_key("1234".to_string())
+            .with_authorized(true)
+            .with_index(0)
+            .build()
+            .unwrap();
+
+        let property = PropertyBuilder::new()
+            .with_name("taco".into())
+            .with_record_id("taco1234".into())
+            .with_property_definition(property_definition.clone())
+            .with_reporters(vec![reporter.clone()])
+            .with_current_page(0)
+            .with_wrapped(true)
+            .build()
+            .unwrap();
+
+        assert_eq!(property.name(), "taco");
+        assert_eq!(property.record_id(), "taco1234");
+        assert_eq!(*property.property_definition(), property_definition);
+        assert!(property.reporters().iter().any(|x| *x == reporter));
+        assert_eq!(*property.current_page(), 0);
+        assert_eq!(*property.wrapped(), true);
+    }
+
+    #[test]
+    fn test_property_bytes() {
+        let property_definition = PropertyDefinitionBuilder::new()
+            .with_name("i dunno".into())
+            .with_data_type(DataType::String)
+            .with_required(true)
+            .with_description("test".into())
+            .build()
+            .unwrap();
+
+        let reporter = ReporterBuilder::new()
+            .with_public_key("1234".to_string())
+            .with_authorized(true)
+            .with_index(0)
+            .build()
+            .unwrap();
+
+        let property = PropertyBuilder::new()
+            .with_name("taco".into())
+            .with_record_id("taco1234".into())
+            .with_property_definition(property_definition.clone())
+            .with_reporters(vec![reporter.clone()])
+            .with_current_page(0)
+            .with_wrapped(true)
+            .build()
+            .unwrap();
+
+        test_from_bytes(property, Property::from_bytes);
+    }
+
+    #[test]
+    fn test_property_list_builder() {
+        let property_definition = PropertyDefinitionBuilder::new()
+            .with_name("i dunno".into())
+            .with_data_type(DataType::String)
+            .with_required(true)
+            .with_description("test".into())
+            .build()
+            .unwrap();
+
+        let reporter = ReporterBuilder::new()
+            .with_public_key("1234".to_string())
+            .with_authorized(true)
+            .with_index(0)
+            .build()
+            .unwrap();
+
+        let property = PropertyBuilder::new()
+            .with_name("taco".into())
+            .with_record_id("taco1234".into())
+            .with_property_definition(property_definition.clone())
+            .with_reporters(vec![reporter.clone()])
+            .with_current_page(0)
+            .with_wrapped(true)
+            .build()
+            .unwrap();
+
+        let property_list = PropertyListBuilder::new()
+            .with_properties(vec![property.clone()])
+            .build()
+            .unwrap();
+
+        assert!(property_list.properties().iter().any(|x| *x == property));
+    }
+
+    #[test]
+    fn test_property_list_bytes() {
+        let property_definition = PropertyDefinitionBuilder::new()
+            .with_name("i dunno".into())
+            .with_data_type(DataType::String)
+            .with_required(true)
+            .with_description("test".into())
+            .build()
+            .unwrap();
+
+        let reporter = ReporterBuilder::new()
+            .with_public_key("1234".to_string())
+            .with_authorized(true)
+            .with_index(0)
+            .build()
+            .unwrap();
+
+        let property = PropertyBuilder::new()
+            .with_name("taco".into())
+            .with_record_id("taco1234".into())
+            .with_property_definition(property_definition.clone())
+            .with_reporters(vec![reporter.clone()])
+            .with_current_page(0)
+            .with_wrapped(true)
+            .build()
+            .unwrap();
+
+        let property_list = PropertyListBuilder::new()
+            .with_properties(vec![property])
+            .build()
+            .unwrap();
+
+        test_from_bytes(property_list, PropertyList::from_bytes);
+    }
+
+    #[test]
+    fn test_property_page() {
+        let property_value = PropertyValueBuilder::new()
+            .with_name("egg".into())
+            .with_data_type(DataType::Number)
+            .with_number_value(42)
+            .build()
+            .unwrap();
+
+        let reported_value = ReportedValueBuilder::new()
+            .with_reporter_index(0)
+            .with_timestamp(214)
+            .with_value(property_value)
+            .build()
+            .unwrap();
+
+        let property_page = PropertyPageBuilder::new()
+            .with_name("egg".into())
+            .with_record_id("egg1234".into())
+            .with_reported_values(vec![reported_value.clone()])
+            .build()
+            .unwrap();
+
+        assert_eq!(property_page.name(), "egg");
+        assert_eq!(property_page.record_id(), "egg1234");
+        assert!(property_page
+            .reported_values()
+            .iter()
+            .any(|x| *x == reported_value));
+    }
+
+    #[test]
+    fn test_property_page_bytes() {
+        let property_value = PropertyValueBuilder::new()
+            .with_name("egg".into())
+            .with_data_type(DataType::Number)
+            .with_number_value(42)
+            .build()
+            .unwrap();
+
+        let reported_value = ReportedValueBuilder::new()
+            .with_reporter_index(0)
+            .with_timestamp(214)
+            .with_value(property_value)
+            .build()
+            .unwrap();
+
+        let property_page = PropertyPageBuilder::new()
+            .with_name("egg".into())
+            .with_record_id("egg1234".into())
+            .with_reported_values(vec![reported_value.clone()])
+            .build()
+            .unwrap();
+
+        test_from_bytes(property_page, PropertyPage::from_bytes);
+    }
+
+    #[test]
+    fn test_property_page_list() {
+        let property_value = PropertyValueBuilder::new()
+            .with_name("egg".into())
+            .with_data_type(DataType::Number)
+            .with_number_value(42)
+            .build()
+            .unwrap();
+
+        let reported_value = ReportedValueBuilder::new()
+            .with_reporter_index(0)
+            .with_timestamp(214)
+            .with_value(property_value)
+            .build()
+            .unwrap();
+
+        let property_page = PropertyPageBuilder::new()
+            .with_name("egg".into())
+            .with_record_id("egg1234".into())
+            .with_reported_values(vec![reported_value.clone()])
+            .build()
+            .unwrap();
+
+        let property_page_list = PropertyPageListBuilder::new()
+            .with_property_pages(vec![property_page.clone()])
+            .build()
+            .unwrap();
+
+        assert!(property_page_list
+            .property_pages()
+            .iter()
+            .any(|x| *x == property_page))
+    }
+
+    #[test]
+    fn test_property_page_list_bytes() {
+        let property_value = PropertyValueBuilder::new()
+            .with_name("egg".into())
+            .with_data_type(DataType::Number)
+            .with_number_value(42)
+            .build()
+            .unwrap();
+
+        let reported_value = ReportedValueBuilder::new()
+            .with_reporter_index(0)
+            .with_timestamp(214)
+            .with_value(property_value)
+            .build()
+            .unwrap();
+
+        let property_page = PropertyPageBuilder::new()
+            .with_name("egg".into())
+            .with_record_id("egg1234".into())
+            .with_reported_values(vec![reported_value.clone()])
+            .build()
+            .unwrap();
+
+        let property_page_list = PropertyPageListBuilder::new()
+            .with_property_pages(vec![property_page.clone()])
+            .build()
+            .unwrap();
+
+        test_from_bytes(property_page_list, PropertyPageList::from_bytes);
+    }
+
+    #[test]
+    fn test_proposal_builder() {
+        let proposal = ProposalBuilder::new()
+            .with_record_id("egg1234".into())
+            .with_timestamp(214)
+            .with_issuing_agent("james".into())
+            .with_receiving_agent("joe".into())
+            .with_role(Role::Owner)
+            .with_properties(vec!["wet".into()])
+            .with_status(Status::Open)
+            .with_terms("a term".into())
+            .build()
+            .unwrap();
+
+        assert_eq!(proposal.record_id(), "egg1234");
+        assert_eq!(*proposal.timestamp(), 214);
+        assert_eq!(proposal.issuing_agent(), "james");
+        assert_eq!(proposal.receiving_agent(), "joe");
+        assert_eq!(*proposal.role(), Role::Owner);
+        assert!(proposal.properties().iter().any(|x| x == "wet"));
+        assert_eq!(*proposal.status(), Status::Open);
+        assert_eq!(proposal.terms(), "a term");
+    }
+
+    #[test]
+    fn test_proposal_bytes() {
+        let proposal = ProposalBuilder::new()
+            .with_record_id("egg1234".into())
+            .with_timestamp(214)
+            .with_issuing_agent("james".into())
+            .with_receiving_agent("joe".into())
+            .with_role(Role::Owner)
+            .with_properties(vec!["wet".into(), "gets everywhere".into()])
+            .with_status(Status::Open)
+            .with_terms("a term".into())
+            .build()
+            .unwrap();
+
+        test_from_bytes(proposal, Proposal::from_bytes);
+    }
+
+    #[test]
+    fn test_proposal_list() {
+        let proposal = ProposalBuilder::new()
+            .with_record_id("egg1234".into())
+            .with_timestamp(214)
+            .with_issuing_agent("james".into())
+            .with_receiving_agent("joe".into())
+            .with_role(Role::Owner)
+            .with_properties(vec!["wet".into(), "gets everywhere".into()])
+            .with_status(Status::Open)
+            .with_terms("a term".into())
+            .build()
+            .unwrap();
+
+        let proposal_list = ProposalListBuilder::new()
+            .with_proposals(vec![proposal.clone()])
+            .build()
+            .unwrap();
+
+        assert!(proposal_list.proposals().iter().any(|x| *x == proposal));
+    }
+
+    #[test]
+    fn test_proposal_list_bytes() {
+        let proposal = ProposalBuilder::new()
+            .with_record_id("egg1234".into())
+            .with_timestamp(214)
+            .with_issuing_agent("james".into())
+            .with_receiving_agent("joe".into())
+            .with_role(Role::Owner)
+            .with_properties(vec!["wet".into(), "gets everywhere".into()])
+            .with_status(Status::Open)
+            .with_terms("a term".into())
+            .build()
+            .unwrap();
+
+        let proposal_list = ProposalListBuilder::new()
+            .with_proposals(vec![proposal.clone()])
+            .build()
+            .unwrap();
+
+        test_from_bytes(proposal_list, ProposalList::from_bytes);
+    }
+
+    #[test]
+    fn test_record_builder() {
+        let associated_agent = AssociatedAgentBuilder::new()
+            .with_agent_id("agent1234".into())
+            .with_timestamp(2132)
+            .build()
+            .unwrap();
+
+        let record = RecordBuilder::new()
+            .with_record_id("egg1234".into())
+            .with_schema("egg".into())
+            .with_owners(vec![associated_agent.clone()])
+            .with_custodians(vec![associated_agent.clone()])
+            .with_field_final(false)
+            .build()
+            .unwrap();
+
+        assert_eq!(record.record_id(), "egg1234");
+        assert_eq!(record.schema(), "egg");
+        assert!(record.owners().iter().any(|x| *x == associated_agent));
+        assert!(record.custodians().iter().any(|x| *x == associated_agent));
+        assert_eq!(*record.field_final(), false);
+    }
+
+    #[test]
+    fn test_record_bytes() {
+        let associated_agent = AssociatedAgentBuilder::new()
+            .with_agent_id("agent1234".into())
+            .with_timestamp(2132)
+            .build()
+            .unwrap();
+
+        let record = RecordBuilder::new()
+            .with_record_id("egg1234".into())
+            .with_schema("egg".into())
+            .with_owners(vec![associated_agent.clone()])
+            .with_custodians(vec![associated_agent.clone()])
+            .with_field_final(false)
+            .build()
+            .unwrap();
+
+        test_from_bytes(record, Record::from_bytes);
+    }
+
+    #[test]
+    fn test_record_list() {
+        let associated_agent = AssociatedAgentBuilder::new()
+            .with_agent_id("agent1234".into())
+            .with_timestamp(2132)
+            .build()
+            .unwrap();
+
+        let record = RecordBuilder::new()
+            .with_record_id("egg1234".into())
+            .with_schema("egg".into())
+            .with_owners(vec![associated_agent.clone()])
+            .with_custodians(vec![associated_agent.clone()])
+            .with_field_final(false)
+            .build()
+            .unwrap();
+
+        let record_list = RecordListBuilder::new()
+            .with_records(vec![record.clone()])
+            .build()
+            .unwrap();
+
+        assert!(record_list.records().iter().any(|x| *x == record));
+    }
+
+    #[test]
+    fn test_record_list_bytes() {
+        let associated_agent = AssociatedAgentBuilder::new()
+            .with_agent_id("agent1234".into())
+            .with_timestamp(2132)
+            .build()
+            .unwrap();
+
+        let record = RecordBuilder::new()
+            .with_record_id("egg1234".into())
+            .with_schema("egg".into())
+            .with_owners(vec![associated_agent.clone()])
+            .with_custodians(vec![associated_agent.clone()])
+            .with_field_final(false)
+            .build()
+            .unwrap();
+
+        let record_list = RecordListBuilder::new()
+            .with_records(vec![record.clone()])
+            .build()
+            .unwrap();
+
+        test_from_bytes(record_list, RecordList::from_bytes);
+    }
+
+}


### PR DESCRIPTION
Adds track and trace protobuf definition that are compatible with Pike and Schema, as well as their corresponding native objects