### PR TITLE
Rest API routes for Grid Schemas

### DIFF
--- a/daemon/src/database/helpers/grid_schemas.rs
+++ b/daemon/src/database/helpers/grid_schemas.rs
@@ -113,3 +113,17 @@ pub fn fetch_grid_schema(conn: &PgConnection, name: &str) -> QueryResult<Option<
         .map(Some)
         .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
 }
+
+pub fn list_grid_property_definitions_with_schema_name(
+    conn: &PgConnection,
+    schema_name: &str,
+) -> QueryResult<Vec<GridPropertyDefinition>> {
+    grid_property_definition::table
+        .select(grid_property_definition::all_columns)
+        .filter(
+            grid_property_definition::schema_name
+                .eq(schema_name)
+                .and(grid_property_definition::end_block_num.eq(MAX_BLOCK_NUM)),
+        )
+        .load::<GridPropertyDefinition>(conn)
+}

--- a/daemon/src/database/helpers/grid_schemas.rs
+++ b/daemon/src/database/helpers/grid_schemas.rs
@@ -15,7 +15,7 @@
  * -----------------------------------------------------------------------------
  */
 
-use super::models::{GridSchema, NewGridPropertyDefinition, NewGridSchema};
+use super::models::{GridPropertyDefinition, GridSchema, NewGridPropertyDefinition, NewGridSchema};
 
 use super::schema::{grid_property_definition, grid_schema};
 use super::MAX_BLOCK_NUM;
@@ -89,4 +89,13 @@ pub fn list_grid_schemas(conn: &PgConnection) -> QueryResult<Vec<GridSchema>> {
         .select(grid_schema::all_columns)
         .filter(grid_schema::end_block_num.eq(MAX_BLOCK_NUM))
         .load::<GridSchema>(conn)
+}
+
+pub fn list_grid_property_definitions(
+    conn: &PgConnection,
+) -> QueryResult<Vec<GridPropertyDefinition>> {
+    grid_property_definition::table
+        .select(grid_property_definition::all_columns)
+        .filter(grid_property_definition::end_block_num.eq(MAX_BLOCK_NUM))
+        .load::<GridPropertyDefinition>(conn)
 }

--- a/daemon/src/database/helpers/grid_schemas.rs
+++ b/daemon/src/database/helpers/grid_schemas.rs
@@ -15,7 +15,7 @@
  * -----------------------------------------------------------------------------
  */
 
-use super::models::{NewGridPropertyDefinition, NewGridSchema};
+use super::models::{GridSchema, NewGridPropertyDefinition, NewGridSchema};
 
 use super::schema::{grid_property_definition, grid_schema};
 use super::MAX_BLOCK_NUM;
@@ -82,4 +82,11 @@ pub fn update_definition_end_block_num(
         .set(grid_property_definition::end_block_num.eq(current_block_num))
         .execute(conn)
         .map(|_| ())
+}
+
+pub fn list_grid_schemas(conn: &PgConnection) -> QueryResult<Vec<GridSchema>> {
+    grid_schema::table
+        .select(grid_schema::all_columns)
+        .filter(grid_schema::end_block_num.eq(MAX_BLOCK_NUM))
+        .load::<GridSchema>(conn)
 }

--- a/daemon/src/database/helpers/grid_schemas.rs
+++ b/daemon/src/database/helpers/grid_schemas.rs
@@ -24,6 +24,7 @@ use diesel::{
     dsl::{insert_into, update},
     pg::PgConnection,
     prelude::*,
+    result::Error::NotFound,
     QueryResult,
 };
 
@@ -98,4 +99,17 @@ pub fn list_grid_property_definitions(
         .select(grid_property_definition::all_columns)
         .filter(grid_property_definition::end_block_num.eq(MAX_BLOCK_NUM))
         .load::<GridPropertyDefinition>(conn)
+}
+
+pub fn fetch_grid_schema(conn: &PgConnection, name: &str) -> QueryResult<Option<GridSchema>> {
+    grid_schema::table
+        .select(grid_schema::all_columns)
+        .filter(
+            grid_schema::name
+                .eq(name)
+                .and(grid_schema::end_block_num.eq(MAX_BLOCK_NUM)),
+        )
+        .first(conn)
+        .map(Some)
+        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
 }

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -21,7 +21,7 @@ use std::thread;
 use crate::database::ConnectionPool;
 pub use crate::rest_api::error::RestApiServerError;
 use crate::rest_api::routes::{
-    fetch_agent, fetch_organization, get_batch_statuses, list_agents, list_organizations,
+    fetch_agent, fetch_organization, get_batch_statuses, list_agents, list_grid_schemas, list_organizations,
     submit_batches,
 };
 use crate::rest_api::routes::{DbExecutor, SawtoothMessageSender};
@@ -68,6 +68,9 @@ fn create_app(
     })
     .resource("/organization/{id}", |r| {
         r.method(Method::GET).with_async(fetch_organization)
+    })
+    .resource("/schema", |r| {
+        r.method(Method::GET).with_async(list_grid_schemas)
     })
 }
 

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -21,8 +21,8 @@ use std::thread;
 use crate::database::ConnectionPool;
 pub use crate::rest_api::error::RestApiServerError;
 use crate::rest_api::routes::{
-    fetch_agent, fetch_organization, get_batch_statuses, list_agents, list_grid_schemas, list_organizations,
-    submit_batches,
+    fetch_agent, fetch_grid_schema, fetch_organization, get_batch_statuses, list_agents,
+    list_grid_schemas, list_organizations, submit_batches,
 };
 use crate::rest_api::routes::{DbExecutor, SawtoothMessageSender};
 use actix::{Actor, Addr, Context, SyncArbiter};
@@ -71,6 +71,9 @@ fn create_app(
     })
     .resource("/schema", |r| {
         r.method(Method::GET).with_async(list_grid_schemas)
+    })
+    .resource("/schema/{name}", |r| {
+        r.method(Method::GET).with_async(fetch_grid_schema)
     })
 }
 

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -15,10 +15,12 @@
 mod agents;
 mod batches;
 mod organizations;
+mod schemas;
 
 pub use agents::*;
 pub use batches::*;
 pub use organizations::*;
+pub use schemas::*;
 
 use crate::database::ConnectionPool;
 

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -61,7 +61,8 @@ mod test {
     use crate::database;
     use crate::database::{
         helpers::MAX_BLOCK_NUM,
-        models::{NewAgent, NewOrganization},
+        models::{NewAgent, NewGridPropertyDefinition, NewGridSchema, NewOrganization},
+        schema::{grid_property_definition, grid_schema},
     };
     use crate::rest_api::{
         routes::{AgentSlice, BatchStatusResponse, OrganizationSlice},
@@ -70,6 +71,7 @@ mod test {
 
     use actix::SyncArbiter;
     use actix_web::{http, http::Method, test::TestServer, HttpMessage};
+    use diesel::dsl::insert_into;
     use diesel::pg::PgConnection;
     use diesel::RunQueryDsl;
     use futures::future::Future;
@@ -214,6 +216,12 @@ mod test {
             })
             .resource("/organization/{id}", |r| {
                 r.method(Method::GET).with_async(fetch_organization)
+            })
+            .resource("/schema", |r| {
+                r.method(Method::GET).with_async(list_grid_schemas)
+            })
+            .resource("/schema/{name}", |r| {
+                r.method(Method::GET).with_async(fetch_grid_schema)
             });
         })
     }
@@ -701,6 +709,83 @@ mod test {
         assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
     }
 
+    /// Verifies a GET /schema responds with an OK response with a
+    ///     list_grid_schemas request.
+    ///
+    ///     The TestServer will receive a request with no parameters,
+    ///         then will respond with an Ok status and a list of Grid Schemas.
+    #[test]
+    fn test_list_schemas() {
+        database::run_migrations(&DATABASE_URL).unwrap();
+        let test_pool = get_connection_pool();
+        let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
+        // Clears the grid schema table in the test database
+        clear_grid_schema_table(&test_pool.get().unwrap());
+        let request = srv.client(http::Method::GET, "/schema").finish().unwrap();
+        let response = srv.execute(request.send()).unwrap();
+        assert!(response.status().is_success());
+        let empty_body: Vec<GridSchemaSlice> =
+            serde_json::from_slice(&*response.body().wait().unwrap()).unwrap();
+        assert!(empty_body.is_empty());
+
+        populate_grid_schema_table(&test_pool.get().unwrap(), &get_grid_schema());
+        let request = srv.client(http::Method::GET, "/schema").finish().unwrap();
+        let response = srv.execute(request.send()).unwrap();
+        assert!(response.status().is_success());
+        let body: Vec<GridSchemaSlice> =
+            serde_json::from_slice(&*response.body().wait().unwrap()).unwrap();
+        assert_eq!(body.len(), 1);
+
+        let test_schema = body.first().unwrap();
+        assert_eq!(test_schema.name, "Test Grid Schema".to_string());
+        assert_eq!(test_schema.owner, "phillips001".to_string());
+        assert_eq!(test_schema.properties.len(), 2);
+    }
+
+    ///
+    /// Verifies a GET /schema/{name} responds with an OK response
+    ///     and the Grid Schema with the specified name
+    ///
+    #[test]
+    fn test_fetch_schema_ok() {
+        database::run_migrations(&DATABASE_URL).unwrap();
+        let test_pool = get_connection_pool();
+        let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
+        populate_grid_schema_table(&test_pool.get().unwrap(), &get_grid_schema());
+        let request = srv
+            .client(
+                http::Method::GET,
+                &format!("/schema/{}", "Test Grid Schema".to_string()),
+            )
+            .finish()
+            .unwrap();
+        let response = srv.execute(request.send()).unwrap();
+        assert!(response.status().is_success());
+        let test_schema: GridSchemaSlice =
+            serde_json::from_slice(&*response.body().wait().unwrap()).unwrap();
+        assert_eq!(test_schema.name, "Test Grid Schema".to_string());
+        assert_eq!(test_schema.owner, "phillips001".to_string());
+        assert_eq!(test_schema.properties.len(), 2);
+    }
+
+    ///
+    /// Verifies a GET /schema/{name} responds with a Not Found error
+    ///     when there is no Grid Schema with the specified name
+    ///
+    #[test]
+    fn test_fetch_schema_not_found() {
+        database::run_migrations(&DATABASE_URL).unwrap();
+        let test_pool = get_connection_pool();
+        let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
+        clear_grid_schema_table(&test_pool.get().unwrap());
+        let request = srv
+            .client(http::Method::GET, "/schema/not_in_database")
+            .finish()
+            .unwrap();
+        let response = srv.execute(request.send()).unwrap();
+        assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    }
+
     fn get_batch_statuses_response_one_id() -> Vec<u8> {
         let mut batch_status_response = ClientBatchStatusResponse::new();
         batch_status_response.set_status(ClientBatchStatusResponse_Status::OK);
@@ -823,5 +908,78 @@ mod test {
     fn clear_organization_table(conn: &PgConnection) {
         use crate::database::schema::organization::dsl::*;
         diesel::delete(organization).execute(conn).unwrap();
+    }
+
+    fn get_grid_schema() -> Vec<NewGridSchema> {
+        vec![NewGridSchema {
+            start_block_num: 0,
+            end_block_num: MAX_BLOCK_NUM,
+            name: "Test Grid Schema".to_string(),
+            description: "Example test grid schema".to_string(),
+            owner: "phillips001".to_string(),
+        }]
+    }
+
+    fn populate_grid_schema_table(conn: &PgConnection, schemas: &[NewGridSchema]) {
+        clear_grid_schema_table(conn);
+        populate_property_definition_table(conn, &get_property_definition());
+        insert_into(grid_schema::table)
+            .values(schemas)
+            .execute(conn)
+            .map(|_| ())
+            .unwrap();
+    }
+
+    fn clear_grid_schema_table(conn: &PgConnection) {
+        use crate::database::schema::grid_schema::dsl::*;
+        diesel::delete(grid_schema).execute(conn).unwrap();
+    }
+
+    fn get_property_definition() -> Vec<NewGridPropertyDefinition> {
+        vec![
+            NewGridPropertyDefinition {
+                start_block_num: 0,
+                end_block_num: MAX_BLOCK_NUM,
+                name: "Definition Name".to_string(),
+                schema_name: "Test Grid Schema".to_string(),
+                data_type: "Lightbulb".to_string(),
+                required: false,
+                description: "Definition Description".to_string(),
+                number_exponent: 0,
+                enum_options: vec![],
+                struct_properties: vec![],
+            },
+            NewGridPropertyDefinition {
+                start_block_num: 0,
+                end_block_num: MAX_BLOCK_NUM,
+                name: "Other Definition Name".to_string(),
+                schema_name: "Test Grid Schema".to_string(),
+                data_type: "New Lightbulb".to_string(),
+                required: false,
+                description: "Definition Description".to_string(),
+                number_exponent: 0,
+                enum_options: vec![],
+                struct_properties: vec![],
+            },
+        ]
+    }
+
+    fn populate_property_definition_table(
+        conn: &PgConnection,
+        definitions: &[NewGridPropertyDefinition],
+    ) {
+        clear_property_definition_table(conn);
+        insert_into(grid_property_definition::table)
+            .values(definitions)
+            .execute(conn)
+            .map(|_| ())
+            .unwrap();
+    }
+
+    fn clear_property_definition_table(conn: &PgConnection) {
+        use crate::database::schema::grid_property_definition::dsl::*;
+        diesel::delete(grid_property_definition)
+            .execute(conn)
+            .unwrap();
     }
 }

--- a/daemon/src/rest_api/routes/schemas.rs
+++ b/daemon/src/rest_api/routes/schemas.rs
@@ -118,3 +118,34 @@ pub fn list_grid_schemas(
         })
         .responder()
 }
+
+struct FetchGridSchema {
+    name: String,
+}
+
+impl Message for FetchGridSchema {
+    type Result = Result<GridSchemaSlice, RestApiResponseError>;
+}
+
+impl Handler<FetchGridSchema> for DbExecutor {
+    type Result = Result<GridSchemaSlice, RestApiResponseError>;
+
+    fn handle(&mut self, msg: FetchGridSchema, _: &mut SyncContext<Self>) -> Self::Result {
+        let properties = db::list_grid_property_definitions_with_schema_name(
+            &*self.connection_pool.get()?,
+            &msg.name,
+        )?;
+        let fetched_schema = match db::fetch_grid_schema(&*self.connection_pool.get()?, &msg.name)?
+        {
+            Some(schema) => GridSchemaSlice::from_schema(&schema, properties),
+            None => {
+                return Err(RestApiResponseError::NotFoundError(format!(
+                    "Could not find schema with name: {}",
+                    msg.name
+                )));
+            }
+        };
+
+        Ok(fetched_schema)
+    }
+}

--- a/daemon/src/rest_api/routes/schemas.rs
+++ b/daemon/src/rest_api/routes/schemas.rs
@@ -1,0 +1,66 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::database::models::{GridPropertyDefinition, GridSchema};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GridSchemaSlice {
+    pub name: String,
+    pub description: String,
+    pub owner: String,
+    pub properties: Vec<GridPropertyDefinitionSlice>,
+}
+
+impl GridSchemaSlice {
+    pub fn from_schema(schema: &GridSchema, properties: Vec<GridPropertyDefinition>) -> Self {
+        Self {
+            name: schema.name.clone(),
+            description: schema.description.clone(),
+            owner: schema.owner.clone(),
+            properties: properties
+                .iter()
+                .map(|prop| GridPropertyDefinitionSlice::from_definition(prop))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GridPropertyDefinitionSlice {
+    pub name: String,
+    pub schema_name: String,
+    pub data_type: String,
+    pub required: bool,
+    pub description: String,
+    pub number_exponent: i64,
+    pub enum_options: Vec<String>,
+    pub struct_properties: Vec<String>,
+}
+
+impl GridPropertyDefinitionSlice {
+    pub fn from_definition(definition: &GridPropertyDefinition) -> Self {
+        Self {
+            name: definition.name.clone(),
+            schema_name: definition.schema_name.clone(),
+            data_type: definition.data_type.clone(),
+            required: definition.required,
+            description: definition.description.clone(),
+            number_exponent: definition.number_exponent,
+            enum_options: definition.enum_options.clone(),
+            struct_properties: definition.struct_properties.clone(),
+        }
+    }
+}

--- a/daemon/src/rest_api/routes/schemas.rs
+++ b/daemon/src/rest_api/routes/schemas.rs
@@ -19,7 +19,7 @@ use crate::database::{
 use crate::rest_api::{error::RestApiResponseError, routes::DbExecutor, AppState};
 
 use actix::{Handler, Message, SyncContext};
-use actix_web::{AsyncResponder, HttpRequest, HttpResponse};
+use actix_web::{AsyncResponder, HttpRequest, HttpResponse, Path};
 use futures::Future;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -148,4 +148,20 @@ impl Handler<FetchGridSchema> for DbExecutor {
 
         Ok(fetched_schema)
     }
+}
+
+pub fn fetch_grid_schema(
+    req: HttpRequest<AppState>,
+    schema_name: Path<String>,
+) -> impl Future<Item = HttpResponse, Error = RestApiResponseError> {
+    req.state()
+        .database_connection
+        .send(FetchGridSchema {
+            name: schema_name.into_inner(),
+        })
+        .from_err()
+        .and_then(move |res| match res {
+            Ok(schema) => Ok(HttpResponse::Ok().json(schema)),
+            Err(err) => Err(err),
+        })
 }

--- a/daemon/src/rest_api/routes/schemas.rs
+++ b/daemon/src/rest_api/routes/schemas.rs
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::database::models::{GridPropertyDefinition, GridSchema};
+use crate::database::{
+    helpers as db,
+    models::{GridPropertyDefinition, GridSchema},
+};
+use crate::rest_api::{error::RestApiResponseError, routes::DbExecutor};
 
+use actix::{Handler, Message, SyncContext};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GridSchemaSlice {
@@ -62,5 +68,37 @@ impl GridPropertyDefinitionSlice {
             enum_options: definition.enum_options.clone(),
             struct_properties: definition.struct_properties.clone(),
         }
+    }
+}
+
+struct ListGridSchemas;
+
+impl Message for ListGridSchemas {
+    type Result = Result<Vec<GridSchemaSlice>, RestApiResponseError>;
+}
+
+impl Handler<ListGridSchemas> for DbExecutor {
+    type Result = Result<Vec<GridSchemaSlice>, RestApiResponseError>;
+
+    fn handle(&mut self, _msg: ListGridSchemas, _: &mut SyncContext<Self>) -> Self::Result {
+        let mut properties = db::list_grid_property_definitions(&*self.connection_pool.get()?)?
+            .into_iter()
+            .fold(HashMap::new(), |mut acc, definition| {
+                acc.entry(definition.schema_name.to_string())
+                    .or_insert_with(|| vec![])
+                    .push(definition);
+                acc
+            });
+
+        let fetched_schemas = db::list_grid_schemas(&*self.connection_pool.get()?)?
+            .iter()
+            .map(|schema| {
+                GridSchemaSlice::from_schema(
+                    schema,
+                    properties.remove(&schema.name).unwrap_or_else(|| vec![]),
+                )
+            })
+            .collect();
+        Ok(fetched_schemas)
     }
 }


### PR DESCRIPTION
Adds the necessary functions, handlers, and implementations for the /schema and /schema/{name} routes to list and fetch grid schemas, respectively. Also adds tests for these two routes. 

To test: `cargo test --features test-api -- --test-threads=1`