### PR TITLE
Add CLI commands to show and list Grid Schemas

### DIFF
--- a/cli/src/actions/schemas.rs
+++ b/cli/src/actions/schemas.rs
@@ -19,6 +19,7 @@ use grid_sdk::protocol::schema::payload::{
 };
 use grid_sdk::protocol::schema::state::{DataType, PropertyDefinition, PropertyDefinitionBuilder};
 use grid_sdk::protos::IntoProto;
+use reqwest::Client;
 
 use crate::error::CliError;
 use serde::Deserialize;
@@ -66,6 +67,16 @@ pub fn display_schema_property_definitions(properties: &[GridPropertyDefinitionS
             def.struct_properties,
         );
     });
+}
+
+pub fn do_list_schemas(url: &str) -> Result<(), CliError> {
+    let client = Client::new();
+    let schemas = client
+        .get(&format!("{}/schema", url))
+        .send()?
+        .json::<Vec<GridSchemaSlice>>()?;
+    schemas.iter().for_each(|schema| display_schema(schema));
+    Ok(())
 }
 
 pub fn do_create_schemas(

--- a/cli/src/actions/schemas.rs
+++ b/cli/src/actions/schemas.rs
@@ -79,6 +79,16 @@ pub fn do_list_schemas(url: &str) -> Result<(), CliError> {
     Ok(())
 }
 
+pub fn do_show_schema(url: &str, name: &str) -> Result<(), CliError> {
+    let client = Client::new();
+    let schema = client
+        .get(&format!("{}/schema/{}", url, name))
+        .send()?
+        .json::<GridSchemaSlice>()?;
+    display_schema(&schema);
+    Ok(())
+}
+
 pub fn do_create_schemas(
     url: &str,
     key: Option<String>,

--- a/cli/src/actions/schemas.rs
+++ b/cli/src/actions/schemas.rs
@@ -21,7 +21,52 @@ use grid_sdk::protocol::schema::state::{DataType, PropertyDefinition, PropertyDe
 use grid_sdk::protos::IntoProto;
 
 use crate::error::CliError;
+use serde::Deserialize;
 use serde_yaml::{Mapping, Sequence, Value};
+
+#[derive(Debug, Deserialize)]
+pub struct GridSchemaSlice {
+    pub name: String,
+    pub description: String,
+    pub owner: String,
+    pub properties: Vec<GridPropertyDefinitionSlice>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GridPropertyDefinitionSlice {
+    pub name: String,
+    pub schema_name: String,
+    pub data_type: String,
+    pub required: bool,
+    pub description: String,
+    pub number_exponent: i64,
+    pub enum_options: Vec<String>,
+    pub struct_properties: Vec<String>,
+}
+
+pub fn display_schema(schema: &GridSchemaSlice) {
+    println!(
+        "Name: {:?}\n Description: {:?}\n Owner: {:?}\n Properties:",
+        schema.name, schema.description, schema.owner,
+    );
+    display_schema_property_definitions(&schema.properties);
+}
+
+pub fn display_schema_property_definitions(properties: &[GridPropertyDefinitionSlice]) {
+    properties.iter().for_each(|def| {
+        println!(
+            "\tName: {:?}\n\t Data Type: {:?}\n\t Required: {:?}\n\t Description: {:?}
+        Number Exponent: {:?}\n\t Enum Options: {:?}\n\t Struct Properties: {:?}",
+            def.name,
+            def.data_type,
+            def.required,
+            def.description,
+            def.number_exponent,
+            def.enum_options,
+            def.struct_properties,
+        );
+    });
+}
 
 pub fn do_create_schemas(
     url: &str,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -106,6 +106,10 @@ fn run() -> Result<(), CliError> {
             (@subcommand list =>
                 (about: "List currently defined schemas")
             )
+            (@subcommand show =>
+                (about: "Show schema specified by name argument")
+                (@arg name: +takes_value +required "Name of schema")
+            )
         )
     )
     .get_matches();
@@ -193,6 +197,7 @@ fn run() -> Result<(), CliError> {
                 schemas::do_update_schemas(&url, key, wait, m.value_of("path").unwrap())?
             }
             ("list", Some(_)) => schemas::do_list_schemas(&url)?,
+            ("show", Some(m)) => schemas::do_show_schema(&url, m.value_of("name").unwrap())?,
             _ => return Err(CliError::UserError("Subcommand not recognized".into())),
         },
         _ => return Err(CliError::UserError("Subcommand not recognized".into())),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -103,6 +103,9 @@ fn run() -> Result<(), CliError> {
                 (about: "Update schemas from a yaml file")
                 (@arg path: +takes_value +required "Path to yaml file containing a list of schema definitions")
             )
+            (@subcommand list =>
+                (about: "List currently defined schemas")
+            )
         )
     )
     .get_matches();
@@ -189,6 +192,7 @@ fn run() -> Result<(), CliError> {
             ("update", Some(m)) => {
                 schemas::do_update_schemas(&url, key, wait, m.value_of("path").unwrap())?
             }
+            ("list", Some(_)) => schemas::do_list_schemas(&url)?,
             _ => return Err(CliError::UserError("Subcommand not recognized".into())),
         },
         _ => return Err(CliError::UserError("Subcommand not recognized".into())),


### PR DESCRIPTION
Adds the CLI commands to list all GridSchemas and show a GridSchema based on the schema name. 

~Note: running `cargo test` in the cli directory will return an error because of a typo getting fixed up in pr #69 although no unit tests were added for these commands~
PR #69 was merged, this no longer stands