### PR TITLE
Implement Fetch Record endpoint

### DIFF
--- a/daemon/migrations/2019-04-04-145511_create-pike-tables/up.sql
+++ b/daemon/migrations/2019-04-04-145511_create-pike-tables/up.sql
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS agent (
     public_key VARCHAR(70) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
     active BOOLEAN NOT NULL,
-    roles VARCHAR(256) [] NOT NULL,
+    roles TEXT [] NOT NULL,
     metadata JSON [] NOT NULL
 ) INHERITS (chain_record);
 

--- a/daemon/migrations/2019-05-02-191951_create_tnt_tables/up.sql
+++ b/daemon/migrations/2019-05-02-191951_create_tnt_tables/up.sql
@@ -67,6 +67,7 @@ CREATE INDEX IF NOT EXISTS proposal_idx
 CREATE TABLE IF NOT EXISTS associated_agent (
     id BIGSERIAL PRIMARY KEY,
     record_id TEXT NOT NULL,
+    role TEXT NOT NULL,
     agent_id TEXT NOT NULL,
     timestamp BIGINT NOT NULL
 ) INHERITS (chain_record);

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -12,21 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
-swagger: '2.0'
-
+openapi: 3.0.0
 info:
-  version: "0.1.0"
+  version: 0.1.0
   title: Grid REST API
-  description:
-    _An API providing HTTP/JSON interface to Hyperledger Grid._
-
+  description: _An API providing HTTP/JSON interface to Hyperledger Grid._
 paths:
   /batches:
     post:
       tags:
-      - sawtooth_validator
+        - Sawtooth Validator
       summary: Sends a BatchList to the Sawtooth Validator
       description: |
         Accepts a protobuf formatted `BatchList` as an octet-stream binary
@@ -35,40 +32,37 @@ paths:
         The API will return immediately with a status of `202`. There will be
         no `data` object, only a `link` to a `/batch_statuses` endpoint to be
         polled to check the status of submitted batches.
-      consumes:
-        - application/octet-stream
-      operationId: "post_batches"
-      produces:
-      - "application/json"
-      parameters:
-        - name: BatchList
-          in: body
-          description: A binary encoded protobuf BatchList
-          schema:
-            $ref: "#/definitions/BatchList"
-          required: true
+      operationId: post_batches
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              $ref: "#/components/schemas/BatchList"
+        description: A binary encoded protobuf BatchList
+        required: true
       responses:
-        202:
+        "202":
           description: Batches submitted for validation, but not yet committed
-          schema:
-            properties:
-              link:
-                $ref: "#/definitions/Link"
-        400:
-          $ref: "#/responses/400BadRequest"
-        429:
-          $ref: "#/responses/429TooManyRequests"
-        500:
-          $ref: "#/responses/500ServerError"
-        503:
-          $ref: "#/responses/503ServiceUnavailable"
-
+          content:
+            application/json:
+              schema:
+                properties:
+                  link:
+                    $ref: "#/components/schemas/Link"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "429":
+          $ref: "#/components/responses/429TooManyRequests"
+        "500":
+          $ref: "#/components/responses/500ServerError"
+        "503":
+          $ref: "#/components/responses/503ServiceUnavailable"
   /batch_statuses:
     get:
       tags:
-      - sawtooth_validator
-      summary: Fetches the committed statuses for a set of batches from the
-        Sawtooth Validator
+        - Sawtooth Validator
+      summary: Fetches the committed statuses for a set of batches from the Sawtooth
+        Validator
       description: |
         Fetches an array of objects with a status and id for each batch
         requested. There are four possible statuses with string values
@@ -84,436 +78,464 @@ paths:
         Note that because this route does not return full resources, the
         response will not be paginated, and there will be no `head` or
         `paging` properties.
-      operationId: "get_batch_statuses_by_id"
-      produces:
-      - "application/json"
+      operationId: get_batch_statuses_by_id
       parameters:
         - name: id
           in: query
           description: A comma-separated list of batch ids
-          type: string
           required: true
-        - $ref: "#/parameters/wait"
-      responses:
-        200:
-          description: Successfully retrieved statuses
           schema:
-            properties:
-              data:
-                $ref: "#/definitions/BatchStatuses"
-              link:
-                $ref: "#/definitions/Link"
-        400:
-          $ref: "#/responses/400BadRequest"
-        500:
-          $ref: "#/responses/500ServerError"
-        503:
-          $ref: "#/responses/503ServiceUnavailable"
-
+            type: string
+        - $ref: "#/components/parameters/wait"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchStatuses"
+                  link:
+                    $ref: "#/components/schemas/Link"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "500":
+          $ref: "#/components/responses/500ServerError"
+        "503":
+          $ref: "#/components/responses/503ServiceUnavailable"
   /schema:
     get:
       tags:
-      - "schema"
-      summary: "Get a list of schemas"
-      description: "Fetches a list of schemas from the reporting database"
-      operationId: "get_schemas"
-      produces:
-      - "application/json"
+        - Schema
+      summary: Get a list of schemas
+      description: Fetches a list of schemas from the reporting database
+      operationId: get_schemas
       responses:
-        200:
-          description: "List of schemas"
-          schema:
-            properties:
-              data:
-                type: array
-                items:
-                 $ref: "#/definitions/Schema"
-
-        400:
-          $ref: "#/responses/400BadRequest"
-        429:
-          $ref: "#/responses/429TooManyRequests"
-        500:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Schema"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "429":
+          $ref: "#/components/responses/429TooManyRequests"
+        "500":
           description: Something went wrong within the database
-          schema:
-            $ref: "#/definitions/Error"
-        503:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
           description: API is unable to reach the database
-          schema:
-            $ref: "#/definitions/Error"
-
-  /schema/{schema_name}:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  "/schema/{schema_name}":
     get:
       tags:
-      - "schema"
-      summary: "Find schema by schema name"
-      description: "Returns a single schema"
-      operationId: "get_schema_by_name"
-      produces:
-      - "application/json"
+        - Schema
+      summary: Find schema by schema name
+      description: Returns a single schema
+      operationId: get_schema_by_name
       parameters:
-      - name: "schema_name"
-        in: "path"
-        description: "Name of the schema to return"
-        required: true
-        type: "string"
+        - name: schema_name
+          in: path
+          description: Name of the schema to return
+          required: true
+          schema:
+            type: string
       responses:
-        200:
+        "200":
           description: Successful operation
-          schema:
-            properties:
-              link:
-                $ref: "#/definitions/Schema"
-        400:
-          $ref: "#/responses/400BadRequest"
-        404:
-          $ref: "#/responses/404NotFound"
-        429:
-          $ref: "#/responses/429TooManyRequests"
-        500:
+          content:
+            application/json:
+              schema:
+                properties:
+                  link:
+                    $ref: "#/components/schemas/Schema"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "404":
+          $ref: "#/components/responses/404NotFound"
+        "429":
+          $ref: "#/components/responses/429TooManyRequests"
+        "500":
           description: Something went wrong within the database
-          schema:
-            $ref: "#/definitions/Error"
-        503:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
           description: API is unable to reach the database
-          schema:
-            $ref: "#/definitions/Error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /agent:
     get:
       tags:
-        - "agent"
-      summary: "Get a list of Agents"
-      description: "Fetches a list of agents from the reporting database"
-      operationId: "list_agents"
-      produces:
-        - "application/json"
+        - Pike
+      summary: Get a list of Agents
+      description: Fetches a list of agents from the reporting database
+      operationId: list_agents
       responses:
-        200:
+        "200":
           description: Successful operation
-          schema:
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: "#/definitions/Agent"
-        400:
-          $ref: "#/responses/400BadRequest"
-        429:
-          $ref: "#/responses/429TooManyRequests"
-        500:
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Agent"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "429":
+          $ref: "#/components/responses/429TooManyRequests"
+        "500":
           description: Something went wrong within the database
-          schema:
-            $ref: "#/definitions/Error"
-        503:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
           description: API is unable to reach the database
-          schema:
-            $ref: "#/definitions/Error"
-
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /organization:
     get:
       tags:
-        - "organization"
-      operationId: "list_organizations"
-      produces:
-        - "application/json"
+        - Pike
+      operationId: list_organizations
       responses:
-        200:
-          description: "Retrieve list of organizations"
-          schema:
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: "#/definitions/Organization"
-        400:
-          $ref: "#/responses/400BadRequest"
-        429:
-          $ref: "#/responses/429TooManyRequests"
-        500:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Organization"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "429":
+          $ref: "#/components/responses/429TooManyRequests"
+        "500":
           description: Something went wrong within the database
-          schema:
-            $ref: "#/definitions/Error"
-        503:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
           description: API is unable to reach the database
-          schema:
-            $ref: "#/definitions/Error"
-
-  /organization/{id}:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  "/organization/{id}":
     get:
       tags:
-        - "organization"
-      operationId: "fetch_organization"
-      produces:
-        - "application/json"
+        - Pike
+      operationId: fetch_organization
       parameters:
-      - name: "id"
-        in: "path"
-        description: "Id of the organization to return"
-        required: true
-        type: "string"
+        - name: id
+          in: path
+          description: Id of the organization to return
+          required: true
+          schema:
+            type: string
       responses:
-        200:
+        "200":
           description: Successful operation
-          schema:
-            properties:
-              link:
-                $ref: "#/definitions/Organization"
-        400:
-          $ref: "#/responses/400BadRequest"
-        404:
-          $ref: "#/responses/404NotFound"
-        429:
-          $ref: "#/responses/429TooManyRequests"
-        500:
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Organization"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "404":
+          $ref: "#/components/responses/404NotFound"
+        "429":
+          $ref: "#/components/responses/429TooManyRequests"
+        "500":
           description: Something went wrong within the database
-          schema:
-            $ref: "#/definitions/Error"
-        503:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
           description: API is unable to reach the database
-          schema:
-            $ref: "#/definitions/Error"
-
-  /agent/{public_key}:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  "/agent/{public_key}":
     get:
       tags:
-        - "agent"
-      summary: "Find agent by public key"
-      description: "Returns a single agent from reporting database"
-      operationId: "fetch_agent"
-      produces:
-        - "application/json"
+        - Pike
+      summary: Find agent by public key
+      description: Returns a single agent from reporting database
+      operationId: fetch_agent
       parameters:
-        - "public_key"
-        in: "path"
-        description: "Public key of the agent to return"
-        required: true
-        type: "string"
+        - name: public_key
+          in: path
+          description: Public key of the agent to return
+          required: true
+          schema:
+            type: string
       responses:
-        200:
+        "200":
           description: Successful operation
-          schema:
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: "#/definitions/Agent"
-        400:
-          $ref: "#/responses/400BadRequest"
-        404:
-          $ref: "#/responses/404NotFound"
-        429:
-          $ref: "#/responses/429TooManyRequests"
-        500:
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Agent"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "404":
+          $ref: "#/components/responses/404NotFound"
+        "429":
+          $ref: "#/components/responses/429TooManyRequests"
+        "500":
           description: Something went wrong within the database
-          schema:
-            $ref: "#/definitions/Error"
-        503:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
           description: API is unable to reach the database
-          schema:
-            $ref: "#/definitions/Error"
-
-
-responses:
-  400BadRequest:
-    description: Request was malformed
-    schema:
-      $ref: "#/definitions/Error"
-  404NotFound:
-    description: Address or id did not match any resource
-    schema:
-      $ref: "#/definitions/Error"
-  429TooManyRequests:
-    description: Too many requests have been made to process batches
-    schema:
-      $ref: "#/definitions/Error"
-  500ServerError:
-    description: Something went wrong within the validator
-    schema:
-      $ref: "#/definitions/Error"
-  503ServiceUnavailable:
-    description: API is unable to reach the validator
-    schema:
-      $ref: "#/definitions/Error"
-
-parameters:
-  batch_id:
-    name: batch_id
-    in: path
-    type: string
-    required: true
-    description: Batch id
-  wait:
-    name: wait
-    in: query
-    type: integer
-    description: A time in seconds to wait for commit
-
-definitions:
-  Link:
-    type: string
-    example: https://api.grid.com/state?head=65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd
-
-  Error:
-    properties:
-      code:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  parameters:
+    batch_id:
+      name: batch_id
+      in: path
+      required: true
+      description: Batch id
+      schema:
+        type: string
+    wait:
+      name: wait
+      in: query
+      description: A time in seconds to wait for commit
+      schema:
         type: integer
-        example: 34
-      title:
+  responses:
+    400BadRequest:
+      description: Request was malformed
+      content:
+        "*/*":
+          schema:
+            $ref: "#/components/schemas/Error"
+    404NotFound:
+      description: Address or id did not match any resource
+      content:
+        "*/*":
+          schema:
+            $ref: "#/components/schemas/Error"
+    429TooManyRequests:
+      description: Too many requests have been made to process batches
+      content:
+        "*/*":
+          schema:
+            $ref: "#/components/schemas/Error"
+    500ServerError:
+      description: Something went wrong within the validator
+      content:
+        "*/*":
+          schema:
+            $ref: "#/components/schemas/Error"
+    503ServiceUnavailable:
+      description: API is unable to reach the validator
+      content:
+        "*/*":
+          schema:
+            $ref: "#/components/schemas/Error"
+  schemas:
+    Link:
+      type: string
+      example: https://api.grid.com/state?head=65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd
+    Error:
+      properties:
+        code:
+          type: integer
+          example: 34
+        title:
           type: string
           example: No Batches Submitted
-      message:
-        type: string
-        example: >
-          The protobuf BatchList you submitted was empty and contained no
-          Batches. You must submit at least one Batch.
-
-  BatchStatuses:
-    type: array
-    items:
+        message:
+          type: string
+          example: >
+            The protobuf BatchList you submitted was empty and contained no
+            Batches. You must submit at least one Batch.
+    BatchStatuses:
+      type: array
+      items:
+        properties:
+          id:
+            type: string
+            example: 89807bfc9089e37e00d87d97357de14cfbc455cd608438d426a625a30a0da9a31c406983803c4aa27e1f32a3ff61709e8ec4b56abbc553d7d330635b5d27029c
+          status:
+            type: string
+            example: INVALID
+            enum:
+              - COMMITTED
+              - INVALID
+              - PENDING
+              - UNKNOWN
+          invalid_transactions:
+            type: array
+            items:
+              properties:
+                id:
+                  type: string
+                  example: 540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a
+                message:
+                  type: string
+                  example: Verb is \"inc\" but name \"foo\" not in state
+                extended_data:
+                  type: string
+                  format: byte
+                  example: ZXJyb3IgZGF0YQ==
+    TransactionHeader:
       properties:
-        id:
+        batcher_public_key:
           type: string
-          example: 89807bfc9089e37e00d87d97357de14cfbc455cd608438d426a625a30a0da9a31c406983803c4aa27e1f32a3ff61709e8ec4b56abbc553d7d330635b5d27029c
-        status:
-          type: string
-          example: INVALID
-          enum:
-            - COMMITTED
-            - INVALID
-            - PENDING
-            - UNKNOWN
-        invalid_transactions:
+          example: 02d260a46457a064733153e09840c322bee1dff34445d7d49e19e60abd18fd0758
+        dependencies:
           type: array
           items:
-            properties:
-              id:
-                type: string
-                example: 540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a
-              message:
-                type: string
-                example: Verb is \"inc\" but name \"foo\" not in state
-              extended_data:
-                type: string
-                format: byte
-                example: ZXJyb3IgZGF0YQ==
-
-  TransactionHeader:
-    properties:
-      batcher_public_key:
-        type: string
-        example: 02d260a46457a064733153e09840c322bee1dff34445d7d49e19e60abd18fd0758
-      dependencies:
-        type: array
-        items:
+            type: string
+            example: 1baee350bdb60bcee60e3d325d43283cf830b4c23b2cb17d3bb43935bd7af3761c2bee79847c72a9e396a9ae58f48add4e43f94eb83f84442c6085c1dd5d4dbe
+        family_name:
           type: string
-          example: 1baee350bdb60bcee60e3d325d43283cf830b4c23b2cb17d3bb43935bd7af3761c2bee79847c72a9e396a9ae58f48add4e43f94eb83f84442c6085c1dd5d4dbe
-      family_name:
-        type: string
-        example: intkey
-      family_version:
-        type: string
-        example: "1.0"
-      inputs:
-        type: array
-        items:
+          example: intkey
+        family_version:
           type: string
-          example: 1cf12650d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c
-      nonce:
-        type: string
-        example: QAApS4L
-      outputs:
-        type: array
-        items:
+          example: "1.0"
+        inputs:
+          type: array
+          items:
+            type: string
+            example: 1cf12650d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c
+        nonce:
           type: string
-          example: 1cf12650d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c
-      payload_sha512:
-        type: string
-        example: fb6135ef73f4fe77367f9384b3bbbb158f4b8603c9d612157108e5c271868fce2242ee4abd7a29397ba63780c3ccab13783dfd4d9f0167beda03cdb0e37b87f4
-      signer_public_key:
-        type: string
-        example: 038bba5708acc262464c9fe30d3de9e905a9a5fa30cedd151dd9cd09ea26d46d00
-  Transaction:
-    properties:
-      header:
-        $ref: "#/definitions/TransactionHeader"
-      header_signature:
-        type: string
-        example: 540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a
-      payload:
-        type: string
-        format: binary
-
-  BatchHeader:
-    properties:
-      signer_public_key:
-        type: string
-        example: 038bba5708acc262464c9fe30d3de9e905a9a5fa30cedd151dd9cd09ea26d46d00
-      transaction_ids:
-        type: array
-        items:
+          example: QAApS4L
+        outputs:
+          type: array
+          items:
+            type: string
+            example: 1cf12650d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c
+        payload_sha512:
+          type: string
+          example: fb6135ef73f4fe77367f9384b3bbbb158f4b8603c9d612157108e5c271868fce2242ee4abd7a29397ba63780c3ccab13783dfd4d9f0167beda03cdb0e37b87f4
+        signer_public_key:
+          type: string
+          example: 038bba5708acc262464c9fe30d3de9e905a9a5fa30cedd151dd9cd09ea26d46d00
+    Transaction:
+      properties:
+        header:
+          $ref: "#/components/schemas/TransactionHeader"
+        header_signature:
           type: string
           example: 540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a
-  Batch:
-    properties:
-      header:
-        $ref: "#/definitions/BatchHeader"
-      header_signature:
-        type: string
-        example:  89807bfc9089e37e00d87d97357de14cfbc455cd608438d426a625a30a0da9a31c406983803c4aa27e1f32a3ff61709e8ec4b56abbc553d7d330635b5d27029c
-      transactions:
-        type: array
-        items:
-          $ref: "#/definitions/Transaction"
-  BatchList:
-    properties:
-      batches:
-        type: array
-        items:
-          $ref: "#/definitions/Batch"
-  Schema:
-    properties:
-      name:
-        type: string
-        example: "Lightbulb"
-      description:
-        type: string
-        example: "Example Lightbulb schema"
-      owener:
-        type: string
-        example: "philips001"
-      properties:
-        type: array
-        items:
-          $ref: "#/definitions/PropertyDefinition"
-
-  PropertyDefinition:
-    properties:
-      name:
-        type: string
-        example: "size"
-      data_type:
-        $ref: '#/definitions/DataTypeEnum'
-      description:
-        type: string
-        example: "Lightbulb radius, in millimeters"
-      required:
-        type: boolean
-        example: true
-      number_exponent:
-        type: integer
-        format: int32
-        example: -6
-      enum_options:
-        type: array
-        items:
+        payload:
           type: string
-        example: ["filament", "CF", "LED"]
-      struct_properties:
-        type: array
-        items:
-          $ref: "#/definitions/PropertyDefinition"
-
-  DataTypeEnum:
+          format: binary
+    BatchHeader:
+      properties:
+        signer_public_key:
+          type: string
+          example: 038bba5708acc262464c9fe30d3de9e905a9a5fa30cedd151dd9cd09ea26d46d00
+        transaction_ids:
+          type: array
+          items:
+            type: string
+            example: 540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a
+    Batch:
+      properties:
+        header:
+          $ref: "#/components/schemas/BatchHeader"
+        header_signature:
+          type: string
+          example: 89807bfc9089e37e00d87d97357de14cfbc455cd608438d426a625a30a0da9a31c406983803c4aa27e1f32a3ff61709e8ec4b56abbc553d7d330635b5d27029c
+        transactions:
+          type: array
+          items:
+            $ref: "#/components/schemas/Transaction"
+    BatchList:
+      properties:
+        batches:
+          type: array
+          items:
+            $ref: "#/components/schemas/Batch"
+    Schema:
+      properties:
+        name:
+          type: string
+          example: Lightbulb
+        description:
+          type: string
+          example: Example Lightbulb schema
+        owner:
+          type: string
+          example: philips001
+        properties:
+          type: array
+          items:
+            $ref: "#/components/schemas/PropertyDefinition"
+    PropertyDefinition:
+      properties:
+        name:
+          type: string
+          example: size
+        data_type:
+          $ref: "#/components/schemas/DataTypeEnum"
+        description:
+          type: string
+          example: Lightbulb radius, in millimeters
+        required:
+          type: boolean
+          example: true
+        number_exponent:
+          type: integer
+          format: int32
+          example: -6
+        enum_options:
+          type: array
+          items:
+            type: string
+          example:
+            - filament
+            - CF
+            - LED
+        struct_properties:
+          type: array
+          items:
+            $ref: "#/components/schemas/PropertyDefinition"
+    DataTypeEnum:
       description: Data type of a PropertyDefinition
       type: string
       enum:
@@ -524,51 +546,48 @@ definitions:
         - ENUM
         - STRUCT
         - LOCATION
-
-  Agent:
-    properties:
-      public_key:
-        type: string
-        example: 038bba5708acc262464c9fe30d3de9e905a9a5fa30cedd151dd9cd09ea26d46d00
-      org_id:
-        type: string
-        example: 03c360a46457a284793153e09840c322bee1dcc34445d7d49e19e60abd18fd0758
-      active:
-        type: boolean
-        example: "true"
-      roles:
-        type: array
-        items:
+    Agent:
+      properties:
+        public_key:
           type: string
-          example: "admin"
-      metadata:
-        type: array
-        items:
-          $ref: '#/definitions/Metadata'
-
-  Organization:
-    type: object
-    properties:
-      id:
-        type: string
-        example: "philips001"
-      name:
-        type: string
-        example: "Philips"
-      address:
-        type: string
-        example: "Amstelplein 2 1096 BC Amsterdam The Netherlands"
-      metadata:
-        type: array
-        items:
-          $ref: '#/definitions/Metadata'
-
-  Metadata:
-    type: object
-    properties:
-      key:
-        type: string
-        example: "industry"
-      value:
-        type: string
-        example: "eletronics"
+          example: 038bba5708acc262464c9fe30d3de9e905a9a5fa30cedd151dd9cd09ea26d46d00
+        org_id:
+          type: string
+          example: 03c360a46457a284793153e09840c322bee1dcc34445d7d49e19e60abd18fd0758
+        active:
+          type: boolean
+          example: "true"
+        roles:
+          type: array
+          items:
+            type: string
+            example: admin
+        metadata:
+          type: array
+          items:
+            $ref: "#/components/schemas/Metadata"
+    Organization:
+      type: object
+      properties:
+        id:
+          type: string
+          example: philips001
+        name:
+          type: string
+          example: Philips
+        address:
+          type: string
+          example: Amstelplein 2 1096 BC Amsterdam The Netherlands
+        metadata:
+          type: array
+          items:
+            $ref: "#/components/schemas/Metadata"
+    Metadata:
+      type: object
+      properties:
+        key:
+          type: string
+          example: industry
+        value:
+          type: string
+          example: eletronics

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -327,6 +327,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  "/record/{record_id}":
+    get:
+      tags:
+        - Track and Trace
+      summary: Fetch a particular record
+      description: Fetches a single record with the given record ID.
+      operationId: fetch_record
+      parameters:
+        - name: record_id
+          in: path
+          description: ID of the record to return
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Record"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "404":
+          $ref: "#/components/responses/404NotFound"
+        "500":
+          $ref: "#/components/responses/500ServerError"
+        "503":
+          $ref: "#/components/responses/503ServiceUnavailable"
 components:
   parameters:
     batch_id:
@@ -591,3 +622,132 @@ components:
         value:
           type: string
           example: eletronics
+    AssociatedAgent:
+      type: object
+      properties:
+        agent_id:
+          type: string
+          example: 02fb5b3a093e20e420ecf9c5839215e74c97f49eb51889069eb87bc6f62ceca8dd
+        timestamp:
+          type: integer
+          example: 1557949075
+    LatLong:
+      type: object
+      properties:
+        latitude:
+          type: integer
+          example: 46786299
+        longitude:
+          type: integer
+          example: -92051336
+    Record:
+      type: object
+      properties:
+        record_id:
+          type: string
+          example: 7h15-45537-15-br173
+        owner:
+          type: string
+          example: 02cd3181dbd7d1539f470436ce222c53ab5e514f67809dc0095895e6cdfba97612
+        custodian:
+          type: string
+          example: 02fb5b3a093e20e420ecf9c5839215e74c97f49eb51889069eb87bc6f62ceca8dd
+        properties:
+          type: array
+          items:
+            $ref: "#/components/schemas/Property"
+        proposals:
+          type: array
+          items:
+            $ref: "#/components/schemas/Proposal"
+        owner_updates:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssociatedAgent"
+        custodian_updates:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssociatedAgent"
+        final:
+          type: boolean
+    ReportedValue:
+      type: object
+      properties:
+        timestamp:
+          type: integer
+          example: 1557949075
+        value:
+          oneOf:
+            - type: string
+            - type: boolean
+            - type: number
+            - type: object
+            - $ref: '#/components/schemas/LatLong'
+          example: -35014970
+        reporter:
+          type: object
+          properties:
+            name:
+              type: string
+              example: Nobuo
+            public_key:
+              type: string
+              example: 02cd3181dbd7d1539f470436ce222c53ab5e514f67809dc0095895e6cdfba97612
+    Property:
+      type: object
+      properties:
+        name:
+          type: string
+          example: location
+        record_id:
+          type: string
+          example: 7h15-45537-15-br173
+        data_type:
+          $ref: "#/components/schemas/DataTypeEnum"
+        authorized_reporters:
+          type: array
+          items:
+            type: string
+            example:
+              - 02cd3181dbd7d1539f470436ce222c53ab5e514f67809dc0095895e6cdfba97612
+              - 0364edd42bd9b2dea1315e2da820b569665f96e36c44b267ceeac488cfdc03bf61
+        value:
+          $ref: "#/components/schemas/ReportedValue"
+        updates:
+          type: array
+          items:
+            $ref: "#/components/schemas/ReportedValue"
+    ProposalRoleEnum:
+      type: string
+      enum:
+        - OWNER
+        - CUSTODIAN
+        - REPORTER
+    ProposalStatusEnum:
+      description: Status of a proposal
+      type: string
+      enum:
+        - OPEN
+        - ACCEPTED
+        - REJECTED
+        - CANCELED
+    Proposal:
+      type: object
+      properties:
+        receiving_agent:
+          type: string
+          example: 02cd3181dbd7d1539f470436ce222c53ab5e514f67809dc0095895e6cdfba97612
+        issuing_agent:
+          type: string
+          example: 02cd3181dbd7d1539f470436ce222c53ab5e514f67809dc0095895e6cdfba97612
+        role:
+          $ref: "#/components/schemas/ProposalRoleEnum"
+        properties:
+          type: array
+          items:
+            type: string
+        status:
+          $ref: "#/components/schemas/ProposalStatusEnum"
+        timestamp:
+          type: integer
+          example: 1557949075

--- a/daemon/src/database/helpers/track_and_trace.rs
+++ b/daemon/src/database/helpers/track_and_trace.rs
@@ -36,6 +36,7 @@ pub fn insert_associated_agents(
         update_associated_agent_end_block_num(
             conn,
             &agent.record_id,
+            &agent.role,
             &agent.agent_id,
             agent.start_block_num,
         )?;
@@ -50,6 +51,7 @@ pub fn insert_associated_agents(
 pub fn update_associated_agent_end_block_num(
     conn: &PgConnection,
     record_id: &str,
+    role: &str,
     agent_id: &str,
     current_block_num: i64,
 ) -> QueryResult<()> {
@@ -57,6 +59,7 @@ pub fn update_associated_agent_end_block_num(
         .filter(
             associated_agent::record_id
                 .eq(record_id)
+                .and(associated_agent::role.eq(role))
                 .and(associated_agent::agent_id.eq(agent_id))
                 .and(associated_agent::end_block_num.eq(MAX_BLOCK_NUM)),
         )

--- a/daemon/src/database/models.rs
+++ b/daemon/src/database/models.rs
@@ -208,6 +208,7 @@ impl FromSql<LatLong, Pg> for LatLongValue {
 #[table_name = "associated_agent"]
 pub struct NewAssociatedAgent {
     pub record_id: String,
+    pub role: String,
     pub start_block_num: i64,
     pub end_block_num: i64,
     pub agent_id: String,
@@ -219,6 +220,7 @@ pub struct NewAssociatedAgent {
 pub struct AssociatedAgent {
     pub id: i64,
     pub record_id: String,
+    pub role: String,
     pub start_block_num: i64,
     pub end_block_num: i64,
     pub agent_id: String,

--- a/daemon/src/database/models.rs
+++ b/daemon/src/database/models.rs
@@ -267,7 +267,6 @@ pub struct NewProposal {
     pub terms: String,
 }
 
-#[allow(dead_code)]
 #[derive(Queryable, Debug)]
 pub struct Proposal {
     pub id: i64,

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -25,7 +25,7 @@ table! {
         public_key -> Varchar,
         org_id -> Varchar,
         active -> Bool,
-        roles -> Array<Varchar>,
+        roles -> Array<Text>,
         metadata -> Array<Json>,
     }
 }

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -34,6 +34,7 @@ table! {
     associated_agent (id) {
         id -> Int8,
         record_id -> Text,
+        role -> Text,
         start_block_num -> Int8,
         end_block_num -> Int8,
         agent_id -> Text,

--- a/daemon/src/rest_api/error.rs
+++ b/daemon/src/rest_api/error.rs
@@ -86,7 +86,7 @@ impl fmt::Display for RestApiResponseError {
                 write!(f, "Sawtooth Validator Response Error: {}", s)
             }
             RestApiResponseError::RequestHandlerError(ref s) => {
-                write!(f, "Sawtooth Validator Response Error: {}", s)
+                write!(f, "Request Handler Error Error: {}", s)
             }
             RestApiResponseError::NotFoundError(ref s) => write!(f, "Not Found Error: {}", s),
             RestApiResponseError::DatabaseError(ref s) => write!(f, "Database Error: {}", s),

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -21,8 +21,8 @@ use std::thread;
 use crate::database::ConnectionPool;
 pub use crate::rest_api::error::RestApiServerError;
 use crate::rest_api::routes::{
-    fetch_agent, fetch_grid_schema, fetch_organization, get_batch_statuses, list_agents,
-    list_grid_schemas, list_organizations, submit_batches,
+    fetch_agent, fetch_grid_schema, fetch_organization, fetch_record, get_batch_statuses,
+    list_agents, list_grid_schemas, list_organizations, submit_batches,
 };
 use crate::rest_api::routes::{DbExecutor, SawtoothMessageSender};
 use actix::{Actor, Addr, Context, SyncArbiter};
@@ -74,6 +74,9 @@ fn create_app(
     })
     .resource("/schema/{name}", |r| {
         r.method(Method::GET).with_async(fetch_grid_schema)
+    })
+    .resource("/record/{record_id}", |r| {
+        r.method(Method::GET).with_async(fetch_record)
     })
 }
 

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -490,7 +490,7 @@ mod test {
         assert!(body.is_empty());
 
         // Adds a single Agent to the test database
-        populate_agent_table(&test_pool.get().unwrap());
+        populate_agent_table(&test_pool.get().unwrap(), &get_agent());
 
         // Making another request to the database
         let request = srv.client(http::Method::GET, "/agent").finish().unwrap();
@@ -677,7 +677,7 @@ mod test {
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
 
         //Adds an agent to the test database
-        populate_agent_table(&test_pool.get().unwrap());
+        populate_agent_table(&test_pool.get().unwrap(), &get_agent());
 
         let request = srv
             .client(http::Method::GET, &format!("/agent/{}", KEY1))
@@ -849,8 +849,9 @@ mod test {
             .expect("Failed to write batch statuses to bytes")
     }
 
-    fn populate_agent_table(conn: &PgConnection) {
-        let agent = NewAgent {
+
+    fn get_agent() -> Vec<NewAgent> {
+        vec![NewAgent {
             public_key: KEY1.to_string(),
             org_id: KEY2.to_string(),
             active: true,
@@ -858,9 +859,12 @@ mod test {
             metadata: vec![],
             start_block_num: 0,
             end_block_num: MAX_BLOCK_NUM,
-        };
+        }]
+    }
+
+    fn populate_agent_table(conn: &PgConnection, agents: &[NewAgent]) {
         clear_agents_table(conn);
-        database::helpers::insert_agents(conn, &[agent]).unwrap();
+        database::helpers::insert_agents(conn, agents).unwrap();
     }
 
     fn clear_agents_table(conn: &PgConnection) {

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -15,11 +15,13 @@
 mod agents;
 mod batches;
 mod organizations;
+mod records;
 mod schemas;
 
 pub use agents::*;
 pub use batches::*;
 pub use organizations::*;
+pub use records::*;
 pub use schemas::*;
 
 use crate::database::ConnectionPool;
@@ -61,8 +63,11 @@ mod test {
     use crate::database;
     use crate::database::{
         helpers::MAX_BLOCK_NUM,
-        models::{NewAgent, NewGridPropertyDefinition, NewGridSchema, NewOrganization},
-        schema::{grid_property_definition, grid_schema},
+        models::{
+            NewAgent, NewAssociatedAgent, NewGridPropertyDefinition, NewGridSchema,
+            NewOrganization, NewProposal, NewRecord,
+        },
+        schema::{associated_agent, grid_property_definition, grid_schema, proposal, record},
     };
     use crate::rest_api::{
         routes::{AgentSlice, BatchStatusResponse, OrganizationSlice},
@@ -222,6 +227,9 @@ mod test {
             })
             .resource("/schema/{name}", |r| {
                 r.method(Method::GET).with_async(fetch_grid_schema)
+            })
+            .resource("/record/{record_id}", |r| {
+                r.method(Method::GET).with_async(fetch_record)
             });
         })
     }
@@ -786,6 +794,117 @@ mod test {
         assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
     }
 
+    ///
+    /// Verifies a GET /record/{record_id} responds with an OK response
+    ///     and the Record with the specified record ID.
+    ///
+    #[test]
+    fn test_fetch_record_ok() {
+        database::run_migrations(&DATABASE_URL).unwrap();
+        let test_pool = get_connection_pool();
+        let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
+        populate_agent_table(&test_pool.get().unwrap(), &get_agents_with_roles());
+        populate_associated_agent_table(&test_pool.get().unwrap(), &get_associated_agents());
+        populate_proposal_table(&test_pool.get().unwrap(), &get_proposal());
+        populate_record_table(&test_pool.get().unwrap(), &get_record());
+        let request = srv
+            .client(
+                http::Method::GET,
+                &format!("/record/{}", "Test Record".to_string()),
+            )
+            .finish()
+            .unwrap();
+        let response = srv.execute(request.send()).unwrap();
+        assert!(response.status().is_success());
+        let test_record: RecordSlice =
+            serde_json::from_slice(&*response.body().wait().unwrap()).unwrap();
+        assert_eq!(test_record.record_id, "Test Record".to_string());
+        assert_eq!(test_record.owner, KEY1.to_string());
+        assert_eq!(test_record.custodian, KEY2.to_string());
+        assert_eq!(test_record.r#final, false);
+
+        assert_eq!(test_record.owner_updates[0].agent_id, KEY1.to_string());
+        assert_eq!(test_record.owner_updates[0].timestamp, 1);
+
+        assert_eq!(test_record.custodian_updates[0].agent_id, KEY2.to_string());
+        assert_eq!(test_record.custodian_updates[0].timestamp, 1);
+
+        assert_eq!(test_record.proposals[0].timestamp, 1);
+        assert_eq!(test_record.proposals[0].role, "OWNER");
+        assert_eq!(
+            test_record.proposals[0].properties,
+            vec!["location".to_string()]
+        );
+        assert_eq!(test_record.proposals[0].status, "OPEN");
+        assert_eq!(test_record.proposals[0].terms, "Proposal Terms".to_string());
+    }
+
+    ///
+    /// Verifies a GET /record/{record_id} responds with an OK response
+    ///     and the Record with the specified record ID after the Record's
+    ///     owners, custodians, and proposals have been updated.
+    ///
+    #[test]
+    fn test_fetch_record_updated_ok() {
+        database::run_migrations(&DATABASE_URL).unwrap();
+        let test_pool = get_connection_pool();
+        let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
+        populate_record_table(&test_pool.get().unwrap(), &get_record_updated());
+        populate_associated_agent_table(
+            &test_pool.get().unwrap(),
+            &get_associated_agents_updated(),
+        );
+        populate_proposal_table(&test_pool.get().unwrap(), &get_proposal_updated());
+        let request = srv
+            .client(
+                http::Method::GET,
+                &format!("/record/{}", "Test Record".to_string()),
+            )
+            .finish()
+            .unwrap();
+        let response = srv.execute(request.send()).unwrap();
+        assert!(response.status().is_success());
+        let test_record: RecordSlice =
+            serde_json::from_slice(&*response.body().wait().unwrap()).unwrap();
+
+        assert_eq!(test_record.record_id, "Test Record".to_string());
+        assert_eq!(test_record.owner, KEY2.to_string());
+        assert_eq!(test_record.custodian, KEY1.to_string());
+        assert_eq!(test_record.r#final, false);
+
+        assert_eq!(test_record.owner_updates[0].agent_id, KEY1.to_string());
+        assert_eq!(test_record.owner_updates[0].timestamp, 1);
+
+        assert_eq!(test_record.custodian_updates[0].agent_id, KEY2.to_string());
+        assert_eq!(test_record.custodian_updates[0].timestamp, 1);
+
+        assert_eq!(test_record.owner_updates[1].agent_id, KEY2.to_string());
+        assert_eq!(test_record.owner_updates[1].timestamp, 2);
+
+        assert_eq!(test_record.custodian_updates[1].agent_id, KEY1.to_string());
+        assert_eq!(test_record.custodian_updates[1].timestamp, 2);
+
+        assert_eq!(test_record.proposals[0].status, "CANCELED");
+    }
+
+    ///
+    /// Verifies a GET /record/{record_id} responds with a Not Found error
+    ///     when there is no Record with the specified record_id.
+    ///
+    #[test]
+    fn test_fetch_record_not_found() {
+        database::run_migrations(&DATABASE_URL).unwrap();
+        let test_pool = get_connection_pool();
+        let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
+        clear_record_table(&test_pool.get().unwrap());
+        let request = srv
+            .client(http::Method::GET, "/record/not_in_database")
+            .finish()
+            .unwrap();
+        let response = srv.execute(request.send()).unwrap();
+        assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    }
+
     fn get_batch_statuses_response_one_id() -> Vec<u8> {
         let mut batch_status_response = ClientBatchStatusResponse::new();
         batch_status_response.set_status(ClientBatchStatusResponse_Status::OK);
@@ -849,7 +968,6 @@ mod test {
             .expect("Failed to write batch statuses to bytes")
     }
 
-
     fn get_agent() -> Vec<NewAgent> {
         vec![NewAgent {
             public_key: KEY1.to_string(),
@@ -860,6 +978,29 @@ mod test {
             start_block_num: 0,
             end_block_num: MAX_BLOCK_NUM,
         }]
+    }
+
+    fn get_agents_with_roles() -> Vec<NewAgent> {
+        vec![
+            NewAgent {
+                public_key: KEY1.to_string(),
+                org_id: KEY3.to_string(),
+                active: true,
+                roles: vec!["OWNER".to_string()],
+                metadata: vec![],
+                start_block_num: 0,
+                end_block_num: MAX_BLOCK_NUM,
+            },
+            NewAgent {
+                public_key: KEY2.to_string(),
+                org_id: KEY3.to_string(),
+                active: true,
+                roles: vec!["CUSTODIAN".to_string()],
+                metadata: vec![],
+                start_block_num: 0,
+                end_block_num: MAX_BLOCK_NUM,
+            },
+        ]
     }
 
     fn populate_agent_table(conn: &PgConnection, agents: &[NewAgent]) {
@@ -924,6 +1065,143 @@ mod test {
         }]
     }
 
+    fn get_associated_agents() -> Vec<NewAssociatedAgent> {
+        vec![
+            NewAssociatedAgent {
+                start_block_num: 0,
+                end_block_num: MAX_BLOCK_NUM,
+                agent_id: KEY1.to_string(),
+                timestamp: 1,
+                record_id: "Test Record".to_string(),
+                role: "OWNER".to_string(),
+            },
+            NewAssociatedAgent {
+                start_block_num: 0,
+                end_block_num: MAX_BLOCK_NUM,
+                agent_id: KEY2.to_string(),
+                timestamp: 1,
+                record_id: "Test Record".to_string(),
+                role: "CUSTODIAN".to_string(),
+            },
+        ]
+    }
+
+    fn get_associated_agents_updated() -> Vec<NewAssociatedAgent> {
+        vec![
+            NewAssociatedAgent {
+                start_block_num: 0,
+                end_block_num: MAX_BLOCK_NUM,
+                agent_id: KEY1.to_string(),
+                timestamp: 1,
+                record_id: "Test Record".to_string(),
+                role: "OWNER".to_string(),
+            },
+            NewAssociatedAgent {
+                start_block_num: 0,
+                end_block_num: MAX_BLOCK_NUM,
+                agent_id: KEY2.to_string(),
+                timestamp: 1,
+                record_id: "Test Record".to_string(),
+                role: "CUSTODIAN".to_string(),
+            },
+            NewAssociatedAgent {
+                start_block_num: 1,
+                end_block_num: MAX_BLOCK_NUM,
+                agent_id: KEY2.to_string(),
+                timestamp: 2,
+                record_id: "Test Record".to_string(),
+                role: "OWNER".to_string(),
+            },
+            NewAssociatedAgent {
+                start_block_num: 1,
+                end_block_num: MAX_BLOCK_NUM,
+                agent_id: KEY1.to_string(),
+                timestamp: 2,
+                record_id: "Test Record".to_string(),
+                role: "CUSTODIAN".to_string(),
+            },
+        ]
+    }
+
+    fn get_proposal() -> Vec<NewProposal> {
+        vec![NewProposal {
+            start_block_num: 0,
+            end_block_num: MAX_BLOCK_NUM,
+            record_id: "Test Record".to_string(),
+            timestamp: 1,
+            issuing_agent: KEY1.to_string(),
+            receiving_agent: KEY2.to_string(),
+            properties: vec!["location".to_string()],
+            role: "OWNER".to_string(),
+            status: "OPEN".to_string(),
+            terms: "Proposal Terms".to_string(),
+        }]
+    }
+
+    fn get_proposal_updated() -> Vec<NewProposal> {
+        vec![
+            NewProposal {
+                start_block_num: 0,
+                end_block_num: 1,
+                record_id: "Test Record".to_string(),
+                timestamp: 1,
+                issuing_agent: KEY1.to_string(),
+                receiving_agent: KEY2.to_string(),
+                properties: vec!["location".to_string()],
+                role: "OWNER".to_string(),
+                status: "OPEN".to_string(),
+                terms: "Proposal Terms".to_string(),
+            },
+            NewProposal {
+                start_block_num: 1,
+                end_block_num: MAX_BLOCK_NUM,
+                record_id: "Test Record".to_string(),
+                timestamp: 1,
+                issuing_agent: KEY1.to_string(),
+                receiving_agent: KEY2.to_string(),
+                properties: vec!["location".to_string()],
+                role: "OWNER".to_string(),
+                status: "CANCELED".to_string(),
+                terms: "Proposal Terms".to_string(),
+            },
+        ]
+    }
+
+    fn get_record() -> Vec<NewRecord> {
+        vec![NewRecord {
+            start_block_num: 0,
+            end_block_num: MAX_BLOCK_NUM,
+            record_id: "Test Record".to_string(),
+            schema: "Test Grid Schema".to_string(),
+            final_: false,
+            owners: vec![KEY1.to_string()],
+            custodians: vec![KEY2.to_string()],
+        }]
+    }
+
+    fn get_record_updated() -> Vec<NewRecord> {
+        vec![
+            NewRecord {
+                start_block_num: 0,
+                end_block_num: 1,
+                record_id: "Test Record".to_string(),
+                schema: "Test Grid Schema".to_string(),
+                final_: false,
+                owners: vec![KEY1.to_string()],
+                custodians: vec![KEY2.to_string()],
+            },
+            NewRecord {
+                start_block_num: 1,
+                end_block_num: MAX_BLOCK_NUM,
+                record_id: "Test Record".to_string(),
+                schema: "Test Grid Schema".to_string(),
+                final_: false,
+                owners: vec![KEY2.to_string(), KEY1.to_string()],
+                custodians: vec![KEY1.to_string(), KEY2.to_string()],
+            },
+        ]
+    }
+
     fn populate_grid_schema_table(conn: &PgConnection, schemas: &[NewGridSchema]) {
         clear_grid_schema_table(conn);
         populate_property_definition_table(conn, &get_property_definition());
@@ -985,5 +1263,50 @@ mod test {
         diesel::delete(grid_property_definition)
             .execute(conn)
             .unwrap();
+    }
+
+    fn populate_associated_agent_table(
+        conn: &PgConnection,
+        associated_agents: &[NewAssociatedAgent],
+    ) {
+        clear_associated_agent_table(conn);
+        insert_into(associated_agent::table)
+            .values(associated_agents)
+            .execute(conn)
+            .map(|_| ())
+            .unwrap();
+    }
+
+    fn clear_associated_agent_table(conn: &PgConnection) {
+        use crate::database::schema::associated_agent::dsl::*;
+        diesel::delete(associated_agent).execute(conn).unwrap();
+    }
+
+    fn populate_proposal_table(conn: &PgConnection, proposals: &[NewProposal]) {
+        clear_proposal_table(conn);
+        insert_into(proposal::table)
+            .values(proposals)
+            .execute(conn)
+            .map(|_| ())
+            .unwrap();
+    }
+
+    fn clear_proposal_table(conn: &PgConnection) {
+        use crate::database::schema::proposal::dsl::*;
+        diesel::delete(proposal).execute(conn).unwrap();
+    }
+
+    fn populate_record_table(conn: &PgConnection, records: &[NewRecord]) {
+        clear_record_table(conn);
+        insert_into(record::table)
+            .values(records)
+            .execute(conn)
+            .map(|_| ())
+            .unwrap();
+    }
+
+    fn clear_record_table(conn: &PgConnection) {
+        use crate::database::schema::record::dsl::*;
+        diesel::delete(record).execute(conn).unwrap();
     }
 }

--- a/daemon/src/rest_api/routes/records.rs
+++ b/daemon/src/rest_api/routes/records.rs
@@ -1,0 +1,161 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::database::{helpers as db, models::AssociatedAgent, models::Proposal, models::Record};
+use crate::rest_api::{error::RestApiResponseError, routes::DbExecutor, AppState};
+
+use actix::{Handler, Message, SyncContext};
+use actix_web::{HttpRequest, HttpResponse, Path};
+use futures::Future;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AssociatedAgentSlice {
+    pub agent_id: String,
+    pub timestamp: u64,
+}
+
+impl AssociatedAgentSlice {
+    pub fn from_model(associated_agent: &AssociatedAgent) -> Self {
+        Self {
+            agent_id: associated_agent.agent_id.clone(),
+            timestamp: associated_agent.timestamp as u64,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProposalSlice {
+    pub receiving_agent: String,
+    pub issuing_agent: String,
+    pub role: String,
+    pub properties: Vec<String>,
+    pub status: String,
+    pub terms: String,
+    pub timestamp: u64,
+}
+
+impl ProposalSlice {
+    pub fn from_model(proposal: &Proposal) -> Self {
+        Self {
+            receiving_agent: proposal.receiving_agent.clone(),
+            issuing_agent: proposal.issuing_agent.clone(),
+            role: proposal.role.clone(),
+            properties: proposal.properties.clone(),
+            status: proposal.status.clone(),
+            terms: proposal.terms.clone(),
+            timestamp: proposal.timestamp as u64,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RecordSlice {
+    pub record_id: String,
+    pub owner: String,
+    pub custodian: String,
+    pub r#final: bool,
+    pub proposals: Vec<ProposalSlice>,
+    pub owner_updates: Vec<AssociatedAgentSlice>,
+    pub custodian_updates: Vec<AssociatedAgentSlice>,
+}
+
+impl RecordSlice {
+    pub fn from_models(
+        record: &Record,
+        proposals: &[Proposal],
+        associated_agents: &[AssociatedAgent],
+    ) -> Self {
+        let mut owner_updates: Vec<AssociatedAgentSlice> = associated_agents
+            .iter()
+            .filter(|agent| agent.role.eq("OWNER"))
+            .map(AssociatedAgentSlice::from_model)
+            .collect();
+        let mut custodian_updates: Vec<AssociatedAgentSlice> = associated_agents
+            .iter()
+            .filter(|agent| agent.role.eq("CUSTODIAN"))
+            .map(AssociatedAgentSlice::from_model)
+            .collect();
+
+        owner_updates.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        custodian_updates.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+
+        Self {
+            record_id: record.record_id.clone(),
+            owner: match owner_updates.last() {
+                Some(owner) => owner.agent_id.clone(),
+                None => "".to_string(),
+            },
+            custodian: match custodian_updates.last() {
+                Some(custodian) => custodian.agent_id.clone(),
+                None => "".to_string(),
+            },
+            r#final: record.final_,
+            proposals: proposals.iter().map(ProposalSlice::from_model).collect(),
+            owner_updates,
+            custodian_updates,
+        }
+    }
+}
+
+struct FetchRecord {
+    record_id: String,
+}
+
+impl Message for FetchRecord {
+    type Result = Result<RecordSlice, RestApiResponseError>;
+}
+
+impl Handler<FetchRecord> for DbExecutor {
+    type Result = Result<RecordSlice, RestApiResponseError>;
+
+    fn handle(&mut self, msg: FetchRecord, _: &mut SyncContext<Self>) -> Self::Result {
+        let record = match db::fetch_record(&*self.connection_pool.get()?, &msg.record_id)? {
+            Some(record) => record,
+            None => {
+                return Err(RestApiResponseError::NotFoundError(format!(
+                    "Could not find record with id: {}",
+                    msg.record_id
+                )));
+            }
+        };
+
+        let proposals = db::list_proposals(&*self.connection_pool.get()?, &msg.record_id)?;
+
+        let associated_agents =
+            db::list_associated_agents(&*self.connection_pool.get()?, &msg.record_id)?;
+
+        Ok(RecordSlice::from_models(
+            &record,
+            &proposals,
+            &associated_agents,
+        ))
+    }
+}
+
+pub fn fetch_record(
+    req: HttpRequest<AppState>,
+    record_id: Path<String>,
+) -> impl Future<Item = HttpResponse, Error = RestApiResponseError> {
+    req.state()
+        .database_connection
+        .send(FetchRecord {
+            record_id: record_id.into_inner(),
+        })
+        .from_err()
+        .and_then(move |res| match res {
+            Ok(record) => Ok(HttpResponse::Ok().json(record)),
+            Err(err) => Err(err),
+        })
+}


### PR DESCRIPTION
This implements the `GET /record/{record_id}` endpoint. List endpoint will be a later PR. Does not include Properties as it will be the same query as for the `GET /record/{record_id}/property/{property_name}` endpoint, which is a different story.