### PR TITLE
Update ZMQ Dependencies

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 clap = "2"
 log = "0.4"
 simple_logger = "1.0"
-sawtooth-sdk = "0.2.0"
+sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
 grid-sdk = { path = "../sdk" }
 rust-crypto = "0.2"
 protobuf = "2"

--- a/contracts/schema/Cargo.toml
+++ b/contracts/schema/Cargo.toml
@@ -36,4 +36,3 @@ sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
 rustc-serialize = "0.3.22"
 log = "0.3.0"
 log4rs = "0.7.0"
-sawtooth-zmq = "0.8.2-dev5"

--- a/contracts/track_and_trace/Cargo.toml
+++ b/contracts/track_and_trace/Cargo.toml
@@ -37,4 +37,3 @@ sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
 rustc-serialize = "0.3.22"
 log = "0.3.0"
 log4rs = "0.7.0"
-sawtooth-zmq = "0.8.2-dev5"


### PR DESCRIPTION
Removes sawtooth-zmq dependency from schema and track_and_trace, and updates sawtooth sdk dependency in client.