### PR TITLE
Updates the Grid CLI to send Sabre transactions

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,7 @@ clap = "2"
 log = "0.4"
 simple_logger = "1.0"
 sawtooth-sdk = "0.3"
+sabre-sdk = "0.3"
 grid-sdk = { path = "../sdk" }
 rust-crypto = "0.2"
 protobuf = "2"

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -16,6 +16,7 @@ use grid_sdk::protos;
 use log;
 use protobuf;
 use reqwest;
+use sabre_sdk;
 use sawtooth_sdk::signing;
 use serde_yaml;
 use std;
@@ -33,6 +34,7 @@ pub enum CliError {
     ProtobufError(protobuf::ProtobufError),
     ReqwestError(reqwest::Error),
     GridProtoError(protos::ProtoConversionError),
+    SabreProtoError(sabre_sdk::protos::ProtoConversionError),
 }
 
 impl StdError for CliError {
@@ -47,6 +49,7 @@ impl StdError for CliError {
             CliError::SigningError(err) => Some(err),
             CliError::ReqwestError(err) => Some(err),
             CliError::GridProtoError(err) => Some(err),
+            CliError::SabreProtoError(err) => Some(err),
         }
     }
 }
@@ -65,6 +68,7 @@ impl std::fmt::Display for CliError {
             }
             CliError::ReqwestError(ref err) => write!(f, "Reqwest Error: {}", err),
             CliError::GridProtoError(ref err) => write!(f, "Grid Proto Error: {}", err),
+            CliError::SabreProtoError(ref err) => write!(f, "Sabre Proto Error: {}", err),
         }
     }
 }
@@ -107,5 +111,11 @@ impl From<reqwest::Error> for CliError {
 impl From<protos::ProtoConversionError> for CliError {
     fn from(err: protos::ProtoConversionError) -> Self {
         CliError::GridProtoError(err)
+    }
+}
+
+impl From<sabre_sdk::protos::ProtoConversionError> for CliError {
+    fn from(err: sabre_sdk::protos::ProtoConversionError) -> Self {
+        CliError::SabreProtoError(err)
     }
 }

--- a/cli/src/transaction.rs
+++ b/cli/src/transaction.rs
@@ -23,6 +23,8 @@ use crypto::sha2::Sha512;
 use protobuf;
 use protobuf::Message;
 
+use sabre_sdk::protocol::payload::{Action, ExecuteContractActionBuilder, SabrePayloadBuilder};
+use sabre_sdk::protos::IntoBytes;
 use sawtooth_sdk::messages::batch::Batch;
 use sawtooth_sdk::messages::batch::BatchHeader;
 use sawtooth_sdk::messages::batch::BatchList;
@@ -41,6 +43,12 @@ const PIKE_FAMILY_VERSION: &str = "0.1";
 pub const GRID_SCHEMA_NAMESPACE: &str = "621dee01";
 const GRID_SCHEMA_FAMILY_NAME: &str = "grid_schema";
 const GRID_SCHEMA_FAMILY_VERSION: &str = "1.0";
+
+const SABRE_FAMILY_NAME: &str = "sabre";
+const SABRE_FAMILY_VERSION: &str = "0.3";
+const SABRE_NAMESPACE_REGISTRY_PREFIX: &str = "00ec00";
+const SABRE_CONTRACT_REGISTRY_PREFIX: &str = "00ec01";
+const SABRE_CONTRACT_PREFIX: &str = "00ec02";
 
 pub fn schema_batch_builder(key: Option<String>) -> BatchBuilder {
     BatchBuilder::new(GRID_SCHEMA_FAMILY_NAME, GRID_SCHEMA_FAMILY_VERSION, key)
@@ -74,6 +82,61 @@ impl BatchBuilder {
         inputs: &[String],
         outputs: &[String],
     ) -> Result<Self, CliError> {
+        // create execute contract action for sabre payload
+        let execute_contract = ExecuteContractActionBuilder::new()
+            .with_name(self.family_name.to_string())
+            .with_version(self.family_version.to_string())
+            .with_inputs(inputs.to_vec())
+            .with_outputs(outputs.to_vec())
+            .with_payload(payload.write_to_bytes()?)
+            .build()
+            .map_err(|err| CliError::UserError(format!("{}", err)))?;
+
+        let sabre_payload = SabrePayloadBuilder::new()
+            .with_action(Action::ExecuteContract(execute_contract))
+            .build()
+            .map_err(|err| CliError::UserError(format!("{}", err)))?;
+
+        let mut input_addresses = vec![
+            compute_contract_registry_address(&self.family_name),
+            compute_contract_address(&self.family_name, &self.family_version),
+        ];
+
+        for input in inputs {
+            let namespace = match input.get(..6) {
+                Some(namespace) => namespace,
+                None => {
+                    return Err(CliError::UserError(format!(
+                        "Input must be at least 6 characters long: {}",
+                        input
+                    )));
+                }
+            };
+
+            input_addresses.push(compute_namespace_registry_address(namespace)?);
+        }
+        input_addresses.append(&mut inputs.to_vec());
+
+        let mut output_addresses = vec![
+            compute_contract_registry_address(&self.family_name),
+            compute_contract_address(&self.family_name, &self.family_version),
+        ];
+
+        for output in outputs {
+            let namespace = match output.get(..6) {
+                Some(namespace) => namespace,
+                None => {
+                    return Err(CliError::UserError(format!(
+                        "Output must be at least 6 characters long: {}",
+                        output
+                    )));
+                }
+            };
+
+            output_addresses.push(compute_namespace_registry_address(namespace)?);
+        }
+        output_addresses.append(&mut outputs.to_vec());
+
         let private_key = key::load_signing_key(self.key_name.clone())?;
         let context = signing::create_context("secp256k1")?;
         let public_key = context.get_public_key(&private_key)?.as_hex();
@@ -83,22 +146,22 @@ impl BatchBuilder {
         let mut txn = Transaction::new();
         let mut txn_header = TransactionHeader::new();
 
-        txn_header.set_family_name(self.family_name.clone());
-        txn_header.set_family_version(self.family_version.clone());
+        txn_header.set_family_name(SABRE_FAMILY_NAME.into());
+        txn_header.set_family_version(SABRE_FAMILY_VERSION.into());
         txn_header.set_nonce(create_nonce());
         txn_header.set_signer_public_key(public_key.clone());
         txn_header.set_batcher_public_key(public_key.clone());
 
-        txn_header.set_inputs(protobuf::RepeatedField::from_vec(inputs.to_vec()));
-        txn_header.set_outputs(protobuf::RepeatedField::from_vec(outputs.to_vec()));
+        txn_header.set_inputs(protobuf::RepeatedField::from_vec(input_addresses));
+        txn_header.set_outputs(protobuf::RepeatedField::from_vec(output_addresses));
 
-        let payload_bytes = payload.write_to_bytes()?;
+        let payload_bytes = sabre_payload.into_bytes()?;
         let mut sha = Sha512::new();
         sha.input(&payload_bytes);
         let hash: &mut [u8] = &mut [0; 64];
         sha.result(hash);
         txn_header.set_payload_sha512(bytes_to_hex_str(hash));
-        txn.set_payload(payload_bytes);
+        txn.set_payload(payload_bytes.to_vec());
 
         let txn_header_bytes = txn_header.write_to_bytes()?;
         txn.set_header(txn_header_bytes.clone());
@@ -149,4 +212,62 @@ fn bytes_to_hex_str(b: &[u8]) -> String {
         .map(|b| format!("{:02x}", b))
         .collect::<Vec<_>>()
         .join("")
+}
+
+/// Returns a state address for a given sabre contract registry
+///
+/// # Arguments
+///
+/// * `name` - the name of the contract registry
+fn compute_contract_registry_address(name: &str) -> String {
+    let hash: &mut [u8] = &mut [0; 64];
+
+    let mut sha = Sha512::new();
+    sha.input(name.as_bytes());
+    sha.result(hash);
+
+    String::from(SABRE_CONTRACT_REGISTRY_PREFIX) + &bytes_to_hex_str(hash)[..64]
+}
+
+/// Returns a state address for a given sabre contract
+///
+/// # Arguments
+///
+/// * `name` - the name of the contract
+/// * `version` - the version of the contract
+fn compute_contract_address(name: &str, version: &str) -> String {
+    let hash: &mut [u8] = &mut [0; 64];
+
+    let s = String::from(name) + "," + version;
+
+    let mut sha = Sha512::new();
+    sha.input(s.as_bytes());
+    sha.result(hash);
+
+    String::from(SABRE_CONTRACT_PREFIX) + &bytes_to_hex_str(hash)[..64]
+}
+
+/// Returns a state address for a given namespace registry
+///
+/// # Arguments
+///
+/// * `namespace` - the address prefix for this namespace
+fn compute_namespace_registry_address(namespace: &str) -> Result<String, CliError> {
+    let prefix = match namespace.get(..6) {
+        Some(x) => x,
+        None => {
+            return Err(CliError::UserError(format!(
+                "Namespace must be at least 6 characters long: {}",
+                namespace
+            )));
+        }
+    };
+
+    let hash: &mut [u8] = &mut [0; 64];
+
+    let mut sha = Sha512::new();
+    sha.input(prefix.as_bytes());
+    sha.result(hash);
+
+    Ok(String::from(SABRE_NAMESPACE_REGISTRY_PREFIX) + &bytes_to_hex_str(hash)[..64])
 }

--- a/contracts/pike/Cargo.toml
+++ b/contracts/pike/Cargo.toml
@@ -25,7 +25,7 @@ grid-sdk = {path = "../../sdk"}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
-sabre-sdk = "0.2"
+sabre-sdk = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 sawtooth-sdk = "0.3"

--- a/contracts/pike/Dockerfile
+++ b/contracts/pike/Dockerfile
@@ -15,27 +15,38 @@
 FROM ubuntu:bionic as grid-pike-builder
 
 RUN apt-get update \
+&& apt-get install gnupg -y
+
+RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
  && apt-get install -y -q \
  curl \
  gcc \
  libssl-dev \
  libzmq3-dev \
  pkg-config \
+ sabre-cli \
  unzip \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=$PATH:/protoc3/bin:/root/.cargo/bin
 
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
  && chmod +x /usr/bin/rustup-init \
  && rustup-init -y
 
-# Install protoc
-RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip \
-    && unzip -o protoc-3.7.1-linux-x86_64.zip -d /usr/local \
-    && rm protoc-3.7.1-linux-x86_64.zip
+RUN rustup update \
+ && rustup default nightly \
+ && rustup target add wasm32-unknown-unknown --toolchain nightly
 
-ENV PATH=$PATH:/root/.cargo/bin
+# For Building Protobufs
+RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
+ && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \
+ && rm protoc-3.5.1-linux-x86_64.zip
 
 COPY ./sdk /sdk
 
@@ -53,16 +64,8 @@ RUN rm src/*.rs
 COPY ./contracts/pike/src ./src
 
 RUN rm ./target/release/grid-pike-tp* ./target/release/deps/grid_pike*
-RUN cargo build --release
+RUN cargo build --target wasm32-unknown-unknown --release
 
-# Create the stand-alone stage
-FROM ubuntu:bionic
+COPY ./contracts/pike/pike.yaml ./pike.yaml
 
-RUN apt-get update \
- && apt-get install -y libssl1.1 libzmq5 \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-COPY --from=grid-pike-builder /contracts/pike/target/release/grid-pike-tp /
-
-CMD ["/grid-pike-tp"]
+ENTRYPOINT []

--- a/contracts/pike/pike.yaml
+++ b/contracts/pike/pike.yaml
@@ -14,7 +14,7 @@
 
 name: pike
 version: '1.0'
-wasm: tp/target/wasm32-unknown-unknown/release/pike.wasm
+wasm: target/wasm32-unknown-unknown/release/grid-pike-tp.wasm
 inputs:
   - 'cad11d'
 outputs:

--- a/contracts/pike/pike.yaml
+++ b/contracts/pike/pike.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: pike
-version: '1.0'
+version: '0.1'
 wasm: target/wasm32-unknown-unknown/release/grid-pike-tp.wasm
 inputs:
   - 'cad11d'

--- a/contracts/schema/Cargo.toml
+++ b/contracts/schema/Cargo.toml
@@ -28,7 +28,7 @@ hex = "0.3.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
-sabre-sdk = "0.2"
+sabre-sdk = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rust-crypto = "0.2.36"

--- a/contracts/schema/Dockerfile
+++ b/contracts/schema/Dockerfile
@@ -14,8 +14,14 @@
 
 FROM ubuntu:bionic as GRID-SCHEMA-BUILDER
 
-# Install base dependencies
 RUN apt-get update \
+&& apt-get install gnupg -y
+
+# Install base dependencies
+RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
     && apt-get install -y -q \
         build-essential \
         curl \
@@ -27,21 +33,26 @@ RUN apt-get update \
         libzmq3-dev \
         openssl \
         pkg-config \
+        sabre-cli \
         unzip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=$PATH:/protoc3/bin:/root/.cargo/bin
 
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
  && chmod +x /usr/bin/rustup-init \
  && rustup-init -y
 
-# Install protoc
-RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip \
-    && unzip -o protoc-3.7.1-linux-x86_64.zip -d /usr/local \
-    && rm protoc-3.7.1-linux-x86_64.zip
+RUN rustup update \
+ && rustup default nightly \
+ && rustup target add wasm32-unknown-unknown --toolchain nightly
 
-ENV PATH=$PATH:/root/.cargo/bin
+# For Building Protobufs
+RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
+    && unzip -o protoc-3.5.1-linux-x86_64.zip -d /usr/local \
+    && rm protoc-3.5.1-linux-x86_64.zip
 
 COPY ./sdk /sdk
 
@@ -59,16 +70,8 @@ RUN rm src/*.rs
 COPY ./contracts/schema/src ./src
 
 RUN rm ./target/release/grid-schema-tp* ./target/release/deps/grid_schema*
-RUN cargo build --release
+RUN cargo build --target wasm32-unknown-unknown --release
 
-# Create the stand-alone stage
-FROM ubuntu:bionic
+COPY ./contracts/schema/schema.yaml ./schema.yaml
 
-RUN apt-get update \
- && apt-get install -y libssl1.1 libzmq5 \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-COPY --from=GRID-SCHEMA-BUILDER /contracts/schema/target/release/grid-schema-tp /
-
-CMD ["/grid-schema-tp"]
+ENTRYPOINT []

--- a/contracts/schema/schema.yaml
+++ b/contracts/schema/schema.yaml
@@ -1,0 +1,22 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: grid_schema
+version: '1.0'
+wasm: target/wasm32-unknown-unknown/release/grid-schema-tp.wasm
+inputs:
+  - '621dee01'
+  - 'cad11d'
+outputs:
+  - '621dee01'

--- a/contracts/track_and_trace/Cargo.toml
+++ b/contracts/track_and_trace/Cargo.toml
@@ -29,7 +29,7 @@ protobuf = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
-sabre-sdk = "0.2"
+sabre-sdk = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rust-crypto = "0.2.36"

--- a/contracts/track_and_trace/Dockerfile
+++ b/contracts/track_and_trace/Dockerfile
@@ -14,8 +14,14 @@
 
 FROM ubuntu:bionic as GRID-TNT-BUILDER
 
-# Install base dependencies
 RUN apt-get update \
+&& apt-get install gnupg -y
+
+# Install base dependencies
+RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
     && apt-get install -y -q \
         build-essential \
         curl \
@@ -27,21 +33,26 @@ RUN apt-get update \
         libzmq3-dev \
         openssl \
         pkg-config \
+        sabre-cli \
         unzip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=$PATH:/protoc3/bin:/root/.cargo/bin
 
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
  && chmod +x /usr/bin/rustup-init \
  && rustup-init -y
 
-# Install protoc
-RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip \
-    && unzip -o protoc-3.7.1-linux-x86_64.zip -d /usr/local \
-    && rm protoc-3.7.1-linux-x86_64.zip
+RUN rustup update \
+ && rustup default nightly \
+ && rustup target add wasm32-unknown-unknown --toolchain nightly
 
-ENV PATH=$PATH:/root/.cargo/bin
+# For Building Protobufs
+RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
+    && unzip -o protoc-3.5.1-linux-x86_64.zip -d /usr/local \
+    && rm protoc-3.5.1-linux-x86_64.zip
 
 COPY ./sdk /sdk
 
@@ -59,16 +70,8 @@ RUN rm src/*.rs
 COPY ./contracts/track_and_trace/src ./src
 
 RUN rm ./target/release/grid-track-and-trace-tp* ./target/release/deps/grid_track_and_trace*
-RUN cargo build --release
+RUN cargo build --target wasm32-unknown-unknown --release
 
-# Create the stand-alone stage
-FROM ubuntu:bionic
+COPY ./contracts/track_and_trace/track_and_trace.yaml ./track_and_trace.yaml
 
-RUN apt-get update \
- && apt-get install -y libssl1.1 libzmq5 \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-COPY --from=GRID-TNT-BUILDER /contracts/track_and_trace/target/release/grid-track-and-trace-tp /
-
-CMD ["/grid-track-and-trace-tp"]
+ENTRYPOINT []

--- a/contracts/track_and_trace/track_and_trace.yaml
+++ b/contracts/track_and_trace/track_and_trace.yaml
@@ -1,0 +1,21 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: grid_track_and_trace
+version: '1.0'
+wasm: target/wasm32-unknown-unknown/release/grid-track-and-trace-tp.wasm
+inputs:
+  - 'a43b46'
+outputs:
+  - 'a43b46'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,9 @@
 
 version: '2.1'
 
+volumes:
+  grid-shared:
+
 services:
 
   track-and-trace-tp:
@@ -57,19 +60,26 @@ services:
       - 4004
     ports:
       - '4020:4004'
+    volumes:
+      - grid-shared:/grid-shared
     # start the validator with an empty genesis batch
     entrypoint: |
       bash -c "
         if [ ! -f /etc/sawtooth/keys/validator.priv ]; then
           sawadm keygen &&
           sawtooth keygen my_key &&
+          cp /root/.sawtooth/keys/my_key.* /grid-shared &&
           sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
           sawset proposal create \
             -k /root/.sawtooth/keys/my_key.priv \
             sawtooth.consensus.algorithm.name=Devmode \
             sawtooth.consensus.algorithm.version=0.1 \
             -o config.batch && 
-          sawadm genesis config-genesis.batch config.batch
+          sawset proposal create \
+            -k /root/.sawtooth/keys/my_key.priv \
+            sawtooth.swa.administrators=$$(cat /grid-shared/my_key.pub) \
+            -o sabre-admin.batch
+          sawadm genesis config-genesis.batch config.batch sabre-admin.batch
         fi;
         sawtooth-validator -vv \
           --endpoint tcp://validator:8800 \
@@ -126,6 +136,13 @@ services:
           /gridd -vv -b gridd:8080 -C tcp://validator:4004 \
               --database-url postgres://grid:grid_example@db/grid
         "
+
+  sabre-tp:
+    image: hyperledger/sawtooth-sabre-tp:latest
+    container_name: sawtooth-sabre-tp
+    depends_on:
+      - validator
+    entrypoint: sawtooth-sabre -vv --connect tcp://validator:4004
 
   sawtooth-shell:
     image: hyperledger/sawtooth-shell:1.1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,15 +38,23 @@ services:
         echo '---------========= track and trace contract is loaded =========---------'
       "
 
-  schema-tp:
-    image: grid-schema-tp
-    container_name: grid-schema-tp
+  schema-contract-builder:
+    image: schema-contract-builder
+    container_name: schema-contract-builder
     build:
       context: .
       dockerfile: contracts/schema/Dockerfile
+    volumes:
+      - grid-shared:/grid-shared
     entrypoint: |
       bash -c "
-        /grid-schema-tp -v -C tcp://validator:4004
+        while true; do curl -s http://grid-sawtooth-rest-api:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
+        sabre cr --create grid_schema --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre upload --filename schema.yaml --key /grid-shared/my_key --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre ns --create 621dee01 --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm 621dee01 grid_schema --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm cad11d grid_schema --key /grid-shared/my_key --read --url http://grid-sawtooth-rest-api:8008 --wait 30
+        echo '---------========= grid schema contract is loaded =========---------'
       "
 
   pike-contract-builder:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,15 +42,22 @@ services:
         /grid-schema-tp -v -C tcp://validator:4004
       "
 
-  pike-tp:
-    image: grid-pike-tp
-    container_name: grid-pike-tp
+  pike-contract-builder:
+    image: pike-contract-builder
+    container_name: pike-contract-builder
     build:
       context: .
       dockerfile: contracts/pike/Dockerfile
+    volumes:
+      - grid-shared:/grid-shared
     entrypoint: |
       bash -c "
-        /grid-pike-tp -vv -C tcp://validator:4004
+        while true; do curl -s http://grid-sawtooth-rest-api:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
+        sabre cr --create pike --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre upload --filename pike.yaml --key /grid-shared/my_key --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre ns --create cad11d --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm cad11d pike --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        echo '---------========= pike contract is loaded =========---------'
       "
 
   validator:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,15 +20,22 @@ volumes:
 
 services:
 
-  track-and-trace-tp:
-    image: grid-track-and-trace-tp
-    container_name: grid-track-and-trace-tp
+  tnt-contract-builder:
+    image: tnt-contract-builder
+    container_name: tnt-contract-builder
     build:
       context: .
       dockerfile: contracts/track_and_trace/Dockerfile
+    volumes:
+      - grid-shared:/grid-shared
     entrypoint: |
       bash -c "
-        /grid-track-and-trace-tp -v -C tcp://validator:4004
+        while true; do curl -s http://grid-sawtooth-rest-api:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
+        sabre cr --create grid_track_and_trace --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre upload --filename track_and_trace.yaml --key /grid-shared/my_key --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre ns --create a43b46 --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm a43b46 grid_track_and_trace --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        echo '---------========= track and trace contract is loaded =========---------'
       "
 
   schema-tp:

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -33,7 +33,7 @@ cfg-if = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rust-crypto-wasm = "0.3"
-sabre-sdk = "0.2"
+sabre-sdk = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rust-crypto = "0.2"


### PR DESCRIPTION
This is built on top of #50 

This includes the version of the sabre-sdk to 0.3 and updating the grid cli to send all transactions wrapped in a sabre transaction.

You can test this by running docker-compose
`docker-compose up --build`

move to the grid/cli and create a new pike organization with the following command:
`cargo run -- -vv --url http://localhost:8080 organization create org_1 OrgTest test_address`

You will see the sabre tp execute a transaction and then you can see the organization by checking hte restapi:
`http://localhost:8080/organization`