### PR TITLE
Update TnT SDE

### DIFF
--- a/daemon/migrations/2019-04-19-191743_create_grid_schema_tables/down.sql
+++ b/daemon/migrations/2019-04-19-191743_create_grid_schema_tables/down.sql
@@ -19,6 +19,4 @@ DROP INDEX IF EXISTS grid_schema_name_block_num_idx;
 DROP TABLE IF EXISTS grid_property_definition;
 DROP INDEX IF EXISTS grid_property_definition_name_block_num_idx;
 
-DROP TABLE IF EXISTS grid_property_value;
-DROP INDEX IF EXISTS grid_property_value_name_block_num_idx;
 DROP TYPE IF EXISTS latlong;

--- a/daemon/migrations/2019-04-19-191743_create_grid_schema_tables/up.sql
+++ b/daemon/migrations/2019-04-19-191743_create_grid_schema_tables/up.sql
@@ -38,7 +38,6 @@ CREATE TABLE IF NOT EXISTS grid_property_definition (
 CREATE INDEX IF NOT EXISTS grid_property_definition_name_block_num_idx
     ON grid_property_definition (name, end_block_num);
 
-
 -- Create the latlong type if it does not already exists;
 DO $$
 BEGIN
@@ -49,19 +48,3 @@ BEGIN
 EXCEPTION
     WHEN duplicate_object THEN null;
 END $$;
-
-CREATE TABLE IF NOT EXISTS grid_property_value (
-    id BIGSERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
-    data_type TEXT NOT NULL,
-    bytes_value BYTEA,
-    boolean_value BOOLEAN,
-    number_value BIGINT,
-    string_value TEXT,
-    enum_value INTEGER,
-    struct_values TEXT [],
-    lat_long_value latlong
-) INHERITS (chain_record);
-
-CREATE INDEX IF NOT EXISTS grid_property_value_name_block_num_idx
-    ON grid_property_value (name, end_block_num);

--- a/daemon/migrations/2019-05-02-191951_create_tnt_tables/up.sql
+++ b/daemon/migrations/2019-05-02-191951_create_tnt_tables/up.sql
@@ -43,7 +43,14 @@ CREATE TABLE IF NOT EXISTS reported_value (
     record_id TEXT NOT NULL,
     reporter_index INTEGER NOT NULL,
     timestamp BIGINT NOT NULL,
-    value_name TEXT NOT NULL
+    data_type TEXT NOT NULL,
+    bytes_value BYTEA,
+    boolean_value BOOLEAN,
+    number_value BIGINT,
+    string_value TEXT,
+    enum_value INTEGER,
+    struct_values TEXT [],
+    lat_long_value latlong
 ) INHERITS (chain_record);
 
 CREATE INDEX IF NOT EXISTS reported_value_idx

--- a/daemon/src/database/helpers/grid_schemas.rs
+++ b/daemon/src/database/helpers/grid_schemas.rs
@@ -15,11 +15,8 @@
  * -----------------------------------------------------------------------------
  */
 
-use super::models::{
-    GridPropertyDefinition, GridSchema, NewGridPropertyDefinition, NewGridPropertyValue,
-    NewGridSchema,
-};
-use super::schema::{grid_property_definition, grid_property_value, grid_schema};
+use super::models::{GridPropertyDefinition, GridSchema, NewGridPropertyDefinition, NewGridSchema};
+use super::schema::{grid_property_definition, grid_schema};
 use super::MAX_BLOCK_NUM;
 
 use diesel::{
@@ -128,34 +125,4 @@ pub fn list_grid_property_definitions_with_schema_name(
                 .and(grid_property_definition::end_block_num.eq(MAX_BLOCK_NUM)),
         )
         .load::<GridPropertyDefinition>(conn)
-}
-
-pub fn insert_grid_property_values(
-    conn: &PgConnection,
-    values: &[NewGridPropertyValue],
-) -> QueryResult<()> {
-    for value in values {
-        update_grid_property_value_end_block_num(conn, &value.name, value.start_block_num)?;
-    }
-
-    insert_into(grid_property_value::table)
-        .values(values)
-        .execute(conn)
-        .map(|_| ())
-}
-
-pub fn update_grid_property_value_end_block_num(
-    conn: &PgConnection,
-    property_name: &str,
-    current_block_num: i64,
-) -> QueryResult<()> {
-    update(grid_property_value::table)
-        .filter(
-            grid_property_value::name
-                .eq(property_name)
-                .and(grid_property_value::end_block_num.eq(MAX_BLOCK_NUM)),
-        )
-        .set(grid_property_value::end_block_num.eq(current_block_num))
-        .execute(conn)
-        .map(|_| ())
 }

--- a/daemon/src/database/helpers/track_and_trace.rs
+++ b/daemon/src/database/helpers/track_and_trace.rs
@@ -101,7 +101,13 @@ pub fn update_property_end_block_num(
 
 pub fn insert_proposals(conn: &PgConnection, proposals: &[NewProposal]) -> QueryResult<()> {
     for proposal in proposals {
-        update_proposal_end_block_num(conn, &proposal.record_id, proposal.start_block_num)?;
+        update_proposal_end_block_num(
+            conn,
+            &proposal.record_id,
+            &proposal.receiving_agent,
+            &proposal.role,
+            proposal.start_block_num,
+        )?;
     }
 
     insert_into(proposal::table)
@@ -113,12 +119,16 @@ pub fn insert_proposals(conn: &PgConnection, proposals: &[NewProposal]) -> Query
 pub fn update_proposal_end_block_num(
     conn: &PgConnection,
     record_id: &str,
+    receiving_agent: &str,
+    role: &str,
     current_block_num: i64,
 ) -> QueryResult<()> {
     update(proposal::table)
         .filter(
             proposal::record_id
                 .eq(record_id)
+                .and(proposal::receiving_agent.eq(receiving_agent))
+                .and(proposal::role.eq(role))
                 .and(proposal::end_block_num.eq(MAX_BLOCK_NUM)),
         )
         .set(proposal::end_block_num.eq(current_block_num))

--- a/daemon/src/database/models.rs
+++ b/daemon/src/database/models.rs
@@ -24,8 +24,8 @@ use serde_json::Value as JsonValue;
 use std::io::Write;
 
 use super::schema::{
-    agent, associated_agent, block, grid_property_definition, grid_property_value, grid_schema,
-    organization, property, proposal, record, reported_value, reporter,
+    agent, associated_agent, block, grid_property_definition, grid_schema, organization, property,
+    proposal, record, reported_value, reporter,
 };
 
 #[derive(Insertable, Queryable)]
@@ -141,38 +141,6 @@ pub struct GridPropertyDefinition {
     pub number_exponent: i64,
     pub enum_options: Vec<String>,
     pub struct_properties: Vec<String>,
-}
-
-#[derive(Insertable, Debug, Default)]
-#[table_name = "grid_property_value"]
-pub struct NewGridPropertyValue {
-    pub start_block_num: i64,
-    pub end_block_num: i64,
-    pub name: String,
-    pub data_type: String,
-    pub bytes_value: Option<Vec<u8>>,
-    pub boolean_value: Option<bool>,
-    pub number_value: Option<i64>,
-    pub string_value: Option<String>,
-    pub enum_value: Option<i32>,
-    pub struct_values: Option<Vec<String>>,
-    pub lat_long_value: Option<LatLongValue>,
-}
-
-#[derive(Queryable, Default, Debug)]
-pub struct GridPropertyValue {
-    pub id: i64,
-    pub start_block_num: i64,
-    pub end_block_num: i64,
-    pub name: String,
-    pub data_type: String,
-    pub bytes_value: Option<Vec<u8>>,
-    pub boolean_value: Option<bool>,
-    pub number_value: Option<i64>,
-    pub string_value: Option<String>,
-    pub enum_value: Option<i32>,
-    pub struct_values: Option<Vec<String>>,
-    pub lat_long_value: Option<LatLongValue>,
 }
 
 #[derive(SqlType, QueryId, Debug, Clone, Copy)]

--- a/daemon/src/database/models.rs
+++ b/daemon/src/database/models.rs
@@ -147,7 +147,7 @@ pub struct GridPropertyDefinition {
 #[postgres(type_name = "latlong")]
 pub struct LatLong;
 
-#[derive(Debug, PartialEq, FromSqlRow, AsExpression)]
+#[derive(Debug, PartialEq, FromSqlRow, AsExpression, Clone)]
 #[sql_type = "LatLong"]
 pub struct LatLongValue(pub i64, pub i64);
 
@@ -274,7 +274,7 @@ pub struct Record {
     pub custodians: Vec<String>,
 }
 
-#[derive(Insertable, Debug, Clone)]
+#[derive(Insertable, Debug, Clone, Default)]
 #[table_name = "reported_value"]
 pub struct NewReportedValue {
     pub start_block_num: i64,
@@ -283,7 +283,14 @@ pub struct NewReportedValue {
     pub record_id: String,
     pub reporter_index: i32,
     pub timestamp: i64,
-    pub value_name: String,
+    pub data_type: String,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<i32>,
+    pub struct_values: Option<Vec<String>>,
+    pub lat_long_value: Option<LatLongValue>,
 }
 
 #[allow(dead_code)]
@@ -296,7 +303,14 @@ pub struct ReportedValue {
     pub record_id: String,
     pub reporter_index: i32,
     pub timestamp: i64,
-    pub value_name: String,
+    pub data_type: String,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<i32>,
+    pub struct_values: Option<Vec<String>>,
+    pub lat_long_value: Option<LatLongValue>,
 }
 
 #[derive(Insertable, Debug, Clone)]

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -74,25 +74,6 @@ table! {
 }
 
 table! {
-    use diesel::sql_types::*;
-    use super::LatLong;
-    grid_property_value (id) {
-        id -> Int8,
-        start_block_num -> Int8,
-        end_block_num -> Int8,
-        name -> Text,
-        data_type -> Text,
-        bytes_value -> Nullable<Bytea>,
-        boolean_value -> Nullable<Bool>,
-        number_value -> Nullable<Int8>,
-        string_value -> Nullable<Text>,
-        enum_value -> Nullable<Int4>,
-        struct_values -> Nullable<Array<Text>>,
-        lat_long_value -> Nullable<LatLong>,
-    }
-}
-
-table! {
     grid_schema (id) {
         id -> Int8,
         start_block_num -> Int8,
@@ -190,7 +171,6 @@ allow_tables_to_appear_in_same_query!(
     block,
     chain_record,
     grid_property_definition,
-    grid_property_value,
     grid_schema,
     organization,
     property,

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -140,6 +140,8 @@ table! {
 }
 
 table! {
+    use diesel::sql_types::*;
+    use super::LatLong;
     reported_value (id) {
         id -> Int8,
         start_block_num -> Int8,
@@ -148,7 +150,14 @@ table! {
         record_id -> Text,
         reporter_index -> Int4,
         timestamp -> Int8,
-        value_name -> Text,
+        data_type -> Text,
+        bytes_value -> Nullable<Bytea>,
+        boolean_value -> Nullable<Bool>,
+        number_value -> Nullable<Int8>,
+        string_value -> Nullable<Text>,
+        enum_value -> Nullable<Int4>,
+        struct_values -> Nullable<Array<Text>>,
+        lat_long_value -> Nullable<LatLong>,
     }
 }
 

--- a/daemon/src/event/block.rs
+++ b/daemon/src/event/block.rs
@@ -20,8 +20,10 @@ use diesel::result::Error;
 use grid_sdk::{
     protocol::{
         pike::state::{AgentList, OrganizationList},
-        schema::state::{DataType, PropertyDefinition, PropertyValue, SchemaList},
-        track_and_trace::state::{PropertyList, PropertyPageList, ProposalList, RecordList},
+        schema::state::{DataType, PropertyDefinition, SchemaList},
+        track_and_trace::state::{
+            PropertyList, PropertyPageList, ProposalList, RecordList, ReportedValue,
+        },
     },
     protos::FromBytes,
 };
@@ -38,8 +40,8 @@ use crate::database::{
     helpers as db,
     models::{
         Block, LatLongValue, NewAgent, NewAssociatedAgent, NewGridPropertyDefinition,
-        NewGridPropertyValue, NewGridSchema, NewOrganization, NewProperty, NewProposal, NewRecord,
-        NewReportedValue, NewReporter,
+        NewGridSchema, NewOrganization, NewProperty, NewProposal, NewRecord, NewReportedValue,
+        NewReporter,
     },
     ConnectionPool,
 };
@@ -293,43 +295,21 @@ fn state_change_to_db_operation(
                 .property_pages()
                 .to_vec();
 
-            let property_values = make_property_values(
-                block_num,
-                &property_pages
-                    .clone()
-                    .into_iter()
-                    .flat_map(|page| {
-                        page.reported_values()
-                            .to_vec()
-                            .into_iter()
-                            .map(|r| r.value().clone())
-                    })
-                    .collect::<Vec<PropertyValue>>(),
-            );
+            let mut reported_values: Vec<NewReportedValue> = vec![];
+            for page in property_pages {
+                page.reported_values().to_vec().iter().try_fold(
+                    &mut reported_values,
+                    |acc, value| match make_reported_values(block_num, page.record_id(), value) {
+                        Ok(mut vals) => {
+                            acc.append(&mut vals);
+                            Ok(acc)
+                        }
+                        Err(err) => Err(err),
+                    },
+                )?;
+            }
 
-            let reported_values = property_pages
-                .clone()
-                .into_iter()
-                .flat_map(|page| {
-                    page.reported_values()
-                        .to_vec()
-                        .into_iter()
-                        .map(move |value| NewReportedValue {
-                            property_name: page.name().to_string(),
-                            record_id: page.record_id().to_string(),
-                            reporter_index: *value.reporter_index() as i32,
-                            timestamp: *value.timestamp() as i64,
-                            value_name: value.value().name().to_string(),
-                            start_block_num: block_num,
-                            end_block_num: db::MAX_BLOCK_NUM,
-                        })
-                })
-                .collect::<Vec<NewReportedValue>>();
-
-            Ok(DbInsertOperation::ReportedValues(
-                reported_values,
-                property_values,
-            ))
+            Ok(DbInsertOperation::ReportedValues(reported_values))
         }
         TRACK_AND_TRACE_PROPOSAL => {
             let proposals = ProposalList::from_bytes(&state_change.value)
@@ -411,7 +391,7 @@ enum DbInsertOperation {
     Organizations(Vec<NewOrganization>),
     GridSchemas(Vec<NewGridSchema>, Vec<NewGridPropertyDefinition>),
     Properties(Vec<NewProperty>, Vec<NewReporter>),
-    ReportedValues(Vec<NewReportedValue>, Vec<NewGridPropertyValue>),
+    ReportedValues(Vec<NewReportedValue>),
     Proposals(Vec<NewProposal>),
     Records(Vec<NewRecord>, Vec<NewAssociatedAgent>),
 }
@@ -429,9 +409,8 @@ impl DbInsertOperation {
                 db::insert_properties(conn, properties)?;
                 db::insert_reporters(conn, reporters)
             }
-            DbInsertOperation::ReportedValues(ref reported_values, ref values) => {
-                db::insert_reported_values(conn, reported_values)?;
-                db::insert_grid_property_values(conn, values)
+            DbInsertOperation::ReportedValues(ref reported_values) => {
+                db::insert_reported_values(conn, reported_values)
             }
             DbInsertOperation::Proposals(ref proposals) => db::insert_proposals(conn, proposals),
             DbInsertOperation::Records(ref records, ref associated_agents) => {
@@ -442,56 +421,81 @@ impl DbInsertOperation {
     }
 }
 
-fn make_property_values(
+fn make_reported_values(
     start_block_num: i64,
-    values: &[PropertyValue],
-) -> Vec<NewGridPropertyValue> {
+    record_id: &str,
+    reported_value: &ReportedValue,
+) -> Result<Vec<NewReportedValue>, EventError> {
     let mut new_values = Vec::new();
 
-    for value in values {
-        let mut new_value = NewGridPropertyValue {
-            name: value.name().to_string(),
-            data_type: format!("{:?}", value.data_type()),
-            start_block_num,
-            end_block_num: db::MAX_BLOCK_NUM,
-            ..NewGridPropertyValue::default()
-        };
+    let mut new_value = NewReportedValue {
+        property_name: reported_value.value().name().to_string(),
+        record_id: record_id.to_string(),
+        reporter_index: *reported_value.reporter_index() as i32,
+        timestamp: *reported_value.timestamp() as i64,
+        start_block_num,
+        end_block_num: db::MAX_BLOCK_NUM,
+        data_type: format!("{:?}", reported_value.value().data_type()),
+        ..NewReportedValue::default()
+    };
 
-        match value.data_type() {
-            DataType::Bytes => new_value.bytes_value = Some(value.bytes_value().to_vec()),
-            DataType::Boolean => new_value.boolean_value = Some(*value.boolean_value()),
-            DataType::Number => new_value.number_value = Some(*value.number_value()),
-            DataType::String => new_value.string_value = Some(value.string_value().to_string()),
-            DataType::Enum => new_value.enum_value = Some(*value.enum_value() as i32),
-            DataType::Struct => {
-                new_value.struct_values = Some(
-                    value
-                        .struct_values()
-                        .iter()
-                        .map(|x| x.name().to_string())
-                        .collect(),
-                )
-            }
-            DataType::LatLong => {
-                let lat_long_value = LatLongValue(
-                    *value.lat_long_value().latitude(),
-                    *value.lat_long_value().longitude(),
-                );
-                new_value.lat_long_value = Some(lat_long_value);
-            }
-        };
-
-        new_values.push(new_value);
-
-        if !value.struct_values().is_empty() {
-            new_values.append(&mut make_property_values(
-                start_block_num,
-                value.struct_values(),
-            ));
+    match reported_value.value().data_type() {
+        DataType::Bytes => {
+            new_value.bytes_value = Some(reported_value.value().bytes_value().to_vec())
         }
-    }
+        DataType::Boolean => {
+            new_value.boolean_value = Some(*reported_value.value().boolean_value())
+        }
+        DataType::Number => new_value.number_value = Some(*reported_value.value().number_value()),
+        DataType::String => {
+            new_value.string_value = Some(reported_value.value().string_value().to_string())
+        }
+        DataType::Enum => new_value.enum_value = Some(*reported_value.value().enum_value() as i32),
+        DataType::Struct => {
+            new_value.struct_values = Some(
+                reported_value
+                    .value()
+                    .struct_values()
+                    .iter()
+                    .map(|x| x.name().to_string())
+                    .collect(),
+            )
+        }
+        DataType::LatLong => {
+            let lat_long_value = LatLongValue(
+                *reported_value.value().lat_long_value().latitude(),
+                *reported_value.value().lat_long_value().longitude(),
+            );
+            new_value.lat_long_value = Some(lat_long_value);
+        }
+    };
 
-    new_values
+    new_values.push(new_value);
+
+    reported_value
+        .value()
+        .struct_values()
+        .iter()
+        .try_fold(&mut new_values, |acc, val| {
+            match reported_value
+                .clone()
+                .into_builder()
+                .with_value(val.clone())
+                .build()
+                .map_err(|err| EventError(format!("Failed to build ReportedValue: {:?}", err)))
+            {
+                Ok(temp_val) => match make_reported_values(start_block_num, record_id, &temp_val) {
+                    Ok(mut vals) => {
+                        acc.append(&mut vals);
+                        Ok(acc)
+                    }
+                    Err(err) => Err(err),
+                },
+                Err(err) => Err(err),
+            }
+        })?;
+
+    Ok(new_values)
 }
 
 fn make_property_definitions(


### PR DESCRIPTION
This PR:
- Removes the `grid_property_table` and adds its fields to the `reported_value` table.  This change is necessary because currently is impossible to associate rows in the reported_value table to rows in the grid_property_value table. The information in the `grid_property_value` needs to be more tightly connected to the Track and Trace Record. So it makes sense to go away with that table completely and keep that information in a TnT specific table. 

- Adds `receiving_agent parameter` to the `update_proposal_end_block_num` method in the database track_and_trace helpers. To uniquely identify a proposal you need `record_id` + the receiving agent key.


