### PR TITLE
Add dyn to trait objects

### DIFF
--- a/contracts/pike/src/handler.rs
+++ b/contracts/pike/src/handler.rs
@@ -54,11 +54,11 @@ fn compute_address(name: &str, resource: Resource) -> String {
 }
 
 pub struct PikeState<'a> {
-    context: &'a mut TransactionContext,
+    context: &'a mut dyn TransactionContext,
 }
 
 impl<'a> PikeState<'a> {
-    pub fn new(context: &'a mut TransactionContext) -> PikeState {
+    pub fn new(context: &'a mut dyn TransactionContext) -> PikeState {
         PikeState { context }
     }
 

--- a/contracts/schema/src/handler.rs
+++ b/contracts/schema/src/handler.rs
@@ -42,7 +42,10 @@ pub const PIKE_NAMESPACE: &str = "cad11d";
 
 #[cfg(target_arch = "wasm32")]
 // Sabre apply must return a bool
-fn apply(request: &TpProcessRequest, context: &mut TransactionContext) -> Result<bool, ApplyError> {
+fn apply(
+    request: &TpProcessRequest,
+    context: &mut dyn TransactionContext,
+) -> Result<bool, ApplyError> {
     let handler = GridSchemaTransactionHandler::new();
     match handler.apply(request, context) {
         Ok(_) => Ok(true),
@@ -89,7 +92,7 @@ impl TransactionHandler for GridSchemaTransactionHandler {
     fn apply(
         &self,
         request: &TpProcessRequest,
-        context: &mut TransactionContext,
+        context: &mut dyn TransactionContext,
     ) -> Result<(), ApplyError> {
         let payload = SchemaPayload::from_bytes(request.get_payload()).map_err(|err| {
             ApplyError::InvalidTransaction(format!("Cannot build schema payload: {}", err))

--- a/contracts/track_and_trace/src/handler.rs
+++ b/contracts/track_and_trace/src/handler.rs
@@ -1047,7 +1047,10 @@ impl TransactionHandler for TrackAndTraceTransactionHandler {
 
 #[cfg(target_arch = "wasm32")]
 // Sabre apply must return a bool
-fn apply(request: &TpProcessRequest, context: &mut TransactionContext) -> Result<bool, ApplyError> {
+fn apply(
+    request: &TpProcessRequest,
+    context: &mut dyn TransactionContext,
+) -> Result<bool, ApplyError> {
     let handler = TrackAndTraceTransactionHandler::new();
     match handler.apply(request, context) {
         Ok(_) => Ok(true),

--- a/contracts/track_and_trace/src/state.rs
+++ b/contracts/track_and_trace/src/state.rs
@@ -34,11 +34,11 @@ use grid_sdk::protos::{FromBytes, IntoBytes};
 use crate::addressing::*;
 
 pub struct TrackAndTraceState<'a> {
-    context: &'a mut TransactionContext,
+    context: &'a mut dyn TransactionContext,
 }
 
 impl<'a> TrackAndTraceState<'a> {
-    pub fn new(context: &'a mut TransactionContext) -> TrackAndTraceState {
+    pub fn new(context: &'a mut dyn TransactionContext) -> TrackAndTraceState {
         TrackAndTraceState { context }
     }
 

--- a/sdk/src/permissions.rs
+++ b/sdk/src/permissions.rs
@@ -62,7 +62,7 @@ impl fmt::Display for PermissionCheckerError {
 }
 
 impl Error for PermissionCheckerError {
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             PermissionCheckerError::Context(_) => None,
             PermissionCheckerError::InvalidPublicKey(_) => None,
@@ -87,7 +87,7 @@ impl From<ProtoConversionError> for PermissionCheckerError {
 pub struct PermissionChecker<'a> {
     /// A PermissionChecker is tied to a version of state, so it has a
     /// reference to a TransactionContext.
-    context: &'a TransactionContext,
+    context: &'a dyn TransactionContext,
 }
 
 impl<'a> PermissionChecker<'a> {
@@ -97,7 +97,7 @@ impl<'a> PermissionChecker<'a> {
     ///
     /// * `context` - A reference to the transaction context.
     ///
-    pub fn new(context: &'a TransactionContext) -> PermissionChecker {
+    pub fn new(context: &'a dyn TransactionContext) -> PermissionChecker {
         PermissionChecker { context }
     }
 

--- a/sdk/src/protocol/pike/payload.rs
+++ b/sdk/src/protocol/pike/payload.rs
@@ -185,7 +185,7 @@ impl StdError for CreateAgentActionBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             CreateAgentActionBuildError::MissingField(_) => None,
         }
@@ -376,7 +376,7 @@ impl StdError for UpdateAgentActionBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             UpdateAgentActionBuildError::MissingField(_) => None,
         }
@@ -559,7 +559,7 @@ impl StdError for CreateOrganizationActionBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             CreateOrganizationActionBuildError::MissingField(_) => None,
         }
@@ -746,7 +746,7 @@ impl StdError for UpdateOrganizationActionBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             UpdateOrganizationActionBuildError::MissingField(_) => None,
         }
@@ -925,7 +925,7 @@ impl StdError for PikePayloadBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             PikePayloadBuildError::MissingField(_) => None,
         }

--- a/sdk/src/protocol/pike/state.rs
+++ b/sdk/src/protocol/pike/state.rs
@@ -100,7 +100,7 @@ impl StdError for KeyValueEntryBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             KeyValueEntryBuildError::MissingField(_) => None,
         }
@@ -256,7 +256,7 @@ impl StdError for AgentBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             AgentBuildError::MissingField(_) => None,
         }
@@ -415,7 +415,7 @@ impl StdError for AgentListBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             AgentListBuildError::MissingField(_) => None,
         }
@@ -563,7 +563,7 @@ impl StdError for OrganizationBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             OrganizationBuildError::MissingField(_) => None,
         }
@@ -719,7 +719,7 @@ impl StdError for OrganizationListBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             OrganizationListBuildError::MissingField(_) => None,
         }

--- a/sdk/src/protocol/schema/payload.rs
+++ b/sdk/src/protocol/schema/payload.rs
@@ -142,7 +142,7 @@ impl StdError for SchemaPayloadBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             SchemaPayloadBuildError::MissingField(_) => None,
         }
@@ -316,7 +316,7 @@ impl StdError for SchemaCreateBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             SchemaCreateBuildError::MissingField(_) => None,
         }
@@ -471,7 +471,7 @@ impl StdError for SchemaUpdateBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             SchemaUpdateBuildError::MissingField(_) => None,
         }

--- a/sdk/src/protocol/schema/state.rs
+++ b/sdk/src/protocol/schema/state.rs
@@ -235,7 +235,7 @@ impl StdError for PropertyDefinitionBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             PropertyDefinitionBuildError::MissingField(_) => None,
             PropertyDefinitionBuildError::EmptyVec(_) => None,
@@ -469,7 +469,7 @@ impl StdError for SchemaBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             SchemaBuildError::MissingField(_) => None,
         }
@@ -630,7 +630,7 @@ impl StdError for SchemaListBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             SchemaListBuildError::MissingField(_) => None,
         }
@@ -815,7 +815,7 @@ impl StdError for PropertyValueBuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             PropertyValueBuildError::MissingField(_) => None,
         }

--- a/sdk/src/protos.rs
+++ b/sdk/src/protos.rs
@@ -28,7 +28,7 @@ impl StdError for ProtoConversionError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             ProtoConversionError::SerializationError(_) => None,
             ProtoConversionError::InvalidTypeError(_) => None,


### PR DESCRIPTION
Fix following nightly warning:

trait objects without an explicit dyn are deprecated

Note: generate protobufs will still throw this error.