### PR TITLE
Fix bug in Pike contract

### DIFF
--- a/contracts/pike/src/handler.rs
+++ b/contracts/pike/src/handler.rs
@@ -353,6 +353,17 @@ fn update_agent(
     };
 
     if !payload.get_roles().is_empty() {
+        // verify that an admin is not removing the role admin from themselves.
+        if signer == payload.get_public_key()
+            && !payload.get_roles().iter().any(|role| role == "admin")
+        {
+            return Err(ApplyError::InvalidTransaction(
+                "An admin cannot remove themselves as admin. 'admin' role must be included
+                    in the roles list."
+                    .to_string(),
+            ));
+        }
+
         agent.set_roles(protobuf::RepeatedField::from_vec(
             payload.get_roles().to_vec(),
         ));

--- a/docs/source/transaction_family_specifications/pike_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/pike_transaction_family.rst
@@ -197,7 +197,8 @@ CREATE_AGENT
 UPDATE_AGENT
     This operation updates the roles, metadata, and active status of an
     existing agent stored in Global State. Only another agent that holds an
-    admin role for the included organization may update an agent.
+    admin role for the included organization may update an agent. An agent
+    cannot remove the admin role from themselves. 
 
     .. code-block:: protobuf
 


### PR DESCRIPTION
Admin agents should not be able to remove the admin role from
themselves. This commit adds a check and returns an InvalidTransaction
if an admin tries to submit a transaction that would remove the role
admin from themselves.

Signed-off-by: Eloá Franca Verona <eloafran@bitwise.io>