### PR TITLE
Move DB Migrations to CLI

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,6 +32,8 @@ reqwest = "0.9"
 dirs = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
+diesel = { version = "1.0", features = ["postgres"] }
+diesel_migrations = "1.4"
 
 [[bin]]
 name = "grid"

--- a/cli/src/actions/database.rs
+++ b/cli/src/actions/database.rs
@@ -1,0 +1,31 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::CliError;
+
+use diesel::{connection::Connection as _, pg::PgConnection};
+
+embed_migrations!("../daemon/migrations");
+
+pub fn run_migrations(database_url: &str) -> Result<(), CliError> {
+    let connection = PgConnection::establish(database_url)
+        .map_err(|err| CliError::DatabaseError(err.to_string()))?;
+
+    embedded_migrations::run(&connection)
+        .map_err(|err| CliError::DatabaseError(err.to_string()))?;
+
+    info!("Successfully applied migrations");
+
+    Ok(())
+}

--- a/cli/src/actions/mod.rs
+++ b/cli/src/actions/mod.rs
@@ -16,6 +16,7 @@
  */
 
 pub mod agents;
+pub mod database;
 pub mod keygen;
 pub mod organizations;
 pub mod schemas;

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -30,6 +30,7 @@ pub enum CliError {
     PayloadError(String),
     UserError(String),
     SigningError(signing::Error),
+    DatabaseError(String),
     IoError(io::Error),
     ProtobufError(protobuf::ProtobufError),
     ReqwestError(reqwest::Error),
@@ -44,6 +45,7 @@ impl StdError for CliError {
             CliError::InvalidYamlError(_) => None,
             CliError::PayloadError(_) => None,
             CliError::UserError(_) => None,
+            CliError::DatabaseError(_) => None,
             CliError::IoError(err) => Some(err),
             CliError::ProtobufError(err) => Some(err),
             CliError::SigningError(err) => Some(err),
@@ -61,6 +63,7 @@ impl std::fmt::Display for CliError {
             CliError::InvalidYamlError(ref err) => write!(f, "InvalidYamlError: {}", err),
             CliError::PayloadError(ref err) => write!(f, "PayloadError: {}", err),
             CliError::IoError(ref err) => write!(f, "IoError: {}", err),
+            CliError::DatabaseError(ref err) => write!(f, "DatabaseError: {}", err),
             CliError::SigningError(ref err) => write!(f, "SigningError: {}", err.description()),
             CliError::ProtobufError(ref err) => write!(f, "ProtobufError: {}", err.description()),
             CliError::LoggingInitializationError(ref err) => {

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -55,8 +55,23 @@ RUN cargo build --release
 RUN rm src/*.rs
 COPY ./daemon/src ./src
 COPY ./daemon/migrations ./migrations
+COPY ./daemon/migrations ../daemon/migrations
+
 
 RUN rm ./target/release/gridd* ./target/release/deps/gridd*
+RUN cargo build --release
+
+WORKDIR ..
+RUN USER=root cargo new --bin cli
+WORKDIR /cli
+
+COPY ./cli/Cargo.toml ./Cargo.toml
+RUN cargo build --release
+
+RUN rm src/*.rs
+COPY ./cli/src ./src
+
+RUN rm ./target/release/grid* ./target/release/deps/grid*
 RUN cargo build --release
 
 # create the standalone image
@@ -68,5 +83,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=BUILDER /daemon/target/release/gridd /
+COPY --from=BUILDER /cli/target/release/grid /
+
 
 CMD ["/gridd"]

--- a/daemon/src/database/mod.rs
+++ b/daemon/src/database/mod.rs
@@ -25,20 +25,11 @@ embed_migrations!("./migrations");
 use std::ops::Deref;
 
 use diesel::{
-    connection::Connection as _,
     pg::PgConnection,
     r2d2::{ConnectionManager, Pool, PooledConnection},
 };
 
 pub use super::database::error::DatabaseError;
-
-pub fn run_migrations(database_url: &str) -> Result<(), DatabaseError> {
-    let connection = PgConnection::establish(database_url)?;
-
-    embedded_migrations::run(&connection)?;
-
-    Ok(())
-}
 
 pub fn create_connection_pool(database_url: &str) -> Result<ConnectionPool, DatabaseError> {
     let connection_manager = ConnectionManager::<PgConnection>::new(database_url);

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -74,8 +74,6 @@ fn run() -> Result<(), DaemonError> {
         .with_cli_args(&matches)
         .build()?;
 
-    database::run_migrations(config.database_url())?;
-
     let sawtooth_connection = SawtoothConnection::new(config.validator_endpoint());
 
     let connection_pool = database::create_connection_pool(config.database_url())?;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -133,7 +133,7 @@ fn run() -> Result<(), DaemonError> {
 
 fn main() {
     if let Err(e) = run() {
-        error!("{:?}", e);
+        error!("{}", e);
         std::process::exit(1);
     }
 }

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -79,9 +79,7 @@ mod test {
 
     use actix::SyncArbiter;
     use actix_web::{http, http::Method, test::TestServer, HttpMessage};
-    use diesel::dsl::insert_into;
-    use diesel::pg::PgConnection;
-    use diesel::RunQueryDsl;
+    use diesel::{dsl::insert_into, Connection, PgConnection, RunQueryDsl};
     use futures::future::Future;
     use sawtooth_sdk::messages::batch::{Batch, BatchList};
     use sawtooth_sdk::messages::client_batch_submit::{
@@ -495,7 +493,7 @@ mod test {
     ///         - body containing a list of Agents
     #[test]
     fn test_list_agents() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         // Clears the agents table in the test database
@@ -529,7 +527,7 @@ mod test {
     ///
     #[test]
     fn test_list_organizations_empty() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         // Clears the organization table in the test database
@@ -551,7 +549,7 @@ mod test {
     ///
     #[test]
     fn test_list_organizations() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
 
@@ -583,7 +581,7 @@ mod test {
     ///
     #[test]
     fn test_list_organizations_updated() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
 
@@ -613,7 +611,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_organization_not_found() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         // Clears the organization table in the test database
@@ -632,7 +630,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_organization_ok() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
 
@@ -662,7 +660,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_organization_updated_ok() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
 
@@ -690,7 +688,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_agent_ok() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
 
@@ -714,7 +712,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_agent_not_found() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         // Clear the agents table in the test database
@@ -734,7 +732,7 @@ mod test {
     ///         then will respond with an Ok status and a list of Grid Schemas.
     #[test]
     fn test_list_schemas() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         // Clears the grid schema table in the test database
@@ -766,7 +764,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_schema_ok() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         populate_grid_schema_table(&test_pool.get().unwrap(), &get_grid_schema());
@@ -792,7 +790,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_schema_not_found() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         clear_grid_schema_table(&test_pool.get().unwrap());
@@ -810,7 +808,7 @@ mod test {
     ///
     #[test]
     fn test_list_records() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         populate_agent_table(&test_pool.get().unwrap(), &get_agents_with_roles());
@@ -951,7 +949,7 @@ mod test {
     ///
     #[test]
     fn test_list_records_updated() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
 
@@ -978,7 +976,7 @@ mod test {
     ///
     #[test]
     fn test_list_records_multiple() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
 
@@ -1012,7 +1010,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_record_ok() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         populate_agent_table(&test_pool.get().unwrap(), &get_agents_with_roles());
@@ -1153,7 +1151,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_record_updated_ok() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         populate_property_definition_table(
@@ -1295,7 +1293,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_record_not_found() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         clear_record_table(&test_pool.get().unwrap());
@@ -1313,7 +1311,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_record_property_ok() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         populate_property_definition_table(
@@ -1493,7 +1491,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_property_name_not_found() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         clear_tnt_property_table(&test_pool.get().unwrap());
@@ -1515,7 +1513,7 @@ mod test {
     ///
     #[test]
     fn test_fetch_property_record_id_not_found() {
-        database::run_migrations(&DATABASE_URL).unwrap();
+        run_migrations(&DATABASE_URL);
         let test_pool = get_connection_pool();
         let mut srv = create_test_server(ResponseType::ClientBatchStatusResponseOK);
         populate_tnt_property_table(
@@ -2215,6 +2213,12 @@ mod test {
     fn clear_record_table(conn: &PgConnection) {
         use crate::database::schema::record::dsl::*;
         diesel::delete(record).execute(conn).unwrap();
+    }
+
+    fn run_migrations(database_url: &str) {
+        let connection = PgConnection::establish(database_url)
+            .expect("Failed to stablish connection with database");
+        diesel_migrations::run_pending_migrations(&connection).expect("Failed to run migrations");
     }
 
     fn get_reported_value() -> Vec<NewReportedValue> {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -157,6 +157,8 @@ services:
               sleep 1
           done
 
+          /grid -vv database migrate \
+              --database-url postgres://grid:grid_example@db/grid &&
           /gridd -vv -b gridd:8080 -C tcp://validator:4004 \
               --database-url postgres://grid:grid_example@db/grid
         "


### PR DESCRIPTION
This PR:
- Adds CLI command to run db migrations 
- Removes the capability of running the database migrations when the daemon starts up. 
- Adds a check on daemon start up that the migrations have been applied, and returns an error if they have not.