### PR TITLE
Update TnT contract namespace permissions

### DIFF
--- a/contracts/track_and_trace/track_and_trace.yaml
+++ b/contracts/track_and_trace/track_and_trace.yaml
@@ -17,5 +17,7 @@ version: '1.0'
 wasm: target/wasm32-unknown-unknown/release/grid-track-and-trace-tp.wasm
 inputs:
   - 'a43b46'
+  - '621dee01'
+  - 'cad11d'
 outputs:
   - 'a43b46'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,8 @@ services:
         sabre upload --filename track_and_trace.yaml --key /grid-shared/my_key --url http://grid-sawtooth-rest-api:8008 --wait 30
         sabre ns --create a43b46 --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
         sabre perm a43b46 grid_track_and_trace --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm 621dee01 grid_track_and_trace --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm cad11d grid_track_and_trace --key /grid-shared/my_key --read --url http://grid-sawtooth-rest-api:8008 --wait 30
         echo '---------========= track and trace contract is loaded =========---------'
       "
 
@@ -96,7 +98,7 @@ services:
             -k /root/.sawtooth/keys/my_key.priv \
             sawtooth.consensus.algorithm.name=Devmode \
             sawtooth.consensus.algorithm.version=0.1 \
-            -o config.batch && 
+            -o config.batch &&
           sawset proposal create \
             -k /root/.sawtooth/keys/my_key.priv \
             sawtooth.swa.administrators=$$(cat /grid-shared/my_key.pub) \


### PR DESCRIPTION
Add Schema and Pike namespace permissions to the Track and Trace
contract. This allows for TnT Record transactions to be submitted.

Signed-off-by: Davey Newhall <newhall@bitwise.io>