### PR TITLE
Add keygen command to CLI

### DIFF
--- a/cli/src/actions/keygen.rs
+++ b/cli/src/actions/keygen.rs
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Intel Corporation
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+use crate::error::CliError;
+use sawtooth_sdk::signing;
+use std::fs::{self, OpenOptions};
+use std::io::prelude::*;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::PathBuf;
+use users::get_current_username;
+
+/// Generates a public/private key pair that can be used to sign transactions.
+/// If no directory is provided, the keys are created in the default directory
+///
+///   $HOME/.grid/keys/
+///
+/// If no key_name is provided the key name is set to USER environment variable.
+pub fn generate_keys(
+    key_name: Option<&str>,
+    force: bool,
+    key_directory: Option<&str>,
+) -> Result<(), CliError> {
+    let key_name = match key_name {
+        Some(name) => name.to_string(),
+        None => get_current_username()
+            .ok_or(0)
+            .and_then(|os_str| os_str.into_string().map_err(|_| 0))
+            .map_err(|_| {
+                CliError::UserError(String::from(
+                    "Could not determine key name, please provide one.",
+                ))
+            })?,
+    };
+
+    let key_dir = match key_directory {
+        Some(path) => {
+            let dir = PathBuf::from(&path);
+            if !dir.exists() {
+                return Err(CliError::UserError(format!("No such directory: {}", path)));
+            }
+            dir
+        }
+        None => {
+            let key_path = dirs::home_dir()
+                .ok_or_else(|| {
+                    CliError::UserError(String::from("Unable to determine home directory"))
+                })
+                .and_then(|mut p| {
+                    p.push(".grid");
+                    p.push("keys");
+                    Ok(p)
+                })?;
+            if !key_path.exists() {
+                fs::create_dir_all(key_path.clone())?;
+            }
+            key_path
+        }
+    };
+
+    let mut public_key_path = key_dir.clone();
+    public_key_path.push(format!("{}.pub", &key_name));
+    let mut private_key_path = key_dir.clone();
+    private_key_path.push(format!("{}.priv", &key_name));
+
+    if (public_key_path.exists() || private_key_path.exists()) && !force {
+        return Err(CliError::UserError(format!(
+            "Key files already exist at {:?}. Rerun with --force to overwrite existing files",
+            key_dir
+        )));
+    }
+
+    let context = signing::create_context("secp256k1")?;
+
+    let private_key = context.new_random_private_key()?;
+
+    let public_key = context.get_public_key(&*private_key)?;
+
+    if public_key_path.exists() {
+        info!("Overwriting file: {:?}", public_key_path);
+    } else {
+        info!("Writing file: {:?}", public_key_path);
+    }
+    let mut public_key_file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .mode(0o644)
+        .open(public_key_path.as_path())?;
+
+    public_key_file.write_all(public_key.as_hex().as_bytes())?;
+
+    if private_key_path.exists() {
+        info!("Overwriting file: {:?}", private_key_path);
+    } else {
+        info!("Writing file: {:?}", private_key_path);
+    }
+    let mut private_key_file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .mode(0o640)
+        .open(private_key_path.as_path())?;
+
+    private_key_file.write_all(private_key.as_hex().as_bytes())?;
+
+    Ok(())
+}

--- a/cli/src/actions/mod.rs
+++ b/cli/src/actions/mod.rs
@@ -16,5 +16,6 @@
  */
 
 pub mod agents;
+pub mod keygen;
 pub mod organizations;
 pub mod schemas;

--- a/cli/src/key.rs
+++ b/cli/src/key.rs
@@ -34,7 +34,7 @@ use crate::error::CliError;
 /// The directory containing the keys is determined using the HOME
 /// environment variable:
 ///
-///   $HOME/.sawtooth/keys/
+///   $HOME/.grid/keys/
 ///
 /// # Arguments
 ///
@@ -68,7 +68,7 @@ pub fn load_signing_key(name: Option<String>) -> Result<Secp256k1PrivateKey, Cli
             ))
         })
         .and_then(|mut p| {
-            p.push(".sawtooth");
+            p.push(".grid");
             p.push("keys");
             p.push(format!("{}.priv", &username));
             Ok(p)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -249,7 +249,7 @@ fn parse_metadata(matches: &ArgMatches) -> Result<Vec<KeyValueEntry>, CliError> 
 
 fn main() {
     if let Err(e) = run() {
-        error!("{:?}", e);
+        error!("{}", e);
         std::process::exit(1);
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -35,7 +35,7 @@ use simple_logger;
 
 use crate::error::CliError;
 
-use actions::{agents, organizations as orgs, schemas};
+use actions::{agents, keygen, organizations as orgs, schemas};
 
 const APP_NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -110,6 +110,12 @@ fn run() -> Result<(), CliError> {
                 (about: "Show schema specified by name argument")
                 (@arg name: +takes_value +required "Name of schema")
             )
+        )
+        (@subcommand keygen =>
+           (about: "Generates keys with which the user can sign transactions and batches.")
+           (@arg key_name: +takes_value "Name of the key to create")
+           (@arg force: --force "Overwrite files if they exist")
+           (@arg key_dir: -d --key_dir +takes_value "Specify the directory for the key files")
         )
     )
     .get_matches();
@@ -200,6 +206,11 @@ fn run() -> Result<(), CliError> {
             ("show", Some(m)) => schemas::do_show_schema(&url, m.value_of("name").unwrap())?,
             _ => return Err(CliError::UserError("Subcommand not recognized".into())),
         },
+        ("keygen", Some(m)) => keygen::generate_keys(
+            m.value_of("key_name"),
+            m.is_present("force"),
+            m.value_of("key_dir"),
+        )?,
         _ => return Err(CliError::UserError("Subcommand not recognized".into())),
     }
 


### PR DESCRIPTION
This PR adds the keygen command to the CLI, this command generates a public/private key pair that can be used to sign transactions.

Signed-off-by: Eloá Franca Verona <eloafran@bitwise.io>