### PR TITLE
Add schema to record responses

### DIFF
--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -672,6 +672,9 @@ components:
         record_id:
           type: string
           example: 7h15-45537-15-br173
+        schema:
+          type: string
+          example: Lightbulb
         owner:
           type: string
           example: 02cd3181dbd7d1539f470436ce222c53ab5e514f67809dc0095895e6cdfba97612

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -821,6 +821,7 @@ mod test {
         assert_eq!(body.len(), 1);
         let test_record = body.first().unwrap();
         assert_eq!(test_record.record_id, "Test Record".to_string());
+        assert_eq!(test_record.schema, "Test Grid Schema".to_string());
         assert_eq!(test_record.owner, KEY1.to_string());
         assert_eq!(test_record.custodian, KEY2.to_string());
         assert_eq!(test_record.r#final, false);
@@ -866,6 +867,7 @@ mod test {
         assert_eq!(body.len(), 1);
         let test_record = body.first().unwrap();
         assert_eq!(test_record.record_id, "Test Record".to_string());
+        assert_eq!(test_record.schema, "Test Grid Schema".to_string());
         assert_eq!(test_record.r#final, true);
     }
 
@@ -918,6 +920,7 @@ mod test {
         let test_record: RecordSlice =
             serde_json::from_slice(&*response.body().wait().unwrap()).unwrap();
         assert_eq!(test_record.record_id, "Test Record".to_string());
+        assert_eq!(test_record.schema, "Test Grid Schema".to_string());
         assert_eq!(test_record.owner, KEY1.to_string());
         assert_eq!(test_record.custodian, KEY2.to_string());
         assert_eq!(test_record.r#final, false);
@@ -967,6 +970,7 @@ mod test {
             serde_json::from_slice(&*response.body().wait().unwrap()).unwrap();
 
         assert_eq!(test_record.record_id, "Test Record".to_string());
+        assert_eq!(test_record.schema, "Test Grid Schema".to_string());
         assert_eq!(test_record.owner, KEY2.to_string());
         assert_eq!(test_record.custodian, KEY1.to_string());
         assert_eq!(test_record.r#final, true);

--- a/daemon/src/rest_api/routes/records.rs
+++ b/daemon/src/rest_api/routes/records.rs
@@ -63,6 +63,7 @@ impl ProposalSlice {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RecordSlice {
     pub record_id: String,
+    pub schema: String,
     pub owner: String,
     pub custodian: String,
     pub r#final: bool,
@@ -93,6 +94,7 @@ impl RecordSlice {
 
         Self {
             record_id: record.record_id.clone(),
+            schema: record.schema.clone(),
             owner: match owner_updates.last() {
                 Some(owner) => owner.agent_id.clone(),
                 None => "".to_string(),


### PR DESCRIPTION
Adds the "schema" type field to record responses. This data exists in the DB but did not get put in the response. It should be there to identify the type of schema that the record is based on.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>