### PR TITLE
Make contracts dir before cargo new

### DIFF
--- a/contracts/pike/Dockerfile
+++ b/contracts/pike/Dockerfile
@@ -50,7 +50,8 @@ RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/proto
 
 COPY ./sdk /sdk
 
-RUN USER=root cargo new --bin contracts/pike
+RUN mkdir contracts \
+ && USER=root cargo new --bin contracts/pike
 WORKDIR /contracts/pike
 
 # Build TP with dummy source in order to cache dependencies in Docker image.

--- a/contracts/schema/Dockerfile
+++ b/contracts/schema/Dockerfile
@@ -56,7 +56,8 @@ RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/proto
 
 COPY ./sdk /sdk
 
-RUN USER=root cargo new --bin contracts/schema
+RUN mkdir contracts \
+ && USER=root cargo new --bin contracts/schema
 WORKDIR /contracts/schema
 
 # Build TP with dummy source in order to cache dependencies in Docker image.

--- a/contracts/track_and_trace/Dockerfile
+++ b/contracts/track_and_trace/Dockerfile
@@ -56,7 +56,8 @@ RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/proto
 
 COPY ./sdk /sdk
 
-RUN USER=root cargo new --bin contracts/track_and_trace
+RUN mkdir contracts \
+ && USER=root cargo new --bin contracts/track_and_trace
 WORKDIR /contracts/track_and_trace
 
 # Build TP with dummy source in order to cache dependencies in Docker image.

--- a/docker/tests
+++ b/docker/tests
@@ -59,19 +59,19 @@ COPY ./contracts/schema/Cargo.toml ./Cargo.toml
 RUN cargo check
 
 WORKDIR /
-RUN USER=root cargo new --bin daemon
+RUN USER=root cargo new --bin daemon --vcs none
 WORKDIR /daemon
 COPY ./daemon/Cargo.toml ./Cargo.toml
 RUN cargo check
 
 WORKDIR /
-RUN USER=root cargo new --bin cli
+RUN USER=root cargo new --bin cli --vcs none
 WORKDIR /cli
 COPY ./cli/Cargo.toml ./Cargo.toml
 RUN cargo check
 
 WORKDIR /
-RUN USER=root cargo new --bin contracts/track_and_trace
+RUN USER=root cargo new --bin contracts/track_and_trace --vcs none
 WORKDIR /contracts/track_and_trace
 
 COPY ./contracts/track_and_trace/Cargo.toml ./Cargo.toml

--- a/docker/tests
+++ b/docker/tests
@@ -50,7 +50,8 @@ RUN rustup update \
 
 COPY ./sdk /sdk
 
-RUN USER=root cargo new --bin contracts/schema
+RUN mkdir contracts \
+ && USER=root cargo new --bin contracts/schema
 WORKDIR /contracts/schema
 
 #Build modules with dummy source in order to cache dependencies in Docker image.


### PR DESCRIPTION
The updated version of cargo in the nightly toolchain throws an error on `cargo new --bin contracts/[CONTRACT]` if the contracts directory doesn't exist.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>