### PR TITLE
Update property update return value

### DIFF
--- a/daemon/src/database/helpers/track_and_trace.rs
+++ b/daemon/src/database/helpers/track_and_trace.rs
@@ -363,7 +363,7 @@ pub fn list_reported_value_reporter_to_agent_metadata(
                 .and(reported_value_reporter_to_agent_metadata::record_id.eq(record_id))
                 .and(
                     reported_value_reporter_to_agent_metadata::reported_value_end_block_num
-                        .le(MAX_BLOCK_NUM),
+                        .eq(MAX_BLOCK_NUM),
                 ),
         )
         .load::<ReportedValueReporterToAgentMetadata>(conn)


### PR DESCRIPTION
Update the method that fetched property update values so that it
returns an array that only contains one copy of each update. This
simplifies the payload returned in API calls to the /records/:recordId?
endpoints.

Signed-off-by: Davey Newhall <newhall@bitwise.io>