### PR TITLE
Retire Inactive Maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @boydjohnson @chenette @davececchi @dcmiddle @dplumb94 @jsmitchell @peterschwarz @rbuysse @RyanLassigBanks @vaporos
+*       @agunde406 @chenette @davececchi @dcmiddle @dplumb94 @jsmitchell @peterschwarz @rbuysse @RyanLassigBanks @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,10 @@
+## Maintainers
+
+### Active Maintainers
 | Name | GitHub | RocketChat |
 | --- | --- | --- |
 | Andi Gunderson | agunde406 | agunde |
 | Anne Chenette | chenette | achenette |
-| Boyd Johnson | boydjohnson | boydjohnson |
 | Dan Middleton | dcmiddle | Dan |
 | Darian Plumb | dplumb94 | dplumb |
 | Dave Cecchi | davececchi | cecchi |
@@ -11,3 +13,8 @@
 | Ryan Banks | RyanLassigBanks | RyanBanks |
 | Ryan Beck-Buysse | rbuysse | rbuysse |
 | Shawn Amundson | vaporos | amundson |
+
+### Retired Maintainers
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Boyd Johnson | boydjohnson | boydjohnson |


### PR DESCRIPTION
Boyd Johnson has asked to be retired.

As described in the Grid Governance RFC changes to maintainers must be approved unanimously by the current group of maintainers.