### PR TITLE
Propose new maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @chenette @davececchi @dcmiddle @dplumb94 @jsmitchell @peterschwarz @rbuysse @RyanLassigBanks @vaporos
+*       @agunde406 @chenette @davececchi @dcmiddle @dplumb94 @eloaverona @jsmitchell @peterschwarz @rberg2 @rbuysse @RyanLassigBanks @shannynalayna @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,10 +8,13 @@
 | Dan Middleton | dcmiddle | Dan |
 | Darian Plumb | dplumb94 | dplumb |
 | Dave Cecchi | davececchi | cecchi |
+| Eloá Franca Verona | eloaverona | eloafran |
 | James Mitchell | jsmitchell | jsmitchell |
 | Peter Schwarz | peterschwarz | pschwarz |
+| Richard Berg | rberg2 | rberg2 |
 | Ryan Banks | RyanLassigBanks | RyanBanks |
 | Ryan Beck-Buysse | rbuysse | rbuysse |
+| Shannyn Telander | shannynalayna | shannynalayna |
 | Shawn Amundson | vaporos | amundson |
 
 ### Retired Maintainers


### PR DESCRIPTION
Propose that Eloá Franca Verona, Richard Berg and
Shannyn Telander be added as maintainers

As described in the Grid Governance RFC changes to maintainers must be approved unanimously by the current group of maintainers.