### PR TITLE
Remove rust nightly from smart contract dockerfiles

### DIFF
--- a/contracts/pike/Dockerfile
+++ b/contracts/pike/Dockerfile
@@ -40,8 +40,7 @@ RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
  && rustup-init -y
 
 RUN rustup update \
- && rustup default nightly \
- && rustup target add wasm32-unknown-unknown --toolchain nightly
+ && rustup target add wasm32-unknown-unknown
 
 # For Building Protobufs
 RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \

--- a/contracts/schema/Dockerfile
+++ b/contracts/schema/Dockerfile
@@ -46,8 +46,7 @@ RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
  && rustup-init -y
 
 RUN rustup update \
- && rustup default nightly \
- && rustup target add wasm32-unknown-unknown --toolchain nightly
+ && rustup target add wasm32-unknown-unknown
 
 # For Building Protobufs
 RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \

--- a/contracts/track_and_trace/Dockerfile
+++ b/contracts/track_and_trace/Dockerfile
@@ -46,8 +46,7 @@ RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
  && rustup-init -y
 
 RUN rustup update \
- && rustup default nightly \
- && rustup target add wasm32-unknown-unknown --toolchain nightly
+ && rustup target add wasm32-unknown-unknown
 
 # For Building Protobufs
 RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \

--- a/docker/tests
+++ b/docker/tests
@@ -45,8 +45,7 @@ RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.7.1/proto
 ENV PATH=$PATH:/root/.cargo/bin:/project/grid/bin
 
 RUN rustup update \
- && rustup default nightly \
- && rustup target add wasm32-unknown-unknown --toolchain nightly
+ && rustup target add wasm32-unknown-unknown
 
 COPY ./sdk /sdk
 


### PR DESCRIPTION
We no longer need rust nightly to compile into wasm.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>