### PR TITLE
Add product properties database field

### DIFF
--- a/daemon/migrations/2019-07-03-161310_create_product_table/up.sql
+++ b/daemon/migrations/2019-07-03-161310_create_product_table/up.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS product (
     prod_id VARCHAR(256) NOT NULL,
     prod_type TEXT NOT NULL,
     owner VARCHAR(256) NOT NULL,
-    metadata JSON [] NOT NULL
+    properties TEXT []
 ) INHERITS (chain_record);
 
 CREATE INDEX IF NOT EXISTS prod_id_block_num_idx

--- a/daemon/src/database/models.rs
+++ b/daemon/src/database/models.rs
@@ -97,7 +97,7 @@ pub struct NewProduct {
     pub prod_id: String,
     pub prod_type: Vec<String>,
     pub owner: String,
-    pub metadata: Vec<JsonValue>,
+    pub properties: Vec<String>,
 
     // The indicators of the start and stop for the slowly-changing dimensions.
     pub start_block_num: i64,
@@ -111,7 +111,7 @@ pub struct Product {
     pub prod_id: String,
     pub prod_type: Vec<String>,
     pub owner: String,
-    pub metadata: Vec<JsonValue>,
+    pub properties: Vec<String>,
 
     // The indicators of the start and stop for the slowly-changing dimensions.
     pub start_block_num: i64,

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -103,7 +103,7 @@ table! {
         prod_id -> Varchar,
         prod_type -> Array<Text>,
         owner -> Varchar,
-        metadata -> Array<Json>,
+        properties -> Array<Text>,
         start_block_num -> Int8,
         end_block_num -> Int8,
     }


### PR DESCRIPTION
Adding the `properties` field to the Product database schema/model (replaces `metatdata` field)