### PR TITLE
Remove constraint on ProductList length

### DIFF
--- a/sdk/src/protocol/product/state.rs
+++ b/sdk/src/protocol/product/state.rs
@@ -367,16 +367,6 @@ impl ProductListBuilder {
             ProductListBuildError::MissingField("'products' field is required".to_string())
         })?;
 
-        let products = {
-            if products.is_empty() {
-                return Err(ProductListBuildError::MissingField(
-                    "'products' cannot be empty".to_string(),
-                ));
-            } else {
-                products
-            }
-        };
-
         Ok(ProductList { products })
     }
 }


### PR DESCRIPTION
When deleting a Product, it is likely that there is only a single Product at the given address. This is not possible with the current `is_empty` constraint on the ProductListBuilder.

This commit removes that constraint to allow for Product deletion.

Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>