### PR TITLE
Implement state entry deletion on Product contract

### DIFF
--- a/contracts/product/src/validation.rs
+++ b/contracts/product/src/validation.rs
@@ -208,5 +208,4 @@ mod tests {
             "InvalidTransaction: Invalid GTIN, GTIN-8 is not supported at this time: 40170725"
         );
     }
-
 }


### PR DESCRIPTION
When deleting a product, if there is only a single product stored at a
given address then we should delete that entry in state. The current
implementation does not handle an address with exactly one product at an
address - this commit implements the state entry deletion in that case.

Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>