### PR TITLE
Implement Product Database Operations

### DIFF
--- a/daemon/migrations/2019-07-03-161310_create_product_table/up.sql
+++ b/daemon/migrations/2019-07-03-161310_create_product_table/up.sql
@@ -16,6 +16,7 @@
 CREATE TABLE IF NOT EXISTS product (
     id BIGSERIAL PRIMARY KEY,
     product_id VARCHAR(256) NOT NULL,
+    product_address VARCHAR(70) NOT NULL,
     product_namespace TEXT NOT NULL,
     owner VARCHAR(256) NOT NULL
 ) INHERITS (chain_record);

--- a/daemon/migrations/2019-08-08-145850_create_product_property_table/up.sql
+++ b/daemon/migrations/2019-08-08-145850_create_product_property_table/up.sql
@@ -16,6 +16,7 @@
 CREATE TABLE IF NOT EXISTS product_property_value (
     id BIGSERIAL PRIMARY KEY,
     product_id VARCHAR(256) NOT NULL,
+    product_address VARCHAR(70) NOT NULL,
     property_name TEXT NOT NULL,
     data_type TEXT NOT NULL,
     bytes_value BYTEA,

--- a/daemon/src/database/helpers/products.rs
+++ b/daemon/src/database/helpers/products.rs
@@ -43,11 +43,43 @@ pub fn insert_product_property_values(
     property_values: &[NewProductPropertyValue],
 ) -> QueryResult<()> {
     for value in property_values {
-        update_prod_property_values(conn, &value.property_name, value.start_block_num)?;
+        update_prod_property_values(conn, &value.product_id, value.start_block_num)?;
     }
 
     insert_into(product_property_value::table)
         .values(property_values)
+        .execute(conn)
+        .map(|_| ())
+}
+
+pub fn delete_product(
+    conn: &PgConnection,
+    address: &str,
+    current_block_num: i64,
+) -> QueryResult<()> {
+    update(product::table)
+        .filter(
+            product::product_address
+                .eq(address)
+                .and(product::end_block_num.eq(MAX_BLOCK_NUM)),
+        )
+        .set(product::end_block_num.eq(current_block_num))
+        .execute(conn)
+        .map(|_| ())
+}
+
+pub fn delete_product_property_values(
+    conn: &PgConnection,
+    address: &str,
+    current_block_num: i64,
+) -> QueryResult<()> {
+    update(product_property_value::table)
+        .filter(
+            product_property_value::product_address
+                .eq(address)
+                .and(product_property_value::end_block_num.eq(MAX_BLOCK_NUM)),
+        )
+        .set(product_property_value::end_block_num.eq(current_block_num))
         .execute(conn)
         .map(|_| ())
 }
@@ -70,13 +102,13 @@ fn update_prod_end_block_num(
 
 fn update_prod_property_values(
     conn: &PgConnection,
-    property_name: &str,
+    product_id: &str,
     current_block_num: i64,
 ) -> QueryResult<()> {
     update(product_property_value::table)
         .filter(
-            product_property_value::property_name
-                .eq(property_name)
+            product_property_value::product_id
+                .eq(product_id)
                 .and(product_property_value::end_block_num.eq(MAX_BLOCK_NUM)),
         )
         .set(product_property_value::end_block_num.eq(current_block_num))

--- a/daemon/src/database/models.rs
+++ b/daemon/src/database/models.rs
@@ -95,6 +95,7 @@ pub struct Organization {
 #[table_name = "product"]
 pub struct NewProduct {
     pub product_id: String,
+    pub product_address: String,
     pub product_namespace: String,
     pub owner: String,
 
@@ -108,6 +109,7 @@ pub struct Product {
     ///  This is the product id for the slowly-changing-dimensions table.
     pub id: i64,
     pub product_id: String,
+    pub product_address: String,
     pub product_namespace: String,
     pub owner: String,
 
@@ -120,6 +122,7 @@ pub struct Product {
 #[table_name = "product_property_value"]
 pub struct NewProductPropertyValue {
     pub product_id: String,
+    pub product_address: String,
     pub property_name: String,
     pub data_type: String,
     pub bytes_value: Option<Vec<u8>>,
@@ -141,6 +144,7 @@ pub struct ProductPropertyValue {
     ///  This is the product id for the slowly-changing-dimensions table.
     pub id: i64,
     pub product_id: String,
+    pub product_address: String,
     pub property_name: String,
     pub data_type: String,
     pub bytes_value: Option<Vec<u8>>,

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -101,6 +101,7 @@ table! {
     product (id) {
         id -> Int8,
         product_id -> Varchar,
+        product_address -> Varchar,
         product_namespace -> Text,
         owner -> Varchar,
         start_block_num -> Int8,
@@ -114,6 +115,7 @@ table! {
     product_property_value (id) {
         id -> Int8,
         product_id -> Varchar,
+        product_address -> Varchar,
         property_name -> Text,
         data_type -> Text,
         bytes_value -> Nullable<Bytea>,

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -840,6 +840,7 @@ mod test {
 
         let test_product = body.first().unwrap();
         assert_eq!(test_product.product_id, "041205707820".to_string());
+        assert_eq!(test_product.product_address, "test_address".to_string());
         assert_eq!(test_product.product_namespace, "Grid Product".to_string());
         assert_eq!(test_product.owner, "phillips001".to_string());
         assert_eq!(test_product.properties.len(), 2);
@@ -867,6 +868,7 @@ mod test {
         let test_product: ProductSlice =
             serde_json::from_slice(&*response.body().wait().unwrap()).unwrap();
         assert_eq!(test_product.product_id, "041205707820".to_string());
+        assert_eq!(test_product.product_address, "test_address".to_string());
         assert_eq!(test_product.product_namespace, "Grid Product".to_string());
         assert_eq!(test_product.owner, "phillips001".to_string());
         assert_eq!(test_product.properties.len(), 2);
@@ -1785,6 +1787,7 @@ mod test {
     fn get_product() -> Vec<NewProduct> {
         vec![NewProduct {
             product_id: "041205707820".to_string(),
+            product_address: "test_address".to_string(),
             product_namespace: "Grid Product".to_string(),
             owner: "phillips001".to_string(),
             start_block_num: 0,
@@ -2289,6 +2292,7 @@ mod test {
                 start_block_num: 0,
                 end_block_num: MAX_BLOCK_NUM,
                 product_id: "041205707820".to_string(),
+                product_address: "test_address".to_string(),
                 property_name: "Test Grid Product".to_string(),
                 data_type: "Lightbulb".to_string(),
                 bytes_value: None,
@@ -2303,6 +2307,7 @@ mod test {
                 start_block_num: 0,
                 end_block_num: MAX_BLOCK_NUM,
                 product_id: "041205707820".to_string(),
+                product_address: "test_address".to_string(),
                 property_name: "Test Grid Product".to_string(),
                 data_type: "Lightbulb".to_string(),
                 bytes_value: None,

--- a/daemon/src/rest_api/routes/products.rs
+++ b/daemon/src/rest_api/routes/products.rs
@@ -31,6 +31,7 @@ use std::collections::HashMap;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProductSlice {
     pub product_id: String,
+    pub product_address: String,
     pub product_namespace: String,
     pub owner: String,
     pub properties: Vec<ProductPropertyValueSlice>,
@@ -40,6 +41,7 @@ impl ProductSlice {
     pub fn from_model(product: &Product, properties: Vec<ProductPropertyValue>) -> Self {
         Self {
             product_id: product.product_id.clone(),
+            product_address: product.product_address.clone(),
             product_namespace: product.product_namespace.clone(),
             owner: product.owner.clone(),
             properties: properties


### PR DESCRIPTION
- Detect StateChange_Type::DELETE in state delta subscriber for GRID_PRODUCT
- Add RemoveProduct(address, current_block_num) as a DbInsertOperation
- Add delete_product and delete_product_property_values functions to db helpers
- Add product_address field to product and product_property_value tables
- Add product_address field to associated Product and ProductPropertyValue structs
- Update all product properties by property_id instead of property_name

See [Jira](https://jira.hyperledger.org/browse/GRID-105)