### PR TITLE
Add integration testing for Product

### DIFF
--- a/bin/run_integration_tests
+++ b/bin/run_integration_tests
@@ -32,5 +32,21 @@ function clean_up {
     docker-compose  down
 }
 
+clean_up
+
+cd $top_dir/integration
+
+docker-compose up --abort-on-container-exit --exit-code-from gridd
+test_exit=$?
+
+if [[ $test_exit != 0 ]]; then
+    exitcode=1
+fi
+
+function clean_up {
+    docker-compose  down
+}
+
 trap clean_up EXIT
+
 exit $exitcode

--- a/bin/run_unit_tests
+++ b/bin/run_unit_tests
@@ -20,7 +20,7 @@ top_dir=$(cd $(dirname $(dirname $0)) && pwd)
 
   cd $top_dir
 
-  result=$(cargo test)
+  result=$(cargo test -- --skip integration)
   test_exit=$?
 
   echo "$result"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,7 @@ name = "grid"
 path = "src/main.rs"
 
 [dependencies]
+assert_cmd = "0.11"
 clap = "2"
 log = "0.4"
 simple_logger = "1.0"

--- a/cli/tests/product.rs
+++ b/cli/tests/product.rs
@@ -1,0 +1,168 @@
+// Copyright (c) 2019 Target Brands, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate assert_cmd;
+extern crate dirs;
+
+use assert_cmd::prelude::*;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use users::get_current_username;
+
+mod integration {
+    use super::*;
+    static KEY_DIR: &str = "/root";
+    static PUB_KEY_FILE: &str = "/root/.grid/keys/root.pub";
+
+    static ORG_ID: &str = "314156";
+    static ORG_NAME: &str = "target";
+    static ORG_ADDRESS: &str = "target hq";
+
+    static PRODUCT_CREATE_FILE: &str = "tests/yaml/test_product_create.yaml";
+    static PRODUCT_UPDATE_FILE: &str = "tests/yaml/test_product_update.yaml";
+
+    static PRODUCT_DELETE_ID: &str = "762111177704";
+
+    /// Verifies a `grid product create` command successfully runs.
+    ///
+    ///     The product information is read in from a yaml file.
+    ///
+    #[test]
+    fn test_product_create() {
+        setup();
+        //run `grid product create`
+        let mut cmd_product_create = make_grid_command();
+        cmd_product_create
+            .arg("product")
+            .arg("create")
+            .arg(&PRODUCT_CREATE_FILE);
+        cmd_product_create.assert().success();
+    }
+
+    /// Verifies a `grid product update` command successfully runs.
+    ///
+    ///     The product information is read in from a yaml file.
+    ///     Products are first created before being updated.
+    ///
+    #[test]
+    fn test_product_update() {
+        setup();
+        //run `grid product create`
+        let mut cmd_product_create = make_grid_command();
+        cmd_product_create
+            .arg("product")
+            .arg("create")
+            .arg(&PRODUCT_CREATE_FILE);
+        cmd_product_create.assert().success();
+
+        //run `grid product update`
+        let mut cmd_product_update = make_grid_command();
+        cmd_product_update
+            .arg("product")
+            .arg("update")
+            .arg(&PRODUCT_UPDATE_FILE);
+        cmd_product_update.assert().success();
+    }
+
+    /// Verifies a `grid product delete` command successfully runs.
+    ///
+    ///     The delete command is supplied the product id and type.
+    ///     Products are first created before being deleted.
+    ///
+    #[test]
+    fn test_product_delete() {
+        setup();
+        //run `grid product create`
+        let mut cmd_product_create = make_grid_command();
+        cmd_product_create
+            .arg("product")
+            .arg("create")
+            .arg(&PRODUCT_CREATE_FILE);
+        cmd_product_create.assert().success();
+
+        //run `grid product delete`
+        let mut cmd_product_delete = make_grid_command();
+        cmd_product_delete
+            .arg("product")
+            .arg("delete")
+            .arg(&PRODUCT_DELETE_ID)
+            .arg("GS1"); //product type
+        cmd_product_delete.assert().success();
+    }
+
+    /// Creates keys, an organization, and an agent
+    ///
+    ///     Necessary to run product commands
+    ///
+    fn setup() {
+        //run `grid keygen`
+        let key_name: String = get_current_username().unwrap().into_string().unwrap();
+        let mut key_dir: PathBuf = dirs::home_dir().unwrap();
+        assert_eq!(PathBuf::from(KEY_DIR), key_dir);
+        key_dir.push(".grid");
+        key_dir.push("keys");
+        key_dir.push(&key_name);
+        let mut cmd_key = make_grid_command();
+        cmd_key.arg("keygen").arg("--force");
+        cmd_key.assert().success();
+        let mut public_key_path = key_dir.clone();
+        public_key_path.set_extension("pub");
+        let mut private_key_path = key_dir.clone();
+        private_key_path.set_extension("priv");
+        assert!(public_key_path.exists());
+        assert!(private_key_path.exists());
+
+        //run `grid organization create`
+        let mut cmd_org_create = make_grid_command();
+        cmd_org_create
+            .arg("organization")
+            .arg("create")
+            .arg(&ORG_ID)
+            .arg(&ORG_NAME)
+            .arg(&ORG_ADDRESS)
+            .args(&["--metadata", "gs1_company_prefixes=314"]);
+        cmd_org_create.assert().success();
+
+        //run `grid agent create`
+        let pub_key = fs::read_to_string(PUB_KEY_FILE).unwrap();
+        let mut cmd_agent_create = make_grid_command();
+        cmd_agent_create
+            .arg("agent")
+            .arg("create")
+            .arg(&ORG_ID)
+            .arg(&pub_key)
+            .arg("true")
+            .args(&[
+                "--roles",
+                "admin",
+                "can_create_product",
+                "can_update_product",
+                "can_delete_product",
+            ]);
+        cmd_agent_create.assert().success();
+    }
+
+    /// Makes a grid system command
+    ///
+    ///     Supplies the command with the grid server's URL from an environment variable
+    ///
+    fn make_grid_command() -> Command {
+        let mut cmd = Command::cargo_bin("grid").unwrap();
+        let url = env::var("INTEGRATION_TEST_URL").unwrap_or("http://gridd:8080".to_string());
+        cmd.args(&["--url", &url]).arg("-vv");
+        return cmd;
+    }
+}

--- a/cli/tests/yaml/test_product_create.yaml
+++ b/cli/tests/yaml/test_product_create.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2019 Target Brands, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+#
+- product_type: "GS1"
+  product_id: "762111177704"
+  owner: "314156"
+  properties:
+    - name: "length"
+      data_type: "NUMBER"
+      number_value: 8
+    - name: "width"
+      data_type: "NUMBER"
+      number_value: 11
+    - name: "depth"
+      data_type: "NUMBER"
+      number_value: 1
+- product_type: "GS1"
+  product_id: "881334009880"
+  owner: "314156"
+  properties:
+    - name: "price"
+      data_type: "NUMBER"
+      number_value: 8
+    - name: "height"
+      data_type: "NUMBER"
+      number_value: 11

--- a/cli/tests/yaml/test_product_update.yaml
+++ b/cli/tests/yaml/test_product_update.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2019 Target Brands, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+#
+- product_type: "GS1"
+  product_id: "762111177704"
+  properties:
+    - name: "length"
+      data_type: "NUMBER"
+      number_value: 88
+    - name: "width"
+      data_type: "NUMBER"
+      number_value: 111
+    - name: "depth"
+      data_type: "NUMBER"
+      number_value: 11
+- product_type: "GS1"
+  product_id: "881334009880"
+  properties:
+    - name: "price"
+      data_type: "NUMBER"
+      number_value: 88
+    - name: "height"
+      data_type: "NUMBER"
+      number_value: 111

--- a/daemon/test/docker-compose.yaml
+++ b/daemon/test/docker-compose.yaml
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-
-version: '2.1'
+version: "2.1"
 
 services:
     test_server:
@@ -26,24 +25,27 @@ services:
             POSTGRES_PASSWORD: grid_test
             POSTGRES_DB: grid_test
 
-    daemon:
-        build:
-          context: ../..
-          dockerfile: docker/tests
-          args:
-            - http_proxy
-            - https_proxy
-            - no_proxy
-        image: grid:tests
-        volumes:
-          - ../..:/project/grid
-        command: |
-          bash -c "
-            # we need to wait for the db to have started.
-            until PGPASSWORD=grid_test psql -h test_server -U grid_test -c '\q'; do
-                >&2 echo \"Database is unavailable - sleeping\"
-                sleep 1
-            done
-            cd daemon
-            cargo test --features test-api --  --test-threads=1
-            "
+  daemon:
+    build:
+      context: ../..
+      dockerfile: docker/tests
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: grid:tests
+    volumes:
+      - ../..:/project/grid
+    command: |
+      bash -c "
+        # we need to wait for the db to have started.
+        until PGPASSWORD=grid_test psql -h test_server -U grid_test -c '\q'; do
+            >&2 echo \"Database is unavailable - sleeping\"
+            sleep 1
+        done
+        cd daemon
+        cargo test --features test-api --  --test-threads=1
+        cd ../cli
+        cargo test actions -- --test-threads=1
+        cargo test yaml_parser -- --test-threads=1
+        "

--- a/daemon/test/docker-compose.yaml
+++ b/daemon/test/docker-compose.yaml
@@ -15,15 +15,15 @@
 version: "2.1"
 
 services:
-    test_server:
-        image: postgres
-        restart: always
-        ports:
-            - '5433:5432'
-        environment:
-            POSTGRES_USER: grid_test
-            POSTGRES_PASSWORD: grid_test
-            POSTGRES_DB: grid_test
+  test_server:
+    image: postgres
+    restart: always
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_USER: grid_test
+      POSTGRES_PASSWORD: grid_test
+      POSTGRES_DB: grid_test
 
   daemon:
     build:

--- a/docker/tests
+++ b/docker/tests
@@ -76,6 +76,13 @@ WORKDIR /contracts/track_and_trace
 COPY ./contracts/track_and_trace/Cargo.toml ./Cargo.toml
 RUN cargo check
 
+WORKDIR /
+RUN USER=root cargo new --bin contracts/product --vcs none
+WORKDIR /contracts/product
+
+COPY ./contracts/product/Cargo.toml ./Cargo.toml
+RUN cargo check
+
 ENTRYPOINT []
 
 WORKDIR /project/grid

--- a/integration/.env
+++ b/integration/.env
@@ -1,0 +1,3 @@
+ISOLATION_ID=latest
+DISTRO=bionic
+REPO_VERSION=0.1.0-dev

--- a/integration/docker-compose.yaml
+++ b/integration/docker-compose.yaml
@@ -1,0 +1,268 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+version: "2.1"
+
+volumes:
+  grid-shared:
+
+services:
+  tnt-contract-builder:
+    logging:
+      driver: none
+    image: tnt-contract-builder
+    container_name: tnt-contract-builder
+    build:
+      context: .
+      dockerfile: contracts/track_and_trace/Dockerfile
+      args:
+        - REPO_VERSION=${REPO_VERSION}
+    volumes:
+      - grid-shared:/grid-shared
+    entrypoint: |
+      bash -c "
+        while true; do curl -s http://grid-sawtooth-rest-api:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
+        sabre cr --create grid_track_and_trace --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre upload --filename /tmp/track_and_trace.yaml --key /grid-shared/my_key --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre ns --create a43b46 --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm a43b46 grid_track_and_trace --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm 621dee01 grid_track_and_trace --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm cad11d grid_track_and_trace --key /grid-shared/my_key --read --url http://grid-sawtooth-rest-api:8008 --wait 30
+        echo '---------========= track and trace contract is loaded =========---------'
+        tail -f /dev/null
+      "
+
+  schema-contract-builder:
+    logging:
+      driver: none
+    image: schema-contract-builder
+    container_name: schema-contract-builder
+    build:
+      context: .
+      dockerfile: contracts/schema/Dockerfile
+      args:
+        - REPO_VERSION=${REPO_VERSION}
+    volumes:
+      - grid-shared:/grid-shared
+    entrypoint: |
+      bash -c "
+        while true; do curl -s http://grid-sawtooth-rest-api:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
+        sabre cr --create grid_schema --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre upload --filename /tmp/schema.yaml --key /grid-shared/my_key --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre ns --create 621dee01 --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm 621dee01 grid_schema --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm cad11d grid_schema --key /grid-shared/my_key --read --url http://grid-sawtooth-rest-api:8008 --wait 30
+        echo '---------========= grid schema contract is loaded =========---------'
+        tail -f /dev/null
+      "
+
+  pike-contract-builder:
+    logging:
+      driver: none
+    image: pike-contract-builder
+    container_name: pike-contract-builder
+    build:
+      context: .
+      dockerfile: contracts/pike/Dockerfile
+      args:
+        - REPO_VERSION=${REPO_VERSION}
+    volumes:
+      - grid-shared:/grid-shared
+    entrypoint: |
+      bash -c "
+        while true; do curl -s http://grid-sawtooth-rest-api:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
+        sabre cr --create pike --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre upload --filename /tmp/pike.yaml --key /grid-shared/my_key --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre ns --create cad11d --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm cad11d pike --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        echo '---------========= pike contract is loaded =========---------'
+        tail -f /dev/null
+      "
+
+  product-contract-builder:
+    logging:
+      driver: none
+    image: product-contract-builder
+    container_name: product-contract-builder
+    build:
+      context: .
+      dockerfile: contracts/product/Dockerfile
+      args:
+        - REPO_VERSION=${REPO_VERSION}
+    volumes:
+      - grid-shared:/grid-shared
+    entrypoint: |
+      bash -c "
+        while true; do curl -s http://grid-sawtooth-rest-api:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
+        sabre cr --create grid_product --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre upload --filename /tmp/product.yaml --key /grid-shared/my_key --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre ns --create cad11d --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre ns --create 621dee01 --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre ns --create 621dee02 --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm cad11d grid_product --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm 621dee01 grid_product --key /grid-shared/my_key --read --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm 621dee02 grid_product --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        echo '---------========= grid_product contract is loaded =========---------'
+        tail -f /dev/null
+      "
+
+  validator:
+    logging:
+      driver: none
+    image: hyperledger/sawtooth-validator:1.1
+    container_name: grid-sawtooth-validator
+    expose:
+      - 4004
+    ports:
+      - "4020:4004"
+    volumes:
+      - grid-shared:/grid-shared
+    # start the validator with an empty genesis batch
+    entrypoint: |
+      bash -c "
+        if [ ! -f /etc/sawtooth/keys/validator.priv ]; then
+          sawadm keygen &&
+          sawtooth keygen my_key &&
+          cp /root/.sawtooth/keys/my_key.* /grid-shared &&
+          sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
+          sawset proposal create \
+            -k /root/.sawtooth/keys/my_key.priv \
+            sawtooth.consensus.algorithm.name=Devmode \
+            sawtooth.consensus.algorithm.version=0.1 \
+            -o config.batch &&
+          sawset proposal create \
+            -k /root/.sawtooth/keys/my_key.priv \
+            sawtooth.swa.administrators=$$(cat /grid-shared/my_key.pub) \
+            -o sabre-admin.batch
+          sawadm genesis config-genesis.batch config.batch sabre-admin.batch
+        fi;
+        sawtooth-validator -vv \
+          --endpoint tcp://validator:8800 \
+          --bind component:tcp://eth0:4004 \
+          --bind network:tcp://eth0:8800 \
+          --bind consensus:tcp://eth0:5050
+      "
+
+  devmode-engine:
+    logging:
+      driver: none
+    image: hyperledger/sawtooth-devmode-engine-rust:1.1
+    container_name: sawtooth-devmode-engine-rust-default
+    depends_on:
+      - validator
+    entrypoint: devmode-engine-rust -C tcp://validator:5050
+
+  settings-tp:
+    logging:
+      driver: none
+    image: hyperledger/sawtooth-settings-tp:1.1
+    container_name: grid-sawtooth-settings-tp
+    depends_on:
+      - validator
+    entrypoint: settings-tp -vv -C tcp://validator:4004
+
+  rest-api:
+    logging:
+      driver: none
+    image: hyperledger/sawtooth-rest-api:1.1
+    container_name: grid-sawtooth-rest-api
+    expose:
+      - 8008
+    ports:
+      - "8024:8008"
+    depends_on:
+      - validator
+    entrypoint: |
+      sawtooth-rest-api -vv
+        --connect tcp://validator:4004
+        --bind rest-api:8008
+
+  gridd:
+    container_name: gridd
+    build:
+      context: ..
+      dockerfile: docker/tests
+    environment:
+      INTEGRATION_TEST_URL: http://gridd:8080
+    expose:
+      - 8080
+    ports:
+      - "8080:8080"
+    volumes:
+      - ..:/project/grid
+    entrypoint: |
+      bash -c "
+        cargo build -p grid-daemon  && \
+        cargo build -p grid-cli  && \
+        # we need to wait for the db to have started.
+        until PGPASSWORD=grid_example psql -h db -U grid -c '\q'; do
+            >&2 echo \"Database is unavailable - sleeping\"
+            sleep 1
+        done
+        cp /project/grid/target/debug/gridd /usr/sbin/gridd && \
+        cp /project/grid/target/debug/grid /usr/bin/grid && \
+        grid database migrate \
+            --database-url postgres://grid:grid_example@db/grid && \
+        gridd -b gridd:8080 -C tcp://validator:4004 \
+            --database-url postgres://grid:grid_example@db/grid &
+        cd cli
+        cargo test integration -- --nocapture --test-threads=1
+      "
+
+  grid-cli:
+    logging:
+      driver: none
+    image: grid-cli:${ISOLATION_ID}
+    container_name: grid-cli
+    build:
+      context: .
+      dockerfile: cli/Dockerfile
+      args:
+        - CARGO_ARGS=${CARGO_ARGS}
+        - REPO_VERSION=${REPO_VERSION}
+    entrypoint: |
+      tail -f /dev/null
+
+  sabre-tp:
+    logging:
+      driver: none
+    image: hyperledger/sawtooth-sabre-tp:latest
+    container_name: sawtooth-sabre-tp
+    depends_on:
+      - validator
+    entrypoint: sawtooth-sabre -vv --connect tcp://validator:4004
+
+  sawtooth-shell:
+    logging:
+      driver: none
+    image: hyperledger/sawtooth-shell:1.1
+    container_name: grid-sawtooth-shell
+    command: |
+      bash -c "
+        sawtooth keygen &&
+        tail -f /dev/null
+      "
+  db:
+    logging:
+      driver: none
+    image: postgres
+    restart: always
+    expose:
+      - 5432
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: grid
+      POSTGRES_PASSWORD: grid_example
+      POSTGRES_DB: grid


### PR DESCRIPTION
- Run tests with `docker-compose -f integration/docker-compose.yaml up`
- Create tests that call CLI functions and check their effects
- Test product create success
- Test product update success
- Test product delete success
- Add these tests to the `bin/run_integration_tests` script
- Add calls for CLI unit tests in `daemon/test/docker-compose.yaml` and `docker/tests`
Note: the unit tests are called by name to avoid also calling integration tests, which
will fail without all services running.
- Format docker compose yaml

This adds a separate docker-compose.yaml (`integration/docker-compose.yaml`) to run integration tests. The compose file is the same as the default `docker-compose.yaml` with logging turned down and a `cargo test` command to run the integration tests after starting the daemon. An optional `INTEGRATION_TEST_URL` can be provided, the default being `http://gridd:8080`.

The tests live in `cli/tests/product.rs`, according to Rust convention, and use the [assert_cmd](https://github.com/assert-rs/assert_cmd) crate recommended by [clap](https://github.com/clap-rs/clap#related-crates). `assert_cmd` takes the rust binary and runs it as a process with given args. The tests currently only verify that the commands do not return errors.

This also adds calls for unit tests in `daemon/test/docker-compose.yaml` and `docker/tests`.

See [Jira](https://jira.hyperledger.org/browse/GRID-106)
Depends on [PR 114](https://github.com/hyperledger/grid/pull/114) and [PR 115](https://github.com/hyperledger/grid/pull/115)