### PR TITLE
Product namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# TODO: replace with root Cargo.toml?
+
+# Quick way to build all sub-projects (expects GNU find)
+.PHONY: build_all
+build_all:
+	find . -name "Cargo.toml" -execdir cargo build ";"
+
+# Quick way to test all sub-projects (expects GNU find)
+.PHONY: test_all
+test_all:
+	find . -name "Cargo.toml" -execdir cargo test ";"

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,14 @@ build_all:
 .PHONY: test_all
 test_all:
 	find . -name "Cargo.toml" -execdir cargo test ";"
+
+# Quick way to lint all sub-projects (expects GNU find and clippy installed)
+.PHONY: clip_all
+clip_all:
+	find . -name "Cargo.toml" -execdir cargo clippy ";"
+
+# Quick way to lint all sub-projects (expects GNU find)
+.PHONY: fmt_all
+fmt_all:
+	find . -name "Cargo.toml" -execdir cargo fmt ";"
+

--- a/cli/src/actions/products.rs
+++ b/cli/src/actions/products.rs
@@ -29,8 +29,8 @@ use crate::error::CliError;
 use serde::Deserialize;
 
 use crate::yaml_parser::{
-    parse_value_as_product_namespace, parse_value_as_repeated_property_values, parse_value_as_sequence,
-    parse_value_as_string,
+    parse_value_as_product_namespace, parse_value_as_repeated_property_values,
+    parse_value_as_sequence, parse_value_as_string,
 };
 
 use sawtooth_sdk::messages::batch::BatchList;

--- a/cli/src/actions/products.rs
+++ b/cli/src/actions/products.rs
@@ -71,7 +71,7 @@ pub struct LatLong {
  */
 pub fn display_product(product: &GridProduct) {
     println!(
-        "Product Id: {:?}\n Product Type: {:?}\n Owner: {:?}\n Properties:",
+        "Product Id: {:?}\n product namespace: {:?}\n Owner: {:?}\n Properties:",
         product.product_id, product.product_namespace, product.owner,
     );
     display_product_property_definitions(&product.properties);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -144,7 +144,7 @@ fn run() -> Result<(), CliError> {
             (@subcommand delete =>
                 (about: "Delete a product")
                 (@arg product_id: +required +takes_value "Unique ID for a product")
-                (@arg product_type: +required +takes_value "Type of product (e.g. GS1")
+                (@arg product_namespace: +required +takes_value "Type of product (e.g. GS1")
             )
             (@subcommand list =>
                 (about: "List currently defined products")
@@ -267,7 +267,7 @@ fn run() -> Result<(), CliError> {
                 key,
                 wait,
                 m.value_of("product_id").unwrap(),
-                m.value_of("product_type").unwrap(),
+                m.value_of("product_namespace").unwrap(),
             )?,
             ("list", Some(_)) => products::do_list_products(&url)?,
             ("show", Some(m)) => {

--- a/cli/src/yaml_parser.rs
+++ b/cli/src/yaml_parser.rs
@@ -262,14 +262,14 @@ pub fn parse_value_as_vec_string(
 /**
  * Given a yaml object, parse it as a Product ProductType
  *
- * product_type - Yaml object we wish to parse in as a Product ProductType
+ * product_namespace - Yaml object we wish to parse in as a Product ProductType
  */
-pub fn parse_value_as_product_type(product_type: &str) -> Result<ProductType, CliError> {
-    match product_type.to_uppercase().as_ref() {
+pub fn parse_value_as_product_namespace(product_namespace: &str) -> Result<ProductType, CliError> {
+    match product_namespace.to_uppercase().as_ref() {
         "GS1" => Ok(ProductType::GS1),
         _ => Err(CliError::InvalidYamlError(format!(
-            "Invalid product_type for value: {}",
-            product_type
+            "Invalid product_namespace for value: {}",
+            product_namespace
         ))),
     }
 }
@@ -652,12 +652,12 @@ mod test {
     }
 
     /*
-     * Verifies parse_value_as_product_type can parse Values as PropertyType for valid inputs
+     * Verifies parse_value_as_product_namespace can parse Values as PropertyType for valid inputs
      */
     #[test]
-    fn test_parse_value_as_product_type() {
+    fn test_parse_value_as_product_namespace() {
         assert_eq!(
-            parse_value_as_product_type("GS1").unwrap(),
+            parse_value_as_product_namespace("GS1").unwrap(),
             ProductType::GS1
         );
     }

--- a/contracts/product/src/handler.rs
+++ b/contracts/product/src/handler.rs
@@ -87,7 +87,7 @@ impl ProductTransactionHandler {
     ) -> Result<(), ApplyError> {
         let product_id = payload.product_id();
         let owner = payload.owner();
-        let product_type = payload.product_type();
+        let product_namespace = payload.product_namespace();
         let properties = payload.properties();
 
         // Check that the agent submitting the transactions exists in state
@@ -121,7 +121,7 @@ impl ProductTransactionHandler {
         }
 
         // Check if the product type is a GS1 product
-        if product_type != &ProductType::GS1 {
+        if product_namespace != &ProductType::GS1 {
             return Err(ApplyError::InvalidTransaction(
                 "Invalid product type enum for product".to_string(),
             ));
@@ -172,7 +172,7 @@ impl ProductTransactionHandler {
         let new_product = ProductBuilder::new()
             .with_product_id(product_id.to_string())
             .with_owner(owner.to_string())
-            .with_product_type(product_type.clone())
+            .with_product_namespace(product_namespace.clone())
             .with_properties(properties.to_vec())
             .build()
             .map_err(|err| {
@@ -192,7 +192,7 @@ impl ProductTransactionHandler {
         perm_checker: &PermissionChecker,
     ) -> Result<(), ApplyError> {
         let product_id = payload.product_id();
-        let product_type = payload.product_type();
+        let product_namespace = payload.product_namespace();
         let properties = payload.properties();
 
         // Check that the agent submitting the transactions exists in state
@@ -218,7 +218,7 @@ impl ProductTransactionHandler {
         }
 
         // Check if the product type is a GS1 product
-        if product_type != &ProductType::GS1 {
+        if product_namespace != &ProductType::GS1 {
             return Err(ApplyError::InvalidTransaction(
                 "Invalid product type enum for product".to_string(),
             ));
@@ -250,7 +250,7 @@ impl ProductTransactionHandler {
         let updated_product = ProductBuilder::new()
             .with_product_id(product_id.to_string())
             .with_owner(product.owner().to_string())
-            .with_product_type(product_type.clone())
+            .with_product_namespace(product_namespace.clone())
             .with_properties(properties.to_vec())
             .build()
             .map_err(|err| {
@@ -270,7 +270,7 @@ impl ProductTransactionHandler {
         perm_checker: &PermissionChecker,
     ) -> Result<(), ApplyError> {
         let product_id = payload.product_id();
-        let product_type = payload.product_type();
+        let product_namespace = payload.product_namespace();
 
         // Check that the agent submitting the transactions exists in state
         let agent = match state.get_agent(signer)? {
@@ -287,7 +287,7 @@ impl ProductTransactionHandler {
         check_permission(perm_checker, signer, "can_delete_product")?;
 
         // Check if the product type is a GS1 product
-        if product_type != &ProductType::GS1 {
+        if product_namespace != &ProductType::GS1 {
             return Err(ApplyError::InvalidTransaction(
                 "Invalid product type enum for product".to_string(),
             ));
@@ -972,7 +972,7 @@ mod tests {
         ProductBuilder::new()
             .with_product_id(PRODUCT_ID.to_string())
             .with_owner(AGENT_ORG_ID.to_string())
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_properties(make_properties())
             .build()
             .expect("Failed to build new_product")
@@ -983,14 +983,14 @@ mod tests {
             ProductBuilder::new()
                 .with_product_id(product_ids[0].to_string())
                 .with_owner(AGENT_ORG_ID.to_string())
-                .with_product_type(ProductType::GS1)
+                .with_product_namespace(ProductType::GS1)
                 .with_properties(make_properties())
                 .build()
                 .expect("Failed to build new_product"),
             ProductBuilder::new()
                 .with_product_id(product_ids[1].to_string())
                 .with_owner(AGENT_ORG_ID.to_string())
-                .with_product_type(ProductType::GS1)
+                .with_product_namespace(ProductType::GS1)
                 .with_properties(make_properties())
                 .build()
                 .expect("Failed to build new_product"),
@@ -1001,7 +1001,7 @@ mod tests {
         ProductBuilder::new()
             .with_product_id(PRODUCT_ID.to_string())
             .with_owner(AGENT_ORG_ID.to_string())
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_properties(make_updated_properties())
             .build()
             .expect("Failed to build new_product")
@@ -1051,7 +1051,7 @@ mod tests {
         ProductCreateActionBuilder::new()
             .with_product_id(PRODUCT_ID.to_string())
             .with_owner(AGENT_ORG_ID.to_string())
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_properties(make_properties())
             .build()
             .expect("Failed to build ProductCreateAction")
@@ -1060,7 +1060,7 @@ mod tests {
     fn make_product_update_action() -> ProductUpdateAction {
         ProductUpdateActionBuilder::new()
             .with_product_id(PRODUCT_ID.to_string())
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_properties(make_updated_properties())
             .build()
             .expect("Failed to build ProductUpdateAction")
@@ -1069,7 +1069,7 @@ mod tests {
     fn make_product_delete_action(product_id: &str) -> ProductDeleteAction {
         ProductDeleteActionBuilder::new()
             .with_product_id(product_id.to_string())
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .build()
             .expect("Failed to build ProductDeleteAction")
     }

--- a/contracts/product/src/handler.rs
+++ b/contracts/product/src/handler.rs
@@ -120,10 +120,10 @@ impl ProductTransactionHandler {
             )));
         }
 
-        // Check if the product type is a GS1 product
+        // Check if the product namespace is a GS1 product
         if product_namespace != &ProductType::GS1 {
             return Err(ApplyError::InvalidTransaction(
-                "Invalid product type enum for product".to_string(),
+                "Invalid product namespace enum for product".to_string(),
             ));
         }
 
@@ -217,10 +217,10 @@ impl ProductTransactionHandler {
             )));
         }
 
-        // Check if the product type is a GS1 product
+        // Check if the product namespace is a GS1 product
         if product_namespace != &ProductType::GS1 {
             return Err(ApplyError::InvalidTransaction(
-                "Invalid product type enum for product".to_string(),
+                "Invalid product namespace enum for product".to_string(),
             ));
         }
 
@@ -286,10 +286,10 @@ impl ProductTransactionHandler {
         // Check signing agent's permission
         check_permission(perm_checker, signer, "can_delete_product")?;
 
-        // Check if the product type is a GS1 product
+        // Check if the product namespace is a GS1 product
         if product_namespace != &ProductType::GS1 {
             return Err(ApplyError::InvalidTransaction(
-                "Invalid product type enum for product".to_string(),
+                "Invalid product namespace enum for product".to_string(),
             ));
         }
 

--- a/contracts/product/src/payload.rs
+++ b/contracts/product/src/payload.rs
@@ -78,7 +78,7 @@ mod tests {
         let mut action = ProductCreateActionProto::new();
         action.set_product_id("688955434684".to_string());
         action.set_owner("my_owner".to_string());
-        action.set_product_type(Product_ProductType::GS1);
+        action.set_product_namespace(Product_ProductType::GS1);
         payload_proto.set_product_create(action);
         let payload = payload_proto.clone().into_native().unwrap();
         assert!(
@@ -98,7 +98,7 @@ mod tests {
         payload_proto.set_action(ActionProto::PRODUCT_CREATE);
         payload_proto.set_timestamp(2);
         let mut action = ProductCreateActionProto::new();
-        action.set_product_type(Product_ProductType::GS1);
+        action.set_product_namespace(Product_ProductType::GS1);
         payload_proto.set_product_create(action.clone());
         let payload = payload_proto.clone().into_native().unwrap();
         match validate_payload(&payload) {
@@ -122,7 +122,7 @@ mod tests {
         payload_proto.set_action(ActionProto::PRODUCT_CREATE);
         payload_proto.set_timestamp(2);
         let mut action = ProductCreateActionProto::new();
-        action.set_product_type(Product_ProductType::GS1);
+        action.set_product_namespace(Product_ProductType::GS1);
         action.set_product_id("688955434684".to_string());
         payload_proto.set_product_create(action.clone());
         let payload = payload_proto.clone().into_native().unwrap();

--- a/contracts/product/src/state.rs
+++ b/contracts/product/src/state.rs
@@ -354,7 +354,7 @@ mod tests {
         ProductBuilder::new()
             .with_product_id(PRODUCT_ID.to_string())
             .with_owner("some_owner".to_string())
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_properties(make_properties())
             .build()
             .expect("Failed to build new_product")

--- a/daemon/src/event/block.rs
+++ b/daemon/src/event/block.rs
@@ -409,7 +409,7 @@ fn state_change_to_db_operation(
                         let new_product = NewProduct {
                             product_id: product.product_id().to_string(),
                             product_address: state_change.address.to_string(),
-                            product_namespace: format!("{:?}", product.product_type()),
+                            product_namespace: format!("{:?}", product.product_namespace()),
                             owner: product.owner().to_string(),
                             start_block_num: block_num,
                             end_block_num: db::MAX_BLOCK_NUM,

--- a/sdk/protos/product_payload.proto
+++ b/sdk/protos/product_payload.proto
@@ -37,24 +37,23 @@ message ProductPayload {
 }
 
 message ProductCreateAction {
-    // product_type and product_id are used in deriving the state address
-    Product.ProductType product_type = 1;
+    // product_namespace and product_id are used in deriving the state address
+    Product.ProductType product_namespace = 1;
     string product_id = 2;
     string owner = 3;
     repeated PropertyValue properties = 4;
 }
 
 message ProductUpdateAction {
-    // product_type and product_id are used in deriving the state address
-    Product.ProductType product_type = 1;
+    // product_namespace and product_id are used in deriving the state address
+    Product.ProductType product_namespace = 1;
     string product_id = 2;
     // this will replace all properties currently defined
     repeated PropertyValue properties = 3;
 }
 
 message ProductDeleteAction {
-    // product_type and product_id are used in deriving the state address
-    Product.ProductType product_type = 1;
+    // product_namespace and product_id are used in deriving the state address
+    Product.ProductType product_namespace = 1;
     string product_id = 2;
  }
- 

--- a/sdk/protos/product_state.proto
+++ b/sdk/protos/product_state.proto
@@ -26,12 +26,12 @@ message Product {
   string product_id = 1;
 
   // What type of product is this (GS1)
-  ProductType product_type = 2;
+  ProductType product_namespace = 2;
 
   // Who owns this product (pike organization id)
   string owner = 3;
 
-  // Addition attributes for custom configurations 
+  // Addition attributes for custom configurations
   repeated PropertyValue properties = 4;
 }
 

--- a/sdk/src/protocol/product/payload.rs
+++ b/sdk/src/protocol/product/payload.rs
@@ -189,15 +189,15 @@ impl ProductPayloadBuilder {
 /// Native implementation for ProductCreateAction
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct ProductCreateAction {
-    product_type: ProductType,
+    product_namespace: ProductType,
     product_id: String,
     owner: String,
     properties: Vec<PropertyValue>,
 }
 
 impl ProductCreateAction {
-    pub fn product_type(&self) -> &ProductType {
-        &self.product_type
+    pub fn product_namespace(&self) -> &ProductType {
+        &self.product_namespace
     }
 
     pub fn product_id(&self) -> &str {
@@ -218,7 +218,7 @@ impl FromProto<product_payload::ProductCreateAction> for ProductCreateAction {
         proto: product_payload::ProductCreateAction,
     ) -> Result<Self, ProtoConversionError> {
         Ok(ProductCreateAction {
-            product_type: ProductType::from_proto(proto.get_product_type())?,
+            product_namespace: ProductType::from_proto(proto.get_product_namespace())?,
             product_id: proto.get_product_id().to_string(),
             owner: proto.get_owner().to_string(),
             properties: proto
@@ -234,7 +234,7 @@ impl FromProto<product_payload::ProductCreateAction> for ProductCreateAction {
 impl FromNative<ProductCreateAction> for product_payload::ProductCreateAction {
     fn from_native(native: ProductCreateAction) -> Result<Self, ProtoConversionError> {
         let mut proto = protos::product_payload::ProductCreateAction::new();
-        proto.set_product_type(native.product_type().clone().into_proto()?);
+        proto.set_product_namespace(native.product_namespace().clone().into_proto()?);
         proto.set_product_id(native.product_id().to_string());
         proto.set_owner(native.owner().to_string());
         proto.set_properties(RepeatedField::from_vec(
@@ -279,7 +279,7 @@ impl IntoNative<ProductCreateAction> for protos::product_payload::ProductCreateA
 
 #[derive(Default, Debug)]
 pub struct ProductCreateActionBuilder {
-    product_type: Option<ProductType>,
+    product_namespace: Option<ProductType>,
     product_id: Option<String>,
     owner: Option<String>,
     properties: Option<Vec<PropertyValue>>,
@@ -289,8 +289,8 @@ impl ProductCreateActionBuilder {
     pub fn new() -> Self {
         ProductCreateActionBuilder::default()
     }
-    pub fn with_product_type(mut self, value: ProductType) -> Self {
-        self.product_type = Some(value);
+    pub fn with_product_namespace(mut self, value: ProductType) -> Self {
+        self.product_namespace = Some(value);
         self
     }
     pub fn with_product_id(mut self, value: String) -> Self {
@@ -306,8 +306,8 @@ impl ProductCreateActionBuilder {
         self
     }
     pub fn build(self) -> Result<ProductCreateAction, BuilderError> {
-        let product_type = self.product_type.ok_or_else(|| {
-            BuilderError::MissingField("'product_type' field is required".to_string())
+        let product_namespace = self.product_namespace.ok_or_else(|| {
+            BuilderError::MissingField("'product_namespace' field is required".to_string())
         })?;
         let product_id = self
             .product_id
@@ -319,7 +319,7 @@ impl ProductCreateActionBuilder {
             .properties
             .ok_or_else(|| BuilderError::MissingField("'properties' field is required".into()))?;
         Ok(ProductCreateAction {
-            product_type,
+            product_namespace,
             product_id,
             owner,
             properties,
@@ -329,15 +329,15 @@ impl ProductCreateActionBuilder {
 
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct ProductUpdateAction {
-    product_type: ProductType,
+    product_namespace: ProductType,
     product_id: String,
     properties: Vec<PropertyValue>,
 }
 
 /// Native implementation for ProductUpdateAction
 impl ProductUpdateAction {
-    pub fn product_type(&self) -> &ProductType {
-        &self.product_type
+    pub fn product_namespace(&self) -> &ProductType {
+        &self.product_namespace
     }
 
     pub fn product_id(&self) -> &str {
@@ -354,7 +354,7 @@ impl FromProto<protos::product_payload::ProductUpdateAction> for ProductUpdateAc
         proto: protos::product_payload::ProductUpdateAction,
     ) -> Result<Self, ProtoConversionError> {
         Ok(ProductUpdateAction {
-            product_type: ProductType::from_proto(proto.get_product_type())?,
+            product_namespace: ProductType::from_proto(proto.get_product_namespace())?,
             product_id: proto.get_product_id().to_string(),
             properties: proto
                 .get_properties()
@@ -369,7 +369,7 @@ impl FromProto<protos::product_payload::ProductUpdateAction> for ProductUpdateAc
 impl FromNative<ProductUpdateAction> for protos::product_payload::ProductUpdateAction {
     fn from_native(native: ProductUpdateAction) -> Result<Self, ProtoConversionError> {
         let mut proto = protos::product_payload::ProductUpdateAction::new();
-        proto.set_product_type(native.product_type().clone().into_proto()?);
+        proto.set_product_namespace(native.product_namespace().clone().into_proto()?);
         proto.set_product_id(native.product_id().to_string());
         proto.set_properties(RepeatedField::from_vec(
             native
@@ -415,7 +415,7 @@ impl IntoNative<ProductUpdateAction> for protos::product_payload::ProductUpdateA
 /// Builder used to create a ProductUpdateAction
 #[derive(Default, Clone)]
 pub struct ProductUpdateActionBuilder {
-    product_type: Option<ProductType>,
+    product_namespace: Option<ProductType>,
     product_id: Option<String>,
     properties: Vec<PropertyValue>,
 }
@@ -425,8 +425,8 @@ impl ProductUpdateActionBuilder {
         ProductUpdateActionBuilder::default()
     }
 
-    pub fn with_product_type(mut self, product_type: ProductType) -> Self {
-        self.product_type = Some(product_type);
+    pub fn with_product_namespace(mut self, product_namespace: ProductType) -> Self {
+        self.product_namespace = Some(product_namespace);
         self
     }
 
@@ -441,8 +441,8 @@ impl ProductUpdateActionBuilder {
     }
 
     pub fn build(self) -> Result<ProductUpdateAction, BuilderError> {
-        let product_type = self.product_type.ok_or_else(|| {
-            BuilderError::MissingField("'product_type' field is required".to_string())
+        let product_namespace = self.product_namespace.ok_or_else(|| {
+            BuilderError::MissingField("'product_namespace' field is required".to_string())
         })?;
 
         let product_id = self.product_id.ok_or_else(|| {
@@ -460,7 +460,7 @@ impl ProductUpdateActionBuilder {
         };
 
         Ok(ProductUpdateAction {
-            product_type,
+            product_namespace,
             product_id,
             properties,
         })
@@ -469,14 +469,14 @@ impl ProductUpdateActionBuilder {
 
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct ProductDeleteAction {
-    product_type: ProductType,
+    product_namespace: ProductType,
     product_id: String,
 }
 
 /// Native implementation for ProductDeleteAction
 impl ProductDeleteAction {
-    pub fn product_type(&self) -> &ProductType {
-        &self.product_type
+    pub fn product_namespace(&self) -> &ProductType {
+        &self.product_namespace
     }
 
     pub fn product_id(&self) -> &str {
@@ -489,7 +489,7 @@ impl FromProto<protos::product_payload::ProductDeleteAction> for ProductDeleteAc
         proto: protos::product_payload::ProductDeleteAction,
     ) -> Result<Self, ProtoConversionError> {
         Ok(ProductDeleteAction {
-            product_type: ProductType::from_proto(proto.get_product_type())?,
+            product_namespace: ProductType::from_proto(proto.get_product_namespace())?,
             product_id: proto.get_product_id().to_string(),
         })
     }
@@ -498,7 +498,7 @@ impl FromProto<protos::product_payload::ProductDeleteAction> for ProductDeleteAc
 impl FromNative<ProductDeleteAction> for protos::product_payload::ProductDeleteAction {
     fn from_native(native: ProductDeleteAction) -> Result<Self, ProtoConversionError> {
         let mut proto = protos::product_payload::ProductDeleteAction::new();
-        proto.set_product_type(native.product_type().clone().into_proto()?);
+        proto.set_product_namespace(native.product_namespace().clone().into_proto()?);
         proto.set_product_id(native.product_id().to_string());
         Ok(proto)
     }
@@ -534,7 +534,7 @@ impl IntoNative<ProductDeleteAction> for protos::product_payload::ProductDeleteA
 /// Builder used to create a ProductDeleteAction
 #[derive(Default, Clone)]
 pub struct ProductDeleteActionBuilder {
-    product_type: Option<ProductType>,
+    product_namespace: Option<ProductType>,
     product_id: Option<String>,
 }
 
@@ -543,8 +543,8 @@ impl ProductDeleteActionBuilder {
         ProductDeleteActionBuilder::default()
     }
 
-    pub fn with_product_type(mut self, product_type: ProductType) -> Self {
-        self.product_type = Some(product_type);
+    pub fn with_product_namespace(mut self, product_namespace: ProductType) -> Self {
+        self.product_namespace = Some(product_namespace);
         self
     }
 
@@ -554,8 +554,8 @@ impl ProductDeleteActionBuilder {
     }
 
     pub fn build(self) -> Result<ProductDeleteAction, BuilderError> {
-        let product_type = self.product_type.ok_or_else(|| {
-            BuilderError::MissingField("'product_type' field is required".to_string())
+        let product_namespace = self.product_namespace.ok_or_else(|| {
+            BuilderError::MissingField("'product_namespace' field is required".to_string())
         })?;
 
         let product_id = self.product_id.ok_or_else(|| {
@@ -563,7 +563,7 @@ impl ProductDeleteActionBuilder {
         })?;
 
         Ok(ProductDeleteAction {
-            product_type,
+            product_namespace,
             product_id,
         })
     }
@@ -580,7 +580,7 @@ mod tests {
     fn test_product_create_builder() {
         let action = ProductCreateActionBuilder::new()
             .with_product_id("688955434684".into()) // GTIN-12
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_owner("Target".into())
             .with_properties(make_properties())
             .build()
@@ -588,7 +588,7 @@ mod tests {
 
         assert_eq!(action.product_id(), "688955434684");
         assert_eq!(action.owner(), "Target");
-        assert_eq!(*action.product_type(), ProductType::GS1);
+        assert_eq!(*action.product_namespace(), ProductType::GS1);
         assert_eq!(action.properties()[0].name(), "description");
         assert_eq!(*action.properties()[0].data_type(), DataType::String);
         assert_eq!(
@@ -605,7 +605,7 @@ mod tests {
     fn test_product_create_into_bytes() {
         let action = ProductCreateActionBuilder::new()
             .with_product_id("688955434684".into()) // GTIN-12
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_owner("Target".into())
             .with_properties(make_properties())
             .build()
@@ -619,13 +619,13 @@ mod tests {
     fn test_product_update_builder() {
         let action = ProductUpdateActionBuilder::new()
             .with_product_id("688955434684".into()) // GTIN-12
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_properties(make_properties())
             .build()
             .unwrap();
 
         assert_eq!(action.product_id(), "688955434684");
-        assert_eq!(*action.product_type(), ProductType::GS1);
+        assert_eq!(*action.product_namespace(), ProductType::GS1);
         assert_eq!(action.properties()[0].name(), "description");
         assert_eq!(*action.properties()[0].data_type(), DataType::String);
         assert_eq!(
@@ -642,7 +642,7 @@ mod tests {
     fn test_product_update_into_bytes() {
         let action = ProductUpdateActionBuilder::new()
             .with_product_id("688955434684".into()) // GTIN-12
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_properties(make_properties())
             .build()
             .unwrap();
@@ -655,12 +655,12 @@ mod tests {
     fn test_product_delete_builder() {
         let action = ProductDeleteActionBuilder::new()
             .with_product_id("688955434684".into()) // GTIN-12
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .build()
             .unwrap();
 
         assert_eq!(action.product_id(), "688955434684");
-        assert_eq!(*action.product_type(), ProductType::GS1);
+        assert_eq!(*action.product_namespace(), ProductType::GS1);
     }
 
     #[test]
@@ -668,7 +668,7 @@ mod tests {
     fn test_product_delete_into_bytes() {
         let action = ProductDeleteActionBuilder::new()
             .with_product_id("688955434684".into()) // GTIN-12
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .build()
             .unwrap();
 
@@ -680,7 +680,7 @@ mod tests {
     fn test_product_payload_builder() {
         let action = ProductCreateActionBuilder::new()
             .with_product_id("688955434684".into()) // GTIN-12
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_owner("Target".into())
             .with_properties(make_properties())
             .build()
@@ -701,7 +701,7 @@ mod tests {
     fn test_product_payload_bytes() {
         let action = ProductCreateActionBuilder::new()
             .with_product_id("688955434684".into()) // GTIN-12
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_owner("Target".into())
             .with_properties(make_properties())
             .build()

--- a/sdk/src/protocol/product/state.rs
+++ b/sdk/src/protocol/product/state.rs
@@ -39,9 +39,9 @@ impl Default for ProductType {
 
 impl FromProto<protos::product_state::Product_ProductType> for ProductType {
     fn from_proto(
-        product_type: protos::product_state::Product_ProductType,
+        product_namespace: protos::product_state::Product_ProductType,
     ) -> Result<Self, ProtoConversionError> {
-        match product_type {
+        match product_namespace {
             protos::product_state::Product_ProductType::GS1 => Ok(ProductType::GS1),
             protos::product_state::Product_ProductType::UNSET_TYPE => {
                 Err(ProtoConversionError::InvalidTypeError(
@@ -53,8 +53,8 @@ impl FromProto<protos::product_state::Product_ProductType> for ProductType {
 }
 
 impl FromNative<ProductType> for protos::product_state::Product_ProductType {
-    fn from_native(product_type: ProductType) -> Result<Self, ProtoConversionError> {
-        match product_type {
+    fn from_native(product_namespace: ProductType) -> Result<Self, ProtoConversionError> {
+        match product_namespace {
             ProductType::GS1 => Ok(protos::product_state::Product_ProductType::GS1),
         }
     }
@@ -67,7 +67,7 @@ impl IntoNative<ProductType> for protos::product_state::Product_ProductType {}
 #[derive(Debug, Clone, PartialEq)]
 pub struct Product {
     product_id: String,
-    product_type: ProductType,
+    product_namespace: ProductType,
     owner: String,
     properties: Vec<PropertyValue>,
 }
@@ -77,8 +77,8 @@ impl Product {
         &self.product_id
     }
 
-    pub fn product_type(&self) -> &ProductType {
-        &self.product_type
+    pub fn product_namespace(&self) -> &ProductType {
+        &self.product_namespace
     }
 
     pub fn owner(&self) -> &str {
@@ -92,7 +92,7 @@ impl Product {
     pub fn into_builder(self) -> ProductBuilder {
         ProductBuilder::new()
             .with_product_id(self.product_id)
-            .with_product_type(self.product_type)
+            .with_product_namespace(self.product_namespace)
             .with_owner(self.owner)
             .with_properties(self.properties)
     }
@@ -102,7 +102,7 @@ impl FromProto<protos::product_state::Product> for Product {
     fn from_proto(product: protos::product_state::Product) -> Result<Self, ProtoConversionError> {
         Ok(Product {
             product_id: product.get_product_id().to_string(),
-            product_type: ProductType::from_proto(product.get_product_type())?,
+            product_namespace: ProductType::from_proto(product.get_product_namespace())?,
             owner: product.get_owner().to_string(),
             properties: product
                 .get_properties()
@@ -118,7 +118,7 @@ impl FromNative<Product> for protos::product_state::Product {
     fn from_native(product: Product) -> Result<Self, ProtoConversionError> {
         let mut proto = protos::product_state::Product::new();
         proto.set_product_id(product.product_id().to_string());
-        proto.set_product_type(product.product_type().clone().into_proto()?);
+        proto.set_product_namespace(product.product_namespace().clone().into_proto()?);
         proto.set_owner(product.owner().to_string());
         proto.set_properties(RepeatedField::from_vec(
             product
@@ -192,7 +192,7 @@ impl std::fmt::Display for ProductBuildError {
 #[derive(Default, Clone, PartialEq)]
 pub struct ProductBuilder {
     pub product_id: Option<String>,
-    pub product_type: Option<ProductType>,
+    pub product_namespace: Option<ProductType>,
     pub owner: Option<String>,
     pub properties: Option<Vec<PropertyValue>>,
 }
@@ -207,8 +207,8 @@ impl ProductBuilder {
         self
     }
 
-    pub fn with_product_type(mut self, product_type: ProductType) -> Self {
-        self.product_type = Some(product_type);
+    pub fn with_product_namespace(mut self, product_namespace: ProductType) -> Self {
+        self.product_namespace = Some(product_namespace);
         self
     }
 
@@ -227,8 +227,8 @@ impl ProductBuilder {
             ProductBuildError::MissingField("'product_id' field is required".to_string())
         })?;
 
-        let product_type = self.product_type.ok_or_else(|| {
-            ProductBuildError::MissingField("'product_type' field is required".to_string())
+        let product_namespace = self.product_namespace.ok_or_else(|| {
+            ProductBuildError::MissingField("'product_namespace' field is required".to_string())
         })?;
 
         let owner = self.owner.ok_or_else(|| {
@@ -242,7 +242,7 @@ impl ProductBuilder {
 
         Ok(Product {
             product_id,
-            product_type,
+            product_namespace,
             owner,
             properties,
         })
@@ -399,7 +399,7 @@ mod tests {
         let product = build_product();
 
         assert_eq!(product.product_id(), "688955434684");
-        assert_eq!(*product.product_type(), ProductType::GS1);
+        assert_eq!(*product.product_namespace(), ProductType::GS1);
         assert_eq!(product.owner(), "Target");
         assert_eq!(product.properties()[0].name(), "description");
         assert_eq!(*product.properties()[0].data_type(), DataType::String);
@@ -420,7 +420,7 @@ mod tests {
         let builder = product.into_builder();
 
         assert_eq!(builder.product_id, Some("688955434684".to_string()));
-        assert_eq!(builder.product_type, Some(ProductType::GS1));
+        assert_eq!(builder.product_namespace, Some(ProductType::GS1));
         assert_eq!(builder.owner, Some("Target".to_string()));
         assert_eq!(builder.properties, Some(make_properties()));
     }
@@ -431,7 +431,7 @@ mod tests {
         let builder = ProductBuilder::new();
         let original = builder
             .with_product_id("688955434684".into())
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_owner("Target".into())
             .with_properties(make_properties())
             .build()
@@ -449,7 +449,7 @@ mod tests {
 
         // Test product 1
         assert_eq!(product_list.products[0].product_id(), "688955434684");
-        assert_eq!(*product_list.products[0].product_type(), ProductType::GS1);
+        assert_eq!(*product_list.products[0].product_namespace(), ProductType::GS1);
         assert_eq!(product_list.products[0].owner(), "Target");
         assert_eq!(
             product_list.products[0].properties()[0].name(),
@@ -472,7 +472,7 @@ mod tests {
 
         // Test product 2
         assert_eq!(product_list.products[1].product_id(), "688955434685");
-        assert_eq!(*product_list.products[1].product_type(), ProductType::GS1);
+        assert_eq!(*product_list.products[1].product_namespace(), ProductType::GS1);
         assert_eq!(product_list.products[1].owner(), "Cargill");
         assert_eq!(
             product_list.products[1].properties()[0].name(),
@@ -516,7 +516,7 @@ mod tests {
     fn build_product() -> Product {
         ProductBuilder::new()
             .with_product_id("688955434684".into()) // GTIN-12
-            .with_product_type(ProductType::GS1)
+            .with_product_namespace(ProductType::GS1)
             .with_owner("Target".into())
             .with_properties(make_properties())
             .build()
@@ -554,14 +554,14 @@ mod tests {
         vec![
             ProductBuilder::new()
                 .with_product_id("688955434684".into()) // GTIN-12
-                .with_product_type(ProductType::GS1)
+                .with_product_namespace(ProductType::GS1)
                 .with_owner("Target".into())
                 .with_properties(make_properties())
                 .build()
                 .expect("Failed to build test product"),
             ProductBuilder::new()
                 .with_product_id("688955434685".into()) // GTIN-12
-                .with_product_type(ProductType::GS1)
+                .with_product_namespace(ProductType::GS1)
                 .with_owner("Cargill".into())
                 .with_properties(make_properties())
                 .build()

--- a/sdk/src/protocol/product/state.rs
+++ b/sdk/src/protocol/product/state.rs
@@ -449,7 +449,10 @@ mod tests {
 
         // Test product 1
         assert_eq!(product_list.products[0].product_id(), "688955434684");
-        assert_eq!(*product_list.products[0].product_namespace(), ProductType::GS1);
+        assert_eq!(
+            *product_list.products[0].product_namespace(),
+            ProductType::GS1
+        );
         assert_eq!(product_list.products[0].owner(), "Target");
         assert_eq!(
             product_list.products[0].properties()[0].name(),
@@ -472,7 +475,10 @@ mod tests {
 
         // Test product 2
         assert_eq!(product_list.products[1].product_id(), "688955434685");
-        assert_eq!(*product_list.products[1].product_namespace(), ProductType::GS1);
+        assert_eq!(
+            *product_list.products[1].product_namespace(),
+            ProductType::GS1
+        );
         assert_eq!(product_list.products[1].owner(), "Cargill");
         assert_eq!(
             product_list.products[1].properties()[0].name(),


### PR DESCRIPTION
Expanded upon the work that @silasdavis started here: https://github.com/hyperledger/grid/pull/125

Closes https://jira.hyperledger.org/browse/GRID-97

This PR also adds a makefile at the top level to quickly run cargo commands across all subdirectories. 
```
make build_all   - (runs cargo build in all the subdirectories with a Cargo.toml)
make test_all   - (runs cargo test in all the subdirectories with a Cargo.toml)
make clip_all   - (runs cargo clippy in all the subdirectories with a Cargo.toml)
make fmt_all   - (runs cargo fmt in all the subdirectories with a Cargo.toml)
```

The Makefile may solve the intent of: https://jira.hyperledger.org/browse/GRID-31