### PR TITLE
Add splinter and sawtooth features

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,3 +38,13 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 diesel = { version = "1.0", features = ["postgres"] }
 diesel_migrations = "1.4"
+
+[features]
+default = ["sawtooth"]
+
+stable = ["sawtooth"]
+
+experimental = ["splinter"]
+
+sawtooth = []
+splinter = []

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,10 @@ version = "0.1.0"
 authors = ["Contributors to Hyperledger Grid"]
 edition = "2018"
 
+[[bin]]
+name = "grid"
+path = "src/main.rs"
+
 [dependencies]
 clap = "2"
 log = "0.4"
@@ -34,7 +38,3 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 diesel = { version = "1.0", features = ["postgres"] }
 diesel_migrations = "1.4"
-
-[[bin]]
-name = "grid"
-path = "src/main.rs"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,6 +24,10 @@ mod actions;
 mod error;
 mod http;
 mod key;
+#[cfg(feature = "sawtooth")]
+mod sawtooth;
+#[cfg(feature = "splinter")]
+mod splinter;
 mod transaction;
 mod yaml_parser;
 

--- a/cli/src/sawtooth/mod.rs
+++ b/cli/src/sawtooth/mod.rs
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */

--- a/cli/src/splinter/mod.rs
+++ b/cli/src/splinter/mod.rs
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -43,4 +43,12 @@ base64 = "0.10"
 byteorder = "1"
 
 [features]
+default = ["sawtooth"]
+
+stable = ["sawtooth"]
+
+experimental = ["splinter"]
+
+sawtooth = []
+splinter = []
 test-api = []

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -18,6 +18,10 @@ version = "0.1.0"
 authors = ["Contributors to Hyperledger Grid"]
 edition = "2018"
 
+[[bin]]
+name = "gridd"
+path = "src/main.rs"
+
 [dependencies]
 actix = "0.7"
 actix-web = "0.7"
@@ -40,7 +44,3 @@ byteorder = "1"
 
 [features]
 test-api = []
-
-[[bin]]
-name = "gridd"
-path = "src/main.rs"

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -31,7 +31,11 @@ mod database;
 mod error;
 mod event;
 mod rest_api;
+#[cfg(feature = "sawtooth")]
+mod sawtooth;
 mod sawtooth_connection;
+#[cfg(feature = "splinter")]
+mod splinter;
 
 use std::process;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/daemon/src/sawtooth/mod.rs
+++ b/daemon/src/sawtooth/mod.rs
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */

--- a/daemon/src/splinter/mod.rs
+++ b/daemon/src/splinter/mod.rs
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */


### PR DESCRIPTION
This adds sawtooth and splinter features to Cargo.toml for daemon and cli, with associated modules. The intent is that sawtooth-specific code will go into the sawtooth module and splinter-specific code will go into the splinter module.