### PR TITLE
Add generic CommitEvent

### DIFF
--- a/daemon/src/event/error.rs
+++ b/daemon/src/event/error.rs
@@ -41,12 +41,20 @@ impl fmt::Display for EventError {
 }
 
 #[derive(Debug)]
-pub struct EventIoError(pub String);
+pub enum EventIoError {
+    ConnectionError(String),
+    InvalidMessage(String),
+}
 
 impl Error for EventIoError {}
 
 impl fmt::Display for EventIoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Event IO Error: {}", self.0)
+        match self {
+            Self::ConnectionError(err) => {
+                write!(f, "event connection encountered an error: {}", err)
+            }
+            Self::InvalidMessage(err) => write!(f, "connection received invalid message: {}", err),
+        }
     }
 }

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -60,6 +60,24 @@ pub enum StateChange {
     Delete { key: String },
 }
 
+impl StateChange {
+    pub fn key_has_prefix(&self, prefix: &str) -> bool {
+        let key = match self {
+            Self::Set { key, .. } => key,
+            Self::Delete { key, .. } => key,
+        };
+        key.get(0..prefix.len())
+            .map(|key_prefix| key_prefix == prefix)
+            .unwrap_or(false)
+    }
+
+    pub fn is_grid_state_change(&self) -> bool {
+        ALL_GRID_NAMESPACES
+            .iter()
+            .any(|namespace| self.key_has_prefix(namespace))
+    }
+}
+
 pub trait EventHandler: Send {
     fn handle_events(&self, events: &[Event]) -> Result<(), EventError>;
 }

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -38,6 +38,8 @@ const TRACK_AND_TRACE_PROPERTY: &str = "a43b46ea";
 const TRACK_AND_TRACE_PROPOSAL: &str = "a43b46aa";
 const TRACK_AND_TRACE_RECORD: &str = "a43b46ec";
 
+const ALL_GRID_NAMESPACES: &[&str] = &[PIKE_NAMESPACE, GRID_NAMESPACE, TRACK_AND_TRACE_NAMESPACE];
+
 /// A notification that some source has committed a set of changes to state
 pub struct CommitEvent {
     /// An identifier for specifying where the event came from
@@ -117,10 +119,7 @@ impl<Conn: EventConnection + 'static> EventProcessor<Conn> {
         event_handlers: Vec<Box<dyn EventHandler>>,
     ) -> Result<Self, EventProcessorError> {
         let unsubscriber = connection
-            .subscribe(
-                &[GRID_NAMESPACE, PIKE_NAMESPACE, TRACK_AND_TRACE_NAMESPACE],
-                last_known_commit_id,
-            )
+            .subscribe(ALL_GRID_NAMESPACES, last_known_commit_id)
             .map_err(|err| EventProcessorError(format!("Unable to unsubscribe: {}", err)))?;
 
         let join_handle = thread::Builder::new()

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -38,6 +38,26 @@ const TRACK_AND_TRACE_PROPERTY: &str = "a43b46ea";
 const TRACK_AND_TRACE_PROPOSAL: &str = "a43b46aa";
 const TRACK_AND_TRACE_RECORD: &str = "a43b46ec";
 
+/// A notification that some source has committed a set of changes to state
+pub struct CommitEvent {
+    /// An identifier for specifying where the event came from
+    pub source: String,
+    /// An identifier that is unique among events from the source
+    pub id: String,
+    /// May be used to provide ordering of commits from the source. If `None`, ordering is not
+    /// explicitly provided, so it must be inferred from the order in which events are received.
+    pub height: Option<u64>,
+    /// All state changes that are included in the commit
+    pub state_changes: Vec<StateChange>,
+}
+
+/// A change that has been applied to state, represented in terms of a key/value pair
+#[derive(Eq, PartialEq)]
+pub enum StateChange {
+    Set { key: String, value: Vec<u8> },
+    Delete { key: String },
+}
+
 pub trait EventHandler: Send {
     fn handle_events(&self, events: &[Event]) -> Result<(), EventError>;
 }

--- a/daemon/src/sawtooth/event.rs
+++ b/daemon/src/sawtooth/event.rs
@@ -15,6 +15,7 @@
  * -----------------------------------------------------------------------------
  */
 
+use std::convert::{TryFrom, TryInto};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use protobuf::Message as _;
@@ -25,15 +26,29 @@ use sawtooth_sdk::{
             ClientEventsSubscribeRequest, ClientEventsSubscribeResponse,
             ClientEventsSubscribeResponse_Status,
         },
-        events::{Event, EventFilter, EventFilter_FilterType, EventList, EventSubscription},
+        events::{
+            Event as SawtoothEvent, EventFilter, EventFilter_FilterType,
+            EventList as SawtoothEventList, EventSubscription,
+        },
+        transaction_receipt::{
+            StateChange as SawtoothStateChange, StateChangeList,
+            StateChange_Type as SawtoothStateChange_Type,
+        },
         validator::{Message, Message_MessageType},
     },
     messaging::stream::{MessageSender, ReceiveError, SendError},
 };
 
-use crate::event::{EventConnection, EventConnectionUnsubscriber, EventIoError};
+use crate::event::{
+    CommitEvent, EventConnection, EventConnectionUnsubscriber, EventIoError, StateChange,
+};
 
 use super::connection::SawtoothConnection;
+
+const BLOCK_COMMIT_EVENT_TYPE: &str = "sawtooth/block-commit";
+const STATE_CHANGE_EVENT_TYPE: &str = "sawtooth/state-delta";
+const BLOCK_ID_ATTR: &str = "block_id";
+const BLOCK_NUM_ATTR: &str = "block_num";
 
 const SHUTDOWN_TIMEOUT: u64 = 2;
 
@@ -78,7 +93,7 @@ impl EventConnection for SawtoothConnection {
         Ok(SawtoothEventUnsubscriber { message_sender })
     }
 
-    fn recv(&self) -> Result<Vec<Event>, EventIoError> {
+    fn recv(&self) -> Result<Vec<SawtoothEvent>, EventIoError> {
         match self.get_receiver().recv() {
             Ok(Ok(msg)) => extract_events(msg),
             Ok(Err(ReceiveError::DisconnectedError)) => Err(EventIoError::ConnectionError(
@@ -191,17 +206,122 @@ fn make_event_filter(namespace: &str) -> EventSubscription {
     event_subscription
 }
 
-fn extract_events(msg: Message) -> Result<Vec<Event>, EventIoError> {
+fn extract_events(msg: Message) -> Result<Vec<SawtoothEvent>, EventIoError> {
     if msg.get_message_type() != Message_MessageType::CLIENT_EVENTS {
         warn!("Received unexpected message: {:?}", msg.get_message_type());
         return Ok(vec![]);
     }
 
-    match protobuf::parse_from_bytes::<EventList>(msg.get_content()) {
+    match protobuf::parse_from_bytes::<SawtoothEventList>(msg.get_content()) {
         Ok(mut event_list) => Ok(event_list.take_events().to_vec()),
         Err(err) => {
             warn!("Unable to parse event list; ignoring: {}", err);
             Ok(vec![])
+        }
+    }
+}
+
+impl TryFrom<&[SawtoothEvent]> for CommitEvent {
+    type Error = EventIoError;
+
+    fn try_from(events: &[SawtoothEvent]) -> Result<Self, Self::Error> {
+        let (id, height) = get_id_and_height(events)?;
+        let state_changes = get_state_changes(events)?;
+
+        Ok(CommitEvent {
+            source: "".into(), // sawtooth is identified by the null source
+            id,
+            height,
+            state_changes,
+        })
+    }
+}
+
+fn get_id_and_height(events: &[SawtoothEvent]) -> Result<(String, Option<u64>), EventIoError> {
+    let block_event = get_block_event(events)?;
+    let block_id = get_required_attribute_from_event(block_event, BLOCK_ID_ATTR)?;
+    let block_num = get_required_attribute_from_event(block_event, BLOCK_NUM_ATTR)?
+        .parse::<u64>()
+        .map_err(|err| {
+            EventIoError::InvalidMessage(format!("block_num was not a valid u64: {}", err))
+        })?;
+    Ok((block_id, Some(block_num)))
+}
+
+fn get_block_event(events: &[SawtoothEvent]) -> Result<&SawtoothEvent, EventIoError> {
+    events
+        .iter()
+        .find(|event| event.get_event_type() == BLOCK_COMMIT_EVENT_TYPE)
+        .ok_or_else(|| EventIoError::InvalidMessage("no block event found".into()))
+}
+
+fn get_required_attribute_from_event(
+    event: &SawtoothEvent,
+    required_attr_key: &str,
+) -> Result<String, EventIoError> {
+    event
+        .get_attributes()
+        .iter()
+        .find(|attr| attr.get_key() == required_attr_key)
+        .map(|attr| attr.get_value().to_string())
+        .ok_or_else(|| {
+            EventIoError::InvalidMessage(format!(
+                "required attribute not in event: {}",
+                required_attr_key
+            ))
+        })
+}
+
+fn get_state_changes(events: &[SawtoothEvent]) -> Result<Vec<StateChange>, EventIoError> {
+    Ok(events
+        .iter()
+        .filter(|event| event.get_event_type() == STATE_CHANGE_EVENT_TYPE)
+        .map(|event| {
+            get_sawtooth_state_changes_from_sawtooth_event(&event)
+                .and_then(sawtooth_state_changes_into_native_state_changes)
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .filter(|state_change| state_change.is_grid_state_change())
+        .collect())
+}
+
+fn get_sawtooth_state_changes_from_sawtooth_event(
+    sawtooth_event: &SawtoothEvent,
+) -> Result<Vec<SawtoothStateChange>, EventIoError> {
+    protobuf::parse_from_bytes::<StateChangeList>(&sawtooth_event.data)
+        .map(|mut list| list.take_state_changes().to_vec())
+        .map_err(|err| {
+            EventIoError::InvalidMessage(format!(
+                "failed to parse state change list from state change event: {}",
+                err
+            ))
+        })
+}
+
+fn sawtooth_state_changes_into_native_state_changes(
+    sawtooth_state_changes: Vec<SawtoothStateChange>,
+) -> Result<Vec<StateChange>, EventIoError> {
+    sawtooth_state_changes
+        .into_iter()
+        .map(|sawtooth_state_change| sawtooth_state_change.try_into())
+        .collect()
+}
+
+impl TryInto<StateChange> for SawtoothStateChange {
+    type Error = EventIoError;
+
+    fn try_into(self) -> Result<StateChange, Self::Error> {
+        match self.field_type {
+            SawtoothStateChange_Type::TYPE_UNSET => Err(EventIoError::InvalidMessage(
+                "state change type unset".into(),
+            )),
+            SawtoothStateChange_Type::SET => Ok(StateChange::Set {
+                key: self.address,
+                value: self.value,
+            }),
+            SawtoothStateChange_Type::DELETE => Ok(StateChange::Delete { key: self.address }),
         }
     }
 }
@@ -226,5 +346,105 @@ impl From<SendError> for EventIoError {
         EventIoError::ConnectionError(format!("Unable to send message: {}", &err))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use sawtooth_sdk::messages::events::Event_Attribute;
+
+    const PIKE_NAMESPACE: &str = "cad11d";
+    const GRID_NAMESPACE: &str = "621dee";
+    const TRACK_AND_TRACE_NAMESPACE: &str = "a43b46";
+
+    /// Verify that a valid set of Sawtooth events can be converted to a `CommitEvent`.
+    #[test]
+    fn sawtooth_events_to_commit_event() {
+        let block_id = "abcdef";
+        let block_num = 1;
+
+        let grid_state_changes = vec![
+            create_state_change(format!("{}01", PIKE_NAMESPACE), Some(vec![0x01])),
+            create_state_change(format!("{}02", GRID_NAMESPACE), Some(vec![0x02])),
+            create_state_change(format!("{}03", TRACK_AND_TRACE_NAMESPACE), None),
+        ];
+        let non_grid_state_changes = vec![create_state_change("ef".into(), None)];
+
+        let sawtooth_events = vec![
+            create_block_event(block_id, block_num),
+            create_state_change_event(&grid_state_changes[0..2]),
+            create_state_change_event(&grid_state_changes[2..]),
+            create_state_change_event(&non_grid_state_changes[..]),
+        ];
+
+        let commit_event = CommitEvent::try_from(sawtooth_events.as_slice())
+            .expect("Failed to convert sawtooth events to a CommitEvent");
+
+        assert_eq!(&commit_event.source, "");
+        assert_eq!(&commit_event.id, block_id);
+        assert_eq!(commit_event.height, Some(block_num));
+        assert_eq!(commit_event.state_changes.len(), grid_state_changes.len());
+        for sawtooth_state_change in grid_state_changes {
+            let expected_state_change = match sawtooth_state_change.get_field_type() {
+                SawtoothStateChange_Type::SET => StateChange::Set {
+                    key: sawtooth_state_change.get_address().into(),
+                    value: sawtooth_state_change.get_value().into(),
+                },
+                SawtoothStateChange_Type::DELETE => StateChange::Delete {
+                    key: sawtooth_state_change.get_address().into(),
+                },
+                _ => panic!("Sawtooth state change type unset"),
+            };
+            assert!(commit_event
+                .state_changes
+                .iter()
+                .any(|state_change| state_change == &expected_state_change));
+        }
+    }
+
+    fn create_block_event(block_id: &str, block_num: u64) -> SawtoothEvent {
+        let mut event = SawtoothEvent::new();
+        event.set_event_type(BLOCK_COMMIT_EVENT_TYPE.into());
+        event.set_attributes(
+            vec![
+                create_attribute(BLOCK_ID_ATTR.into(), block_id.into()),
+                create_attribute(BLOCK_NUM_ATTR.into(), block_num.to_string()),
+            ]
+            .into(),
+        );
+        event
+    }
+
+    fn create_attribute(key: String, value: String) -> Event_Attribute {
+        let mut attribute = Event_Attribute::new();
+        attribute.set_key(key);
+        attribute.set_value(value);
+        attribute
+    }
+
+    fn create_state_change(address: String, value: Option<Vec<u8>>) -> SawtoothStateChange {
+        let mut state_change = SawtoothStateChange::new();
+        state_change.set_address(address);
+        match value {
+            Some(value) => {
+                state_change.set_field_type(SawtoothStateChange_Type::SET);
+                state_change.set_value(value);
+            }
+            None => state_change.set_field_type(SawtoothStateChange_Type::DELETE),
+        }
+        state_change
+    }
+
+    fn create_state_change_event(state_changes: &[SawtoothStateChange]) -> SawtoothEvent {
+        let mut event = SawtoothEvent::new();
+        event.set_event_type(STATE_CHANGE_EVENT_TYPE.into());
+        let mut state_change_list = StateChangeList::new();
+        state_change_list.set_state_changes(state_changes.into());
+        event.set_data(
+            state_change_list
+                .write_to_bytes()
+                .expect("failed to serialize StateChangeList"),
+        );
+        event
     }
 }


### PR DESCRIPTION
Add the `CommitEvent` struct, which will be used as a generic way to
represent a commit and its associated state changes from some arbitrary
source.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

Add a `TryFrom<&[SawtoothEvent]>` implementation for `CommitEvent` that
converts Sawtooth events into a native `CommitEvent` for Grid.

Signed-off-by: Logan Seeley <seeley@bitwise.io>