### PR TITLE
Add serial id and source to Block schema

### DIFF
--- a/daemon/migrations/2019-12-10-231138_update-block-schema/down.sql
+++ b/daemon/migrations/2019-12-10-231138_update-block-schema/down.sql
@@ -1,0 +1,22 @@
+-- Copyright 2019 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE block DROP CONSTRAINT pk_id;
+
+ALTER TABLE block DROP COLUMN id;
+
+ALTER TABLE block DROP COLUMN source;
+
+ALTER TABLE block ADD CONSTRAINT pk_block_id PRIMARY KEY(block_id);

--- a/daemon/migrations/2019-12-10-231138_update-block-schema/up.sql
+++ b/daemon/migrations/2019-12-10-231138_update-block-schema/up.sql
@@ -1,0 +1,20 @@
+-- Copyright 2019 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE block DROP CONSTRAINT pk_block_id;
+
+ALTER TABLE block ADD COLUMN id SERIAL CONSTRAINT pk_id PRIMARY KEY;
+
+ALTER TABLE block ADD COLUMN IF NOT EXISTS source TEXT;

--- a/daemon/src/database/helpers/blocks.rs
+++ b/daemon/src/database/helpers/blocks.rs
@@ -15,7 +15,7 @@
  * -----------------------------------------------------------------------------
  */
 
-use super::models::Block;
+use super::models::{Block, NewBlock};
 use super::schema::{block, chain_record};
 use super::MAX_BLOCK_NUM;
 
@@ -29,7 +29,7 @@ use diesel::{
 
 const NULL_BLOCK_ID: &str = "0000000000000000";
 
-pub fn insert_block(conn: &PgConnection, block: &Block) -> QueryResult<()> {
+pub fn insert_block(conn: &PgConnection, block: &NewBlock) -> QueryResult<()> {
     insert_into(block::table)
         .values(block)
         .execute(conn)

--- a/daemon/src/database/models.rs
+++ b/daemon/src/database/models.rs
@@ -30,10 +30,20 @@ use super::schema::{
 
 #[derive(Insertable, Queryable)]
 #[table_name = "block"]
-pub struct Block {
+pub struct NewBlock {
     pub block_id: String,
     pub block_num: i64,
     pub state_root_hash: String,
+    pub source: Option<String>,
+}
+
+#[derive(Queryable, Debug)]
+pub struct Block {
+    pub id: i64,
+    pub block_id: String,
+    pub block_num: i64,
+    pub state_root_hash: String,
+    pub source: Option<String>,
 }
 
 #[derive(Insertable, Debug)]

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -45,10 +45,12 @@ table! {
 }
 
 table! {
-    block (block_id) {
+    block (id) {
+        id -> Int8,
         block_id -> Varchar,
         block_num -> Int8,
         state_root_hash -> Varchar,
+        source -> Nullable<Text>,
     }
 }
 

--- a/daemon/src/event/db_handler.rs
+++ b/daemon/src/event/db_handler.rs
@@ -37,7 +37,7 @@ use std::i64;
 use crate::database::{
     helpers as db,
     models::{
-        Block, LatLongValue, NewAgent, NewAssociatedAgent, NewGridPropertyDefinition,
+        LatLongValue, NewAgent, NewAssociatedAgent, NewBlock, NewGridPropertyDefinition,
         NewGridSchema, NewOrganization, NewProduct, NewProductPropertyValue, NewProperty,
         NewProposal, NewRecord, NewReportedValue, NewReporter,
     },
@@ -105,14 +105,16 @@ impl EventHandler for DatabaseEventHandler {
     }
 }
 
-fn create_db_block_from_commit_event(event: &CommitEvent) -> Result<Block, EventError> {
+fn create_db_block_from_commit_event(event: &CommitEvent) -> Result<NewBlock, EventError> {
     let block_id = event.id.clone();
     let block_num = commit_event_height_to_block_num(event.height)?;
     let state_root_hash = "".into();
-    Ok(Block {
+    let source = Some(event.source.clone());
+    Ok(NewBlock {
         block_id,
         block_num,
         state_root_hash,
+        source,
     })
 }
 


### PR DESCRIPTION
Adds a new primary key to the Block schema, which is just a serial ID. This is required to allow commits sourced from difference services to coexist in the database.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>