### PR TITLE
Add prefixes to connect endpoint

### DIFF
--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -31,6 +31,7 @@ pub enum DaemonError {
     RestApiError(RestApiServerError),
     StartUpError(Box<dyn Error>),
     ShutdownError(String),
+    UnsupportedEndpoint(String),
 }
 
 impl Error for DaemonError {
@@ -43,6 +44,7 @@ impl Error for DaemonError {
             DaemonError::RestApiError(err) => Some(err),
             DaemonError::StartUpError(err) => Some(&**err),
             DaemonError::ShutdownError(_) => None,
+            DaemonError::UnsupportedEndpoint(_) => None,
         }
     }
 }
@@ -59,6 +61,7 @@ impl fmt::Display for DaemonError {
             DaemonError::RestApiError(e) => write!(f, "Rest API error: {}", e),
             DaemonError::StartUpError(e) => write!(f, "Start-up error: {}", e),
             DaemonError::ShutdownError(msg) => write!(f, "Unable to cleanly shutdown: {}", msg),
+            DaemonError::UnsupportedEndpoint(msg) => write!(f, "{}", msg),
         }
     }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -80,7 +80,10 @@ fn run() -> Result<(), DaemonError> {
     let sawtooth_connection = if config.endpoint().is_sawtooth() {
         SawtoothConnection::new(&config.endpoint().url())
     } else {
-        panic!("Unsupported endpoint type: {}", config.endpoint().url());
+        return Err(DaemonError::UnsupportedEndpoint(format!(
+            "Unsupported endpoint type: {}",
+            config.endpoint().url()
+        )));
     };
 
     let connection_pool = database::create_connection_pool(config.database_url())?;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -57,7 +57,7 @@ fn run() -> Result<(), DaemonError> {
         (version: VERSION)
         (author: "Contributors to Hyperledger Grid")
         (about: "Daemon Package for Hyperledger Grid")
-        (@arg connect: -C --connect +takes_value "connection endpoint for validator")
+        (@arg connect: -C --connect +takes_value "connection endpoint for sawtooth or splinter")
         (@arg verbose: -v +multiple "Log verbosely")
         (@arg database_url: --("database-url") +takes_value
          "specifies the database URL to connect to.")
@@ -77,7 +77,11 @@ fn run() -> Result<(), DaemonError> {
         .with_cli_args(&matches)
         .build()?;
 
-    let sawtooth_connection = SawtoothConnection::new(config.validator_endpoint());
+    let sawtooth_connection = if config.endpoint().is_sawtooth() {
+        SawtoothConnection::new(&config.endpoint().url())
+    } else {
+        panic!("Unsupported endpoint type: {}", config.endpoint().url());
+    };
 
     let connection_pool = database::create_connection_pool(config.database_url())?;
 


### PR DESCRIPTION
Adds two type of prefixes that can be added to the `--connect` url.
`--connect` now accepts the following optional prefixes:

`sawtooth` - used to specfiy that the url is for connecting to a
sawtooth validator.

`splinter` - used to specfiy that the url is for connecting to a
splinter node.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>