### PR TITLE
Make last commit id optional

### DIFF
--- a/daemon/src/database/helpers/commits.rs
+++ b/daemon/src/database/helpers/commits.rs
@@ -27,8 +27,6 @@ use diesel::{
     QueryResult,
 };
 
-const NULL_COMMIT_ID: &str = "0000000000000000";
-
 pub fn insert_commit(conn: &PgConnection, commit: &NewCommit) -> QueryResult<()> {
     insert_into(commit::table)
         .values(commit)
@@ -65,19 +63,14 @@ pub fn get_commit_by_commit_num(
         .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
 }
 
-pub fn get_current_commit_id(conn: &PgConnection) -> QueryResult<String> {
+pub fn get_current_commit_id(conn: &PgConnection) -> QueryResult<Option<String>> {
     commit::table
         .select(commit::commit_id)
         .order_by(commit::commit_num.desc())
         .limit(1)
         .first(conn)
-        .or_else(|err| {
-            if err == NotFound {
-                Ok(NULL_COMMIT_ID.into())
-            } else {
-                Err(err)
-            }
-        })
+        .map(Some)
+        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
 }
 
 pub fn get_next_commit_num(conn: &PgConnection) -> QueryResult<i64> {

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -101,7 +101,7 @@ pub trait EventConnection: Send {
     fn subscribe(
         &mut self,
         namespaces: &[&str],
-        last_commit_id: &str,
+        last_commit_id: Option<&str>,
     ) -> Result<Self::Unsubscriber, EventIoError>;
 
     fn close(self) -> Result<(), EventIoError>;
@@ -121,7 +121,7 @@ impl<EC: EventConnection> EventConnection for Box<EC> {
     fn subscribe(
         &mut self,
         namespaces: &[&str],
-        last_commit_id: &str,
+        last_commit_id: Option<&str>,
     ) -> Result<Self::Unsubscriber, EventIoError> {
         (**self).subscribe(namespaces, last_commit_id)
     }
@@ -155,7 +155,7 @@ pub struct EventProcessor<Conn: EventConnection> {
 impl<Conn: EventConnection + 'static> EventProcessor<Conn> {
     pub fn start(
         mut connection: Conn,
-        last_known_commit_id: &str,
+        last_known_commit_id: Option<&str>,
         event_handlers: Vec<Box<dyn EventHandler>>,
     ) -> Result<Self, EventProcessorError> {
         let unsubscriber = connection

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -120,7 +120,7 @@ fn run_sawtooth(config: GridConfig, connection_pool: ConnectionPool) -> Result<(
 
     let evt_processor = EventProcessor::start(
         sawtooth_connection,
-        &current_commit,
+        current_commit.as_ref().map(String::as_str),
         event_handlers![DatabaseEventHandler::new(connection_pool)],
     )
     .map_err(|err| DaemonError::EventProcessorError(Box::new(err)))?;

--- a/daemon/src/sawtooth/event.rs
+++ b/daemon/src/sawtooth/event.rs
@@ -48,6 +48,7 @@ use crate::event::{
 
 use super::connection::SawtoothConnection;
 
+const NULL_BLOCK_ID: &str = "0000000000000000";
 const BLOCK_COMMIT_EVENT_TYPE: &str = "sawtooth/block-commit";
 const STATE_CHANGE_EVENT_TYPE: &str = "sawtooth/state-delta";
 const BLOCK_ID_ATTR: &str = "block_id";
@@ -65,11 +66,12 @@ impl EventConnection for SawtoothConnection {
     fn subscribe(
         &mut self,
         namespaces: &[&str],
-        last_commit_id: &str,
+        last_commit_id: Option<&str>,
     ) -> Result<Self::Unsubscriber, EventIoError> {
         let message_sender = self.get_sender();
 
-        let request = create_subscription_request(last_commit_id, namespaces);
+        let request =
+            create_subscription_request(last_commit_id.unwrap_or(NULL_BLOCK_ID), namespaces);
         let mut future = message_sender.send(
             Message_MessageType::CLIENT_EVENTS_SUBSCRIBE_REQUEST,
             &correlation_id(),


### PR DESCRIPTION
The last commit id should be optional, as the decision with what to do with the value should be left to the underlying implementation of the `EventConnection`.  In Sawtooth's case, it will pass the
`NULL_BLOCK_IDENTIFIER`.  In Splinter's case, it will omit the argument when subscribing for events.
