### PR TITLE
Add newline to key files generated by grid CLI

### DIFF
--- a/cli/src/actions/admin.rs
+++ b/cli/src/actions/admin.rs
@@ -25,6 +25,8 @@ use sawtooth_sdk::signing;
 
 use crate::error::CliError;
 
+use super::write_hex_to_file;
+
 const DEFAULT_KEY_DIR: &str = "/etc/grid/keys";
 
 pub enum ConflictStrategy {
@@ -109,7 +111,7 @@ pub fn do_keygen(
         .mode(0o644)
         .open(public_key_path.as_path())?;
 
-    public_key_file.write_all(public_key.as_hex().as_bytes())?;
+    write_hex_to_file(&public_key.as_hex(), &mut public_key_file)?;
 
     if private_key_path.exists() {
         println!("Overwriting file: {:?}", private_key_path);
@@ -122,7 +124,7 @@ pub fn do_keygen(
         .mode(0o640)
         .open(private_key_path.as_path())?;
 
-    private_key_file.write_all(private_key.as_hex().as_bytes())?;
+    write_hex_to_file(&private_key.as_hex(), &mut private_key_file)?;
 
     Ok(())
 }

--- a/cli/src/actions/keygen.rs
+++ b/cli/src/actions/keygen.rs
@@ -15,13 +15,16 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
-use crate::error::CliError;
-use sawtooth_sdk::signing;
+
 use std::fs::{self, OpenOptions};
 use std::io::prelude::*;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
+
+use sawtooth_sdk::signing;
 use users::get_current_username;
+
+use crate::error::CliError;
 
 /// Generates a public/private key pair that can be used to sign transactions.
 /// If no directory is provided, the keys are created in the default directory

--- a/cli/src/actions/keygen.rs
+++ b/cli/src/actions/keygen.rs
@@ -26,6 +26,8 @@ use users::get_current_username;
 
 use crate::error::CliError;
 
+use super::write_hex_to_file;
+
 /// Generates a public/private key pair that can be used to sign transactions.
 /// If no directory is provided, the keys are created in the default directory
 ///
@@ -103,7 +105,7 @@ pub fn generate_keys(
         .mode(0o644)
         .open(public_key_path.as_path())?;
 
-    public_key_file.write_all(public_key.as_hex().as_bytes())?;
+    write_hex_to_file(&public_key.as_hex(), &mut public_key_file)?;
 
     if private_key_path.exists() {
         info!("Overwriting file: {:?}", private_key_path);
@@ -117,6 +119,8 @@ pub fn generate_keys(
         .open(private_key_path.as_path())?;
 
     private_key_file.write_all(private_key.as_hex().as_bytes())?;
+
+    write_hex_to_file(&private_key.as_hex(), &mut private_key_file)?;
 
     Ok(())
 }

--- a/cli/src/actions/mod.rs
+++ b/cli/src/actions/mod.rs
@@ -23,3 +23,14 @@ pub mod keygen;
 pub mod organizations;
 pub mod products;
 pub mod schemas;
+
+use std::fs::File;
+use std::io::Write;
+
+use crate::error::CliError;
+
+/// Write the given hex string to the given file, appending a newline at the end.
+fn write_hex_to_file(hex: &str, file: &mut File) -> Result<(), CliError> {
+    writeln!(file, "{}", hex)?;
+    Ok(())
+}

--- a/cli/src/key.rs
+++ b/cli/src/key.rs
@@ -87,7 +87,7 @@ pub fn load_signing_key(name: Option<String>) -> Result<Secp256k1PrivateKey, Cli
     f.read_to_string(&mut contents)?;
 
     let key_str = match contents.lines().next() {
-        Some(k) => k,
+        Some(k) => k.trim(),
         None => {
             return Err(CliError::UserError(format!(
                 "Empty key file: {}",


### PR DESCRIPTION
This makes the output nicer when calling `cat` on a key file.

Also updates the reading of key files to trim any whitespace, which is
necessary now that key files contain a newline.

Signed-off-by: Logan Seeley <seeley@bitwise.io>