### PR TITLE
CLI cleanup

### DIFF
--- a/cli/src/actions/admin.rs
+++ b/cli/src/actions/admin.rs
@@ -78,7 +78,7 @@ pub fn do_keygen(
             }
 
             if public_key_path.exists() && private_key_path.exists() {
-                println!("Admin keys exist; skipping generation");
+                debug!("Admin keys exist; skipping generation");
                 return Ok(());
             }
         }
@@ -99,9 +99,9 @@ pub fn do_keygen(
     let public_key = context.get_public_key(&*private_key)?;
 
     if public_key_path.exists() {
-        println!("Overwriting file: {:?}", public_key_path);
+        debug!("Overwriting file: {:?}", public_key_path);
     } else {
-        println!("Writing file: {:?}", public_key_path);
+        debug!("Writing file: {:?}", public_key_path);
     }
     let mut public_key_file = OpenOptions::new()
         .write(true)
@@ -112,9 +112,9 @@ pub fn do_keygen(
     public_key_file.write_all(public_key.as_hex().as_bytes())?;
 
     if private_key_path.exists() {
-        println!("Overwriting file: {:?}", private_key_path);
+        debug!("Overwriting file: {:?}", private_key_path);
     } else {
-        println!("Writing file: {:?}", private_key_path);
+        debug!("Writing file: {:?}", private_key_path);
     }
     let mut private_key_file = OpenOptions::new()
         .write(true)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -73,7 +73,7 @@ fn run() -> Result<(), CliError> {
                 (@arg org_id: +takes_value +required "organization ID")
                 (@arg public_key: +takes_value +required "public key")
                 (@arg active: "Is user active")
-                (@arg roles: --roles +takes_value +multiple "Roles assigned to agent")
+                (@arg role: --role +takes_value +use_delimiter +multiple "Roles assigned to agent")
                 (@arg metadata: --metadata +takes_value +multiple
                     "Comma-separated key value pairs stored in metadata")
             )
@@ -82,7 +82,7 @@ fn run() -> Result<(), CliError> {
                 (@arg org_id: +takes_value +required "organization ID")
                 (@arg public_key: +takes_value +required "public key")
                 (@arg active: "Is user active")
-                (@arg roles: --roles +takes_value +multiple "Roles assigned to agent")
+                (@arg role: --role +takes_value +use_delimiter +multiple "Roles assigned to agent")
                 (@arg metadata: --metadata +takes_value +multiple
                     "Comma-separated key value pairs stored in metadata")
             )
@@ -252,7 +252,7 @@ fn run() -> Result<(), CliError> {
                     .with_public_key(m.value_of("public_key").unwrap().into())
                     .with_active(m.is_present("active"))
                     .with_roles(
-                        m.values_of("roles")
+                        m.values_of("role")
                             .unwrap_or_default()
                             .map(String::from)
                             .collect::<Vec<String>>(),
@@ -269,7 +269,7 @@ fn run() -> Result<(), CliError> {
                     .with_public_key(m.value_of("public_key").unwrap().into())
                     .with_active(m.is_present("active"))
                     .with_roles(
-                        m.values_of("roles")
+                        m.values_of("role")
                             .unwrap_or_default()
                             .map(String::from)
                             .collect::<Vec<String>>(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -72,7 +72,10 @@ fn run() -> Result<(), CliError> {
                 (about: "Create an agent")
                 (@arg org_id: +takes_value +required "organization ID")
                 (@arg public_key: +takes_value +required "public key")
-                (@arg active: "Is user active")
+                (@arg active: --active conflicts_with[inactive] required_unless[inactive]
+                    "Set agent as active")
+                (@arg inactive: --inactive conflicts_with[active] required_unless[active]
+                    "Set agent as inactive")
                 (@arg role: --role +takes_value +use_delimiter +multiple "Roles assigned to agent")
                 (@arg metadata: --metadata +takes_value +multiple
                     "Comma-separated key value pairs stored in metadata")
@@ -81,7 +84,10 @@ fn run() -> Result<(), CliError> {
                 (about: "Update an agent")
                 (@arg org_id: +takes_value +required "organization ID")
                 (@arg public_key: +takes_value +required "public key")
-                (@arg active: "Is user active")
+                (@arg active: --active conflicts_with[inactive] required_unless[inactive]
+                    "Set agent as active")
+                (@arg inactive: --inactive conflicts_with[active] required_unless[active]
+                    "Set agent as inactive")
                 (@arg role: --role +takes_value +use_delimiter +multiple "Roles assigned to agent")
                 (@arg metadata: --metadata +takes_value +multiple
                     "Comma-separated key value pairs stored in metadata")
@@ -247,10 +253,19 @@ fn run() -> Result<(), CliError> {
         },
         ("agent", Some(m)) => match m.subcommand() {
             ("create", Some(m)) => {
+                let active = if m.is_present("inactive") {
+                    false
+                } else if m.is_present("active") {
+                    true
+                } else {
+                    return Err(CliError::UserError(
+                        "--active or --inactive flag must be provided".to_string(),
+                    ));
+                };
                 let create_agent = CreateAgentActionBuilder::new()
                     .with_org_id(m.value_of("org_id").unwrap().into())
                     .with_public_key(m.value_of("public_key").unwrap().into())
-                    .with_active(m.is_present("active"))
+                    .with_active(active)
                     .with_roles(
                         m.values_of("role")
                             .unwrap_or_default()
@@ -264,10 +279,19 @@ fn run() -> Result<(), CliError> {
                 agents::do_create_agent(&url, key, wait, create_agent, service_id)?
             }
             ("update", Some(m)) => {
+                let active = if m.is_present("inactive") {
+                    false
+                } else if m.is_present("active") {
+                    true
+                } else {
+                    return Err(CliError::UserError(
+                        "--active or --inactive flag must be provided".to_string(),
+                    ));
+                };
                 let update_agent = UpdateAgentActionBuilder::new()
                     .with_org_id(m.value_of("org_id").unwrap().into())
                     .with_public_key(m.value_of("public_key").unwrap().into())
-                    .with_active(m.is_present("active"))
+                    .with_active(active)
                     .with_roles(
                         m.values_of("role")
                             .unwrap_or_default()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -62,6 +62,7 @@ fn run() -> Result<(), CliError> {
         (@arg wait: --wait +takes_value "How long to wait for transaction to be committed")
         (@arg key: -k +takes_value "base name for private key file")
         (@arg verbose: -v +multiple +global "Log verbosely")
+        (@arg quiet: -q --quiet +global "Do not display output")
         (@arg service_id: --service_id +takes_value "The ID of the service the payload should be \
             sent to; required if running on Splinter. Format <circuit-id>::<service-id>")
         (@subcommand agent =>
@@ -205,11 +206,15 @@ fn run() -> Result<(), CliError> {
 
     let matches = app.get_matches();
 
-    let log_level = match matches.occurrences_of("verbose") {
-        0 => log::LevelFilter::Warn,
-        1 => log::LevelFilter::Info,
-        2 => log::LevelFilter::Debug,
-        _ => log::LevelFilter::Trace,
+    let log_level = if matches.is_present("quiet") {
+        log::LevelFilter::Error
+    } else {
+        match matches.occurrences_of("verbose") {
+            0 => log::LevelFilter::Warn,
+            1 => log::LevelFilter::Info,
+            2 => log::LevelFilter::Debug,
+            _ => log::LevelFilter::Trace,
+        }
     };
     let mut log_spec_builder = LogSpecBuilder::new();
     log_spec_builder.default(log_level);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -61,7 +61,7 @@ fn run() -> Result<(), CliError> {
         (@arg url: --url  +takes_value "URL for the REST API")
         (@arg wait: --wait +takes_value "How long to wait for transaction to be committed")
         (@arg key: -k +takes_value "base name for private key file")
-        (@arg verbose: -v +multiple "Log verbosely")
+        (@arg verbose: -v +multiple +global "Log verbosely")
         (@arg service_id: --service_id +takes_value "The ID of the service the payload should be \
             sent to; required if running on Splinter. Format <circuit-id>::<service-id>")
         (@subcommand agent =>


### PR DESCRIPTION
This PR:
- Changes the `active` argument in the CLI command `agent create` and `agent update` to be flags: `--active` `--not-active`. Orginially the argument took a boolean value
- Changes the `--roles` argument  in the CLI command `agent create` and `agent update` so it accepts comma separated values
- Changes the `verbose` flag to be global, meaning it can be used in any of the subcommands.
- Adds a `quiet` global flag to omit the output
- Changes some printlns to debug level log