### PR TITLE
Remove double write of private key

### DIFF
--- a/cli/src/actions/admin.rs
+++ b/cli/src/actions/admin.rs
@@ -25,8 +25,6 @@ use sawtooth_sdk::signing;
 
 use crate::error::CliError;
 
-use super::write_hex_to_file;
-
 const DEFAULT_KEY_DIR: &str = "/etc/grid/keys";
 
 pub enum ConflictStrategy {
@@ -105,26 +103,26 @@ pub fn do_keygen(
     } else {
         debug!("Writing file: {:?}", public_key_path);
     }
-    let mut public_key_file = OpenOptions::new()
+    let public_key_file = OpenOptions::new()
         .write(true)
         .create(true)
         .mode(0o644)
         .open(public_key_path.as_path())?;
 
-    write_hex_to_file(&public_key.as_hex(), &mut public_key_file)?;
+    writeln!(&public_key_file, "{}", &public_key.as_hex())?;
 
     if private_key_path.exists() {
         debug!("Overwriting file: {:?}", private_key_path);
     } else {
         debug!("Writing file: {:?}", private_key_path);
     }
-    let mut private_key_file = OpenOptions::new()
+    let private_key_file = OpenOptions::new()
         .write(true)
         .create(true)
         .mode(0o640)
         .open(private_key_path.as_path())?;
 
-    write_hex_to_file(&private_key.as_hex(), &mut private_key_file)?;
+    writeln!(&private_key_file, "{}", &private_key.as_hex())?;
 
     Ok(())
 }

--- a/cli/src/actions/keygen.rs
+++ b/cli/src/actions/keygen.rs
@@ -26,8 +26,6 @@ use users::get_current_username;
 
 use crate::error::CliError;
 
-use super::write_hex_to_file;
-
 /// Generates a public/private key pair that can be used to sign transactions.
 /// If no directory is provided, the keys are created in the default directory
 ///
@@ -99,28 +97,26 @@ pub fn generate_keys(
     } else {
         info!("Writing file: {:?}", public_key_path);
     }
-    let mut public_key_file = OpenOptions::new()
+    let public_key_file = OpenOptions::new()
         .write(true)
         .create(true)
         .mode(0o644)
         .open(public_key_path.as_path())?;
 
-    write_hex_to_file(&public_key.as_hex(), &mut public_key_file)?;
+    writeln!(&public_key_file, "{}", public_key.as_hex())?;
 
     if private_key_path.exists() {
         info!("Overwriting file: {:?}", private_key_path);
     } else {
         info!("Writing file: {:?}", private_key_path);
     }
-    let mut private_key_file = OpenOptions::new()
+    let private_key_file = OpenOptions::new()
         .write(true)
         .create(true)
         .mode(0o640)
         .open(private_key_path.as_path())?;
 
-    private_key_file.write_all(private_key.as_hex().as_bytes())?;
-
-    write_hex_to_file(&private_key.as_hex(), &mut private_key_file)?;
+    writeln!(&private_key_file, "{}", &private_key.as_hex())?;
 
     Ok(())
 }

--- a/cli/src/actions/mod.rs
+++ b/cli/src/actions/mod.rs
@@ -23,14 +23,3 @@ pub mod keygen;
 pub mod organizations;
 pub mod products;
 pub mod schemas;
-
-use std::fs::File;
-use std::io::Write;
-
-use crate::error::CliError;
-
-/// Write the given hex string to the given file, appending a newline at the end.
-fn write_hex_to_file(hex: &str, file: &mut File) -> Result<(), CliError> {
-    writeln!(file, "{}", hex)?;
-    Ok(())
-}


### PR DESCRIPTION
Prior to this commit, the keygen command was writing the private key twice to the file, once without a new line, once with, creating a too-long private key string. This first write has been removed.

Additionally, removed the unnecessary wrapper function around writeln.

