### PR TITLE
 Log as debug when unknown state change received 

### DIFF
--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -38,6 +38,10 @@ const TRACK_AND_TRACE_RECORD: &str = "a43b46ec";
 
 const ALL_GRID_NAMESPACES: &[&str] = &[PIKE_NAMESPACE, GRID_NAMESPACE, TRACK_AND_TRACE_NAMESPACE];
 
+const SABRE_NAMESPACE: &str = "00ec";
+
+const IGNORED_NAMESPACES: &[&str] = &[SABRE_NAMESPACE];
+
 /// A notification that some source has committed a set of changes to state
 pub struct CommitEvent {
     /// An identifier for specifying where the event came from

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -188,7 +188,7 @@ fn run_splinter(config: GridConfig, connection_pool: ConnectionPool) -> Result<(
         ScabbardEventConnectionFactory::new(&config.endpoint().url(), reactor.igniter());
 
     app_auth_handler::run(
-        config.endpoint().url().into(),
+        config.endpoint().url(),
         scabbard_event_connection_factory,
         connection_pool.clone(),
         reactor.igniter(),

--- a/daemon/src/splinter/app_auth_handler/node.rs
+++ b/daemon/src/splinter/app_auth_handler/node.rs
@@ -34,7 +34,6 @@ impl fmt::Display for GetNodeError {
 }
 
 pub fn get_node_id(splinterd_url: String) -> Result<String, GetNodeError> {
-    let splinterd_url = splinterd_url.to_owned();
     let uri = format!("{}/status", splinterd_url);
 
     let body: Value = reqwest::blocking::get(&uri)
@@ -44,11 +43,11 @@ pub fn get_node_id(splinterd_url: String) -> Result<String, GetNodeError> {
 
     let node_id_val = body
         .get("node_id")
-        .ok_or_else(|| GetNodeError(format!("Node status response did not contain a node ID.")))?;
+        .ok_or_else(|| GetNodeError("Node status response did not contain a node ID".into()))?;
 
     let node_id = node_id_val
         .as_str()
-        .ok_or_else(|| GetNodeError(format!("Node status returned an invalid ID.")))?;
+        .ok_or_else(|| GetNodeError("Node status returned an invalid ID".into()))?;
 
     Ok(node_id.to_string())
 }


### PR DESCRIPTION
When a state change is received for a key that gridd does not recognize,
this should be logged as a debug message rather than an error. It's
perfectly normal for state to change in ways that aren't directly
relevant to the grid daemon.

Signed-off-by: Logan Seeley <seeley@bitwise.io>