### PR TITLE
Update product cli tests for updated pike agent command

### DIFF
--- a/cli/tests/product.rs
+++ b/cli/tests/product.rs
@@ -144,9 +144,9 @@ mod integration {
             .arg("create")
             .arg(&ORG_ID)
             .arg(&pub_key)
-            .arg("true")
             .args(&[
-                "--roles",
+                "--active",
+                "--role",
                 "admin",
                 "can_create_product",
                 "can_update_product",


### PR DESCRIPTION
The pike agent command was updated to have --active instead of true and --roles was replaced with --role