### PR TITLE
Only run wasm builds for smart contracts in dev image

### DIFF
--- a/ci/grid-dev
+++ b/ci/grid-dev
@@ -77,7 +77,7 @@ RUN find . -name 'Cargo.toml' -exec \
     sh -c 'x="{}"; cargo build --release --manifest-path "$x" ' \;
 
 # Do wasm builds for the contracts
-RUN find . -name 'Cargo.toml' -exec \
+RUN find contracts -name 'Cargo.toml' -exec \
     sh -c 'x="{}"; cargo build --target wasm32-unknown-unknown --release --manifest-path "$x" ' \;
 
 # Clean up built files


### PR DESCRIPTION
Performing the find at the root can cause problems if components have
dependencies that can't be compiled to wasm. This should speed up builds as
well.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>