### PR TITLE
Add env variables for key and url CLI args

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,6 +31,8 @@ mod splinter;
 mod transaction;
 mod yaml_parser;
 
+use std::env;
+
 use clap::ArgMatches;
 use flexi_logger::{LogSpecBuilder, Logger};
 use grid_sdk::protocol::pike::{
@@ -50,6 +52,9 @@ use actions::admin;
 
 const APP_NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const GRID_DAEMON_KEY: &str = "GRID_DAEMON_KEY";
+const GRID_DAEMON_ENDPOINT: &str = "GRID_DAEMON_ENDPOINT";
 
 fn run() -> Result<(), CliError> {
     #[allow(unused_mut)]
@@ -227,9 +232,16 @@ fn run() -> Result<(), CliError> {
 
     Logger::with(log_spec_builder.build()).start()?;
 
-    let url = matches.value_of("url").unwrap_or("http://localhost:8000");
+    let url = matches
+        .value_of("url")
+        .map(String::from)
+        .or_else(|| env::var(GRID_DAEMON_ENDPOINT).ok())
+        .unwrap_or_else(|| String::from("http://localhost:8000"));
 
-    let key = matches.value_of("key").map(ToString::to_string);
+    let key = matches
+        .value_of("key")
+        .map(String::from)
+        .or_else(|| env::var(GRID_DAEMON_KEY).ok());
 
     let wait = value_t!(matches, "wait", u64).unwrap_or(0);
 

--- a/examples/splinter/README.md
+++ b/examples/splinter/README.md
@@ -224,7 +224,7 @@ circuit is created.
 
 3. Create a new organization, `myorg`.
 
-   `root@gridd-alpha:/# grid -k alpha-agent --url 'http://localhost:8080' --service-id 'my-grid-circuit::grid-scabbard-a' organization create 314156 myorg '123 main street' --metadata gs1_company_prefixes=314156`
+   `root@gridd-alpha:/# grid --service-id 'my-grid-circuit::grid-scabbard-a' organization create 314156 myorg '123 main street' --metadata gs1_company_prefixes=314156`
 
    This command creates and submits a transaction to create a new Pike
    organization that is signed by the admin key. It also creates a new Pike
@@ -236,8 +236,7 @@ circuit is created.
    deleting Grid products.
 
    ```
-   root@gridd-alpha:/# grid -k alpha-agent --url http://localhost:8080 \
-   --service-id my-grid-circuit::grid-scabbard-a \
+   root@gridd-alpha:/# grid --service-id my-grid-circuit::grid-scabbard-a \
    agent update 314156 $(cat ~/.grid/keys/alpha-agent.pub) --active \
    --role can_create_product \
    --role can_update_product \
@@ -272,8 +271,7 @@ circuit is created.
    `product.yaml`.
 
    ```
-   root@gridd-alpha:/# grid -k alpha-agent --url http://localhost:8080 \
-   --service-id my-grid-circuit::grid-scabbard-a \
+   root@gridd-alpha:/# grid --service-id my-grid-circuit::grid-scabbard-a \
    product create product.yaml
    ```
 
@@ -284,8 +282,7 @@ circuit is created.
 8. Display all products.
 
    ```
-   root@gridd-beta:/# grid --url http://gridd-beta:8080 \
-   --service-id my-grid-circuit::grid-scabbard-b \
+   root@gridd-beta:/# grid --service-id my-grid-circuit::grid-scabbard-b \
    product list
    ```
 

--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -133,6 +133,9 @@ services:
       - 8080
     ports:
       - "8080:8080"
+    environment:
+      GRID_DAEMON_KEY: "alpha-agent"
+      GRID_DAEMON_ENDPOINT: "http://gridd-alpha:8080"
     entrypoint: |
         bash -c "
           # we need to wait for the db to have started.
@@ -218,6 +221,9 @@ services:
       - 8080
     ports:
       - "8081:8080"
+    environment:
+      GRID_DAEMON_KEY: "beta-agent"
+      GRID_DAEMON_ENDPOINT: "http://gridd-beta:8080"
     entrypoint: |
         bash -c "
           # we need to wait for the db to have started.
@@ -302,6 +308,9 @@ services:
       - 8080
     ports:
       - "8082:8080"
+    environment:
+      GRID_DAEMON_KEY: "gamma-agent"
+      GRID_DAEMON_ENDPOINT: "http://gridd-gamma:8080"
     entrypoint: |
         bash -c "
           # we need to wait for the db to have started.


### PR DESCRIPTION
Adds environment variables to the Splinter example docker-compose file for the key and url CLI arguments, as well as checks within the Grid CLI for these values. 

Also updates the README to remove the use of -k and --url in the commands for gridd.