### PR TITLE
Add exponential back-off to status check

### DIFF
--- a/daemon/src/splinter/app_auth_handler/node.rs
+++ b/daemon/src/splinter/app_auth_handler/node.rs
@@ -17,6 +17,8 @@
 use serde_json::Value;
 use std::error::Error;
 use std::fmt;
+use std::thread;
+use std::time::Duration;
 
 #[derive(Debug, PartialEq)]
 pub struct GetNodeError(pub String);
@@ -36,10 +38,7 @@ impl fmt::Display for GetNodeError {
 pub fn get_node_id(splinterd_url: String) -> Result<String, GetNodeError> {
     let uri = format!("{}/status", splinterd_url);
 
-    let body: Value = reqwest::blocking::get(&uri)
-        .map_err(|err| GetNodeError(format!("Failed to get set up request: {}", err)))?
-        .json()
-        .map_err(|err| GetNodeError(format!("Failed to parse response body: {}", err)))?;
+    let body = wait_for_status(&uri)?;
 
     let node_id_val = body
         .get("node_id")
@@ -50,4 +49,25 @@ pub fn get_node_id(splinterd_url: String) -> Result<String, GetNodeError> {
         .ok_or_else(|| GetNodeError("Node status returned an invalid ID".into()))?;
 
     Ok(node_id.to_string())
+}
+
+fn wait_for_status(uri: &str) -> Result<Value, GetNodeError> {
+    let mut wait_time = 1;
+    loop {
+        match reqwest::blocking::get(uri) {
+            Ok(res) => {
+                return res.json().map_err(|err| {
+                    GetNodeError(format!("Failed to parse response body: {}", err))
+                });
+            }
+            Err(err) => {
+                warn!("Unable to get splinter status: {}", err);
+                wait_time = if wait_time >= 256 { 300 } else { wait_time * 2 };
+
+                warn!("Retrying in: {} seconds", wait_time);
+                thread::sleep(Duration::from_secs(wait_time));
+                continue;
+            }
+        };
+    }
 }


### PR DESCRIPTION
`get_node_id` now tries indefinitely to check the node status doubling
it's wait time after each failed attempt with a maximum wait time of 300
seconds.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>