### PR TITLE
Display output for keygen commands

### DIFF
--- a/cli/src/actions/admin.rs
+++ b/cli/src/actions/admin.rs
@@ -99,9 +99,9 @@ pub fn do_keygen(
     let public_key = context.get_public_key(&*private_key)?;
 
     if public_key_path.exists() {
-        debug!("Overwriting file: {:?}", public_key_path);
+        info!("Overwriting file: {:?}", public_key_path);
     } else {
-        debug!("Writing file: {:?}", public_key_path);
+        info!("Writing file: {:?}", public_key_path);
     }
     let public_key_file = OpenOptions::new()
         .write(true)
@@ -112,9 +112,9 @@ pub fn do_keygen(
     writeln!(&public_key_file, "{}", &public_key.as_hex())?;
 
     if private_key_path.exists() {
-        debug!("Overwriting file: {:?}", private_key_path);
+        info!("Overwriting file: {:?}", private_key_path);
     } else {
-        debug!("Writing file: {:?}", private_key_path);
+        info!("Writing file: {:?}", private_key_path);
     }
     let private_key_file = OpenOptions::new()
         .write(true)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -221,9 +221,8 @@ fn run() -> Result<(), CliError> {
         log::LevelFilter::Error
     } else {
         match matches.occurrences_of("verbose") {
-            0 => log::LevelFilter::Warn,
-            1 => log::LevelFilter::Info,
-            2 => log::LevelFilter::Debug,
+            0 => log::LevelFilter::Info,
+            1 => log::LevelFilter::Debug,
             _ => log::LevelFilter::Trace,
         }
     };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -77,7 +77,7 @@ fn run() -> Result<(), CliError> {
         (@arg wait: --wait +takes_value "How long to wait for transaction to be committed")
         (@arg key: -k +takes_value "base name for private key file")
         (@arg verbose: -v +multiple +global "Log verbosely")
-        (@arg quiet: -q --quiet +global "Do not display output")
+        (@arg quiet: -q --quiet +global conflicts_with[verbose] "Do not display output")
         (@arg service_id: --("service-id") +takes_value "The ID of the service the payload should be \
             sent to; required if running on Splinter. Format <circuit-id>::<service-id>")
         (@subcommand agent =>


### PR DESCRIPTION
This PR fix some of the log levels in the Grid CLI. Now the `grid keygen` and `grid admin keygen` CLI commands to display an output unless the `--quiet` flag is present. 