### PR TITLE
Service-id environment variable

### DIFF
--- a/cli/src/actions/agents.rs
+++ b/cli/src/actions/agents.rs
@@ -28,7 +28,7 @@ pub fn do_create_agent(
     key: Option<String>,
     wait: u64,
     create_agent: CreateAgentAction,
-    service_id: Option<&str>,
+    service_id: Option<String>,
 ) -> Result<(), CliError> {
     let payload = PikePayloadBuilder::new()
         .with_action(Action::CreateAgent)
@@ -44,7 +44,7 @@ pub fn do_create_agent(
         )?
         .create_batch_list();
 
-    submit_batches(url, wait, &batch_list, service_id)
+    submit_batches(url, wait, &batch_list, service_id.as_deref())
 }
 
 pub fn do_update_agent(
@@ -52,7 +52,7 @@ pub fn do_update_agent(
     key: Option<String>,
     wait: u64,
     update_agent: UpdateAgentAction,
-    service_id: Option<&str>,
+    service_id: Option<String>,
 ) -> Result<(), CliError> {
     let payload = PikePayloadBuilder::new()
         .with_action(Action::UpdateAgent)
@@ -68,5 +68,5 @@ pub fn do_update_agent(
         )?
         .create_batch_list();
 
-    submit_batches(url, wait, &batch_list, service_id)
+    submit_batches(url, wait, &batch_list, service_id.as_deref())
 }

--- a/cli/src/actions/organizations.rs
+++ b/cli/src/actions/organizations.rs
@@ -30,7 +30,7 @@ pub fn do_create_organization(
     key: Option<String>,
     wait: u64,
     create_org: CreateOrganizationAction,
-    service_id: Option<&str>,
+    service_id: Option<String>,
 ) -> Result<(), CliError> {
     let payload = PikePayloadBuilder::new()
         .with_action(Action::CreateOrganization)
@@ -46,7 +46,7 @@ pub fn do_create_organization(
         )?
         .create_batch_list();
 
-    submit_batches(url, wait, &batch_list, service_id)
+    submit_batches(url, wait, &batch_list, service_id.as_deref())
 }
 
 pub fn do_update_organization(
@@ -54,7 +54,7 @@ pub fn do_update_organization(
     key: Option<String>,
     wait: u64,
     update_org: UpdateOrganizationAction,
-    service_id: Option<&str>,
+    service_id: Option<String>,
 ) -> Result<(), CliError> {
     let payload = PikePayloadBuilder::new()
         .with_action(Action::UpdateOrganization)
@@ -70,5 +70,5 @@ pub fn do_update_organization(
         )?
         .create_batch_list();
 
-    submit_batches(url, wait, &batch_list, service_id)
+    submit_batches(url, wait, &batch_list, service_id.as_deref())
 }

--- a/cli/src/actions/products.rs
+++ b/cli/src/actions/products.rs
@@ -105,7 +105,7 @@ pub fn display_product_property_definitions(properties: &[GridPropertyValue]) {
  *
  * url - Url for the REST API
  */
-pub fn do_list_products(url: &str, service_id: Option<&str>) -> Result<(), CliError> {
+pub fn do_list_products(url: &str, service_id: Option<String>) -> Result<(), CliError> {
     let client = Client::new();
     let mut final_url = format!("{}/product", url);
     if let Some(service_id) = service_id {
@@ -125,7 +125,7 @@ pub fn do_list_products(url: &str, service_id: Option<&str>) -> Result<(), CliEr
 pub fn do_show_products(
     url: &str,
     product_id: &str,
-    service_id: Option<&str>,
+    service_id: Option<String>,
 ) -> Result<(), CliError> {
     let client = Client::new();
     let mut final_url = format!("{}/product/{}", url, product_id);
@@ -150,11 +150,11 @@ pub fn do_create_products(
     key: Option<String>,
     wait: u64,
     path: &str,
-    service_id: Option<&str>,
+    service_id: Option<String>,
 ) -> Result<(), CliError> {
     let payloads = parse_product_yaml(path, Action::ProductCreate(ProductCreateAction::default()))?;
     let batch_list = build_batches_from_payloads(payloads, key)?;
-    submit_batches(url, wait, &batch_list, service_id)
+    submit_batches(url, wait, &batch_list, service_id.as_deref())
 }
 
 /**
@@ -170,11 +170,11 @@ pub fn do_update_products(
     key: Option<String>,
     wait: u64,
     path: &str,
-    service_id: Option<&str>,
+    service_id: Option<String>,
 ) -> Result<(), CliError> {
     let payloads = parse_product_yaml(path, Action::ProductUpdate(ProductUpdateAction::default()))?;
     let batch_list = build_batches_from_payloads(payloads, key)?;
-    submit_batches(url, wait, &batch_list, service_id)
+    submit_batches(url, wait, &batch_list, service_id.as_deref())
 }
 
 /**
@@ -191,7 +191,7 @@ pub fn do_delete_products(
     wait: u64,
     product_id: &str,
     product_type: &str,
-    service_id: Option<&str>,
+    service_id: Option<String>,
 ) -> Result<(), CliError> {
     let parsed_product_type = parse_value_as_product_type(product_type)?;
     let payloads = vec![generate_delete_product_payload(
@@ -199,7 +199,7 @@ pub fn do_delete_products(
         product_id,
     )?];
     let batch_list = build_batches_from_payloads(payloads, key)?;
-    submit_batches(url, wait, &batch_list, service_id)
+    submit_batches(url, wait, &batch_list, service_id.as_deref())
 }
 
 /**

--- a/cli/src/actions/schemas.rs
+++ b/cli/src/actions/schemas.rs
@@ -74,7 +74,7 @@ pub fn display_schema_property_definitions(properties: &[GridPropertyDefinitionS
     });
 }
 
-pub fn do_list_schemas(url: &str, service_id: Option<&str>) -> Result<(), CliError> {
+pub fn do_list_schemas(url: &str, service_id: Option<String>) -> Result<(), CliError> {
     let client = Client::new();
     let mut final_url = format!("{}/schema", url);
     if let Some(service_id) = service_id {
@@ -88,7 +88,7 @@ pub fn do_list_schemas(url: &str, service_id: Option<&str>) -> Result<(), CliErr
     Ok(())
 }
 
-pub fn do_show_schema(url: &str, name: &str, service_id: Option<&str>) -> Result<(), CliError> {
+pub fn do_show_schema(url: &str, name: &str, service_id: Option<String>) -> Result<(), CliError> {
     let client = Client::new();
     let mut final_url = format!("{}/schema/{}", url, name);
     if let Some(service_id) = service_id {
@@ -104,7 +104,7 @@ pub fn do_create_schemas(
     key: Option<String>,
     wait: u64,
     path: &str,
-    service_id: Option<&str>,
+    service_id: Option<String>,
 ) -> Result<(), CliError> {
     let payloads = parse_yaml(path, Action::SchemaCreate(SchemaCreateAction::default()))?;
     let mut batch_list_builder = schema_batch_builder(key);
@@ -121,7 +121,7 @@ pub fn do_create_schemas(
 
     let batch_list = batch_list_builder.create_batch_list();
 
-    submit_batches(url, wait, &batch_list, service_id)
+    submit_batches(url, wait, &batch_list, service_id.as_deref())
 }
 
 pub fn do_update_schemas(
@@ -129,7 +129,7 @@ pub fn do_update_schemas(
     key: Option<String>,
     wait: u64,
     path: &str,
-    service_id: Option<&str>,
+    service_id: Option<String>,
 ) -> Result<(), CliError> {
     let payloads = parse_yaml(path, Action::SchemaUpdate(SchemaUpdateAction::default()))?;
     let mut batch_list_builder = schema_batch_builder(key);
@@ -146,7 +146,7 @@ pub fn do_update_schemas(
 
     let batch_list = batch_list_builder.create_batch_list();
 
-    submit_batches(url, wait, &batch_list, service_id)
+    submit_batches(url, wait, &batch_list, service_id.as_deref())
 }
 
 fn parse_yaml(path: &str, action: Action) -> Result<Vec<SchemaPayload>, CliError> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -55,6 +55,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const GRID_DAEMON_KEY: &str = "GRID_DAEMON_KEY";
 const GRID_DAEMON_ENDPOINT: &str = "GRID_DAEMON_ENDPOINT";
+const GRID_SERVICE_ID: &str = "GRID_SERVICE_ID";
 
 fn run() -> Result<(), CliError> {
     #[allow(unused_mut)]
@@ -245,7 +246,10 @@ fn run() -> Result<(), CliError> {
 
     let wait = value_t!(matches, "wait", u64).unwrap_or(0);
 
-    let service_id = matches.value_of("service_id");
+    let service_id = matches
+        .value_of("service_id")
+        .map(String::from)
+        .or_else(|| env::var(GRID_SERVICE_ID).ok());
 
     match matches.subcommand() {
         #[cfg(feature = "admin-keygen")]

--- a/examples/splinter/README.md
+++ b/examples/splinter/README.md
@@ -224,7 +224,7 @@ circuit is created.
 
 3. Create a new organization, `myorg`.
 
-   `root@gridd-alpha:/# grid --service-id 'my-grid-circuit::grid-scabbard-a' organization create 314156 myorg '123 main street' --metadata gs1_company_prefixes=314156`
+   `root@gridd-alpha:/# grid organization create 314156 myorg '123 main street' --metadata gs1_company_prefixes=314156`
 
    This command creates and submits a transaction to create a new Pike
    organization that is signed by the admin key. It also creates a new Pike
@@ -236,7 +236,7 @@ circuit is created.
    deleting Grid products.
 
    ```
-   root@gridd-alpha:/# grid --service-id my-grid-circuit::grid-scabbard-a \
+   root@gridd-alpha:/# grid \
    agent update 314156 $(cat ~/.grid/keys/alpha-agent.pub) --active \
    --role can_create_product \
    --role can_update_product \
@@ -271,8 +271,7 @@ circuit is created.
    `product.yaml`.
 
    ```
-   root@gridd-alpha:/# grid --service-id my-grid-circuit::grid-scabbard-a \
-   product create product.yaml
+   root@gridd-alpha:/# grid product create product.yaml
    ```
 
 7. Open a new terminal and connect to the `gridd-beta` container.
@@ -282,8 +281,7 @@ circuit is created.
 8. Display all products.
 
    ```
-   root@gridd-beta:/# grid --service-id my-grid-circuit::grid-scabbard-b \
-   product list
+   root@gridd-beta:/# grid product list
    ```
 
 ## Demonstrate Circuit Scope

--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -136,6 +136,7 @@ services:
     environment:
       GRID_DAEMON_KEY: "alpha-agent"
       GRID_DAEMON_ENDPOINT: "http://gridd-alpha:8080"
+      GRID_SERVICE_ID: "my-grid-circuit::grid-scabbard-a"
     entrypoint: |
         bash -c "
           # we need to wait for the db to have started.
@@ -224,6 +225,7 @@ services:
     environment:
       GRID_DAEMON_KEY: "beta-agent"
       GRID_DAEMON_ENDPOINT: "http://gridd-beta:8080"
+      GRID_SERVICE_ID: "my-grid-circuit::grid-scabbard-b"
     entrypoint: |
         bash -c "
           # we need to wait for the db to have started.


### PR DESCRIPTION
Adds a `GRID_SPLINTER_SERVICE_ID` environment variable to the gridd alpha and beta docker containers for the Splinter example. Also changes around the actions functions to expect Option<String> instead of Option<&str> because the environment variable gets returned as Option<String> but is unable to directly be converted using `deref` because the value being created is temporary when fetched using `env::var`.