### PR TITLE
Change CommitEvent service_id to Option<String>

### DIFF
--- a/daemon/src/event/db_handler.rs
+++ b/daemon/src/event/db_handler.rs
@@ -116,7 +116,7 @@ fn create_db_commit_from_commit_event(
 ) -> Result<NewCommit, EventError> {
     let commit_id = event.id.clone();
     let commit_num = commit_event_height_to_commit_num(event.height, conn)?;
-    let service_id = Some(event.service_id.clone());
+    let service_id = event.service_id.clone();
     Ok(NewCommit {
         commit_id,
         commit_num,

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -45,7 +45,7 @@ const IGNORED_NAMESPACES: &[&str] = &[SABRE_NAMESPACE];
 /// A notification that some source has committed a set of changes to state
 pub struct CommitEvent {
     /// An identifier for specifying where the event came from
-    pub service_id: String,
+    pub service_id: Option<String>,
     /// An identifier that is unique among events from the source
     pub id: String,
     /// May be used to provide ordering of commits from the source. If `None`, ordering is not
@@ -60,8 +60,9 @@ impl std::fmt::Display for CommitEvent {
         f.write_str("(")?;
         f.write_str(&self.id)?;
         f.write_str(", ")?;
-        f.write_str(&self.service_id)?;
-        f.write_str(", ")?;
+        if self.service_id.is_some() {
+            write!(f, "{}, ", self.service_id.as_ref().unwrap())?;
+        }
         if self.height.is_some() {
             write!(f, "height: {}, ", self.height.as_ref().unwrap())?;
         }

--- a/daemon/src/sawtooth/event.rs
+++ b/daemon/src/sawtooth/event.rs
@@ -237,7 +237,7 @@ impl TryFrom<&[SawtoothEvent]> for CommitEvent {
         let state_changes = get_state_changes(events)?;
 
         Ok(CommitEvent {
-            service_id: "".into(), // sawtooth is identified by the null service_id
+            service_id: None, // sawtooth is identified by the null service_id
             id,
             height,
             state_changes,
@@ -388,7 +388,7 @@ mod tests {
         let commit_event = CommitEvent::try_from(sawtooth_events.as_slice())
             .expect("Failed to convert sawtooth events to a CommitEvent");
 
-        assert_eq!(&commit_event.service_id, "");
+        assert!(&commit_event.service_id.is_none());
         assert_eq!(&commit_event.id, block_id);
         assert_eq!(commit_event.height, Some(block_num));
         assert_eq!(commit_event.state_changes.len(), grid_state_changes.len());

--- a/daemon/src/splinter/event.rs
+++ b/daemon/src/splinter/event.rs
@@ -170,7 +170,7 @@ impl EventConnection for ScabbardEventConnection {
         match *connection_state {
             ConnectionState::Connected(ref receiver) => match receiver.recv() {
                 Ok(ConnectionCommand::Message(scabbard_evt)) => Ok(CommitEvent {
-                    service_id: self.name.clone(),
+                    service_id: Some(self.name.clone()),
                     id: scabbard_evt.id,
                     height: None,
                     state_changes: scabbard_evt


### PR DESCRIPTION
Using docker-compose.yaml and grid-cli to create a test organization, I ended up with an empty string as service_id in the PostgreSQL db. gridd expects service_id to be null in places like <https://github.com/hyperledger/grid/blob/master/daemon/src/database/helpers/organizations.rs#L72>. Thus the gridd REST API returns nothing. This seems to fix the issue.