### PR TITLE
Update README Grid on Splinter example

### DIFF
--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -136,7 +136,6 @@ services:
     environment:
       GRID_DAEMON_KEY: "alpha-agent"
       GRID_DAEMON_ENDPOINT: "http://gridd-alpha:8080"
-      GRID_SERVICE_ID: "my-grid-circuit::grid-scabbard-a"
     entrypoint: |
         bash -c "
           # we need to wait for the db to have started.
@@ -232,7 +231,6 @@ services:
     environment:
       GRID_DAEMON_KEY: "beta-agent"
       GRID_DAEMON_ENDPOINT: "http://gridd-beta:8080"
-      GRID_SERVICE_ID: "my-grid-circuit::grid-scabbard-b"
     entrypoint: |
         bash -c "
           # we need to wait for the db to have started.


### PR DESCRIPTION
To test:
1. Makes sure to pull the most up to date splinter docker images 
```
docker-compose -f examples/splinter/docker-compose.yaml pull
```
2. Follow the instructions in the README. 