### PR TITLE
Sabre transaction building updates

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -44,11 +44,11 @@ grid-sdk = { path = "../sdk" }
 log = "0.4"
 protobuf = "2"
 reqwest = { version = "0.10.1", optional = true, features = ["json", "blocking"] }
-rust-crypto = { version = "0.2", optional = true }
 sabre-sdk = { version = "0.5", optional = true }
-sawtooth-sdk = "0.3"
+sawtooth-sdk = { version = "0.4", features = ["transact-compat"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+transact = { version = "0.2", optional = true }
 url = "2.1"
 uuid = { version = "0.6", features = ["v4"] }
 
@@ -65,7 +65,7 @@ stable = ["sawtooth-support"]
 experimental = ["splinter-support"]
 
 sawtooth-support = []
-splinter-support = ["splinter", "reqwest", "sabre-sdk", "rust-crypto"]
+splinter-support = ["splinter", "reqwest", "sabre-sdk", "transact", "transact/contract-archive"]
 test-api = []
 
 [package.metadata.deb]

--- a/daemon/src/splinter/app_auth_handler/sabre.rs
+++ b/daemon/src/splinter/app_auth_handler/sabre.rs
@@ -15,55 +15,41 @@
  * -----------------------------------------------------------------------------
  */
 
-use std::time::Instant;
+use std::convert::TryInto;
 
-use crypto::digest::Digest;
-use crypto::sha2::Sha512;
-use protobuf::Message;
 use sabre_sdk::protocol::payload::{
-    Action, CreateContractActionBuilder, CreateContractRegistryActionBuilder,
+    CreateContractActionBuilder, CreateContractRegistryActionBuilder,
     CreateNamespaceRegistryActionBuilder, CreateNamespaceRegistryPermissionActionBuilder,
-    SabrePayloadBuilder,
 };
-use sabre_sdk::protocol::ADMINISTRATORS_SETTING_ADDRESS;
-use sabre_sdk::protos::IntoBytes as SabreIntoBytes;
-use sawtooth_sdk::messages::batch::{Batch, BatchHeader, BatchList};
-use sawtooth_sdk::messages::transaction::{Transaction, TransactionHeader};
-use sawtooth_sdk::signing::secp256k1::Secp256k1PrivateKey;
-use sawtooth_sdk::signing::{create_context, CryptoFactory, Signer};
-use splinter::service::scabbard::client::{SabreSmartContractDefinition, ScabbardClient};
+use sawtooth_sdk::signing::{
+    create_context, secp256k1::Secp256k1PrivateKey, transact::TransactSigner,
+    Signer as SawtoothSigner,
+};
+use splinter::service::scabbard::client::{ScabbardClient, ServiceId};
+use transact::{
+    contract::archive::{default_scar_path, SmartContractArchive},
+    protocol::{batch::BatchBuilder, transaction::Transaction},
+    signing::Signer,
+};
 
 use crate::splinter::app_auth_handler::error::AppAuthHandlerError;
 
 const SCABBARD_SUBMISSION_WAIT_SECS: u64 = 10;
 
-/// The namespace registry prefix for global state (00ec00)
-const NAMESPACE_REGISTRY_PREFIX: &str = "00ec00";
-
-/// The contract registry prefix for global state (00ec01)
-const CONTRACT_REGISTRY_PREFIX: &str = "00ec01";
-
-/// The contract prefix for global state (00ec02)
-const CONTRACT_PREFIX: &str = "00ec02";
-
-/// The smart permission prefix for global state (00ec03)
-const SMART_PERMISSION_PREFIX: &str = "00ec03";
-
-/// Sabre constants
-const SABRE_FAMILY_NAME: &str = "sabre";
-const SABRE_FAMILY_VERSION: &str = "0.5";
-
 // Pike constants
 const PIKE_PREFIX: &str = "cad11d";
-const PIKE_CONTRACT_FILENAME: &str = "grid-pike_0.1.0-dev.scar";
+const PIKE_CONTRACT_NAME: &str = "grid-pike";
+const PIKE_CONTRACT_VERSION_REQ: &str = "0.1.0-dev";
 
 // Product constants
 const PRODUCT_PREFIX: &str = "621dee02";
-const PRODUCT_CONTRACT_FILENAME: &str = "grid-product_0.1.0-dev.scar";
+const PRODUCT_CONTRACT_NAME: &str = "grid-product";
+const PRODUCT_CONTRACT_VERSION_REQ: &str = "0.1.0-dev";
 
 // Schema constants
 const SCHEMA_PREFIX: &str = "621dee01";
-const SCHEMA_CONTRACT_FILENAME: &str = "grid-schema_0.1.0-dev.scar";
+const SCHEMA_CONTRACT_NAME: &str = "grid-schema";
+const SCHEMA_CONTRACT_VERSION_REQ: &str = "0.1.0-dev";
 
 pub fn setup_grid(
     scabbard_admin_key: &str,
@@ -72,13 +58,10 @@ pub fn setup_grid(
     service_id: &str,
     circuit_id: &str,
 ) -> Result<(), AppAuthHandlerError> {
-    let context = create_context("secp256k1")?;
-    let factory = CryptoFactory::new(&*context);
-    let private_key = Secp256k1PrivateKey::from_hex(&scabbard_admin_key)?;
-    let signer = factory.new_signer(&private_key);
+    let signer = new_signer(&scabbard_admin_key)?;
 
     // The node with the first key in the list of scabbard admins is responsible for setting up xo
-    let public_key = signer.get_public_key()?.as_hex();
+    let public_key = bytes_to_hex_str(signer.public_key());
     let is_submitter = match proposed_admin_pubkeys.get(0) {
         Some(submitting_key) => &public_key == submitting_key,
         None => false,
@@ -88,64 +71,50 @@ pub fn setup_grid(
     }
 
     // Make Pike transactions
-    let pike_contract = SabreSmartContractDefinition::new_from_scar(&format!(
-        "/usr/share/scar/{}",
-        PIKE_CONTRACT_FILENAME
-    ))?;
+    let pike_contract = SmartContractArchive::from_scar_file(
+        PIKE_CONTRACT_NAME,
+        PIKE_CONTRACT_VERSION_REQ,
+        &default_scar_path(),
+    )?;
     let pike_contract_registry_txn =
         make_contract_registry_txn(&signer, &pike_contract.metadata.name)?;
-    let pike_contract_txn = make_upload_contract_txn(
-        &signer,
-        &pike_contract.metadata.name,
-        &pike_contract.metadata.version,
-        pike_contract.contract,
-        PIKE_PREFIX,
-    )?;
+    let pike_contract_txn = make_upload_contract_txn(&signer, &pike_contract, PIKE_PREFIX)?;
     let pike_namespace_registry_txn = make_namespace_registry_txn(&signer, PIKE_PREFIX)?;
     let pike_namespace_permissions_txn =
-        make_namespace_permissions_txn(&signer, &pike_contract.metadata.name, PIKE_PREFIX)?;
+        make_namespace_permissions_txn(&signer, &pike_contract, PIKE_PREFIX)?;
 
     // Make Product transactions
-    let product_contract = SabreSmartContractDefinition::new_from_scar(&format!(
-        "/usr/share/scar/{}",
-        PRODUCT_CONTRACT_FILENAME
-    ))?;
+    let product_contract = SmartContractArchive::from_scar_file(
+        PRODUCT_CONTRACT_NAME,
+        PRODUCT_CONTRACT_VERSION_REQ,
+        &default_scar_path(),
+    )?;
     let product_contract_registry_txn =
         make_contract_registry_txn(&signer, &product_contract.metadata.name)?;
-    let product_contract_txn = make_upload_contract_txn(
-        &signer,
-        &product_contract.metadata.name,
-        &product_contract.metadata.version,
-        product_contract.contract,
-        PRODUCT_PREFIX,
-    )?;
+    let product_contract_txn =
+        make_upload_contract_txn(&signer, &product_contract, PRODUCT_PREFIX)?;
     let product_namespace_registry_txn = make_namespace_registry_txn(&signer, PRODUCT_PREFIX)?;
     let product_namespace_permissions_txn =
-        make_namespace_permissions_txn(&signer, &product_contract.metadata.name, PRODUCT_PREFIX)?;
+        make_namespace_permissions_txn(&signer, &product_contract, PRODUCT_PREFIX)?;
     let product_pike_namespace_permissions_txn =
-        make_namespace_permissions_txn(&signer, &product_contract.metadata.name, PIKE_PREFIX)?;
+        make_namespace_permissions_txn(&signer, &product_contract, PIKE_PREFIX)?;
     let product_schema_namespace_permissions_txn =
-        make_namespace_permissions_txn(&signer, &product_contract.metadata.name, SCHEMA_PREFIX)?;
+        make_namespace_permissions_txn(&signer, &product_contract, SCHEMA_PREFIX)?;
 
     // Make schema transactions
-    let schema_contract = SabreSmartContractDefinition::new_from_scar(&format!(
-        "/usr/share/scar/{}",
-        SCHEMA_CONTRACT_FILENAME
-    ))?;
+    let schema_contract = SmartContractArchive::from_scar_file(
+        SCHEMA_CONTRACT_NAME,
+        SCHEMA_CONTRACT_VERSION_REQ,
+        &default_scar_path(),
+    )?;
     let schema_contract_registry_txn =
         make_contract_registry_txn(&signer, &schema_contract.metadata.name)?;
-    let schema_contract_txn = make_upload_contract_txn(
-        &signer,
-        &schema_contract.metadata.name,
-        &schema_contract.metadata.version,
-        schema_contract.contract,
-        SCHEMA_PREFIX,
-    )?;
+    let schema_contract_txn = make_upload_contract_txn(&signer, &schema_contract, SCHEMA_PREFIX)?;
     let schema_namespace_registry_txn = make_namespace_registry_txn(&signer, SCHEMA_PREFIX)?;
     let schema_namespace_permissions_txn =
-        make_namespace_permissions_txn(&signer, &schema_contract.metadata.name, SCHEMA_PREFIX)?;
+        make_namespace_permissions_txn(&signer, &schema_contract, SCHEMA_PREFIX)?;
     let schema_pike_namespace_permissions_txn =
-        make_namespace_permissions_txn(&signer, &schema_contract.metadata.name, PIKE_PREFIX)?;
+        make_namespace_permissions_txn(&signer, &schema_contract, PIKE_PREFIX)?;
 
     let txns = vec![
         pike_contract_registry_txn,
@@ -164,15 +133,12 @@ pub fn setup_grid(
         schema_pike_namespace_permissions_txn,
         schema_namespace_permissions_txn,
     ];
-
-    let batch = create_batch(txns, &signer)?;
-    let batch_list = create_batch_list_from_one(batch);
+    let batch = BatchBuilder::new().with_transactions(txns).build(&signer)?;
 
     ScabbardClient::new(&splinterd_url)
         .submit(
-            circuit_id,
-            service_id,
-            batch_list,
+            &ServiceId::new(circuit_id, service_id),
+            vec![batch],
             Some(SCABBARD_SUBMISSION_WAIT_SECS),
         )
         .map_err(|err| AppAuthHandlerError::BatchSubmitError(err.to_string()))?;
@@ -180,190 +146,66 @@ pub fn setup_grid(
     Ok(())
 }
 
+fn new_signer(private_key: &str) -> Result<TransactSigner, AppAuthHandlerError> {
+    let context = create_context("secp256k1")?;
+    let private_key = Box::new(Secp256k1PrivateKey::from_hex(private_key)?);
+    Ok(SawtoothSigner::new_boxed(context, private_key).try_into()?)
+}
+
 fn make_contract_registry_txn(
-    signer: &Signer,
+    signer: &dyn Signer,
     name: &str,
 ) -> Result<Transaction, AppAuthHandlerError> {
-    let action = CreateContractRegistryActionBuilder::new()
+    Ok(CreateContractRegistryActionBuilder::new()
         .with_name(String::from(name))
-        .with_owners(vec![signer.get_public_key()?.as_hex()])
-        .build()?;
-    let payload = SabrePayloadBuilder::new()
-        .with_action(Action::CreateContractRegistry(action))
-        .build()?
-        .into_bytes()?;
-    let addresses = vec![
-        compute_contract_registry_address(name),
-        ADMINISTRATORS_SETTING_ADDRESS.into(),
-    ];
-
-    create_txn(signer, addresses, payload)
+        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .into_payload_builder()?
+        .into_transaction_builder(signer)?
+        .build(signer)?)
 }
 
 fn make_upload_contract_txn(
-    signer: &Signer,
-    name: &str,
-    version: &str,
-    contract: Vec<u8>,
+    signer: &dyn Signer,
+    contract: &SmartContractArchive,
     contract_prefix: &str,
 ) -> Result<Transaction, AppAuthHandlerError> {
-    let action_addresses = vec![
-        SMART_PERMISSION_PREFIX.into(),
-        PIKE_PREFIX.into(),
-        contract_prefix.into(),
-    ];
-    let action = CreateContractActionBuilder::new()
-        .with_name(name.into())
-        .with_version(version.into())
+    let action_addresses = vec![PIKE_PREFIX.into(), contract_prefix.into()];
+    Ok(CreateContractActionBuilder::new()
+        .with_name(contract.metadata.name.clone())
+        .with_version(contract.metadata.version.clone())
         .with_inputs(action_addresses.clone())
         .with_outputs(action_addresses)
-        .with_contract(contract)
-        .build()?;
-    let payload = SabrePayloadBuilder::new()
-        .with_action(Action::CreateContract(action))
-        .build()?
-        .into_bytes()?;
-    let addresses = vec![
-        compute_contract_registry_address(name),
-        compute_contract_address(name, version),
-    ];
-
-    create_txn(signer, addresses, payload)
+        .with_contract(contract.contract.clone())
+        .into_payload_builder()?
+        .into_transaction_builder(signer)?
+        .build(signer)?)
 }
 
 fn make_namespace_registry_txn(
-    signer: &Signer,
+    signer: &dyn Signer,
     contract_prefix: &str,
 ) -> Result<Transaction, AppAuthHandlerError> {
-    let action = CreateNamespaceRegistryActionBuilder::new()
+    Ok(CreateNamespaceRegistryActionBuilder::new()
         .with_namespace(contract_prefix.into())
-        .with_owners(vec![signer.get_public_key()?.as_hex()])
-        .build()?;
-    let payload = SabrePayloadBuilder::new()
-        .with_action(Action::CreateNamespaceRegistry(action))
-        .build()?
-        .into_bytes()?;
-    let addresses = vec![
-        compute_namespace_registry_address(contract_prefix)?,
-        ADMINISTRATORS_SETTING_ADDRESS.into(),
-    ];
-
-    create_txn(signer, addresses, payload)
-}
-
-fn create_txn(
-    signer: &Signer,
-    addresses: Vec<String>,
-    payload: Vec<u8>,
-) -> Result<Transaction, AppAuthHandlerError> {
-    let public_key = signer.get_public_key()?.as_hex();
-
-    let mut txn = Transaction::new();
-    let mut txn_header = TransactionHeader::new();
-
-    txn_header.set_family_name(String::from(SABRE_FAMILY_NAME));
-    txn_header.set_family_version(String::from(SABRE_FAMILY_VERSION));
-    txn_header.set_nonce(create_nonce());
-    txn_header.set_signer_public_key(public_key.clone());
-    txn_header.set_batcher_public_key(public_key);
-    txn_header.set_inputs(protobuf::RepeatedField::from_vec(addresses.clone()));
-    txn_header.set_outputs(protobuf::RepeatedField::from_vec(addresses));
-
-    let mut sha = Sha512::new();
-    sha.input(&payload);
-    let hash: &mut [u8] = &mut [0; 64];
-    sha.result(hash);
-    txn_header.set_payload_sha512(bytes_to_hex_str(hash));
-    txn.set_payload(payload);
-
-    let txn_header_bytes = txn_header.write_to_bytes().map_err(|err| {
-        AppAuthHandlerError::SawtoothError(format!(
-            "failed to serialize transaction header to bytes: {}",
-            err
-        ))
-    })?;
-    txn.set_header(txn_header_bytes.clone());
-
-    let b: &[u8] = &txn_header_bytes;
-    txn.set_header_signature(signer.sign(b)?);
-
-    Ok(txn)
+        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .into_payload_builder()?
+        .into_transaction_builder(signer)?
+        .build(signer)?)
 }
 
 fn make_namespace_permissions_txn(
-    signer: &Signer,
-    name: &str,
+    signer: &dyn Signer,
+    contract: &SmartContractArchive,
     contract_prefix: &str,
 ) -> Result<Transaction, AppAuthHandlerError> {
-    let action = CreateNamespaceRegistryPermissionActionBuilder::new()
+    Ok(CreateNamespaceRegistryPermissionActionBuilder::new()
         .with_namespace(contract_prefix.into())
-        .with_contract_name(name.into())
+        .with_contract_name(contract.metadata.name.clone())
         .with_read(true)
         .with_write(true)
-        .build()?;
-    let payload = SabrePayloadBuilder::new()
-        .with_action(Action::CreateNamespaceRegistryPermission(action))
-        .build()?
-        .into_bytes()?;
-    let addresses = vec![
-        compute_namespace_registry_address(PIKE_PREFIX)?,
-        compute_namespace_registry_address(contract_prefix)?,
-        ADMINISTRATORS_SETTING_ADDRESS.into(),
-    ];
-
-    create_txn(signer, addresses, payload)
-}
-
-/// Returns a Batch for the given Transactions and Signer
-///
-/// # Arguments
-///
-/// * `txns` - list of Transactions
-/// * `signer` - the signer to be used to sign the transaction
-/// * `public_key` - the public key associated with the signer
-pub fn create_batch(txns: Vec<Transaction>, signer: &Signer) -> Result<Batch, AppAuthHandlerError> {
-    let public_key = signer.get_public_key()?.as_hex();
-
-    let mut batch = Batch::new();
-    let mut batch_header = BatchHeader::new();
-
-    batch_header.set_transaction_ids(protobuf::RepeatedField::from_vec(
-        txns.iter()
-            .map(|txn| txn.header_signature.clone())
-            .collect(),
-    ));
-    batch_header.set_signer_public_key(public_key);
-    batch.set_transactions(protobuf::RepeatedField::from_vec(txns));
-
-    let batch_header_bytes = batch_header.write_to_bytes().map_err(|err| {
-        AppAuthHandlerError::SawtoothError(format!(
-            "failed to serialize batch header to bytes: {}",
-            err
-        ))
-    })?;
-    batch.set_header(batch_header_bytes.clone());
-
-    let b: &[u8] = &batch_header_bytes;
-    batch.set_header_signature(signer.sign(b)?);
-
-    Ok(batch)
-}
-
-/// Returns a BatchList containing the provided Batch
-///
-/// # Arguments
-///
-/// * `batch` - a Batch
-pub fn create_batch_list_from_one(batch: Batch) -> BatchList {
-    let mut batch_list = BatchList::new();
-    batch_list.set_batches(protobuf::RepeatedField::from_vec(vec![batch]));
-    batch_list
-}
-
-/// Creates a nonce appropriate for a TransactionHeader
-fn create_nonce() -> String {
-    let elapsed = Instant::now().elapsed();
-    format!("{}{}", elapsed.as_secs(), elapsed.subsec_nanos())
+        .into_payload_builder()?
+        .into_transaction_builder(signer)?
+        .build(signer)?)
 }
 
 /// Returns a hex string representation of the supplied bytes
@@ -376,62 +218,4 @@ fn bytes_to_hex_str(b: &[u8]) -> String {
         .map(|b| format!("{:02x}", b))
         .collect::<Vec<_>>()
         .join("")
-}
-
-/// Returns a state address for a given namespace registry
-///
-/// # Arguments
-///
-/// * `namespace` - the address prefix for this namespace
-fn compute_namespace_registry_address(namespace: &str) -> Result<String, AppAuthHandlerError> {
-    let prefix = match namespace.get(..6) {
-        Some(x) => x,
-        None => {
-            return Err(AppAuthHandlerError::SabreError(format!(
-                "Namespace must be at least 6 characters long: {}",
-                namespace
-            )));
-        }
-    };
-
-    let hash: &mut [u8] = &mut [0; 64];
-
-    let mut sha = Sha512::new();
-    sha.input(prefix.as_bytes());
-    sha.result(hash);
-
-    Ok(String::from(NAMESPACE_REGISTRY_PREFIX) + &bytes_to_hex_str(hash)[..64])
-}
-
-/// Returns a state address for a given contract registry
-///
-/// # Arguments
-///
-/// * `name` - the name of the contract registry
-fn compute_contract_registry_address(name: &str) -> String {
-    let hash: &mut [u8] = &mut [0; 64];
-
-    let mut sha = Sha512::new();
-    sha.input(name.as_bytes());
-    sha.result(hash);
-
-    String::from(CONTRACT_REGISTRY_PREFIX) + &bytes_to_hex_str(hash)[..64]
-}
-
-/// Returns a state address for a given contract
-///
-/// # Arguments
-///
-/// * `name` - the name of the contract
-/// * `version` - the version of the contract
-fn compute_contract_address(name: &str, version: &str) -> String {
-    let hash: &mut [u8] = &mut [0; 64];
-
-    let s = String::from(name) + "," + version;
-
-    let mut sha = Sha512::new();
-    sha.input(s.as_bytes());
-    sha.result(hash);
-
-    String::from(CONTRACT_PREFIX) + &bytes_to_hex_str(hash)[..64]
 }

--- a/examples/splinter/README.md
+++ b/examples/splinter/README.md
@@ -358,7 +358,8 @@ circuits.
 5. Upload the smart contract.
 
    ```
-   root@scabbard-cli-alpha:/# scabbard contract upload ./xo_0.4.2.scar \
+   root@scabbard-cli-alpha:/# scabbard contract upload xo:0.4.2 \
+   --path . \
    -k gridd \
    -U 'http://splinterd-alpha:8085' \
    --service-id $CIRCUIT_ID::grid-scabbard-a


### PR DESCRIPTION
 Update splinter example to use sabre build pattern

- Update the splinter example to use the new Sabre transaction builder
pattern enabled by Transact, Sawtooth SDK, and Sawtooth Sabre.
- Switch to Transact's .scar loading capability, which is more robust.
- Remove the smart permission namespace from the addresses for upload
transactions, since smart permissions aren't used by Grid smart
contracts right now.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

~~This PR will not build until the splinter crate is updated to include the changes in https://github.com/Cargill/splinter/pull/522~~