### PR TITLE
Implement log in/register sapling

### DIFF
--- a/grid-ui/docker/docker-compose.yaml
+++ b/grid-ui/docker/docker-compose.yaml
@@ -226,7 +226,8 @@
 
     sapling-dev-server:
       build:
-        context: ../sapling-dev-server
+        context: ..
+        dockerfile: sapling-dev-server/Dockerfile
       container_name: sapling-dev-server
       expose:
         - 80

--- a/grid-ui/sapling-dev-server/Dockerfile
+++ b/grid-ui/sapling-dev-server/Dockerfile
@@ -12,14 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM httpd:2.4
 
-COPY . /usr/local/apache2/htdocs/
+FROM node:lts-alpine as build-stage
+
+RUN apk update && apk add git
+
+RUN npm config set unsafe-perm true
+
+COPY . .
+
+RUN cd /saplings/register-login && \
+  npm config set unsafe-perm true && \
+  npm install && \
+  yarn deploy
+
+FROM httpd:2.4 as prod-stage
 
 RUN echo "\
   \n\
   Header set Access-Control-Allow-Origin "*"\n\
   \n\
   " >>/usr/local/apache2/conf/httpd.conf
+
+COPY --from=build-stage /sapling-dev-server/* /usr/local/apache2/htdocs/
 
 EXPOSE 80/tcp

--- a/grid-ui/sapling-dev-server/configSaplings
+++ b/grid-ui/sapling-dev-server/configSaplings
@@ -1,5 +1,13 @@
 [
   {
+    "namespace": "login",
+    "runtimeFiles": [
+      "localhost:3030/sapling-dev-server/register-login.js"
+    ],
+    "styleFiles": [],
+    "workerFiles": []
+  },
+  {
     "namespace": "profile",
     "runtimeFiles": [
       "localhost:3030/sapling-dev-server/profile.js"

--- a/grid-ui/saplings/register-login/.eslintrc
+++ b/grid-ui/saplings/register-login/.eslintrc
@@ -1,0 +1,42 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint",
+    "html"
+  ],
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [
+          ".js",
+          ".ts"
+        ]
+      }
+    }
+  },
+  "env": {
+    "es6": true,
+    "jest": true,
+    "browser": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
+  "rules": {
+    "import/no-default-export": 2,
+    "import/prefer-default-export": 0,
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        "js": "never",
+        "ts": "never"
+      }
+    ]
+  },
+  "extends": [
+    "plugin:@typescript-eslint/recommended",
+    "airbnb",
+    "plugin:prettier/recommended"
+  ]
+}

--- a/grid-ui/saplings/register-login/.prettierrc
+++ b/grid-ui/saplings/register-login/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/grid-ui/saplings/register-login/jest.config.js
+++ b/grid-ui/saplings/register-login/jest.config.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom'
+};

--- a/grid-ui/saplings/register-login/package.json
+++ b/grid-ui/saplings/register-login/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "register-login-sapling",
+  "private": true,
+  "version": "0.0.0-alpha",
+  "license": "Apache-2.0",
+  "author": "Cargill Incorporated",
+  "main": "dist/index.js",
+  "dependencies": {
+    "axios": "^0.19.0",
+    "history": "^4.10.1",
+    "js-sha256": "^0.9.0",
+    "splinter-saplingjs": "github:cargill/splinter-saplingjs#master"
+  },
+  "scripts": {
+    "test": "jest",
+    "build": "webpack",
+    "add-to-canopy": "cp ./dist/* ../../sapling-dev-server/",
+    "deploy": "npm run build && npm run add-to-canopy",
+    "format": "prettier --write \"**/*.+(ts|*rc|json|js)\"",
+    "lint": "eslint src/*"
+  },
+  "devDependencies": {
+    "@types/jest": "^24.0.19",
+    "@typescript-eslint/eslint-plugin": "^2.5.0",
+    "@typescript-eslint/parser": "^2.5.0",
+    "eslint": "^6.5.1",
+    "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-prettier": "^6.4.0",
+    "eslint-plugin-html": "^6.0.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-prettier": "^3.1.1",
+    "html-loader": "^0.5.5",
+    "jest": "^24.9.0",
+    "prettier": "^1.18.2",
+    "ts-jest": "^24.1.0",
+    "ts-loader": "^6.2.1",
+    "typescript": "^3.7.2",
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.10"
+  }
+}

--- a/grid-ui/saplings/register-login/src/index.ts
+++ b/grid-ui/saplings/register-login/src/index.ts
@@ -1,0 +1,214 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  registerConfigSapling,
+  getUser,
+  registerApp,
+  setUser,
+  getSharedConfig,
+  hideCanopy
+} from 'splinter-saplingjs';
+import { createBrowserHistory } from 'history';
+import axios from 'axios';
+import { sha256 } from 'js-sha256';
+
+import html from './register-login.html';
+
+const history = createBrowserHistory();
+
+interface FormEventHandler {
+  (this: HTMLFormElement, event: Event): void;
+}
+
+registerConfigSapling('login', () => {
+  let shouldRender = false;
+  const canopyURL = new URL(window.location.href);
+
+  if (!getUser()) {
+    shouldRender = true;
+    if (canopyURL.pathname !== '/login') {
+      history.push('/login');
+    }
+  } else if (canopyURL.pathname === '/login') {
+    history.push('/');
+  }
+
+  if (shouldRender) {
+    hideCanopy();
+
+    registerApp(domNode => {
+      const div = domNode as HTMLDivElement;
+      div.innerHTML = html;
+
+      const tabs = Array.from(div.querySelectorAll('.tab-box-option'));
+      const forms = Array.from(div.querySelectorAll('form'));
+
+      const errorMessageNode = div.querySelector(
+        '#login-register-error-message'
+      );
+
+      const [loginForm, registerForm] = forms;
+      const panels = Array.from(div.querySelectorAll('.tab-box-content'));
+
+      function formSumbitEventToFormData(event: Event): FormData {
+        event.preventDefault();
+        return new FormData(event.target as HTMLFormElement);
+      }
+
+      function showErrorResponse(message): void {
+        errorMessageNode.innerHTML = message;
+      }
+
+      function createFormActionCapture(
+        action: 'register' | 'login'
+      ): FormEventHandler {
+        return async function captureForm(
+          this: HTMLFormElement,
+          event: Event
+        ): Promise<void> {
+          const formData = formSumbitEventToFormData(event);
+
+          if (
+            action === 'register' &&
+            formData.get('password') !== formData.get('confirmPassword')
+          ) {
+            showErrorResponse('Passwords do not match');
+            return;
+          }
+
+          const user = {
+            displayName: formData.get('username') as string
+          };
+
+          const hash = sha256.hmac.create(formData.get('username') as string);
+          hash.update(formData.get('password') as string);
+          const hashedPassword = hash.hex();
+
+          const http = axios.create({
+            baseURL: getSharedConfig().canopyConfig.splinterURL
+          });
+
+          const target = event.target as HTMLFormElement;
+          const formParent = target.parentNode as HTMLDivElement;
+
+          const progressNode = document.createElement('div');
+          progressNode.setAttribute(
+            'style',
+            'width: 100%; height: 100%; display: flex; justify-content: center; align-items: center;'
+          );
+
+          formParent.replaceChild(progressNode, target);
+
+          let animationRequest = null;
+
+          function doProgress(ts = 0): void {
+            const step = (Math.sin(ts / 500) + 1) / 2;
+            progressNode.innerHTML = `<progress class='progress' max="${1000}" value="${step *
+              1000}"/>`;
+            animationRequest = window.requestAnimationFrame(doProgress);
+          }
+          doProgress();
+
+          tabs.forEach(tab => {
+            tab.setAttribute('disabled', 'true');
+          });
+
+          try {
+            const jsonPayload = {
+              username: formData.get('username') as string,
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              hashed_password: hashedPassword
+            };
+
+            if (action === 'register') {
+              await http.post(`/biome/register`, jsonPayload);
+            }
+
+            const response = await http.post(`/biome/login`, jsonPayload);
+            delete response.data.message;
+            setUser({
+              token: response.data.token,
+              userId: response.data.user_id,
+              displayName: user.displayName
+            });
+            window.location.href = canopyURL.href;
+          } catch (err) {
+            switch (err.response.status) {
+              case 400:
+                showErrorResponse(`${err.response.data.message}`);
+                break;
+              case 404:
+                showErrorResponse('Splinter node could not be found');
+                break;
+              case 500:
+                showErrorResponse(`${err.response.data.message}`);
+                break;
+              default:
+                showErrorResponse(
+                  'Unknown error communicating with Splinter node'
+                );
+            }
+            tabs.forEach(tab => {
+              tab.removeAttribute('disabled');
+            });
+            window.cancelAnimationFrame(animationRequest);
+            formParent.replaceChild(target, progressNode);
+          }
+        };
+      }
+
+      const handleRegisterEvent = createFormActionCapture('register');
+      const handleLoginEvent = createFormActionCapture('login');
+
+      registerForm.addEventListener('submit', handleRegisterEvent);
+
+      loginForm.addEventListener('submit', handleLoginEvent);
+
+      forms.forEach(form => {
+        form.addEventListener('submit', e => {
+          e.preventDefault();
+        });
+      });
+
+      function setSelectedTab(tabIndex): void {
+        tabs.forEach((tab, i) => {
+          const selected = i === tabIndex;
+          tab.setAttribute('tabindex', selected ? '0' : '-1');
+          tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+          tab.setAttribute(
+            'class',
+            selected ? 'tab-box-option active' : 'tab-box-option'
+          );
+        });
+
+        panels.forEach((panel, i) => {
+          if (i === tabIndex) {
+            panel.removeAttribute('hidden');
+          } else {
+            panel.setAttribute('hidden', 'true');
+          }
+        });
+      }
+
+      tabs.forEach((tab, index) => {
+        tab.addEventListener('click', () => {
+          setSelectedTab(index);
+        });
+      });
+    });
+  }
+});

--- a/grid-ui/saplings/register-login/src/register-login.html
+++ b/grid-ui/saplings/register-login/src/register-login.html
@@ -1,0 +1,71 @@
+<!--
+Copyright 2018-2020 Cargill Incorporated
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div
+  style="background-color: #222325; height: 100%; display: flex; align-items: center; justify-content: center; padding: 3rem">
+  <div class="tab-box">
+    <div class="tab-box-options" role="tablist" aria-label="login-or-register">
+      <button class="tab-box-option active" role="tab" aria-selected="true" aria-controls="login-panel"
+        id="login-panel-tab" tabindex="0">
+        Log In
+      </button>
+      <button class="tab-box-option" role="tab" aria-selected="false" aria-controls="register-panel"
+        id="register-panel-tab" tabindex="-1">
+        Register
+      </button>
+    </div>
+    <div class="tab-box-content" id="login-panel" role="tabpanel" tabindex="0" aria-labelledby="login-panel-tab">
+      <div class="auth-form">
+        <h3>Log In</h3>
+        <hr />
+        <form id="login-form">
+          <div class="input">
+            <label htmlFor="username">username</label>
+            <input type="text" id="username" name="username" required="true" />
+          </div>
+          <div class="input">
+            <label htmlFor="password">password</label>
+            <input type="password" id="password" name="password" required="true" />
+          </div>
+          <button class="button submit" type="submit">Log In</button>
+        </form>
+      </div>
+    </div>
+    <div class="tab-box-content" id="register-panel" role="tabpanel" tabindex="0" aria-labelledby="register-panel-tab"
+      hidden>
+      <div class="auth-form">
+        <h3>Register</h3>
+        <hr />
+        <form id="register-form">
+          <div class="input">
+            <label htmlFor="username">username</label>
+            <input type="text" id="username" name="username" required="true" />
+          </div>
+          <div class="input">
+            <label htmlFor="password">password</label>
+            <input type="password" id="password" name="password" required="true" />
+          </div>
+          <div class="input">
+            <label htmlFor="confirmPassword">confirm password</label>
+            <input type="password" id="confirmPassword" name="confirmPassword" required="true" />
+          </div>
+          <button class="button submit" type="submit">Register</button>
+        </form>
+      </div>
+    </div>
+    <span id='login-register-error-message' class='color-danger'></span>
+  </div>
+</div>

--- a/grid-ui/saplings/register-login/tsconfig.json
+++ b/grid-ui/saplings/register-login/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "es2015",
+      "dom"
+    ],
+    "esModuleInterop": true
+  },
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts"
+  ],
+  "include": [
+    "src/**/*",
+    "types/*"
+  ],
+  "resolve": {
+    "extensions": [
+      ".ts",
+      ".html"
+    ]
+  }
+}

--- a/grid-ui/saplings/register-login/types/index.d.ts
+++ b/grid-ui/saplings/register-login/types/index.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare module '*.html' {
+  const value: string;
+  // eslint-disable-next-line import/no-default-export
+  export default value;
+}

--- a/grid-ui/saplings/register-login/webpack.config.js
+++ b/grid-ui/saplings/register-login/webpack.config.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  mode: 'production',
+  entry: './src/index.ts',
+  output: {
+    library: 'register-login',
+    libraryTarget: 'umd',
+    filename: 'register-login.js',
+    globalObject: 'this'
+  },
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    rules: [
+      { test: /\.ts$/, loader: 'ts-loader' },
+      {
+        test: /\.html$/i,
+        loader: 'html-loader'
+      }
+    ]
+  }
+};

--- a/grid-ui/src/theme/colors.scss
+++ b/grid-ui/src/theme/colors.scss
@@ -17,7 +17,7 @@
 $color-primary: #f35f19 !default;
 $color-primary-light: lighten($color-primary, 15%) !default;
 $color-primary-dark: darken($color-primary, 15%) !default;
-$color-secondary: rgb(115, 29, 216) !default;
+$color-secondary: #50e2ae !default;
 $color-secondary-light: lighten($color-secondary, 15%);
 $color-secondary-dark: darken($color-secondary, 15%);
 


### PR DESCRIPTION
Adds a config sapling for logging in/registering in the Grid UI.

To test, run the following commands from the Grid repo:

1. `$ export 'CARGO_ARGS=-- --features experimental'`

2. `$ docker-compose -f grid-ui/docker/docker-compose.yaml up --build`

The UI is available on localhost:3030. The log in/register page should be visible. Try registering as a new user. Once you are logged in, the main Grid UI view will load. You have to clear the session storage to log back out (log out functionality will be in the profile sapling).