### PR TITLE
Profile sapling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,51 @@
-# Cargo
-**/target
-**/Cargo.lock
+# Exclude IDE and Editor files
+/.idea/
+*.sublime*
+*.vscode*
+
+# Rust
+Cargo.lock
+target/
+
+contracts/*/bin/
+
+contracts/track_and_trace/src/messages/
 
 # Node
 **/node_modules
 **/yarn.lock
+**/.pnp
+**/.pnp.js
 **/package-lock.json
 **/npm-debug.log
+
+# testing
+**/coverage
+
+# Webpack
+**/build
+**/dist
+
+tests/sawtooth_sc_test/protobuf/
+
+/server/config.json
+**/generated_protos.json
+
+/docs/build/
+/docs/source/_autogen/
+/docs/source/cli/output/
+
+grid-ui/sapling-dev-server/product
+grid-ui/sapling-dev-server/register-login.js
+grid-ui/sapling-dev-server/profile
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ contracts/track_and_trace/src/messages/
 **/.pnp.js
 **/package-lock.json
 **/npm-debug.log
-**/yarn.lock
 
 # testing
 **/coverage
@@ -35,6 +34,10 @@ tests/sawtooth_sc_test/protobuf/
 /docs/build/
 /docs/source/_autogen/
 /docs/source/cli/output/
+
+grid-ui/sapling-dev-server/product
+grid-ui/sapling-dev-server/register-login.js
+grid-ui/sapling-dev-server/profile
 
 # misc
 .DS_Store

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,6 +81,7 @@ pipeline {
             steps {
                 sh 'docker build grid-ui -f grid-ui/docker/test/Dockerfile -t grid-ui:$ISOLATION_ID'
                 sh 'docker build grid-ui/saplings/product -f grid-ui/saplings/product/test/Dockerfile -t product-sapling:$ISOLATION_ID'
+                sh 'docker build grid-ui/saplings/profile -f grid-ui/saplings/profile/test/Dockerfile -t profile-sapling:$ISOLATION_ID'
             }
         }
 
@@ -88,6 +89,7 @@ pipeline {
             steps {
                 sh 'docker run --rm --env CI=true grid-ui:$ISOLATION_ID yarn lint'
                 sh 'docker run --rm --env CI=true product-sapling:$ISOLATION_ID yarn lint'
+                sh 'docker run --rm --env CI=true profile-sapling:$ISOLATION_ID yarn lint'
             }
         }
 

--- a/grid-ui/.prettierignore
+++ b/grid-ui/.prettierignore
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 saplings/*
-build/*
+**/build/*

--- a/grid-ui/sapling-dev-server/Dockerfile
+++ b/grid-ui/sapling-dev-server/Dockerfile
@@ -30,6 +30,10 @@ RUN cd /saplings/product && \
   npm install && \
   yarn deploy
 
+RUN cd /saplings/profile && \
+  npm install && \
+  yarn deploy
+
 FROM httpd:2.4 as prod-stage
 
 RUN echo "\

--- a/grid-ui/sapling-dev-server/configSaplings
+++ b/grid-ui/sapling-dev-server/configSaplings
@@ -10,9 +10,11 @@
   {
     "namespace": "profile",
     "runtimeFiles": [
-      "localhost:3030/sapling-dev-server/profile.js"
+      "localhost:3030/sapling-dev-server/profile/js/profile.js"
     ],
-    "styleFiles": [],
+    "styleFiles": [
+      "localhost:3030/sapling-dev-server/profile/css/profile.css"
+    ],
     "workerFiles": []
   }
 ]

--- a/grid-ui/sapling-dev-server/profile.js
+++ b/grid-ui/sapling-dev-server/profile.js
@@ -18,7 +18,7 @@ window.$CANOPY.registerConfigSapling('profile', () => {
   console.log('Registering Profile Sapling');
 
   if (window.location.pathname === '/profile') {
-    window.$CANOPY.registerApp(function (domNode) {
+    window.$CANOPY.registerApp(function(domNode) {
       console.log('Rendering Profile JS App');
       domNode.innerHTML = `<h1>Profile<h1>`;
     });

--- a/grid-ui/saplings/profile/.eslintignore
+++ b/grid-ui/saplings/profile/.eslintignore
@@ -1,0 +1,18 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+saplings/*
+build/*
+sapling-dev-server/*
+scripts/build.js

--- a/grid-ui/saplings/profile/.eslintrc
+++ b/grid-ui/saplings/profile/.eslintrc
@@ -1,0 +1,33 @@
+{
+  "env": {
+    "es6": true,
+    "jest": true,
+    "browser": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
+  "extends": [
+    "airbnb",
+    "prettier",
+    "prettier/react"
+  ],
+  "rules": {
+    "react/jsx-filename-extension": 0,
+    "react/prefer-stateless-function": 0,
+    "react/button-has-type": 0,
+    "react/forbid-prop-types": 0,
+    "import/prefer-default-export": 0,
+    "camelcase": 0,
+    "no-underscore-dangle": 0
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": [
+          "src"
+        ]
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/profile/README.md
+++ b/grid-ui/saplings/profile/README.md
@@ -1,0 +1,38 @@
+A config sapling for viewing and managing a Biome user and associated keys.
+
+## Available Scripts
+
+In the project directory, you can run:
+
+### `yarn start`
+
+Runs the app in the development mode.<br /> Open
+[http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+The page will reload if you make edits.<br /> You will also see any lint errors
+in the console.
+
+### `yarn test`
+
+Launches the test runner in the interactive watch mode.<br /> See the section
+about
+[running tests](https://facebook.github.io/create-react-app/docs/running-tests)
+for more information.
+
+### `yarn build`
+
+Builds the app for production to the `build` folder.<br /> It correctly bundles
+React in production mode and optimizes the build for the best performance.
+
+The build is minified and the filenames include the hashes.<br /> Your app is
+ready to be deployed!
+
+See the section about
+[deployment](https://facebook.github.io/create-react-app/docs/deployment) for
+more information.
+
+### `yarn watch`
+
+Builds the app for production to the `build` folder similar to the `yarn build`
+command. It then watches for changes and rebuilds when changes are detected in
+the project.

--- a/grid-ui/saplings/profile/package.json
+++ b/grid-ui/saplings/profile/package.json
@@ -31,6 +31,7 @@
     "eject": "react-scripts eject",
     "add-to-canopy": "mkdir -p ../../sapling-dev-server/profile && cp -r ./build/static/** ../../sapling-dev-server/profile",
     "deploy": "npm run build && npm run add-to-canopy",
+    "lint": "eslint .",
     "watch": "nodemon --ext js,scss,ts,css --watch src --exec npm run deploy"
   },
   "eslintConfig": {
@@ -49,6 +50,14 @@
     ]
   },
   "devDependencies": {
+    "eslint": "^6.6.0",
+    "eslint-config-airbnb": "18.0.1",
+    "eslint-config-prettier": "^6.4.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^1.7.0",
     "nodemon": "^2.0.2"
   }
 }

--- a/grid-ui/saplings/profile/package.json
+++ b/grid-ui/saplings/profile/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "profile",
+  "version": "0.0.0-alpha",
+  "license": "Apache-2.0",
+  "author": "Cargill Incorporated",
+  "private": true,
+  "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.25",
+    "@fortawesome/free-regular-svg-icons": "^5.11.2",
+    "@fortawesome/free-solid-svg-icons": "^5.12.0",
+    "@fortawesome/react-fontawesome": "^0.1.8",
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.3.2",
+    "@testing-library/user-event": "^7.1.2",
+    "classnames": "^2.2.6",
+    "js-sha256": "^0.9.0",
+    "node-sass": "^4.13.0",
+    "prop-types": "^15.7.2",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
+    "react-scripts": "^3.4.0",
+    "rewire": "^4.0.1",
+    "sjcl": "^1.0.8",
+    "splinter-saplingjs": "github:cargill/splinter-saplingjs#master",
+    "transact-sdk-javascript": "github:hyperledger/transact-sdk-javascript#master"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "node ./scripts/build.js",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject",
+    "add-to-canopy": "mkdir -p ../../sapling-dev-server/profile && cp -r ./build/static/** ../../sapling-dev-server/profile",
+    "deploy": "npm run build && npm run add-to-canopy",
+    "watch": "nodemon --ext js,scss,ts,css --watch src --exec npm run deploy"
+  },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.2"
+  }
+}

--- a/grid-ui/saplings/profile/public/index.html
+++ b/grid-ui/saplings/profile/public/index.html
@@ -1,0 +1,29 @@
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <title>React App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/grid-ui/saplings/profile/public/manifest.json
+++ b/grid-ui/saplings/profile/public/manifest.json
@@ -1,0 +1,8 @@
+{
+  "short_name": "Profile Sapling",
+  "name": "Canopy Profile Sapling",
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
+}

--- a/grid-ui/saplings/profile/scripts/build.js
+++ b/grid-ui/saplings/profile/scripts/build.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const rewire = require('rewire');
+
+const defaults = rewire('react-scripts/scripts/build.js');
+const config = defaults.__get__('config');
+
+config.optimization.splitChunks = {
+  cacheGroups: {
+    default: false
+  }
+};
+
+config.optimization.runtimeChunk = false;
+
+// JS
+config.output.filename = 'static/js/profile.js';
+// CSS. "5" is MiniCssPlugin
+config.plugins[5].options.moduleFilename = () => 'static/css/profile.css';

--- a/grid-ui/saplings/profile/src/ActionList.js
+++ b/grid-ui/saplings/profile/src/ActionList.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useState } from 'react';
+import proptypes from 'prop-types';
+import './ActionList.scss';
+
+export function ActionList({ children }) {
+  const [open, setOpen] = useState(0);
+  return (
+    <div className="action-list">
+      <button
+        className={`flat action-button${open ? ' open' : ''}`}
+        onClick={() => setOpen(!open)}
+      >
+        Actions
+        <div className="hamburger">
+          <div className="top" />
+          <div className="middle" />
+          <div className="bottom" />
+        </div>
+      </button>
+      <div className={`actions${open ? ' open' : ''}`}>{children}</div>
+    </div>
+  );
+}
+
+ActionList.propTypes = {
+  children: proptypes.node.isRequired
+};

--- a/grid-ui/saplings/profile/src/ActionList.scss
+++ b/grid-ui/saplings/profile/src/ActionList.scss
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.action-list {
+  width: fit-content;
+
+  .action-button {
+    transition: all 0.2s;
+    width: fit-content;
+    display: flex;
+    border-color: #ffffff !important;
+    color: #ffffff !important;
+
+    .hamburger {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      width: 14px;
+      height: 14px;
+      margin-left: 0.5rem;
+      align-self: center;
+
+      div {
+        height: 3px;
+        background: #ffffff;
+        transition: all 0.2s;
+      }
+      .top {
+        width: 10px;
+      }
+
+      .middle {
+        width: 6px;
+      }
+
+      .bottom {
+        width: 14px;
+      }
+    }
+
+    &:hover,
+    &.open {
+      background: #ffffff !important;
+      color: #333333 !important;
+
+      .hamburger {
+        div {
+          background: #333333;
+          width: 14px;
+        }
+      }
+    }
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    transform: translateY(-2rem);
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0.2s, opacity 0.2s, transform 0.2s;
+
+    &.open {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+      transition: visibility 0, opacity 0.2s, transform 0.2s;
+    }
+
+    > * {
+      border-color: #ffffff !important;
+
+      &:hover {
+        border-color: #ffffff !important;
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/profile/src/App.js
+++ b/grid-ui/saplings/profile/src/App.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import './App.scss';
+import { Profile } from './Profile';
+
+function App() {
+  return <Profile />;
+}
+
+export default App;

--- a/grid-ui/saplings/profile/src/App.scss
+++ b/grid-ui/saplings/profile/src/App.scss
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#root {
+  height: 100%;
+}
+
+#profile {
+  position: relative;
+  background: var(--color-dark-grey);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  .user-info {
+    position: relative;
+    display: flex;
+    padding: 1.5rem;
+    justify-content: flex-start;
+    align-items: flex-end;
+
+    .display-name {
+      margin: 3rem 0 2rem;
+      color: var(--color-text-lighter--on-dark);
+    }
+
+    .action-list {
+      .actions.open {
+        background: #ffffff;
+      }
+    }
+  }
+
+  .action-list {
+    position: absolute;
+    top: 1rem;
+    right: 0.25rem;
+  }
+
+  .user-keys {
+    background: #ffffff;
+    flex: 0 1 100%;
+    padding: 1.5rem;
+
+    #keys-label {
+      display: inline-block;
+      width: 150px;
+      padding-bottom: 0.5rem;
+      border-bottom: 2px solid #000000;
+    }
+
+    .key-list {
+      display: grid;
+      grid-auto-columns: 20rem;
+      grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+      grid-template-rows: auto;
+      grid-column-gap: 1rem;
+      grid-row-gap: 3rem;
+      justify-content: center;
+      align-items: flex-start;
+    }
+
+    .add-key {
+      position: fixed;
+      bottom: 3rem;
+      right: 3rem;
+
+      .icon {
+        width: 2rem;
+        height: 2rem;
+      }
+    }
+  }
+}
+
+.info-field {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: 1fr;
+  grid-template-areas: 'info actions';
+  width: fit-content;
+
+  .label {
+    width: fit-content;
+    color: var(--color-text-light--on-dark);
+  }
+
+  .value {
+    width: fit-content;
+    margin: 0;
+  }
+
+  .field-action {
+    margin: 0 2rem;
+    align-self: center;
+    justify-self: flex-start;
+  }
+}
+
+button {
+  border: none;
+  color: #ffffff;
+  background: #555555;
+  padding: 1rem;
+
+  &.flat {
+    background: transparent;
+    color: #555555;
+    border: 1px solid #555555;
+    transition: all 0.2s;
+
+    &:hover {
+      background: #555555;
+      color: #ffffff;
+    }
+  }
+
+  &.fab {
+    border-radius: 50%;
+    background: var(--color-secondary);
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+form {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  padding: 1rem;
+
+  button.submit {
+    margin: 1rem 0 0;
+    position: relative;
+    left: 100%;
+    transform: translateX(-100%);
+  }
+}
+
+.form-wrapper {
+  display: flex;
+  flex-direction: column;
+
+  .error {
+    border: 1px solid var(--color-failure);
+    padding: 1rem;
+    margin: 1rem 0;
+    color: var(--color-failure);
+  }
+}
+
+button.submit {
+  background: var(--color-secondary);
+
+  &:disabled {
+    background: var(--color-grey);
+  }
+}

--- a/grid-ui/saplings/profile/src/App.scss
+++ b/grid-ui/saplings/profile/src/App.scss
@@ -83,91 +83,93 @@
       }
     }
   }
-}
-
-.info-field {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  grid-template-rows: 1fr;
-  grid-template-areas: 'info actions';
-  width: fit-content;
-
-  .label {
+  .info-field {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: 1fr;
+    grid-template-areas: 'info actions';
     width: fit-content;
-    color: var(--color-text-light--on-dark);
-  }
 
-  .value {
-    width: fit-content;
-    margin: 0;
-  }
+    .label {
+      width: fit-content;
+      color: var(--color-text-light--on-dark);
+    }
 
-  .field-action {
-    margin: 0 2rem;
-    align-self: center;
-    justify-self: flex-start;
-  }
-}
+    .value {
+      width: fit-content;
+      margin: 0;
+    }
 
-button {
-  border: none;
-  color: #ffffff;
-  background: #555555;
-  padding: 1rem;
-
-  &.flat {
-    background: transparent;
-    color: #555555;
-    border: 1px solid #555555;
-    transition: all 0.2s;
-
-    &:hover {
-      background: #555555;
-      color: #ffffff;
+    .field-action {
+      margin: 0 2rem;
+      align-self: center;
+      justify-self: flex-start;
     }
   }
 
-  &.fab {
-    border-radius: 50%;
-    background: var(--color-secondary);
+  button {
+    border: none;
+    color: #ffffff;
+    background: #555555;
+    padding: 1rem;
+
+    &.flat {
+      background: transparent;
+      color: #555555;
+      border: 1px solid #555555;
+      transition: all 0.2s;
+
+      &:hover {
+        background: #555555;
+        color: #ffffff;
+      }
+    }
+
+    &.fab {
+      border-radius: 50%;
+      background: var(--color-secondary);
+      color: #333333;
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 
-  &:hover {
-    cursor: pointer;
-  }
-}
+  form {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    padding: 1rem;
 
-form {
-  position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  padding: 1rem;
+    button.submit {
+      margin: 1rem 0 0;
+      position: relative;
+      left: 100%;
+      transform: translateX(-100%);
+    }
+  }
+
+  .form-wrapper {
+    display: flex;
+    flex-direction: column;
+
+    .error {
+      border: 1px solid var(--color-failure);
+      padding: 1rem;
+      margin: 1rem 0;
+      color: var(--color-failure);
+    }
+  }
 
   button.submit {
-    margin: 1rem 0 0;
-    position: relative;
-    left: 100%;
-    transform: translateX(-100%);
-  }
-}
+    background: var(--color-secondary);
+    color: #333333;
 
-.form-wrapper {
-  display: flex;
-  flex-direction: column;
-
-  .error {
-    border: 1px solid var(--color-failure);
-    padding: 1rem;
-    margin: 1rem 0;
-    color: var(--color-failure);
-  }
-}
-
-button.submit {
-  background: var(--color-secondary);
-
-  &:disabled {
-    background: var(--color-grey);
+    &:disabled {
+      background: var(--color-grey);
+      color: #ffffff;
+    }
   }
 
   button.danger {

--- a/grid-ui/saplings/profile/src/App.scss
+++ b/grid-ui/saplings/profile/src/App.scss
@@ -169,4 +169,9 @@ button.submit {
   &:disabled {
     background: var(--color-grey);
   }
+
+  button.danger {
+    background: var(--color-failure);
+    color: #333333;
+  }
 }

--- a/grid-ui/saplings/profile/src/Input.js
+++ b/grid-ui/saplings/profile/src/Input.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import proptypes from 'prop-types';
+import './Input.scss';
+
+export function Input({ type, id, label, name, value, onChange, required }) {
+  return (
+    <div className="grid-input">
+      <input
+        type={type}
+        id={id}
+        aria-label={`${label} field`}
+        placeholder={`${label}`}
+        name={name}
+        value={value}
+        onChange={onChange}
+        required={required}
+      />
+      <label htmlFor={id}>{label}</label>
+    </div>
+  );
+}
+
+Input.propTypes = {
+  type: proptypes.string,
+  id: proptypes.string,
+  label: proptypes.string,
+  name: proptypes.string,
+  value: proptypes.any,
+  onChange: proptypes.func.isRequired,
+  required: proptypes.bool
+};
+
+Input.defaultProps = {
+  type: 'text',
+  id: undefined,
+  label: undefined,
+  name: undefined,
+  value: null,
+  required: false
+};

--- a/grid-ui/saplings/profile/src/Input.scss
+++ b/grid-ui/saplings/profile/src/Input.scss
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.grid-input {
+  position: relative;
+  padding: 1rem 0 0;
+  margin-top: 0.5rem;
+  width: 100%;
+
+  label {
+    position: absolute;
+    top: 0;
+    display: block;
+    transition: 0.2s;
+    font-size: 0.7rem;
+  }
+
+  input {
+    height: calc(2rem + 2px);
+    width: 100%;
+    border: 1px solid #333333;
+    padding: 0.5rem;
+    background: transparent;
+    outline: none;
+    transition: border-color 0.2s;
+    font-size: 1rem;
+
+    &::placeholder {
+      color: transparent;
+    }
+
+    &:placeholder-shown {
+      border-color: #555555;
+
+      & ~ label {
+        cursor: text;
+        top: 1.5rem;
+        padding-left: 0.5rem;
+        font-size: 1rem;
+      }
+    }
+
+    &:focus {
+      border-color: var(--color-primary);
+
+      ~ label {
+        font-size: 0.7rem;
+        font-weight: bold;
+        top: 0;
+        padding-left: 0;
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/profile/src/KeyCard.js
+++ b/grid-ui/saplings/profile/src/KeyCard.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
+
+import './KeyCard.scss';
+
+export function KeyCard({ userKey, isActive, setActiveFn, editFn }) {
+  const setActive = () => {
+    try {
+      setActiveFn();
+    } catch (err) {
+      return null;
+    }
+    return null;
+  };
+
+  return (
+    <div className={classnames('key-card', isActive && 'active')}>
+      <div className="header">
+        <span className="name">{userKey.display_name}</span>
+        <FontAwesomeIcon icon={faPencilAlt} className="edit" onClick={editFn} />
+      </div>
+      <div className="keys">
+        <span className="label">Public key:</span>
+        <span className="key" id={`public-key-${userKey.public_key}`}>
+          {userKey.public_key}
+        </span>
+      </div>
+      {!isActive && (
+        <button className="set-active" onClick={setActive}>
+          Set active
+        </button>
+      )}
+      {isActive && <div className="active">Active</div>}
+    </div>
+  );
+}
+
+KeyCard.defaultProps = {
+  isActive: false
+};
+
+KeyCard.propTypes = {
+  userKey: PropTypes.object.isRequired,
+  isActive: PropTypes.bool,
+  setActiveFn: PropTypes.func.isRequired,
+  editFn: PropTypes.func.isRequired
+};

--- a/grid-ui/saplings/profile/src/KeyCard.scss
+++ b/grid-ui/saplings/profile/src/KeyCard.scss
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#profile {
+  .key-card {
+    display: grid;
+    grid-template-columns: 100%;
+    grid-template-rows: 1.8rem 1fr 2rem;
+    grid-template-areas:
+      'header'
+      'info'
+      'action';
+    padding-top: 1rem;
+    border-radius: 1rem;
+    overflow: hidden;
+    background: var(--background-color-light);
+    min-width: 250px;
+
+    .header {
+      grid-area: header;
+      padding: 0 1rem;
+      display: flex;
+      justify-content: space-between;
+
+      .name {
+        font-weight: bold;
+      }
+
+      .edit {
+        cursor: pointer;
+        color: var(--color-grey);
+
+        &:hover {
+          color: var(--color-dark-grey);
+        }
+      }
+    }
+
+    .keys {
+      grid-area: info;
+      display: flex;
+      flex-direction: column;
+      padding: 1rem;
+
+      span {
+        overflow-wrap: break-word;
+
+        &.label {
+          font-style: italic;
+        }
+      }
+    }
+
+    .set-active,
+    .active {
+      grid-area: action;
+      width: 100%;
+      height: 2rem;
+      padding: 0;
+      justify-content: center;
+      font-family: var(--fontFamily-primary);
+      font-size: 1rem;
+    }
+
+    .active {
+      display: flex;
+      align-items: center;
+      background-image: linear-gradient(
+        to right,
+        var(--color-primary) 0%,
+        var(--color-primary-light) 60%
+      );
+      color: var(--color-grey);
+    }
+
+    .set-active {
+      background-image: linear-gradient(
+        to right,
+        var(--color-secondary) 0%,
+        var(--color-secondary-light) 60%
+      );
+      color: var(--color-dark-grey);
+      border-width: 0;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+      transform: translateY(100%);
+      transition: all 0.2s;
+    }
+
+    &:hover {
+      .set-active {
+        transform: translateY(0);
+      }
+    }
+  }
+
+  @media only screen and (min-device-width: 320px) and (max-device-width: 1024px) {
+    .key-card {
+      .set-active {
+        transform: translateY(0);
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/profile/src/Loader.js
+++ b/grid-ui/saplings/profile/src/Loader.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import classnames from 'classnames';
+import './Loader.scss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
+import proptypes from 'prop-types';
+
+export function Loader({ state }) {
+  return (
+    <div className={classnames('loader', state && 'complete')}>
+      <div className="dots">
+        <div className="dot" />
+        <div className="dot" />
+        <div className="dot" />
+      </div>
+      <div
+        className={classnames(
+          'state',
+          state === 'success' && 'success',
+          state === 'failure' && 'failure'
+        )}
+      >
+        <FontAwesomeIcon icon={state === 'success' ? faCheck : faTimes} />
+      </div>
+    </div>
+  );
+}
+
+Loader.propTypes = {
+  state: proptypes.oneOf(['success', 'failure'])
+};
+
+Loader.defaultProps = {
+  state: undefined
+};

--- a/grid-ui/saplings/profile/src/Loader.scss
+++ b/grid-ui/saplings/profile/src/Loader.scss
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@keyframes bounce {
+  45% {
+    transform: translateY(-1rem);
+  }
+  95% {
+    transform: translateY(0.2rem);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+.loader {
+  display: block;
+  width: 6rem;
+  height: 30px;
+  position: relative;
+  margin: auto;
+  top: 50%;
+  transform: translateY(-50%);
+
+  .dots {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    > .dot {
+      width: 1.5rem;
+      height: 1.5rem;
+      background: #333333;
+      border-radius: 50%;
+      animation-duration: 0.9s;
+      animation-name: bounce;
+      animation-iteration-count: infinite;
+    }
+
+    :nth-child(2) {
+      animation-delay: 0.3s;
+    }
+
+    :last-child {
+      animation-delay: 0.6s;
+    }
+  }
+
+  &.complete {
+    .dots {
+      display: none;
+    }
+  }
+
+  .state {
+    width: 0;
+    height: 0;
+    display: none;
+    border-radius: 50%;
+    transition: all 0.3s;
+  }
+
+  &.complete {
+    .state {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 4rem;
+      height: 4rem;
+      margin: auto;
+      font-size: 2rem;
+
+      &.success {
+        border: 3px solid var(--color-success);
+        color: var(--color-success);
+      }
+
+      &.failure {
+        border: 3px solid var(--color-failure);
+        color: var(--color-failure);
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/profile/src/OverlayModal.js
+++ b/grid-ui/saplings/profile/src/OverlayModal.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import './OverlayModal.scss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+
+export function OverlayModal({ open, closeFn, children }) {
+  return (
+    <div className={classnames('overlay-modal', 'modal', open && 'open')}>
+      <FontAwesomeIcon
+        icon={faTimes}
+        className="close"
+        onClick={closeFn}
+        tabIndex="0"
+      />
+      <div className="content">{children}</div>
+    </div>
+  );
+}
+
+OverlayModal.defaultProps = {
+  open: false,
+  children: undefined
+};
+
+OverlayModal.propTypes = {
+  open: PropTypes.bool,
+  closeFn: PropTypes.func.isRequired,
+  children: PropTypes.node
+};

--- a/grid-ui/saplings/profile/src/OverlayModal.scss
+++ b/grid-ui/saplings/profile/src/OverlayModal.scss
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.overlay-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  visibility: hidden;
+  z-index: -1;
+  width: 0;
+  height: 0;
+  background: rgba(85, 85, 85, 0.8);
+  transition: all 0.2s;
+  overflow-y: auto;
+
+  .close {
+    display: none;
+    width: 1.5rem;
+    height: 1.5rem;
+    position: relative;
+    top: 0.5rem;
+    left: calc(100% - 2rem);
+    color: #ffffff;
+  }
+
+  .content {
+    display: none;
+    width: fit-content;
+    height: fit-content;
+    max-width: 60%;
+    max-height: 60%;
+    min-width: 40%;
+    position: relative;
+    top: 40%;
+    transform: translateY(-50%);
+    margin: auto;
+    background: #ffffff;
+    padding: 1rem;
+    border-radius: 0.25rem;
+    overflow-y: auto;
+  }
+
+  &.open {
+    visibility: visible;
+    width: 100vw;
+    height: 100vh;
+    z-index: 100;
+
+    .close,
+    .content {
+      display: block;
+    }
+  }
+}

--- a/grid-ui/saplings/profile/src/Profile.js
+++ b/grid-ui/saplings/profile/src/Profile.js
@@ -26,6 +26,7 @@ import {
 } from 'splinter-saplingjs';
 import { ActionList } from './ActionList';
 import { KeyCard } from './KeyCard';
+import { ChangePasswordForm } from './forms/ChangePasswordForm';
 import { AddKeyForm } from './forms/AddKeyForm';
 import { OverlayModal } from './OverlayModal';
 import { http } from './http';
@@ -84,6 +85,8 @@ export function Profile() {
     switch (formName) {
       case 'add-key':
         return <AddKeyForm successFn={params.successFn} />;
+      case 'update-password':
+        return <ChangePasswordForm />;
       default:
         break;
     }
@@ -105,6 +108,7 @@ export function Profile() {
         <ActionList className="user-actions">
           <button
             className="flat"
+            onClick={() => openModalForm('update-password')}
           >
             Change password
           </button>

--- a/grid-ui/saplings/profile/src/Profile.js
+++ b/grid-ui/saplings/profile/src/Profile.js
@@ -175,6 +175,13 @@ export function Profile() {
     setModalActive(false);
   };
 
+  const logout = () => {
+    sessionStorage.removeItem('CANOPY_USER');
+    sessionStorage.removeItem('CANOPY_KEYS');
+    sessionStorage.removeItem('KEY_SECRET');
+    window.location.href = `${window.location.origin}/login`;
+  };
+
   return (
     <div id="profile">
       <section className="user-info">
@@ -189,6 +196,9 @@ export function Profile() {
             onClick={() => openModalForm('update-password')}
           >
             Change password
+          </button>
+          <button className="flat" onClick={logout}>
+            Logout
           </button>
         </ActionList>
       </section>

--- a/grid-ui/saplings/profile/src/Profile.js
+++ b/grid-ui/saplings/profile/src/Profile.js
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  decryptKey,
+  getKeys,
+  getSharedConfig,
+  getUser,
+  setKeys as setSigningKeys
+} from 'splinter-saplingjs';
+import { ActionList } from './ActionList';
+import { KeyCard } from './KeyCard';
+import { AddKeyForm } from './forms/AddKeyForm';
+import { OverlayModal } from './OverlayModal';
+import { http } from './http';
+
+export function Profile() {
+  const [modalActive, setModalActive] = useState(false);
+  const [form, setForm] = useState({
+    formName: '',
+    params: {}
+  });
+  const [keys, setKeys] = useState([]);
+  const [stateKeys, setStateKeys] = useState(getKeys);
+  const user = getUser();
+
+  useEffect(() => {
+    async function fetchUserKeys() {
+      if (user) {
+        try {
+          const { splinterURL } = getSharedConfig().canopyConfig;
+          const userKeys = await http(
+            'GET',
+            `${splinterURL}/biome/users/${user.userId}/keys`,
+            {},
+            request => {
+              request.setRequestHeader('Authorization', `Bearer ${user.token}`);
+            }
+          );
+          setKeys(JSON.parse(userKeys).data);
+        } catch (err) {
+          switch (err.code) {
+            case '401':
+              window.location.href = `${window.location.origin}/login`;
+              break;
+            default:
+              break;
+          }
+        }
+      } else {
+        window.location.href = `${window.location.origin}/login`;
+      }
+    }
+    fetchUserKeys();
+  }, [user]);
+
+  const openModalForm = (formName, params) => {
+    const name = formName || '';
+    const adata = { ...params } || {};
+    setForm({
+      formName: name,
+      params: adata
+    });
+    setModalActive(true);
+  };
+
+  const formView = ({ formName, params }) => {
+    switch (formName) {
+      case 'add-key':
+        return <AddKeyForm successFn={params.successFn} />;
+      default:
+        break;
+    }
+  };
+
+  const addKeyCallback = key => {
+    setKeys([...keys, key]);
+    setModalActive(false);
+  };
+
+  return (
+    <div id="profile">
+      <section className="user-info">
+        <div className="display-name info-field">
+          <div className="info">
+            <h1 className="value">{user && user.displayName}</h1>
+          </div>
+        </div>
+        <ActionList className="user-actions">
+          <button
+            className="flat"
+          >
+            Change password
+          </button>
+        </ActionList>
+      </section>
+      <section className="user-keys">
+        <h3 id="keys-label">Keys</h3>
+        <div className="key-list">
+          {keys.length === 0 && <span>No keys added yet</span>}
+          {keys.length > 0 &&
+            keys.map(key => (
+              <KeyCard
+                key={key.public_key}
+                userKey={key}
+                isActive={stateKeys && key.public_key === stateKeys.publicKey}
+                setActiveFn={() => activateKey(key)}
+                editFn={() => openModalForm('update-key', { key })}
+              />
+            ))}
+        </div>
+        <button
+          className="fab add-key"
+          onClick={() =>
+            openModalForm('add-key', {
+              successFn: value => addKeyCallback(value)
+            })
+          }
+        >
+          <FontAwesomeIcon icon={faPlus} className="icon" />
+        </button>
+      </section>
+      <OverlayModal open={modalActive} closeFn={() => setModalActive(false)}>
+        {formView(form)}
+      </OverlayModal>
+    </div>
+  );
+}

--- a/grid-ui/saplings/profile/src/forms/AddKeyForm.js
+++ b/grid-ui/saplings/profile/src/forms/AddKeyForm.js
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useState } from 'react';
+import proptypes from 'prop-types';
+import { encryptKey, getSharedConfig } from 'splinter-saplingjs';
+import { Secp256k1Context } from 'transact-sdk-javascript';
+import crypto from 'crypto';
+import { MultiStepForm, Step, StepInput } from './MultiStepForm';
+import { Loader } from '../Loader';
+import { http } from '../http';
+
+import './AddKeyForm.scss';
+
+export function AddKeyForm({ successFn }) {
+  const [state, setState] = useState({
+    name: null,
+    publicKey: null,
+    privateKey: null,
+    password: null
+  });
+
+  const [loading, setLoading] = useState(false);
+  const [loadingState, setLoadingState] = useState(null);
+  const [error, setError] = useState(null);
+
+  const reset = () => {
+    setState({
+      name: null,
+      publicKey: null,
+      privateKey: null,
+      password: null
+    });
+    setError(null);
+    setLoading(false);
+  };
+
+  async function submitAddKey() {
+    setLoading(true);
+    const canopyUser = JSON.parse(window.sessionStorage.getItem('CANOPY_USER'));
+    const keySecret = crypto
+      .createHash('sha256')
+      .update(state.password)
+      .digest('hex');
+    const encryptedPrivateKey = encryptKey(state.privateKey, keySecret);
+    const body = JSON.stringify({
+      display_name: state.name,
+      encrypted_private_key: encryptedPrivateKey,
+      public_key: state.publicKey,
+      user_id: canopyUser.userId
+    });
+
+    try {
+      const { splinterURL } = getSharedConfig().canopyConfig;
+      await http(
+        'POST',
+        `${splinterURL}/biome/users/${canopyUser.userId}/keys`,
+        body,
+        request => {
+          request.setRequestHeader(
+            'Authorization',
+            `Bearer ${canopyUser.token}`
+          );
+        }
+      );
+      reset();
+      successFn(JSON.parse(body));
+    } catch (err) {
+      const e = JSON.parse(err);
+      setLoadingState('failure');
+      setError(e.message);
+    }
+  }
+
+  const handleChange = event => {
+    const { name, value } = event.target;
+    setState({
+      ...state,
+      [name]: value
+    });
+  };
+
+  const generateKeys = e => {
+    e.preventDefault();
+    const context = new Secp256k1Context();
+    const privKey = context.newRandomPrivateKey();
+    const pubKey = context.getPublicKey(privKey);
+    setState({
+      ...state,
+      publicKey: pubKey.asHex(),
+      privateKey: privKey.asHex()
+    });
+  };
+
+  return (
+    <div className="wrapper form-wrapper">
+      {!loading && (
+        <MultiStepForm
+          formName="Add key"
+          handleSubmit={submitAddKey}
+          disabled={
+            !(
+              state.name &&
+              state.privateKey &&
+              state.publicKey &&
+              state.password
+            )
+          }
+        >
+          <Step step={1}>
+            <StepInput
+              type="text"
+              label="Key name"
+              id="key-name"
+              name="name"
+              value={state.name}
+              onChange={handleChange}
+              required
+            />
+            <StepInput
+              type="text"
+              label="Public key"
+              id="public-key"
+              name="publicKey"
+              value={state.publicKey}
+              onChange={handleChange}
+              required
+            />
+            <StepInput
+              type="password"
+              label="Private key"
+              id="private-key"
+              name="privateKey"
+              value={state.privateKey}
+              onChange={handleChange}
+              required
+            />
+            <button onClick={generateKeys} style={{ marginTop: '0.5rem' }}>
+              Generate keys
+            </button>
+          </Step>
+          <Step step={2}>
+            <StepInput
+              type="password"
+              label="Password"
+              id="password"
+              name="password"
+              value={state.password}
+              onChange={handleChange}
+              required
+            />
+          </Step>
+        </MultiStepForm>
+      )}
+      {loading && <Loader state={loadingState} />}
+      {error && (
+        <div className="error-wrapper">
+          <div
+            className="error"
+            style={{ color: 'var(--color-failure', wordWrap: 'break-word' }}
+          >
+            <span>{error}</span>
+          </div>
+          <div className="actions">
+            <button onClick={reset}>Reset</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+AddKeyForm.propTypes = {
+  successFn: proptypes.func.isRequired
+};

--- a/grid-ui/saplings/profile/src/forms/AddKeyForm.scss
+++ b/grid-ui/saplings/profile/src/forms/AddKeyForm.scss
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.wrapper {
+  width: 50vw;
+
+  .error-wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+
+    .error {
+      width: 80%;
+      color: var(--color-failure);
+      word-wrap: break-word;
+    }
+
+    .actions {
+      width: 80%;
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-end;
+    }
+  }
+}

--- a/grid-ui/saplings/profile/src/forms/ChangePasswordForm.js
+++ b/grid-ui/saplings/profile/src/forms/ChangePasswordForm.js
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useState, useEffect } from 'react';
+import { sha256 } from 'js-sha256';
+import { getSharedConfig } from 'splinter-saplingjs';
+import { MultiStepForm, Step, StepInput } from './MultiStepForm';
+import { http } from '../http';
+import { Loader } from '../Loader';
+import { useDebounce } from '../useDebounce';
+
+export function ChangePasswordForm() {
+  const [state, setState] = useState({
+    password: null,
+    newPassword: null,
+    confirmPassword: null
+  });
+
+  const [loading, setLoading] = useState(false);
+  const [loadingState, setLoadingState] = useState(null);
+  const [error, setError] = useState(null);
+
+  const debouncedNewPassword = useDebounce(state.newPassword, 500);
+  const debouncedConfirmPassword = useDebounce(state.confirmPassword, 500);
+
+  useEffect(() => {
+    if (debouncedNewPassword && debouncedConfirmPassword) {
+      if (debouncedNewPassword !== debouncedConfirmPassword) {
+        setError('Passwords do not match');
+      } else {
+        setError(null);
+      }
+    }
+  }, [debouncedNewPassword, debouncedConfirmPassword]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setLoadingState(null);
+      setLoading(false);
+    }, 5000);
+  }, [loadingState]);
+
+  const submitChangePassword = async () => {
+    setLoading(true);
+
+    const { displayName, token, userId } = JSON.parse(
+      window.sessionStorage.getItem('CANOPY_USER')
+    );
+
+    const hashedPassword = sha256.hmac
+      .create(displayName)
+      .update(state.password)
+      .hex();
+
+    const newHashedPassword = sha256.hmac
+      .create(displayName)
+      .update(debouncedNewPassword)
+      .hex();
+
+    const body = JSON.stringify({
+      username: displayName,
+      hashed_password: hashedPassword,
+      new_password: newHashedPassword
+    });
+
+    try {
+      const { splinterURL } = getSharedConfig().canopyConfig;
+      await http(
+        'PUT',
+        `${splinterURL}/biome/users/${userId}`,
+        body,
+        request => {
+          request.setRequestHeader('Authorization', `Bearer ${token}`);
+        }
+      );
+      setLoadingState('success');
+      setState({
+        password: null,
+        newPassword: null,
+        confirmPassword: null
+      });
+    } catch (err) {
+      const e = JSON.parse(err);
+      setLoadingState('failure');
+      setError(e.message);
+    }
+  };
+
+  const handleChange = event => {
+    const { name, value } = event.target;
+    setState({
+      ...state,
+      [name]: value
+    });
+  };
+
+  return (
+    <div
+      className="wrapper form-wrapper"
+      style={{ width: '50vw', 'min-height': '50vh' }}
+    >
+      {!loading && (
+        <MultiStepForm
+          formName="Change password"
+          handleSubmit={submitChangePassword}
+          disabled={
+            !(
+              state.password &&
+              debouncedNewPassword &&
+              debouncedConfirmPassword
+            )
+          }
+          error={error}
+        >
+          <Step step={1}>
+            <StepInput
+              type="password"
+              label="Current password"
+              id="existing-password"
+              name="password"
+              value={state.password}
+              onChange={handleChange}
+              required
+            />
+          </Step>
+          <Step step={2}>
+            <StepInput
+              type="password"
+              label="New password"
+              id="new-password"
+              name="newPassword"
+              value={state.newPassword}
+              onChange={handleChange}
+              required
+            />
+            <StepInput
+              type="password"
+              label="Confirm password"
+              id="confirm-password"
+              name="confirmPassword"
+              value={state.confirmPassword}
+              onChange={handleChange}
+              required
+            />
+          </Step>
+        </MultiStepForm>
+      )}
+      {loading && <Loader state={loadingState} />}
+      {error && (
+        <div className="error" style={{ color: 'var(--color-failure' }}>
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/grid-ui/saplings/profile/src/forms/EnterPasswordForm.js
+++ b/grid-ui/saplings/profile/src/forms/EnterPasswordForm.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useState } from 'react';
+import proptypes from 'prop-types';
+import crypto from 'crypto';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { Input } from '../Input';
+
+export function EnterPasswordForm({ callbackFn, errorMessage }) {
+  const [password, setPassword] = useState(null);
+  const [error, setError] = useState(!!errorMessage);
+  const [errorMsg, setErrorMsg] = useState(errorMessage);
+
+  const handleChange = event => {
+    const { value } = event.target;
+    setPassword(value);
+  };
+
+  const reset = () => {
+    setPassword('');
+    setErrorMsg(null);
+    setError(false);
+  };
+
+  const handleSubmit = event => {
+    event.preventDefault();
+    const hashedSecret = crypto
+      .createHash('sha256')
+      .update(password)
+      .digest('hex');
+    sessionStorage.setItem('KEY_SECRET', hashedSecret);
+    reset();
+    try {
+      callbackFn();
+    } catch (err) {
+      sessionStorage.removeItem('KEY_SECRET');
+      setError(true);
+      setErrorMsg(
+        `Unable to decrypt key. You may have entered an incorrect password. Error: ${err.message}`
+      );
+    }
+  };
+
+  return (
+    <div className="wrapper">
+      {!error && (
+        <>
+          <h2>Enter your password</h2>
+          <form id="enter-password-form" aria-label="enter-password-form">
+            <Input
+              type="password"
+              label="Password"
+              id="password"
+              name="password"
+              onChange={handleChange}
+              value={password}
+            />
+            <button
+              className="submit"
+              onClick={handleSubmit}
+              disabled={!password}
+            >
+              Submit
+            </button>
+          </form>
+        </>
+      )}
+      {error && (
+        <div className="error-wrapper">
+          <FontAwesomeIcon className="icon" icon={faTimes} />
+          <div className="error">
+            <span>{errorMsg}</span>
+          </div>
+          <div className="actions-wrapper">
+            <button onClick={reset}>Reset</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+EnterPasswordForm.propTypes = {
+  callbackFn: proptypes.func.isRequired,
+  errorMessage: proptypes.string
+};
+
+EnterPasswordForm.defaultProps = {
+  errorMessage: null
+};

--- a/grid-ui/saplings/profile/src/forms/EnterPasswordForm.scss
+++ b/grid-ui/saplings/profile/src/forms/EnterPasswordForm.scss
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.wrapper {
+
+  .error-wrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin: 2rem 0;
+
+    .icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 4rem;
+      height: 4rem;
+      margin: auto;
+      font-size: 2rem;
+      border: 3px solid var(--color-failure);
+      border-radius: 50%;
+      color: var(--color-failure);
+    }
+
+    .error {
+      width: 80%;
+      border: 1px solid var(--color-failure);
+      color: var(--color-failure);
+      word-wrap: break-word;
+      padding: 2rem;
+      margin: 2rem;
+    }
+
+    .actions-wrapper {
+      width: 80%;
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+}

--- a/grid-ui/saplings/profile/src/forms/MultiStepForm.js
+++ b/grid-ui/saplings/profile/src/forms/MultiStepForm.js
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import { Input } from '../Input';
+
+import './MultiStepForm.scss';
+
+export function StepInput({
+  type,
+  label,
+  id,
+  name,
+  value,
+  onChange,
+  required
+}) {
+  return (
+    <Input
+      type={type}
+      label={label}
+      id={id}
+      name={name}
+      value={value}
+      onChange={onChange}
+      required={required}
+    />
+  );
+}
+
+export function Step({ step, currentStep, children }) {
+  if (step !== currentStep) {
+    return null;
+  }
+  return <div className="step">{children}</div>;
+}
+
+export function MultiStepForm({
+  formName,
+  handleSubmit,
+  style,
+  disabled,
+  error,
+  children
+}) {
+  const [step, setStep] = useState(1);
+
+  const _previous = () => {
+    setStep(step - 1);
+  };
+
+  const _next = () => {
+    setStep(step + 1);
+  };
+
+  const submit = () => {
+    handleSubmit();
+    setStep(1);
+  };
+
+  return (
+    <div className="multiStepForm" style={style}>
+      <h2>{formName}</h2>
+      <div className="stepCounter">
+        <div
+          className="progressTracker"
+          style={{
+            '--form-progress': `${((step - 1) / (children.length - 1)) * 100}%`
+          }}
+        />
+        <div className="steps">
+          {children.map((s, i) => (
+            <div
+              className={classnames(
+                'step',
+                i === step - 1 && 'active',
+                i < step - 1 && 'entered'
+              )}
+            >
+              <span>{i + 1}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        {children.map(child =>
+          React.cloneElement(child, { currentStep: step })
+        )}
+      </form>
+      <div className="actions">
+        {step > 1 && <button onClick={_previous}>Previous</button>}
+        {step < children.length && <button onClick={_next}>Next</button>}
+        {step === children.length && (
+          <button
+            onClick={submit}
+            className="submit"
+            disabled={disabled || error}
+          >
+            Submit
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+StepInput.propTypes = {
+  type: PropTypes.string,
+  label: PropTypes.string,
+  id: PropTypes.string,
+  name: PropTypes.string,
+  value: PropTypes.any,
+  onChange: PropTypes.func.isRequired,
+  required: PropTypes.bool
+};
+
+StepInput.defaultProps = {
+  type: 'text',
+  label: undefined,
+  id: undefined,
+  name: undefined,
+  value: null,
+  required: false
+};
+
+Step.propTypes = {
+  step: PropTypes.number,
+  currentStep: PropTypes.number,
+  children: PropTypes.node
+};
+
+Step.defaultProps = {
+  step: 1,
+  currentStep: 1,
+  children: undefined
+};
+
+MultiStepForm.propTypes = {
+  formName: PropTypes.string.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+  children: PropTypes.node,
+  style: PropTypes.object,
+  disabled: PropTypes.bool,
+  error: PropTypes.bool
+};
+
+MultiStepForm.defaultProps = {
+  children: undefined,
+  style: undefined,
+  disabled: false,
+  error: false
+};

--- a/grid-ui/saplings/profile/src/forms/MultiStepForm.scss
+++ b/grid-ui/saplings/profile/src/forms/MultiStepForm.scss
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.multiStepForm {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  > h2 {
+    display: inline-block;
+    width: 100%;
+    margin: 1rem 0;
+  }
+
+  .stepCounter {
+    height: calc(1.5rem + 2px);
+    width: 80%;
+
+    .steps {
+      position: relative;
+      top: 0;
+      display: flex;
+      flex: 1 1 100%;
+      justify-content: space-between;
+
+      .step {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 1.5rem;
+        height: 1.5rem;
+        background: #ffffff;
+        border: 1px solid #555;
+        color: #555;
+        transition: all 0.3s;
+
+        &.active {
+          border: var(--color-primary);
+          background: var(--color-primary);
+          color: #333333;
+          font-weight: bold;
+        }
+
+        &.entered {
+          border-color: var(--color-primary);
+        }
+      }
+    }
+
+    .progressTracker {
+      width: 100%;
+      height: 1.5px;
+      background: #555555;
+      position: relative;
+      top: 50%;
+
+      &:after {
+        display: block;
+        content: '';
+        width: var(--form-progress);
+        height: 3px;
+        transform: translateY(-50%);
+        background: var(--color-primary);
+        transition: width 1s;
+      }
+    }
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    width: 90%;
+
+    .step {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+
+    > * {
+      margin: 0 0.5rem;
+    }
+  }
+}

--- a/grid-ui/saplings/profile/src/forms/UpdateKeyForm.js
+++ b/grid-ui/saplings/profile/src/forms/UpdateKeyForm.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useState } from 'react';
+import proptypes from 'prop-types';
+import { getSharedConfig } from 'splinter-saplingjs';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { Input } from '../Input';
+import { http } from '../http';
+
+import './UpdateKeyForm.scss';
+
+export function UpdateKeyForm({ userKey, closeFn }) {
+  const [keyName, setKeyName] = useState(null);
+  const [error, setError] = useState(false);
+  const [errorMsg, setErrorMsg] = useState(null);
+
+  const submitUpdateKey = async e => {
+    e.preventDefault();
+    const canopyUser = JSON.parse(window.sessionStorage.getItem('CANOPY_USER'));
+    const body = JSON.stringify({
+      public_key: userKey.public_key,
+      new_display_name: keyName
+    });
+
+    try {
+      const { splinterURL } = getSharedConfig().canopyConfig;
+      await http(
+        'PATCH',
+        `${splinterURL}/biome/users/${canopyUser.userId}/keys`,
+        body,
+        request => {
+          request.setRequestHeader(
+            'Authorization',
+            `Bearer ${canopyUser.token}`
+          );
+        }
+      );
+      closeFn();
+    } catch (err) {
+      const { message } = JSON.parse(err);
+      setErrorMsg(message);
+      setError(true);
+    }
+  };
+
+  const handleChange = event => {
+    const { value } = event.target;
+    setKeyName(value);
+  };
+
+  const reset = () => {
+    setError(false);
+    setErrorMsg(null);
+    setKeyName(null);
+  };
+
+  return (
+    <div className="wrapper">
+      {!error && (
+        <>
+          <h2>Update key name</h2>
+          <div className="info display-name">
+            <span>Current name: </span>
+            <b>{userKey.display_name}</b>
+          </div>
+          <div className="info public-key">
+            <span>public key: </span>
+            <b>{userKey.public_key}</b>
+          </div>
+          <form id="change-key-form" aria-label="Change-key-form">
+            <Input
+              type="text"
+              label="New key name"
+              id="change-key"
+              value={keyName}
+              onChange={handleChange}
+              required
+            />
+            <button
+              className="submit"
+              onClick={submitUpdateKey}
+              disabled={!keyName}
+            >
+              Submit
+            </button>
+          </form>
+        </>
+      )}
+      {error && (
+        <div className="error-wrapper">
+          <FontAwesomeIcon className="icon" icon={faTimes} />
+          <div className="error">
+            <span>{errorMsg}</span>
+          </div>
+          <div className="actions-wrapper">
+            <button onClick={reset}>Reset</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+UpdateKeyForm.propTypes = {
+  userKey: proptypes.object.isRequired,
+  closeFn: proptypes.func.isRequired
+};

--- a/grid-ui/saplings/profile/src/forms/UpdateKeyForm.scss
+++ b/grid-ui/saplings/profile/src/forms/UpdateKeyForm.scss
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.wrapper {
+  > h2 {
+    margin: 1rem 0;
+  }
+
+  .info {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 0.5rem 0;
+
+    span {
+      font-style: italic;
+    }
+
+    > * {
+      width: 100%;
+      overflow-wrap: break-word;
+    }
+  }
+
+  .error-wrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin: 2rem 0;
+
+    .icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 4rem;
+      height: 4rem;
+      margin: auto;
+      font-size: 2rem;
+      border: 3px solid var(--color-failure);
+      border-radius: 50%;
+      color: var(--color-failure);
+    }
+
+    .error {
+      width: 80%;
+      border: 1px solid var(--color-failure);
+      color: var(--color-failure);
+      word-wrap: break-word;
+      padding: 2rem;
+      margin: 2rem;
+    }
+
+    .actions-wrapper {
+      width: 80%;
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+}

--- a/grid-ui/saplings/profile/src/http.js
+++ b/grid-ui/saplings/profile/src/http.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Wrapper function to set up XHR.
+ * @param {string}      method    HTTP method for the request
+ * @param {string}      url       endpoint to make the request to
+ * @param {object}      data      Byte array representation of the request body
+ * @param {function}    headerFn  Function to set the correct request headers
+ */
+export async function http(method, url, data, headerFn) {
+  return new Promise((resolve, reject) => {
+    const request = new XMLHttpRequest();
+    request.open(method, url);
+    if (headerFn) {
+      headerFn(request);
+    }
+    request.onload = () => {
+      if (request.status >= 200 && request.status < 300) {
+        resolve(request.response);
+      } else {
+        reject(request.response);
+      }
+    };
+    request.onerror = () => {
+      reject(
+        Error(
+          'The server has encountered an error. Please contact the administrator.'
+        )
+      );
+    };
+    request.send(data);
+  });
+}

--- a/grid-ui/saplings/profile/src/index.css
+++ b/grid-ui/saplings/profile/src/index.css
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+html,
+body {
+  margin: 0;
+  height: 100vh;
+}

--- a/grid-ui/saplings/profile/src/index.js
+++ b/grid-ui/saplings/profile/src/index.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import './index.css';
+import { registerApp, registerConfigSapling } from 'splinter-saplingjs';
+import App from './App';
+
+registerConfigSapling('profile', () => {
+  if (window.location.pathname === '/profile') {
+    registerApp(domNode => {
+      ReactDOM.render(<App />, domNode);
+    });
+  }
+});

--- a/grid-ui/saplings/profile/src/useDebounce.js
+++ b/grid-ui/saplings/profile/src/useDebounce.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from 'react';
+
+export function useDebounce(value, delay) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/grid-ui/saplings/profile/test/Dockerfile
+++ b/grid-ui/saplings/profile/test/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile for running unit tests and lint on the Grid UI
+FROM node:lts-alpine
+
+WORKDIR /grid-ui/saplings/profile
+
+COPY package*.json ./
+
+RUN apk add git
+
+# Gives npm permission to run the prepare script in splinter-canopyjs as root
+RUN npm config set unsafe-perm true && npm install
+
+COPY . .

--- a/grid-ui/src/theme/colors.scss
+++ b/grid-ui/src/theme/colors.scss
@@ -33,6 +33,8 @@ $color-secondary-dark: darken($color-secondary, 15%);
   --color-text--on-dark: rbga(255, 255, 255, 0.9);
   --color-text-light--on-dark: rgba(255, 255, 255, 0.7);
   --color-text-lighter--on-dark: rgba(255, 255, 255, 0.4);
+  --color-success: rgb(0, 192, 127);
+  --color-failure: rgb(255, 101, 98);
 }
 
 $brand-colors: (


### PR DESCRIPTION
This adds the initial profile sapling for displaying and modifying a Biome user. This sapling can be extended/updated along with any additions or modifications to the Biome APIs.

## Testing

* Run `export 'CARGO_ARGS=-- --features experimental'` from the Grid directory
* Run `docker-compose -f grid-ui/docker/docker-compose.yaml build gridd grid-db splinter-db splinterd`
* Run `docker-compose -f grid-ui/docker/docker-compose.yaml up gridd grid-db splinter-db splinterd`
* Navigate to the `grid/grid-ui` directory
* Run `npm install`
* Navigate to any of the sapling directories that are required for testing, in this case `grid/grid-ui/saplings/profile` and `grid/grid-ui/saplings/register-login`, and run `npm install && npm run deploy` in them.
* Navigate back to the `grid/grid-ui` directory and run `npm run start`
* Once the UI opens in the browser, create a user
* Navigate to the profile sapling by clicking the icon in the bottom of the nav bar