### PR TITLE
Add javascript dependencies to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,9 @@
+# Cargo
 **/target
 **/Cargo.lock
+
+# Node
+**/node_modules
+**/yarn.lock
+**/package-lock.json
+**/npm-debug.log


### PR DESCRIPTION
This will stop any built dependencies from being copied to a docker
container. This is good because we want a fresh rebuild of our
dependencies when running in a docker environment.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>