### PR TITLE
Document products endpoints

### DIFF
--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -1,5 +1,6 @@
 # Copyright 2017 Intel Corporation
 # Copyright 2019 Bitwise IO, Inc.
+# Copyright 2020 Cargill Incorporated
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -422,6 +423,79 @@ paths:
             $ref: "#/components/responses/500ServerError"
           "503":
             $ref: "#/components/responses/503ServiceUnavailable"
+  /product:
+    get:
+      tags:
+        - Product
+      summary: List all products
+      description: Get a list of products
+      operationId: list_products
+      parameters:
+        - name: service_id
+          in: query
+          description: |
+            The ID of the service the payload should be sent to; required if
+            running on Splinter.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Product"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "500":
+          $ref: "#/components/responses/500ServerError"
+        "503":
+          $ref: "#/components/responses/503ServiceUnavailable"
+  "/product/{product_id}":
+    get:
+      tags:
+        - Product
+      summary: Fetch a specific product
+      description: Fetches a single product with the given product ID
+      operationId: fetch_product
+      parameters:
+        - name: product_id
+          in: path
+          description: ID of the property to fetch.
+          required: true
+          schema:
+            type: string
+        - name: service_id
+          in: query
+          description: |
+            The ID of the service the payload should be sent to; required if
+            running on Splinter.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Product"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "404":
+          $ref: "#/components/responses/404NotFound"
+        "500":
+          $ref: "#/components/responses/500ServerError"
+        "503":
+          $ref: "#/components/responses/503ServiceUnavailable"
+
 components:
   parameters:
     batch_id:
@@ -850,3 +924,52 @@ components:
       type: string
       format: byte
       example: "AQIDBA=="
+    ProductNamespaceEnum:
+      description: Namespace of a product
+      type: string
+      enum:
+        - UNSET_NAMESPACE
+        - GS1
+    ProductPropertyValue:
+        type: object
+        properties:
+          name:
+            type: string
+            example: location
+          data_type:
+            type: string
+            example: boolean
+          boolean_value:
+            type: boolean
+          number_value:
+            type: integer
+            format: int64
+          string_value:
+            type: string
+          enum_value:
+            type: integer
+            format: int32
+          struct_values:
+            type: array
+            items:
+              type: string
+          lat_long_value:
+            $ref: '#/components/schemas/LatLong'
+    Product:
+      type: object
+      properties:
+        product_id:
+          type: string
+          example: 00122765988220
+        product_address:
+          type: string
+          example: 621dee0201000000000000000000000000000000000000000000000012276598822000
+        product_namespace:
+          $ref: "#/components/schemas/ProductNamespaceEnum"
+        owner:
+          type: string
+          example: 02cd3181dbd7d1539f470436ce222c53ab5e514f67809dc0095895e6cdfba97612
+        properties:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProductPropertyValue"


### PR DESCRIPTION
Adds the necessary information for the products endpoints,
including /products and /products/{product_id}, as well as
the product definition to the openapi spec.
