### PR TITLE
Initialize product sapling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,18 +80,21 @@ pipeline {
         stage("Build Grid UI Test Dependencies") {
             steps {
                 sh 'docker build grid-ui -f grid-ui/docker/test/Dockerfile -t grid-ui:$ISOLATION_ID'
+                sh 'docker build grid-ui/saplings/product -f grid-ui/saplings/product/test/Dockerfile -t product-sapling:$ISOLATION_ID'
             }
         }
 
         stage("Run Lint on Grid UI") {
             steps {
                 sh 'docker run --rm --env CI=true grid-ui:$ISOLATION_ID yarn lint'
+                sh 'docker run --rm --env CI=true product-sapling:$ISOLATION_ID yarn lint'
             }
         }
 
         stage("Run Grid UI tests") {
             steps {
                 sh 'docker run --rm --env CI=true grid-ui:$ISOLATION_ID yarn test'
+                sh 'docker run --rm --env CI=true product-sapling:$ISOLATION_ID yarn test'
             }
         }
 

--- a/grid-ui/.dockerignore
+++ b/grid-ui/.dockerignore
@@ -1,0 +1,13 @@
+# Node
+**/node_modules
+**/yarn.lock
+**/package-lock.json
+**/npm-debug.log
+
+# Build artifacts
+**/build
+**/dist
+
+# Sapling artifacts
+sapling-dev-server/product
+sapling-dev-server/register-login.js

--- a/grid-ui/sapling-dev-server/Dockerfile
+++ b/grid-ui/sapling-dev-server/Dockerfile
@@ -26,6 +26,10 @@ RUN cd /saplings/register-login && \
   npm install && \
   yarn deploy
 
+RUN cd /saplings/product && \
+  npm install && \
+  yarn deploy
+
 FROM httpd:2.4 as prod-stage
 
 RUN echo "\
@@ -34,6 +38,6 @@ RUN echo "\
   \n\
   " >>/usr/local/apache2/conf/httpd.conf
 
-COPY --from=build-stage /sapling-dev-server/* /usr/local/apache2/htdocs/
+COPY --from=build-stage /sapling-dev-server/ /usr/local/apache2/htdocs/
 
 EXPOSE 80/tcp

--- a/grid-ui/sapling-dev-server/userSaplings
+++ b/grid-ui/sapling-dev-server/userSaplings
@@ -3,9 +3,11 @@
     "displayName": "Product",
     "namespace": "product",
     "runtimeFiles": [
-      "localhost:3030/sapling-dev-server/product.js"
+      "localhost:3030/sapling-dev-server/product/js/product.js"
     ],
-    "styleFiles": [],
+    "styleFiles": [
+      "localhost:3030/sapling-dev-server/product/css/product.css"
+    ],
     "workerFiles": [],
     "icon": "https://via.placeholder.com/48/333333/FFFFFF?text=P"
   }

--- a/grid-ui/saplings/product/.eslintignore
+++ b/grid-ui/saplings/product/.eslintignore
@@ -1,0 +1,17 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+saplings/*
+build/*
+sapling-dev-server/*

--- a/grid-ui/saplings/product/.eslintrc
+++ b/grid-ui/saplings/product/.eslintrc
@@ -1,0 +1,29 @@
+{
+  "env": {
+    "es6": true,
+    "jest": true,
+    "browser": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
+  "extends": [
+    "airbnb",
+    "prettier",
+    "prettier/react"
+  ],
+  "rules": {
+    "react/jsx-filename-extension": 0,
+    "react/prefer-stateless-function": 0,
+    "import/prefer-default-export": 0
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": [
+          "src"
+        ]
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/product/.prettierignore
+++ b/grid-ui/saplings/product/.prettierignore
@@ -1,0 +1,16 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+saplings/*
+build/*

--- a/grid-ui/saplings/product/.prettierrc
+++ b/grid-ui/saplings/product/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "proseWrap": always
+}

--- a/grid-ui/saplings/product/package.json
+++ b/grid-ui/saplings/product/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "product",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "node ./scripts/build.js",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject",
+    "add-to-canopy": "mkdir -p ../../sapling-dev-server/product && cp -r ./build/static/* ../../sapling-dev-server/product",
+    "deploy": "npm run build && npm run add-to-canopy"
+  },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.27",
+    "@fortawesome/free-solid-svg-icons": "^5.12.1",
+    "@fortawesome/react-fontawesome": "^0.1.9",
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.3.2",
+    "@testing-library/user-event": "^7.1.2",
+    "prop-types": "^15.7.2",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0",
+    "react-scripts": "3.4.0",
+    "rewire": "^4.0.1",
+    "splinter-saplingjs": "github:cargill/splinter-saplingjs#master"
+  },
+  "devDependencies": {
+    "eslint": "^6.6.0",
+    "eslint-config-airbnb": "18.0.1",
+    "eslint-config-prettier": "^6.4.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^1.7.0",
+    "http-server": "^0.12.1",
+    "node-sass": "^4.13.1",
+    "nodemon": "^2.0.2",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^1.18.2"
+  }
+}

--- a/grid-ui/saplings/product/package.json
+++ b/grid-ui/saplings/product/package.json
@@ -7,6 +7,7 @@
     "build": "node ./scripts/build.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
+    "lint": "eslint .",
     "add-to-canopy": "mkdir -p ../../sapling-dev-server/product && cp -r ./build/static/* ../../sapling-dev-server/product",
     "deploy": "npm run build && npm run add-to-canopy"
   },

--- a/grid-ui/saplings/product/public/index.html
+++ b/grid-ui/saplings/product/public/index.html
@@ -1,0 +1,34 @@
+<!--
+Copyright 2018-2020 Cargill Incorporated
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Product sapling" />
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <title>Product</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+</body>
+
+</html>

--- a/grid-ui/saplings/product/public/manifest.json
+++ b/grid-ui/saplings/product/public/manifest.json
@@ -1,0 +1,8 @@
+{
+  "short_name": "Product",
+  "name": "Product sapling",
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
+}

--- a/grid-ui/saplings/product/public/robots.txt
+++ b/grid-ui/saplings/product/public/robots.txt
@@ -1,0 +1,3 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Disallow:

--- a/grid-ui/saplings/product/scripts/build.js
+++ b/grid-ui/saplings/product/scripts/build.js
@@ -14,7 +14,21 @@
  * limitations under the License.
  */
 
-window.$CANOPY.registerApp(function (domNode) {
-  console.log('Rendering Vanilla JS App');
-  domNode.innerHTML = `<h1>Grid Product<h1>`;
-});
+const rewire = require('rewire');
+
+const defaults = rewire('react-scripts/scripts/build.js');
+// eslint-disable-next-line no-underscore-dangle
+const config = defaults.__get__('config');
+
+config.optimization.splitChunks = {
+  cacheGroups: {
+    default: false
+  }
+};
+
+config.optimization.runtimeChunk = false;
+
+// JS
+config.output.filename = 'static/js/product.js';
+// CSS. "5" is MiniCssPlugin
+config.plugins[5].options.moduleFilename = () => 'static/css/product.css';

--- a/grid-ui/saplings/product/src/App.js
+++ b/grid-ui/saplings/product/src/App.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import {
+  faCaretUp,
+  faCaretDown,
+  faCheck,
+  faPenSquare
+} from '@fortawesome/free-solid-svg-icons';
+
+import { ServiceProvider } from './state/service-context';
+import FilterBar from './components/FilterBar';
+import ProductsTable from './components/ProductsTable';
+import './App.scss';
+
+library.add(faCaretUp, faCaretDown, faCheck, faPenSquare);
+
+function App() {
+  return (
+    <ServiceProvider>
+      <div className="product-app">
+        <FilterBar />
+        <ProductsTable />
+      </div>
+    </ServiceProvider>
+  );
+}
+
+export default App;

--- a/grid-ui/saplings/product/src/App.scss
+++ b/grid-ui/saplings/product/src/App.scss
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.product-app {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}

--- a/grid-ui/saplings/product/src/App.test.js
+++ b/grid-ui/saplings/product/src/App.test.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<App />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});

--- a/grid-ui/saplings/product/src/components/CircuitDropdown.js
+++ b/grid-ui/saplings/product/src/components/CircuitDropdown.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useRef, useEffect } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { useServiceState, useServiceDispatch } from '../state/service-context';
+import useOnClickOutside from '../hooks/on-click-outside';
+import './CircuitDropdown.scss';
+
+const CircuitDropdown = () => {
+  const { services, selectedService } = useServiceState();
+  const serviceDispatch = useServiceDispatch();
+  const [listOpen, setListOpen] = useState(false);
+  const [headerText, setHeaderText] = useState('All services');
+
+  const caretUp = <FontAwesomeIcon icon="caret-up" />;
+  const caretDown = <FontAwesomeIcon icon="caret-down" />;
+
+  const handleSelect = serviceID => {
+    setListOpen(false);
+    serviceDispatch({
+      type: 'select',
+      payload: {
+        serviceID
+      }
+    });
+  };
+
+  const handleSelectAll = () => {
+    setListOpen(false);
+    serviceDispatch({
+      type: 'selectAll'
+    });
+  };
+
+  const listItems = services.map(item => (
+    <div
+      className="dd-list-item"
+      role="button"
+      tabIndex="0"
+      onClick={() => handleSelect(item.serviceID)}
+      onKeyPress={() => handleSelect(item.serviceID)}
+    >
+      {item.serviceID}
+      {item.serviceID === selectedService && <FontAwesomeIcon icon="check" />}
+    </div>
+  ));
+
+  const ref = useRef();
+  useOnClickOutside(ref, () => setListOpen(false));
+
+  useEffect(() => {
+    if (selectedService === 'all') {
+      setHeaderText('All services');
+    } else {
+      setHeaderText(selectedService);
+    }
+  }, [selectedService]);
+
+  return (
+    <div className="dd-wrapper" ref={ref}>
+      <div
+        className="dd-header"
+        role="button"
+        tabIndex="0"
+        onClick={() => setListOpen(!listOpen)}
+        onKeyPress={() => setListOpen(!listOpen)}
+      >
+        <div className="dd-header-text">{headerText}</div>
+        {listOpen ? caretUp : caretDown}
+      </div>
+      {listOpen && (
+        <ul className="dd-list">
+          <div
+            className="dd-list-item"
+            role="button"
+            tabIndex="0"
+            onClick={handleSelectAll}
+            onKeyPress={handleSelectAll}
+          >
+            All services
+            {selectedService === 'all' && <FontAwesomeIcon icon="check" />}
+          </div>
+          {listItems}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default CircuitDropdown;

--- a/grid-ui/saplings/product/src/components/CircuitDropdown.scss
+++ b/grid-ui/saplings/product/src/components/CircuitDropdown.scss
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.dd-wrapper {
+  position: relative;
+  user-select: none;
+  margin-left: 3rem;
+  width: 20rem;
+  height: 2rem;
+
+  :focus {
+    outline: none;
+  }
+
+  .dd-header {
+    border: 1px solid var(--color-dark-grey);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    line-height: calc(2rem-2px);
+    padding: 0 1rem;
+  }
+
+  .dd-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    width: 20rem;
+    border: 1px solid var(--color-dark-grey);
+    border-top: none;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    background-color: white;
+    max-height: 20rem;
+    overflow-y: scroll;
+
+    .dd-list-item {
+      display: flex;
+      justify-content: space-between;
+      width: 100%;
+      padding: 0.5rem;
+
+      &:hover {
+        color: white;
+        background-color: var(--color-primary);
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/product/src/components/FilterBar.js
+++ b/grid-ui/saplings/product/src/components/FilterBar.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import CircuitDropdown from './CircuitDropdown';
+import './FilterBar.scss';
+
+function FilterBar() {
+  return (
+    <div className="filter-bar">
+      <CircuitDropdown />
+    </div>
+  );
+}
+
+export default FilterBar;

--- a/grid-ui/saplings/product/src/components/FilterBar.scss
+++ b/grid-ui/saplings/product/src/components/FilterBar.scss
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.filter-bar {
+  position: sticky;
+  z-index: 99;
+  top: 0;
+  height: 4rem;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  padding: 1rem;
+  background-color: white;
+}

--- a/grid-ui/saplings/product/src/components/ProductCard.js
+++ b/grid-ui/saplings/product/src/components/ProductCard.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import './ProductCard.scss';
+
+function ProductCard(props) {
+  const { gtin, name, owner, imageURL } = props;
+
+  return (
+    <div className="product-card">
+      <button type="button" className="product-card-edit-button">
+        <FontAwesomeIcon className="icon" icon="pen-square" />
+      </button>
+      <div className="product-card-content">
+        <div className="product-card-properties">
+          <Property label="GTIN" value={gtin} />
+          <Property label="Product Name" value={name} />
+          <Property label="Owner" value={owner} />
+        </div>
+        {imageURL && (
+          <img className="product-card-image" src={imageURL} alt={name} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+ProductCard.propTypes = {
+  gtin: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  owner: PropTypes.string.isRequired,
+  imageURL: PropTypes.string
+};
+
+ProductCard.defaultProps = {
+  imageURL: null
+};
+
+function Property(props) {
+  const { label, value } = props;
+
+  return (
+    <div className="product-card-property">
+      <div className="label">{label}</div>
+      <div className="value">{value}</div>
+    </div>
+  );
+}
+
+Property.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired
+};
+
+export default ProductCard;

--- a/grid-ui/saplings/product/src/components/ProductCard.scss
+++ b/grid-ui/saplings/product/src/components/ProductCard.scss
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.product-card {
+  position: relative;
+  border: 2px solid var(--color-dark-grey);
+  border-radius: 5px;
+  padding: 0.8rem;
+  height: 12rem;
+
+  &:hover {
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  }
+
+  .product-card-edit-button {
+    position: absolute;
+    z-index: 10;
+    padding: 0;
+    top: 0.8rem;
+    right: 0.8rem;
+    width: 1rem;
+    height: 1rem;
+    border: none;
+    color: var(--color-grey);
+
+    :hover {
+      color: var(--color-dark-grey);
+    }
+
+    .icon {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
+
+  .product-card-content {
+    display: flex;
+    height: 100%;
+    justify-content: space-between;
+
+    .product-card-properties {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+
+      .product-card-property {
+        display: flex;
+        flex-direction: column;
+
+        .label {
+          color: var(--color-grey);
+          font-weight: 300;
+        }
+
+        .value {
+          font-size: 1.3rem;
+        }
+      }
+    }
+
+    .product-card-image {
+      width: 8rem;
+      height: 8rem;
+      align-self: center;
+      object-fit: contain;
+    }
+  }
+}

--- a/grid-ui/saplings/product/src/components/ProductsTable.js
+++ b/grid-ui/saplings/product/src/components/ProductsTable.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { useServiceState } from '../state/service-context';
+
+import './ProductsTable.scss';
+import ProductCard from './ProductCard';
+import mockProducts from '../test/mock-products';
+
+function ProductsTable() {
+  const [products, setProducts] = useState(mockProducts);
+  const { selectedService } = useServiceState();
+
+  useEffect(() => {
+    if (selectedService === 'all') {
+      setProducts(mockProducts);
+    } else {
+      setProducts(
+        mockProducts.filter(product => product.service_id === selectedService)
+      );
+    }
+  }, [selectedService]);
+
+  const productCards = products.map(product => {
+    const findProperty = name => {
+      const property = product.properties.find(p => p.name === name);
+      return property ? property.string_value : null;
+    };
+
+    return (
+      <ProductCard
+        key={`${findProperty('gtin')}_${product.service_id}`}
+        gtin={findProperty('gtin')}
+        name={findProperty('product_name')}
+        owner={product.owner}
+        imageURL={findProperty('image_url')}
+      />
+    );
+  });
+
+  return (
+    <div className="products-table-container">
+      <div className="products-table-header">
+        <h5 className="title">Products</h5>
+        <hr />
+      </div>
+      <div className="products-table">{productCards}</div>
+    </div>
+  );
+}
+
+export default ProductsTable;

--- a/grid-ui/saplings/product/src/components/ProductsTable.scss
+++ b/grid-ui/saplings/product/src/components/ProductsTable.scss
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.products-table-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem 3rem;
+
+  .products-table-header {
+    .title {
+      margin: 0;
+    }
+
+    hr {
+      border-top: 2px solid var(--color-dark-grey);
+      margin-left: 0;
+      margin-bottom: 1rem;
+      width: 12rem;
+    }
+  }
+
+  .products-table {
+    display: grid;
+    grid-gap: 1rem;
+    grid-template-columns: repeat(auto-fit, 22rem);
+  }
+}

--- a/grid-ui/saplings/product/src/hooks/on-click-outside.js
+++ b/grid-ui/saplings/product/src/hooks/on-click-outside.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from 'react';
+
+function useOnClickOutside(ref, handler) {
+  useEffect(() => {
+    const listener = event => {
+      if (!ref.current || ref.current.contains(event.target)) {
+        return;
+      }
+
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+    };
+  }, [ref, handler]);
+}
+
+export default useOnClickOutside;

--- a/grid-ui/saplings/product/src/index.css
+++ b/grid-ui/saplings/product/src/index.css
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+body {
+  margin: 0;
+}

--- a/grid-ui/saplings/product/src/index.js
+++ b/grid-ui/saplings/product/src/index.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { registerApp } from 'splinter-saplingjs';
+
+import './index.css';
+import App from './App';
+
+registerApp(domNode => {
+  ReactDOM.render(<App />, domNode);
+});

--- a/grid-ui/saplings/product/src/setupTests.js
+++ b/grid-ui/saplings/product/src/setupTests.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom/extend-expect';

--- a/grid-ui/saplings/product/src/state/service-context.js
+++ b/grid-ui/saplings/product/src/state/service-context.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import mockServices from '../test/mock-services';
+
+const ServiceStateContext = React.createContext();
+const ServiceDispatchContext = React.createContext();
+
+const serviceReducer = (state, action) => {
+  switch (action.type) {
+    case 'select': {
+      return { ...state, selectedService: action.payload.serviceID };
+    }
+    case 'selectAll': {
+      return { ...state, selectedService: 'all' };
+    }
+    default:
+      throw new Error(`unhandled action type: ${action.type}`);
+  }
+};
+
+function ServiceProvider({ children }) {
+  const [state, dispatch] = React.useReducer(serviceReducer, mockServices);
+
+  return (
+    <ServiceStateContext.Provider value={state}>
+      <ServiceDispatchContext.Provider value={dispatch}>
+        {children}
+      </ServiceDispatchContext.Provider>
+    </ServiceStateContext.Provider>
+  );
+}
+
+ServiceProvider.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+function useServiceState() {
+  const context = React.useContext(ServiceStateContext);
+  if (context === undefined) {
+    throw new Error('useServiceState must be used within a ServiceProvider');
+  }
+  return context;
+}
+
+function useServiceDispatch() {
+  const context = React.useContext(ServiceDispatchContext);
+  if (context === undefined) {
+    throw new Error('useServiceDispatch must be used within a ServiceProvider');
+  }
+  return context;
+}
+
+export { ServiceProvider, useServiceState, useServiceDispatch };

--- a/grid-ui/saplings/product/src/test/mock-products.js
+++ b/grid-ui/saplings/product/src/test/mock-products.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default [
+  {
+    service_id: 'cargill-target0',
+    product_id: '1',
+    owner: 'Target',
+    properties: [
+      {
+        name: 'product_name',
+        string_value: 'Canola Oil'
+      },
+      {
+        name: 'gtin',
+        string_value: '00012345600012'
+      },
+      {
+        name: 'image_url',
+        string_value:
+          'https://target.scene7.com/is/image/Target/GUEST_e8106dc8-b312-49d3-b9f5-ae4f01553452?fmt=webp&wid=1400&qlt=80'
+      }
+    ]
+  },
+  {
+    service_id: 'cargill-target1',
+    product_id: '2',
+    owner: 'Cargill',
+    properties: [
+      {
+        name: 'product_name',
+        string_value: 'Truvia 80 ct.'
+      },
+      {
+        name: 'gtin',
+        string_value: '00012345600099'
+      },
+      {
+        name: 'image_url',
+        string_value:
+          'https://target.scene7.com/is/image/Target/GUEST_b7a6e983-b391-40a5-ad89-2f906bce5743?fmt=webp&wid=1400&qlt=80'
+      }
+    ]
+  },
+  {
+    service_id: 'cargill-target5',
+    product_id: '3',
+    owner: 'Cargill',
+    properties: [
+      {
+        name: 'product_name',
+        string_value: 'Anonymous Product'
+      },
+      {
+        name: 'gtin',
+        string_value: '00000000000001'
+      }
+    ]
+  }
+];

--- a/grid-ui/saplings/product/src/test/mock-services.js
+++ b/grid-ui/saplings/product/src/test/mock-services.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default {
+  selectedService: 'all',
+  services: [
+    {
+      id: 0,
+      serviceID: 'cargill-target0'
+    },
+    {
+      id: 1,
+      serviceID: 'cargill-target1'
+    },
+    {
+      id: 2,
+      serviceID: 'cargill-target2'
+    },
+    {
+      id: 3,
+      serviceID: 'cargill-target3'
+    },
+    {
+      id: 4,
+      serviceID: 'cargill-target4'
+    },
+    {
+      id: 5,
+      serviceID: 'cargill-target5'
+    }
+  ]
+};

--- a/grid-ui/saplings/product/test/Dockerfile
+++ b/grid-ui/saplings/product/test/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile for running unit tests and lint on the Grid UI
+FROM node:lts-alpine
+
+WORKDIR /grid-ui/saplings/product
+
+COPY package*.json ./
+
+RUN apk add git
+
+# Gives npm permission to run the prepare script in splinter-canopyjs as root
+RUN npm config set unsafe-perm true && npm install
+
+COPY . .


### PR DESCRIPTION
Initial PR for the product sapling. Implements the product list view, as well as react boilerplate, linting, and tests.

To test, run the following commands from the Grid repo:

1. $ export 'CARGO_ARGS=-- --features experimental'

2. $ docker-compose -f grid-ui/docker/docker-compose.yaml up --build

The UI is available on localhost:3030. The log in/register page should be visible. Try registering as a new user. Once you are logged in, the main Grid UI view will load.

Click the link to the product sapling on the nav bar. The UI should display several mock products. You can try filtering them by changing which service is being viewed from the dropdown on the filter bar.