### PR TITLE
Add service_id to rest api response objects

### DIFF
--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -735,6 +735,15 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Metadata"
+        service_id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+      required:
+        - public_key
+        - org_id
+        - active
+        - roles
+        - metadata
     Organization:
       type: object
       properties:

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -972,6 +972,18 @@ components:
               type: string
           lat_long_value:
             $ref: '#/components/schemas/LatLong'
+        service_id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+      required:
+        - name
+        - data_type
+        - boolean_value
+        - number_value
+        - string_value
+        - enum_value
+        - struct_values
+        - lat_long_value
     Product:
       type: object
       properties:
@@ -990,3 +1002,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ProductPropertyValue"
+        service_id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+      required:
+        - product_id
+        - product_address
+        - product_namespace
+        - owner
+        - properties

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -760,6 +760,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Metadata"
+        service_id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+      required:
+        - id
+        - name
+        - address
+        - metadata
     Metadata:
       type: object
       properties:

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -675,6 +675,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/PropertyDefinition"
+        service_id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+      required:
+        - name
+        - description
+        - owner
+        - properties
     PropertyDefinition:
       properties:
         name:
@@ -704,6 +712,18 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/PropertyDefinition"
+        service_id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+      required:
+        - name
+        - data_type
+        - active
+        - description
+        - required
+        - number_exponent
+        - enum_options
+        - struct_properties
     DataTypeEnum:
       description: Data type of a PropertyDefinition
       type: string

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -786,6 +786,12 @@ components:
         timestamp:
           type: integer
           example: 1557949075
+        service_id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+      required:
+        - agent_id
+        - timestamp
     LatLong:
       type: object
       properties:
@@ -828,6 +834,19 @@ components:
             $ref: "#/components/schemas/AssociatedAgent"
         final:
           type: boolean
+        service_id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+      required:
+        - record_id
+        - schema
+        - owner
+        - custodian
+        - properties
+        - proposals
+        - owner_updates
+        - custodian_updates
+        - final
     ReportedValue:
       type: object
       properties:
@@ -855,6 +874,19 @@ components:
             public_key:
               type: string
               example: 02cd3181dbd7d1539f470436ce222c53ab5e514f67809dc0095895e6cdfba97612
+            service_id:
+              type: string
+              example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+          required:
+            - metadata
+            - public_key
+        service_id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+      required:
+        - timestamp
+        - value
+        - reporter
     Property:
       type: object
       properties:
@@ -879,6 +911,16 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ReportedValue"
+        service_id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+      required:
+        - name
+        - record_id
+        - data_type
+        - authorized_reporters
+        - value
+        - updates
     ProposalRoleEnum:
       type: string
       enum:
@@ -913,6 +955,16 @@ components:
         timestamp:
           type: integer
           example: 1557949075
+        service_id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901::grid-scabbard-a
+      required:
+        - receiving_agent
+        - issuing_agent
+        - role
+        - properties
+        - status
+        - timestamp
     StructPropertyValue:
       type: object
       properties:

--- a/daemon/src/rest_api/routes/agents.rs
+++ b/daemon/src/rest_api/routes/agents.rs
@@ -29,6 +29,9 @@ pub struct AgentSlice {
     pub active: bool,
     pub roles: Vec<String>,
     pub metadata: JsonValue,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
 }
 
 impl AgentSlice {
@@ -39,6 +42,7 @@ impl AgentSlice {
             active: agent.active,
             roles: agent.roles.clone(),
             metadata: agent.metadata.clone(),
+            service_id: agent.service_id.clone(),
         }
     }
 }

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -1537,9 +1537,7 @@ mod test {
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
 
         assert_eq!(property_info.data_type, "Struct".to_string());
-
         assert_eq!(property_info.name, "TestProperty".to_string());
-
         assert_eq!(property_info.record_id, "record_01".to_string());
 
         assert_eq!(
@@ -1586,9 +1584,7 @@ mod test {
 
     fn validate_current_value(property_value: &PropertyValueSlice) {
         validate_reporter(&property_value.reporter, KEY1, "Arya Stark");
-
         assert_eq!(property_value.timestamp, 5);
-
         match &property_value.value {
             Value::Struct(struct_values) => {
                 assert_eq!(struct_values.len(), 5);

--- a/daemon/src/rest_api/routes/organizations.rs
+++ b/daemon/src/rest_api/routes/organizations.rs
@@ -28,6 +28,9 @@ pub struct OrganizationSlice {
     pub name: String,
     pub address: String,
     pub metadata: Vec<JsonValue>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
 }
 
 impl OrganizationSlice {
@@ -37,6 +40,7 @@ impl OrganizationSlice {
             name: organization.name.clone(),
             address: organization.address.clone(),
             metadata: organization.metadata.clone(),
+            service_id: organization.service_id.clone(),
         }
     }
 }

--- a/daemon/src/rest_api/routes/products.rs
+++ b/daemon/src/rest_api/routes/products.rs
@@ -36,6 +36,9 @@ pub struct ProductSlice {
     pub product_namespace: String,
     pub owner: String,
     pub properties: Vec<ProductPropertyValueSlice>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
 }
 
 impl ProductSlice {
@@ -49,6 +52,7 @@ impl ProductSlice {
                 .iter()
                 .map(|prop| ProductPropertyValueSlice::from_model(prop))
                 .collect(),
+            service_id: product.service_id.clone(),
         }
     }
 }
@@ -57,6 +61,9 @@ impl ProductSlice {
 pub struct ProductPropertyValueSlice {
     pub name: String,
     pub data_type: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
     pub bytes_value: Option<Vec<u8>>,
     pub boolean_value: Option<bool>,
     pub number_value: Option<i64>,
@@ -71,6 +78,7 @@ impl ProductPropertyValueSlice {
         Self {
             name: property_value.property_name.clone(),
             data_type: property_value.data_type.clone(),
+            service_id: property_value.service_id.clone(),
             bytes_value: property_value.bytes_value.clone(),
             boolean_value: property_value.boolean_value,
             number_value: property_value.number_value,

--- a/daemon/src/rest_api/routes/records.rs
+++ b/daemon/src/rest_api/routes/records.rs
@@ -34,6 +34,9 @@ use serde_json::{Map, Value as JsonValue};
 pub struct AssociatedAgentSlice {
     pub agent_id: String,
     pub timestamp: u64,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
 }
 
 impl AssociatedAgentSlice {
@@ -41,6 +44,7 @@ impl AssociatedAgentSlice {
         Self {
             agent_id: associated_agent.agent_id.clone(),
             timestamp: associated_agent.timestamp as u64,
+            service_id: associated_agent.service_id.clone(),
         }
     }
 }
@@ -54,6 +58,9 @@ pub struct ProposalSlice {
     pub status: String,
     pub terms: String,
     pub timestamp: u64,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
 }
 
 impl ProposalSlice {
@@ -66,6 +73,7 @@ impl ProposalSlice {
             status: proposal.status.clone(),
             terms: proposal.terms.clone(),
             timestamp: proposal.timestamp as u64,
+            service_id: proposal.service_id.clone(),
         }
     }
 }
@@ -81,6 +89,9 @@ pub struct RecordSlice {
     pub proposals: Vec<ProposalSlice>,
     pub owner_updates: Vec<AssociatedAgentSlice>,
     pub custodian_updates: Vec<AssociatedAgentSlice>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
 }
 
 impl RecordSlice {
@@ -120,6 +131,7 @@ impl RecordSlice {
             proposals: proposals.iter().map(ProposalSlice::from_model).collect(),
             owner_updates,
             custodian_updates,
+            service_id: record.service_id.clone(),
         }
     }
 }
@@ -284,6 +296,9 @@ pub struct PropertySlice {
     pub reporters: Vec<String>,
     pub updates: Vec<PropertyValueSlice>,
     pub value: Option<PropertyValueSlice>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
 }
 impl PropertySlice {
     pub fn from_model(
@@ -300,6 +315,7 @@ impl PropertySlice {
             reporters: reporters.to_vec(),
             updates: updates.to_vec(),
             value,
+            service_id: property.service_id.clone(),
         }
     }
 }
@@ -309,6 +325,9 @@ pub struct PropertyValueSlice {
     pub timestamp: u64,
     pub value: Value,
     pub reporter: ReporterSlice,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -342,6 +361,9 @@ impl LatLong {
 pub struct ReporterSlice {
     pub public_key: String,
     pub metadata: JsonValue,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -382,7 +404,9 @@ impl PropertyValueSlice {
                     .metadata
                     .clone()
                     .unwrap_or_else(|| JsonValue::Object(Map::new())),
+                service_id: reported_value_with_reporter.service_id.clone(),
             },
+            service_id: reported_value_with_reporter.service_id.clone(),
         })
     }
 }

--- a/daemon/src/rest_api/routes/schemas.rs
+++ b/daemon/src/rest_api/routes/schemas.rs
@@ -31,6 +31,9 @@ pub struct GridSchemaSlice {
     pub description: String,
     pub owner: String,
     pub properties: Vec<GridPropertyDefinitionSlice>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
 }
 
 impl GridSchemaSlice {
@@ -43,6 +46,7 @@ impl GridSchemaSlice {
                 .iter()
                 .map(|prop| GridPropertyDefinitionSlice::from_definition(prop))
                 .collect(),
+            service_id: schema.service_id.clone(),
         }
     }
 }
@@ -57,6 +61,9 @@ pub struct GridPropertyDefinitionSlice {
     pub number_exponent: i64,
     pub enum_options: Vec<String>,
     pub struct_properties: Vec<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
 }
 
 impl GridPropertyDefinitionSlice {
@@ -70,6 +77,7 @@ impl GridPropertyDefinitionSlice {
             number_exponent: definition.number_exponent,
             enum_options: definition.enum_options.clone(),
             struct_properties: definition.struct_properties.clone(),
+            service_id: definition.service_id.clone(),
         }
     }
 }


### PR DESCRIPTION
Adds an optional service id to all the rest api response objects. Also adds a check for this in the existing tests and adds documentation to the api spec.