### PR TITLE
Add Grid UI to splinter example docker network

### DIFF
--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -175,11 +175,16 @@ services:
           echo 'waiting for key registry'; \
           sleep 1; \
         done && \
+        until PGPASSWORD=admin psql -h splinter-db-alpha -U admin -d splinter -c '\q'; do
+          >&2 echo \"Database is unavailable - sleeping\"
+          sleep 1
+        done
         cp /key_registry_shared/keys.yaml /var/lib/splinter && \
         if [ ! -f /etc/splinter/certs/private/server.key ]
         then
           splinter-cli cert generate --force
         fi && \
+        splinter database migrate -C postgres://admin:admin@splinter-db-alpha:5432/splinter && \
         splinterd -vv \
         --registry-backend FILE \
         --registry-file /configs/nodes.yaml \
@@ -193,9 +198,45 @@ services:
         --client-key /etc/splinter/certs/private/client.key \
         --server-cert /etc/splinter/certs/server.crt \
         --server-key /etc/splinter/certs/private/server.key \
+        --enable-biome \
+        --database postgres://admin:admin@splinter-db-alpha:5432/splinter \
         --insecure
       "
 
+  splinter-db-alpha:
+    image: postgres
+    container_name: splinter-db-alpha
+    restart: always
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: splinter
+
+  grid-ui-alpha:
+    build:
+      context: ../../grid-ui
+      args:
+        REPO_VERSION: ${REPO_VERSION}
+        REACT_APP_SPLINTER_URL: '/splinterd'
+        REACT_APP_SAPLING_URL: '/sapling-dev-server'
+        SPLINTER_URL: 'http://splinterd-alpha:8085'
+        SAPLING_URL: ' http://sapling-dev-server-alpha:80'
+    image: grid-ui-alpha
+    container_name: grid-ui-alpha
+    expose:
+      - 80
+    ports:
+      - '3030:80'
+
+  sapling-dev-server-alpha:
+    build:
+      context: ../../grid-ui
+      dockerfile: sapling-dev-server/Dockerfile
+    container_name: sapling-dev-server-alpha
+    expose:
+      - 80
 
 # ---== beta node ==---
 
@@ -270,11 +311,16 @@ services:
           echo 'waiting for key registry'; \
           sleep 1; \
         done && \
+        until PGPASSWORD=admin psql -h splinter-db-beta -U admin -d splinter -c '\q'; do
+          >&2 echo \"Database is unavailable - sleeping\"
+          sleep 1
+        done
         cp /key_registry_shared/keys.yaml /var/lib/splinter && \
         if [ ! -f /etc/splinter/certs/private/server.key ]
         then
           splinter-cli cert generate --force
         fi && \
+        splinter database migrate -C postgres://admin:admin@splinter-db-beta:5432/splinter && \
         splinterd -vv \
         --registry-backend FILE \
         --registry-file /configs/nodes.yaml \
@@ -288,8 +334,45 @@ services:
         --client-key /etc/splinter/certs/private/client.key \
         --server-cert /etc/splinter/certs/server.crt \
         --server-key /etc/splinter/certs/private/server.key \
+        --enable-biome \
+        --database postgres://admin:admin@splinter-db-beta:5432/splinter \
         --insecure
       "
+
+  splinter-db-beta:
+    image: postgres
+    container_name: splinter-db-beta
+    restart: always
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: splinter
+
+  grid-ui-beta:
+    build:
+      context: ../../grid-ui
+      args:
+        REPO_VERSION: ${REPO_VERSION}
+        REACT_APP_SPLINTER_URL: '/splinterd'
+        REACT_APP_SAPLING_URL: '/sapling-dev-server'
+        SPLINTER_URL: 'http://splinterd-beta:8085'
+        SAPLING_URL: ' http://sapling-dev-server-beta:80'
+    image: grid-ui-beta
+    container_name: grid-ui-beta
+    expose:
+      - 80
+    ports:
+      - '3031:80'
+
+  sapling-dev-server-beta:
+    build:
+      context: ../../grid-ui
+      dockerfile: sapling-dev-server/Dockerfile
+    container_name: sapling-dev-server-beta
+    expose:
+      - 80
 
 # ---== gamma node ==---
 
@@ -357,11 +440,16 @@ services:
           echo 'waiting for key registry'; \
           sleep 1; \
         done && \
+        until PGPASSWORD=admin psql -h splinter-db-gamma -U admin -d splinter -c '\q'; do
+          >&2 echo \"Database is unavailable - sleeping\"
+          sleep 1
+        done
         cp /key_registry_shared/keys.yaml /var/lib/splinter && \
         if [ ! -f /etc/splinter/certs/private/server.key ]
         then
           splinter-cli cert generate --force
         fi && \
+        splinter database migrate -C postgres://admin:admin@splinter-db-gamma:5432/splinter && \
         splinterd -vv \
         --registry-backend FILE \
         --registry-file /configs/nodes.yaml \
@@ -375,5 +463,42 @@ services:
         --client-key /etc/splinter/certs/private/client.key \
         --server-cert /etc/splinter/certs/server.crt \
         --server-key /etc/splinter/certs/private/server.key \
+        --enable-biome \
+        --database postgres://admin:admin@splinter-db-gamma:5432/splinter \
         --insecure
       "
+
+  splinter-db-gamma:
+    image: postgres
+    container_name: splinter-db-gamma
+    restart: always
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: splinter
+
+  grid-ui-gamma:
+    build:
+      context: ../../grid-ui
+      args:
+        REPO_VERSION: ${REPO_VERSION}
+        REACT_APP_SPLINTER_URL: '/splinterd'
+        REACT_APP_SAPLING_URL: '/sapling-dev-server'
+        SPLINTER_URL: 'http://splinterd-gamma:8085'
+        SAPLING_URL: ' http://sapling-dev-server-gamma:80'
+    image: grid-ui-gamma
+    container_name: grid-ui-gamma
+    expose:
+      - 80
+    ports:
+      - '3032:80'
+
+  sapling-dev-server-gamma:
+    build:
+      context: ../../grid-ui
+      dockerfile: sapling-dev-server/Dockerfile
+    container_name: sapling-dev-server-gamma
+    expose:
+      - 80

--- a/grid-ui/Dockerfile
+++ b/grid-ui/Dockerfile
@@ -32,8 +32,20 @@ RUN tar c -z . -f ../grid_ui_v${REPO_VERSION}.tar.gz
 # prod stage
 FROM httpd:2.4 as prod-stage
 
+ARG SPLINTER_URL
+ARG SAPLING_URL
+
 COPY --from=build-stage /grid_ui/grid_ui_*.tar.gz /tmp
 RUN tar -xzvf /tmp/grid_ui_*.tar.gz -C /usr/local/apache2/htdocs/
 COPY /configs/apache/httpd.conf /usr/local/apache2/conf/httpd.conf
+
+RUN echo "\
+  \n\
+  ProxyPass /splinterd $SPLINTER_URL\n\
+  ProxyPassReverse /splinterd $SPLINTER_URL\n\
+  ProxyPass /sapling-dev-server $SAPLING_URL\n\
+  ProxyPassReverse /sapling-dev-server $SAPLING_URL\n\
+  \n\
+  " >>/usr/local/apache2/conf/httpd.conf
 
 EXPOSE 80/tcp

--- a/grid-ui/configs/apache/httpd.conf
+++ b/grid-ui/configs/apache/httpd.conf
@@ -548,9 +548,3 @@ Include conf/extra/proxy-html.conf
 SSLRandomSeed startup builtin
 SSLRandomSeed connect builtin
 </IfModule>
-
-ProxyPass /splinterd http://splinterd:8085
-ProxyPassReverse /splinterd http://splinterd:8085
-
-ProxyPass /sapling-dev-server http://sapling-dev-server:80
-ProxyPassReverse /sapling-dev-server http://sapling-dev-server:80

--- a/grid-ui/docker/docker-compose.yaml
+++ b/grid-ui/docker/docker-compose.yaml
@@ -217,6 +217,8 @@
           REPO_VERSION: ${REPO_VERSION}
           REACT_APP_SPLINTER_URL: '/splinterd'
           REACT_APP_SAPLING_URL: '/sapling-dev-server'
+          SPLINTER_URL: 'http://splinterd:8085'
+          SAPLING_URL: ' http://sapling-dev-server:80'
       image: grid-ui
       container_name: grid-ui
       expose:


### PR DESCRIPTION
This allows us to test the Grid UI against the network defined in the splinter example docker-compose file.

To test: 

1. Run the splinter example as described in https://github.com/hyperledger/grid/blob/master/examples/splinter/README.md

2. Navigate to the Grid UIs, (localhost:3030, localhost:3031, localhost:3032) and register as normal. Navigate to different saplings. Ensure docker-compose logs show the correct services being called and no errors are present.