### PR TITLE
Add view for the AddProductForm

### DIFF
--- a/grid-ui/.prettierignore
+++ b/grid-ui/.prettierignore
@@ -14,3 +14,4 @@
 
 saplings/*
 **/build/*
+sapling-dev-server/*

--- a/grid-ui/saplings/product/.eslintrc
+++ b/grid-ui/saplings/product/.eslintrc
@@ -14,6 +14,7 @@
   ],
   "rules": {
     "react/jsx-filename-extension": 0,
+    "react/forbid-prop-types": 0,
     "react/prefer-stateless-function": 0,
     "import/prefer-default-export": 0
   },

--- a/grid-ui/saplings/product/package.json
+++ b/grid-ui/saplings/product/package.json
@@ -7,9 +7,11 @@
     "build": "node ./scripts/build.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
+    "format": "prettier --write \"**/*.+(js|jsx|json|css|scss|md)\"",
     "lint": "eslint .",
     "add-to-canopy": "mkdir -p ../../sapling-dev-server/product && cp -r ./build/static/* ../../sapling-dev-server/product",
-    "deploy": "npm run build && npm run add-to-canopy"
+    "deploy": "npm run build && npm run add-to-canopy",
+    "watch": "nodemon --ext js,scss,ts,css --watch src --exec npm run deploy"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -33,6 +35,9 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "classnames": "^2.2.6",
+    "lodash": "^4.17.15",
+    "papaparse": "^5.1.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",

--- a/grid-ui/saplings/product/src/App.js
+++ b/grid-ui/saplings/product/src/App.js
@@ -36,7 +36,7 @@ library.add(faCaretUp, faCaretDown, faCheck, faPenSquare, faChevronLeft);
 function App() {
   return (
     <ServiceProvider>
-      <div className="product-app">
+      <div id="product-sapling" className="product-app">
         <FilterBar />
         <Router>
           <Switch>

--- a/grid-ui/saplings/product/src/App.js
+++ b/grid-ui/saplings/product/src/App.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import {
@@ -22,18 +22,36 @@ import {
   faCaretDown,
   faCheck,
   faPenSquare,
-  faChevronLeft
+  faChevronLeft,
+  faPlus,
+  faTimes
 } from '@fortawesome/free-solid-svg-icons';
 
 import { ServiceProvider } from './state/service-context';
 import FilterBar from './components/FilterBar';
 import ProductsTable from './components/ProductsTable';
 import ProductInfo from './components/ProductInfo';
+import { AddProductForm } from './components/AddProductForm';
 import './App.scss';
 
-library.add(faCaretUp, faCaretDown, faCheck, faPenSquare, faChevronLeft);
+library.add(faCaretUp, faCaretDown, faCheck, faPenSquare, faChevronLeft, faPlus, faTimes);
 
 function App() {
+  const [activeForm, setActiveForm] = useState(null);
+
+  function addProduct() {
+    setActiveForm('add-product');
+  }
+
+  function openForm(formName) {
+    switch (formName) {
+      case 'add-product':
+        return <AddProductForm closeFn={() => setActiveForm(null)} />;
+      default:
+    }
+    return null;
+  }
+
   return (
     <ServiceProvider>
       <div id="product-sapling" className="product-app">
@@ -41,13 +59,14 @@ function App() {
         <Router>
           <Switch>
             <Route exact path="/product">
-              <ProductsTable />
+              <ProductsTable actions={{ addProduct }} />
             </Route>
             <Route path="/product/products/:id">
               <ProductInfo />
             </Route>
           </Switch>
         </Router>
+        {activeForm && openForm(activeForm)}
       </div>
     </ServiceProvider>
   );

--- a/grid-ui/saplings/product/src/App.scss
+++ b/grid-ui/saplings/product/src/App.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-.product-app {
+#product-sapling {
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/grid-ui/saplings/product/src/App.scss
+++ b/grid-ui/saplings/product/src/App.scss
@@ -18,6 +18,28 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+
+  button {
+    &:hover {
+      cursor: pointer;
+    }
+
+    &.fab {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      width: 4rem;
+      height: 4rem;
+      border-radius: 50%;
+      border: none;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background: var(--color-secondary);
+      color: #ffffff;
+      font-size: 2rem;
+    }
+  }
 }
 
 .link {

--- a/grid-ui/saplings/product/src/components/AddProductForm.js
+++ b/grid-ui/saplings/product/src/components/AddProductForm.js
@@ -1,0 +1,330 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useCallback, useEffect, useReducer, useState } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import _ from 'lodash';
+import papa from 'papaparse';
+import { useServiceState } from '../state/service-context';
+import { MultiStepForm, Step, StepInput } from './MultiStepForm';
+import { Chips, Chip } from './Chips';
+import { MultiSelect } from './MultiSelect';
+
+import './forms.scss';
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'add':
+      return [...new Set([...state, ...action.payload])];
+    case 'remove':
+      return state.filter(item => item !== action.payload);
+    case 'set':
+      return action.payload;
+    case 'clear':
+      return [];
+    default:
+      throw new Error(`Invalid action type: ${action.type}`);
+  }
+};
+
+export function AddProductForm({ closeFn }) {
+  const initialErrors = [
+    'GTIN: please enter a valid GTIN',
+    'Services: please select at least one service'
+  ];
+  const { services } = useServiceState();
+  const [errors, dispatchErrors] = useReducer(reducer, initialErrors);
+  const [gtin, setGtin] = useState(null);
+  const [selectedServices, dispatchSelectedServices] = useReducer(reducer, []);
+  const [imgFile, setImgFile] = useState(null);
+  const [imgPreview, setImgPreview] = useState(null);
+  const [fileLabel, setFileLabel] = useState('Upload master data file');
+  const [imgLabel, setImgLabel] = useState('Upload product image');
+  const [attributes, setAttributes] = useState([]);
+  const [attrState, setAttrState] = useState({
+    type: '',
+    name: '',
+    value: ''
+  });
+
+  useEffect(() => {
+    const errorMessage = 'Services: please select at least one service';
+    if (!selectedServices.length) {
+      dispatchErrors({ type: 'add', payload: [errorMessage] });
+    } else {
+      dispatchErrors({ type: 'remove', payload: errorMessage });
+    }
+  }, [selectedServices]);
+
+  const gtinValidator = '\\b\\d{8}(?:\\d{4,6})?\\b';
+
+  const handleGtinChange = e => {
+    const { value } = e.target;
+    const errorMessage = 'GTIN: please enter a valid GTIN';
+    if (!e.target.validity.valid) {
+      dispatchErrors({ type: 'add', payload: [errorMessage] });
+    } else {
+      dispatchErrors({ type: 'remove', payload: errorMessage });
+    }
+    setGtin(value);
+  };
+
+  const handleFileUpload = e => {
+    setFileLabel(e.target.files[0].name);
+    papa.parse(e.target.files[0], {
+      complete(results) {
+        setAttributes([...attributes, ...results.data]);
+      },
+      header: true,
+      skipEmptyLines: true
+    });
+  };
+
+  const handleImgUpload = e => {
+    e.preventDefault();
+    const file = e.target.files[0];
+    setImgLabel(file.name);
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setImgFile(file);
+      setImgPreview(reader.result);
+    };
+
+    reader.readAsDataURL(file);
+    return imgFile;
+  };
+
+  const handleServiceChange = useCallback(
+    newServices => {
+      dispatchSelectedServices({ type: 'set', payload: [...newServices] });
+    },
+    [dispatchSelectedServices]
+  );
+
+  const addAttribute = e => {
+    e.preventDefault();
+    setAttributes([...attributes, attrState]);
+    setAttrState({
+      type: '',
+      name: '',
+      value: ''
+    });
+  };
+
+  const removeAttr = attr => {
+    setAttributes(attributes.filter(attribute => !_.isEqual(attribute, attr)));
+  };
+
+  const handleAttrChange = e => {
+    const { name, value } = e.target;
+    setAttrState({
+      ...attrState,
+      [name]: value
+    });
+  };
+
+  const createAttrData = attribute => {
+    return (
+      <div className="attribute-data">
+        <span className="name">{attribute.name}</span>
+        <span className="type">{attribute.type}</span>
+        <span className="value">{attribute.value}</span>
+      </div>
+    );
+  };
+
+  const clearState = () => {
+    setGtin(null);
+    dispatchSelectedServices({ type: 'clear' });
+    dispatchErrors({type: 'add', payload: initialErrors});
+    setAttributes([]);
+    setAttrState({
+      type: '',
+      name: '',
+      value: ''
+    });
+    setImgFile(null);
+    setImgPreview(null);
+    setFileLabel('Upload master data file');
+    setImgLabel('Upload product image');
+  };
+
+  const submitFn = () => {
+    clearState();
+  };
+
+  const makeListItems = () => {
+    return services.map(service => ({
+      label: service.serviceID,
+      value: service.id
+    }));
+  };
+
+  return (
+    <div className="modalForm">
+      <FontAwesomeIcon icon="times" className="close" onClick={closeFn} />
+      <div className="content">
+        <MultiStepForm
+          formName="Add Product"
+          handleSubmit={submitFn}
+          disabled={!!errors.length}
+        >
+          <Step step={1} label="Specify product">
+            <StepInput
+              type="text"
+              label="GTIN"
+              name="gtin"
+              value={gtin}
+              pattern={gtinValidator}
+              onChange={handleGtinChange}
+            />
+            <div className="divider" />
+            <h6>Select service(s)</h6>
+            <MultiSelect
+              listItems={makeListItems()}
+              placeholder="No services selected"
+              onChange={handleServiceChange}
+              value={selectedServices}
+            />
+          </Step>
+          <Step step={2} label="Add master data">
+            <StepInput
+              type="file"
+              accept="text/csv"
+              id="add-master-data-file"
+              label={fileLabel}
+              onChange={handleFileUpload}
+            />
+            <div className="divider" />
+            <h6>Add attributes</h6>
+            <div className="form-group">
+              <StepInput
+                type="select"
+                label="Attribute type"
+                name="type"
+                value={attrState.type}
+                onChange={handleAttrChange}
+              >
+                <option value="">(none)</option>
+                <option value="text" default>
+                  Text
+                </option>
+                <option value="number">Number</option>
+                <option value="boolean">Boolean</option>
+              </StepInput>
+            </div>
+            <div className="form-group">
+              <StepInput
+                type="text"
+                label="Attribute name"
+                name="name"
+                value={attrState.name}
+                onChange={handleAttrChange}
+              />
+              <StepInput
+                type={attrState.type}
+                label="Attribute value"
+                name="value"
+                value={attrState.value}
+                onChange={handleAttrChange}
+              />
+              <button
+                className="confirm"
+                type="button"
+                onClick={addAttribute}
+                disabled={
+                  !(attrState.type && attrState.name && attrState.value)
+                }
+              >
+                Add
+              </button>
+            </div>
+            <Chips>
+              {attributes.map(attribute => {
+                const data = createAttrData(attribute);
+                return (
+                  <Chip
+                    label={attribute.name}
+                    data={data}
+                    removeFn={() => removeAttr(attribute)}
+                    deleteable
+                  />
+                );
+              })}
+            </Chips>
+          </Step>
+          <Step step={3} label="Add attachments">
+            <h6>Add additional info</h6>
+            <StepInput
+              type="file"
+              accept="image/png, image/jpeg"
+              id="add-master-data-file"
+              label={imgLabel}
+              onChange={handleImgUpload}
+            />
+            {imgPreview && (
+              <div className="preview-container">
+                <img className="img-preview" src={imgPreview} alt="preview" />
+              </div>
+            )}
+          </Step>
+          <Step step={4} label="Review and submit">
+            {!!errors.length && (
+              <div className="error-messages">
+                {errors.map(error => (
+                  <span>{error}</span>
+                ))}
+              </div>
+            )}
+            <h6>Review new product</h6>
+            <span>
+              GTIN: <b>{gtin}</b>
+            </span>
+            {imgPreview && (
+              <div className="preview-container">
+                <img className="img-preview" src={imgPreview} alt="preview" />
+              </div>
+            )}
+            <h6>Selected services</h6>
+            <Chips>
+              {selectedServices.length > 0 &&
+                selectedServices.map(service => {
+                  const data = services.filter(s => s.id === service);
+
+                  return data.length && <Chip label={data[0].serviceID} />;
+                })}
+              {!selectedServices.length && <span>No services selected</span>}
+            </Chips>
+            <h6>Attributes</h6>
+            <Chips>
+              {attributes.length > 0 &&
+                attributes.map(attribute => {
+                  const data = createAttrData(attribute);
+                  return <Chip label={attribute.name} data={data} />;
+                })}
+              {!attributes.length && <span>No attributes entered</span>}
+            </Chips>
+          </Step>
+        </MultiStepForm>
+      </div>
+    </div>
+  );
+}
+
+AddProductForm.propTypes = {
+  closeFn: PropTypes.func.isRequired
+};

--- a/grid-ui/saplings/product/src/components/Chips.js
+++ b/grid-ui/saplings/product/src/components/Chips.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import './Chips.scss';
+
+export function Chips({ children }) {
+  return <div className="chips">{children}</div>;
+}
+
+export function Chip({ label, removeFn, data, deleteable }) {
+  return (
+    <div className="chip-group">
+      <div className="chip">
+        <span className="label">{label}</span>
+        {deleteable && (
+          <FontAwesomeIcon icon="times" className="delete" onClick={removeFn} />
+        )}
+      </div>
+      <div className="chip-data">{data}</div>
+    </div>
+  );
+}
+
+Chips.propTypes = {
+  children: PropTypes.node
+};
+
+Chips.defaultProps = {
+  children: undefined
+};
+
+Chip.propTypes = {
+  label: PropTypes.string,
+  removeFn: PropTypes.func,
+  data: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  deleteable: PropTypes.bool
+};
+
+Chip.defaultProps = {
+  label: '',
+  removeFn: undefined,
+  data: undefined,
+  deleteable: false
+};

--- a/grid-ui/saplings/product/src/components/Chips.scss
+++ b/grid-ui/saplings/product/src/components/Chips.scss
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.chips {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin: 1rem 0;
+
+  .chip-group {
+    display: flex;
+    flex-direction: column;
+    height: 22px;
+    margin-bottom: 8px;
+
+    &:not(:last-of-type) {
+      margin-right: 8px;
+    }
+
+    .chip {
+      height: calc(1rem + 4px);
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+      border: 1px solid var(--color-primary);
+      border-radius: calc(0.5rem + 2px);
+      padding: 2px 4px;
+      width: fit-content;
+
+      .label {
+        padding: 2px 12px 2px 4px;
+      }
+
+      .delete {
+        width: 12px;
+        height: 12px;
+
+        &:hover {
+          cursor: pointer;
+        }
+      }
+
+      &:hover {
+        + .chip-data {
+          visibility: visible;
+          opacity: 1;
+        }
+      }
+    }
+
+    .chip-data {
+      visibility: none;
+      width: 0;
+      height: 0;
+      opacity: 0;
+      z-index: 3;
+      transition: all 0.3s;
+    }
+  }
+}

--- a/grid-ui/saplings/product/src/components/FilterBar.scss
+++ b/grid-ui/saplings/product/src/components/FilterBar.scss
@@ -16,7 +16,7 @@
 
 .filter-bar {
   position: sticky;
-  z-index: 99;
+  z-index: 2;
   top: 0;
   height: 4rem;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);

--- a/grid-ui/saplings/product/src/components/Input.js
+++ b/grid-ui/saplings/product/src/components/Input.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import './Input.scss';
+
+export function Input({
+  type,
+  accept,
+  id,
+  label,
+  name,
+  value,
+  pattern,
+  onChange,
+  required,
+  multiple,
+  children
+}) {
+  return (
+    <div className="grid-input">
+      {type === 'select' && (
+        <>
+          <select
+            id={id}
+            aria-label={`${label} select`}
+            name={name}
+            onChange={onChange}
+            required={required}
+            multiple={multiple}
+            value={value}
+          >
+            {children}
+          </select>
+          <label htmlFor={id}>{label}</label>
+        </>
+      )}
+      {type === 'boolean' && (
+        <>
+          <select
+            id={id}
+            aria-label={`${label} select`}
+            name={name}
+            onChange={onChange}
+            required={required}
+            multiple={multiple}
+            value={value}
+          >
+            <option value="" default>
+              (none)
+            </option>
+            <option value="true">True</option>
+            <option value="false">False</option>
+          </select>
+          <label htmlFor={id}>{label}</label>
+        </>
+      )}
+      {type !== 'select' && type !== 'boolean' && (
+        <>
+          <input
+            type={type}
+            id={id}
+            accept={accept}
+            aria-label={`${label} field`}
+            placeholder={label}
+            name={name}
+            value={value}
+            pattern={pattern}
+            onChange={onChange}
+            required={required}
+          />
+          <label htmlFor={id}>{label}</label>
+        </>
+      )}
+    </div>
+  );
+}
+
+Input.propTypes = {
+  type: PropTypes.oneOf(['text', 'password', 'file', 'select', 'number']),
+  accept: PropTypes.string,
+  id: PropTypes.string,
+  label: PropTypes.string,
+  name: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  pattern: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  required: PropTypes.bool,
+  multiple: PropTypes.bool,
+  children: PropTypes.node
+};
+
+Input.defaultProps = {
+  type: 'text',
+  accept: undefined,
+  id: undefined,
+  label: undefined,
+  name: undefined,
+  value: null,
+  pattern: undefined,
+  required: false,
+  multiple: undefined,
+  children: undefined
+};

--- a/grid-ui/saplings/product/src/components/Input.scss
+++ b/grid-ui/saplings/product/src/components/Input.scss
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#product-sapling {
+  .grid-input {
+    position: relative;
+    padding: 1rem 0 0;
+    margin-top: 0.5rem;
+    width: 100%;
+
+    label {
+      position: absolute;
+      top: 0;
+      display: block;
+      transition: 0.2s;
+      font-size: 0.7rem;
+    }
+
+    input {
+      height: calc(2rem + 2px);
+      width: 100%;
+      border: 1px solid #333333;
+      padding: 0.5rem;
+      background: transparent;
+      outline: none;
+      transition: border-color 0.2s;
+      font-size: 1rem;
+
+      &::placeholder {
+        color: transparent;
+      }
+
+      &:placeholder-shown {
+        border-color: #555555;
+
+        & ~ label {
+          cursor: text;
+          top: 1.5rem;
+          padding-left: 0.5rem;
+          font-size: 1rem;
+          pointer-events: none;
+        }
+      }
+
+      &:focus {
+        border-color: var(--color-primary);
+
+        ~ label {
+          font-size: 0.7rem;
+          font-weight: bold;
+          top: 0;
+          padding-left: 0;
+        }
+      }
+
+      &[type='file'] {
+        height: 100%;
+        z-index: 2;
+        opacity: 0;
+        overflow: hidden;
+        position: absolute !important;
+        white-space: nowrap;
+        width: 100%;
+        padding: 0;
+        margin: 0;
+        border: none;
+
+        &::-webkit-file-upload-button {
+          width: 100%;
+          height: 100%;
+        }
+
+        + label {
+          width: 100%;
+          padding: 2rem;
+          border: 1px dashed #333333;
+          color: #333333;
+          font-size: 2rem;
+          font-weight: 300;
+          display: inline-block;
+          position: relative;
+          text-align: center;
+
+          &:hover {
+            cursor: pointer;
+            background: rgba(0, 0, 0, 0.1);
+          }
+        }
+      }
+    }
+
+    select {
+      height: calc(2rem + 2px);
+      width: 100%;
+      border: 0;
+      outline: 1px solid #333333;
+      padding: 0.5rem;
+      background: transparent;
+      transition: border-color 0.2s;
+      font-size: 1rem;
+
+      & ~ label {
+        cursor: text;
+        top: 0;
+        font-size: 0.7rem;
+      }
+
+      &:focus {
+        outline-color: var(--color-primary);
+
+        ~ label {
+          font-weight: bold;
+        }
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/product/src/components/MultiSelect.js
+++ b/grid-ui/saplings/product/src/components/MultiSelect.js
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState, useRef, useReducer } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import useOnClickOutside from '../hooks/on-click-outside';
+
+import './MultiSelect.scss';
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'add':
+      return [...new Set([...state, ...action.payload])];
+    case 'remove':
+      return state.filter(item => item !== action.payload);
+    case 'clear':
+      return [];
+    default:
+      throw new Error(`Invalid action type: ${action.type}`);
+  }
+};
+
+export const MultiSelect = ({ listItems, value, placeholder, onChange }) => {
+  const [listOpen, setListOpen] = useState(false);
+  const [headerText, setHeaderText] = useState(placeholder);
+  const [selectedValues, dispatchSelectedValues] = useReducer(reducer, value);
+  const caretUp = <FontAwesomeIcon className="icon" icon="caret-up" />;
+  const caretDown = <FontAwesomeIcon className="icon" icon="caret-down" />;
+
+  const checkSelected = item => {
+    return selectedValues.includes(item.value);
+  };
+
+  const handleSelect = item => {
+    if (checkSelected(item)) {
+      dispatchSelectedValues({ type: 'remove', payload: item.value });
+    } else {
+      dispatchSelectedValues({ type: 'add', payload: [item.value] });
+    }
+  };
+
+  useEffect(() => {
+    onChange(selectedValues);
+  }, [selectedValues, onChange]);
+
+  useEffect(() => {
+    if (selectedValues.length > 0) {
+      setHeaderText(`${selectedValues.length} selected`);
+    } else {
+      setHeaderText(placeholder);
+    }
+  }, [selectedValues, placeholder]);
+
+  const handleSelectAll = () => {
+    if (selectedValues.length === listItems.length) {
+      dispatchSelectedValues({ type: 'clear' });
+    } else {
+      dispatchSelectedValues({
+        type: 'add',
+        payload: listItems.map(item => item.value)
+      });
+    }
+  };
+
+  const ref = useRef();
+  useOnClickOutside(ref, () => setListOpen(false));
+
+  return (
+    <div className="multi-select-wrapper" value={selectedValues}>
+      <div
+        className="multi-select-header"
+        role="button"
+        tabIndex="0"
+        onClick={() => setListOpen(!listOpen)}
+        onKeyPress={() => setListOpen(!listOpen)}
+      >
+        <div className="multi-select-header-text">{headerText}</div>
+        {listOpen ? caretUp : caretDown}
+      </div>
+      {listOpen && (
+        <ul className="multi-select-options-list">
+          <MultiSelectOption
+            label="Select all"
+            onClick={handleSelectAll}
+            onKeyPress={handleSelectAll}
+          />
+          {listItems.map(item => (
+            <MultiSelectOption
+              value={item.value}
+              label={item.label}
+              onClick={() => handleSelect(item)}
+              onKeyPress={() => handleSelect(item)}
+              selected={checkSelected(item)}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+const MultiSelectOption = ({ value, label, onClick, onKeyPress, selected }) => {
+  return (
+    <div
+      className="multi-select-option"
+      role="button"
+      value={value}
+      tabIndex="0"
+      onClick={onClick}
+      onKeyPress={onKeyPress}
+      selected={selected}
+    >
+      {label}
+      {selected && <FontAwesomeIcon icon="check" />}
+    </div>
+  );
+};
+
+MultiSelect.propTypes = {
+  listItems: PropTypes.array,
+  value: PropTypes.array,
+  placeholder: PropTypes.string,
+  onChange: PropTypes.func.isRequired
+};
+
+MultiSelect.defaultProps = {
+  listItems: [],
+  value: [],
+  placeholder: ''
+};
+
+MultiSelectOption.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  label: PropTypes.string,
+  onClick: PropTypes.func.isRequired,
+  onKeyPress: PropTypes.func,
+  selected: PropTypes.bool
+};
+
+MultiSelectOption.defaultProps = {
+  value: undefined,
+  label: '',
+  onKeyPress: undefined,
+  selected: false
+};

--- a/grid-ui/saplings/product/src/components/MultiSelect.scss
+++ b/grid-ui/saplings/product/src/components/MultiSelect.scss
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#product-sapling {
+  .multi-select-wrapper {
+    position: relative;
+    width: 100%;
+    margin-top: 0.5rem;
+    padding: 1rem 0 0;
+
+    .multi-select-header {
+      display: flex;
+      justify-content: space-between;
+      width: 100%;
+      height: calc(2rem + 2px);
+      border: 1px solid #333333;
+      padding: 0.5rem;
+      margin-left: 1px;
+      background: transparent;
+      outline: none;
+      transition: border-color 0.2s;
+      font-size: 1rem;
+
+      .multi-select-header-text {
+        flex-basis: 0 1 100%;
+      }
+    }
+
+    .multi-select-options-list {
+      width: 100%;
+      max-height: calc(8rem + 0.5rem);
+      overflow-y: auto;
+      border: 1px solid #555555;
+      border-top-width: 0;
+      padding: 0;
+      margin: 0 0 0 1px;
+
+      .multi-select-option {
+        width: 100%;
+        padding: 0.5rem;
+        display: flex;
+        justify-content: space-between;
+
+        &:not(:last-of-type) {
+          border-bottom: 1px solid #555555;
+        }
+
+        &:hover {
+          background: rgba(0, 0, 0, 0.1);
+        }
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/product/src/components/MultiStepForm.js
+++ b/grid-ui/saplings/product/src/components/MultiStepForm.js
@@ -1,0 +1,205 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Input } from './Input';
+
+import './MultiStepForm.scss';
+
+export function StepInput({
+  type,
+  accept,
+  label,
+  id,
+  name,
+  value,
+  pattern,
+  onChange,
+  required,
+  multiple,
+  children
+}) {
+  return (
+    <Input
+      type={type}
+      accept={accept}
+      label={label}
+      id={id}
+      name={name}
+      value={value}
+      pattern={pattern}
+      onChange={onChange}
+      multiple={multiple}
+      required={required}
+    >
+      {children}
+    </Input>
+  );
+}
+
+export function Step({ step, currentStep, children }) {
+  if (step !== currentStep) {
+    return null;
+  }
+  return <div className="step">{children}</div>;
+}
+
+export function MultiStepForm({
+  formName,
+  handleSubmit,
+  style,
+  disabled,
+  error,
+  children
+}) {
+  const [step, setStep] = useState(1);
+
+  const previous = e => {
+    e.preventDefault();
+    setStep(step - 1);
+  };
+
+  const next = e => {
+    e.preventDefault();
+    setStep(step + 1);
+  };
+
+  const submit = () => {
+    handleSubmit();
+    setStep(1);
+  };
+
+  return (
+    <div className="multiStepForm" style={style}>
+      <div className="info">
+        <h5>{formName}</h5>
+        <div className="stepCounter">
+          <div
+            className="progressTracker"
+            style={{
+              '--form-progress': `${((step - 1) / (children.length - 1)) *
+                100}%`
+            }}
+          />
+          <div className="steps">
+            {children.map((s, i) => (
+              <div
+                className={classnames(
+                  'step',
+                  i === step - 1 && 'active',
+                  i < step - 1 && 'entered'
+                )}
+              >
+                <div className="stepBox">
+                  {i < step - 1 && <FontAwesomeIcon icon="check" />}
+                </div>
+                <span className="stepLabel">{s.props.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="formWrapper">
+        <form>
+          {children.map(child =>
+            React.cloneElement(child, { currentStep: step })
+          )}
+        </form>
+        <div className="actions">
+          {step > 1 && (
+            <button type="button" onClick={previous}>
+              Previous
+            </button>
+          )}
+          {step < children.length && (
+            <button type="button" className="confirm" onClick={next}>
+              Next
+            </button>
+          )}
+          {step === children.length && (
+            <button
+              type="button"
+              onClick={submit}
+              className="submit"
+              disabled={disabled || error}
+            >
+              Submit
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+StepInput.propTypes = {
+  type: PropTypes.oneOf(['text', 'password', 'file', 'select', 'number']),
+  accept: PropTypes.string,
+  label: PropTypes.string,
+  id: PropTypes.string,
+  name: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  pattern: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  required: PropTypes.bool,
+  multiple: PropTypes.bool,
+  children: PropTypes.node
+};
+
+StepInput.defaultProps = {
+  type: 'text',
+  accept: undefined,
+  label: '',
+  id: undefined,
+  name: undefined,
+  value: null,
+  pattern: undefined,
+  required: false,
+  multiple: false,
+  children: undefined
+};
+
+Step.propTypes = {
+  step: PropTypes.number,
+  currentStep: PropTypes.number,
+  children: PropTypes.node
+};
+
+Step.defaultProps = {
+  step: 1,
+  currentStep: 1,
+  children: undefined
+};
+
+MultiStepForm.propTypes = {
+  formName: PropTypes.string,
+  handleSubmit: PropTypes.func.isRequired,
+  style: PropTypes.object,
+  disabled: PropTypes.bool,
+  error: PropTypes.bool,
+  children: PropTypes.node
+};
+
+MultiStepForm.defaultProps = {
+  formName: '',
+  style: undefined,
+  disabled: false,
+  error: false,
+  children: undefined
+};

--- a/grid-ui/saplings/product/src/components/MultiStepForm.scss
+++ b/grid-ui/saplings/product/src/components/MultiStepForm.scss
@@ -1,0 +1,209 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#product-sapling {
+  .multiStepForm {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: flex-start;
+    width: 100%;
+
+    .divider {
+      width: 100%;
+      background: var(--color-grey);
+      height: 2px;
+      margin: 2rem 0 0;
+    }
+
+    .info {
+      width: 30%;
+      min-width: 200px;
+      height: 100%;
+      padding: 0 48px;
+      display: flex;
+      flex-direction: column;
+      background: #333333;
+      color: #ffffff;
+      border-radius: 5px 0 0 5px;
+
+      > h5 {
+        display: inline-block;
+        width: 100%;
+        border-bottom: 1px solid #ffffff;
+        margin: 36px 0;
+      }
+
+      .stepCounter {
+        width: 100%;
+        height: 60%;
+
+        .progressTracker {
+          height: 100%;
+          width: 1.5px;
+          background: #555555;
+          position: relative;
+          top: 0;
+          left: 0.75rem;
+          transform: translateX(-50%);
+
+          &:after {
+            display: block;
+            content: '';
+            height: var(--form-progress);
+            width: 3px;
+            transform: translateX(-50%);
+            background: var(--color-primary);
+            transition: height 1s;
+          }
+        }
+
+        .steps {
+          height: 100%;
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+          transform: translateY(-100%);
+
+          .step {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            max-height: 1.5rem;
+
+            .stepBox {
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              width: 1.5rem;
+              min-width: 1.5rem;
+              height: 1.5rem;
+              min-height: 1.5rem;
+              border: 1px solid #555;
+              background-color: #333333;
+              color: #555;
+              transition: all 0.3s;
+            }
+
+            .stepLabel {
+              padding-left: 0.5rem;
+              font-weight: 300;
+              font-style: italic;
+              color: rgba(255, 255, 255, 0.6);
+            }
+
+            &.active {
+              .stepBox {
+                border: 1px solid var(--color-primary);
+              }
+
+              .stepLabel {
+                color: var(--color-primary);
+              }
+            }
+
+            &.entered {
+              .stepBox {
+                border-color: var(--color-primary);
+                background: var(--color-primary);
+                color: #ffffff;
+              }
+
+              .stepLabel {
+                font-weight: 400;
+                font-style: normal;
+                color: #ffffff;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    .formWrapper {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      flex: 0 1 100%;
+      align-items: center;
+      justify-content: space-between;
+
+      form {
+        display: flex;
+        flex-direction: column;
+        flex: 0 1 100%;
+        width: 100%;
+        padding: 0 5%;
+        overflow-y: auto;
+
+        .step {
+          display: flex;
+          flex-direction: column;
+          margin-top: 1rem;
+        }
+
+        .form-group {
+          width: 100%;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: wrap;
+
+          .grid-input {
+            flex: 0 1 40%;
+
+            &:not(:last-child) {
+              margin-right: 5%;
+            }
+          }
+
+          button {
+            height: 34px;
+            margin-top: 1.5rem;
+          }
+        }
+      }
+
+      .actions {
+        display: flex;
+        width: 90%;
+        flex-direction: row;
+        justify-content: flex-end;
+        padding: 1.5rem 0;
+        border-top: 1px solid #555555;
+
+        > * {
+          margin: 0 0.5rem;
+        }
+      }
+    }
+
+    h6 {
+      margin: 1rem 0;
+    }
+
+    button {
+      height: 38px;
+      width: fit-content;
+      border: 1px solid inset var(--color-grey);
+
+      &.confirm,
+      &.submit {
+        background: var(--color-secondary);
+        border: none;
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/product/src/components/ProductCard.scss
+++ b/grid-ui/saplings/product/src/components/ProductCard.scss
@@ -28,7 +28,6 @@
 
   .product-card-edit-button {
     position: absolute;
-    z-index: 10;
     padding: 0;
     top: 0.8rem;
     right: 0.8rem;

--- a/grid-ui/saplings/product/src/components/ProductsTable.js
+++ b/grid-ui/saplings/product/src/components/ProductsTable.js
@@ -15,6 +15,8 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useServiceState } from '../state/service-context';
 
 import './ProductsTable.scss';
@@ -22,7 +24,7 @@ import ProductCard from './ProductCard';
 import mockProducts from '../test/mock-products';
 import { getProperty } from '../data/property-parsing';
 
-function ProductsTable() {
+function ProductsTable({ actions }) {
   const [products, setProducts] = useState(mockProducts);
   const { selectedService } = useServiceState();
 
@@ -56,8 +58,19 @@ function ProductsTable() {
         <hr />
       </div>
       <div className="products-table">{productCards}</div>
+      <button
+        className="fab add-product"
+        type="button"
+        onClick={actions.addProduct}
+      >
+        <FontAwesomeIcon icon="plus" />
+      </button>
     </div>
   );
 }
+
+ProductsTable.propTypes = {
+  actions: PropTypes.object.isRequired
+};
 
 export default ProductsTable;

--- a/grid-ui/saplings/product/src/components/forms.scss
+++ b/grid-ui/saplings/product/src/components/forms.scss
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#product-sapling {
+  .modalForm {
+    z-index: 2;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(51, 51, 51, 0.85);
+
+    .close {
+      position: absolute;
+      top: 2rem;
+      right: 2rem;
+      color: #fff;
+      font-size: 2rem;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+
+    .content {
+      display: flex;
+      background: #ffffff;
+      border-radius: 5px;
+      width: 78%;
+      height: 60%;
+      position: relative;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+
+      .error-messages {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        border: 1px solid var(--color-failure);
+        padding: 1rem;
+        color: var(--color-failure);
+      }
+    }
+
+    .dd-wrapper {
+      margin-left: 0;
+    }
+  }
+
+  .chip-data {
+    .attribute-data {
+      margin-top: 8px;
+      min-width: 120px;
+      width: fit-content;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      background: var(--color-dark-grey);
+      padding: 8px;
+      border-radius: 3px;
+
+      .name {
+        color: rgba(255, 255, 255, 0.7);
+      }
+
+      .type {
+        font-weight: 300;
+        font-style: italic;
+        font-size: 0.66rem;
+        margin: 0.34rem 0 0 0.25rem;
+        color: rgba(255, 255, 255, 0.4);
+      }
+
+      .value {
+        width: 100%;
+        color: rgb(255, 255, 255);
+      }
+    }
+  }
+
+  .preview-container {
+    width: 100%;
+    padding: 1rem;
+    display: flex;
+    justify-content: center;
+
+    .img-preview {
+      display: block;
+      width: auto;
+      height: auto;
+      max-width: 250px;
+      max-height: 312px;
+    }
+  }
+}


### PR DESCRIPTION
This adds the view for the form to add products in the Product sapling for a selected group of services. It is not currently hooked up to gridd. This PR also includes several components and config updates required for building this form.

## Testing

* Run `export 'CARGO_ARGS=-- --features experimental'` from the Grid directory
* Run `docker-compose -f grid-ui/docker/docker-compose.yaml build gridd grid-db splinter-db splinterd`
* Run `docker-compose -f grid-ui/docker/docker-compose.yaml up gridd grid-db splinter-db splinterd`
* Navigate to the `grid/grid-ui` directory
* Run `npm install`
* Navigate to any of the sapling directories that are required for testing, in this case `grid/grid-ui/saplings/product`, and run `npm install && npm run deploy` in them.
* Navigate back to the `grid/grid-ui` directory and run `npm run start`
* Once the app opens in the browser navigate to the profile sapling by clicking the icon in the bottom of the nav bar