### PR TITLE
Add product info view

### DIFF
--- a/grid-ui/saplings/product/package.json
+++ b/grid-ui/saplings/product/package.json
@@ -37,7 +37,7 @@
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "3.4.0",
+    "react-scripts": "^3.4.0",
     "rewire": "^4.0.1",
     "splinter-saplingjs": "github:cargill/splinter-saplingjs#master"
   },

--- a/grid-ui/saplings/product/package.json
+++ b/grid-ui/saplings/product/package.json
@@ -36,6 +36,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
+    "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.0",
     "rewire": "^4.0.1",
     "splinter-saplingjs": "github:cargill/splinter-saplingjs#master"

--- a/grid-ui/saplings/product/src/App.js
+++ b/grid-ui/saplings/product/src/App.js
@@ -20,7 +20,8 @@ import {
   faCaretUp,
   faCaretDown,
   faCheck,
-  faPenSquare
+  faPenSquare,
+  faChevronLeft
 } from '@fortawesome/free-solid-svg-icons';
 
 import { ServiceProvider } from './state/service-context';

--- a/grid-ui/saplings/product/src/App.js
+++ b/grid-ui/saplings/product/src/App.js
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import {
   faCaretUp,
@@ -27,16 +28,26 @@ import {
 import { ServiceProvider } from './state/service-context';
 import FilterBar from './components/FilterBar';
 import ProductsTable from './components/ProductsTable';
+import ProductInfo from './components/ProductInfo';
 import './App.scss';
 
-library.add(faCaretUp, faCaretDown, faCheck, faPenSquare);
+library.add(faCaretUp, faCaretDown, faCheck, faPenSquare, faChevronLeft);
 
 function App() {
   return (
     <ServiceProvider>
       <div className="product-app">
         <FilterBar />
-        <ProductsTable />
+        <Router>
+          <Switch>
+            <Route exact path="/product">
+              <ProductsTable />
+            </Route>
+            <Route path="/product/products/:id">
+              <ProductInfo />
+            </Route>
+          </Switch>
+        </Router>
       </div>
     </ServiceProvider>
   );

--- a/grid-ui/saplings/product/src/App.scss
+++ b/grid-ui/saplings/product/src/App.scss
@@ -19,3 +19,7 @@
   display: flex;
   flex-direction: column;
 }
+
+.link {
+  text-decoration: none;
+}

--- a/grid-ui/saplings/product/src/components/ProductCard.js
+++ b/grid-ui/saplings/product/src/components/ProductCard.js
@@ -15,34 +15,38 @@
  */
 
 import React from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import ProductProperty from './ProductProperty';
 import './ProductCard.scss';
 
 function ProductCard(props) {
-  const { gtin, name, owner, imageURL } = props;
-
+  const { productID, gtin, name, owner, imageURL } = props;
   return (
     <div className="product-card">
       <button type="button" className="product-card-edit-button">
         <FontAwesomeIcon className="icon" icon="pen-square" />
       </button>
-      <div className="product-card-content">
-        <div className="product-card-properties">
-          <Property label="GTIN" value={gtin} />
-          <Property label="Product Name" value={name} />
-          <Property label="Owner" value={owner} />
+      <Link className="link" to={`/product/products/${productID}`}>
+        <div className="product-card-content">
+          <div className="product-card-properties">
+            <ProductProperty label="GTIN" value={gtin} />
+            <ProductProperty label="Product Name" value={name} />
+            <ProductProperty label="Owner" value={owner} />
+          </div>
+          {imageURL && (
+            <img className="product-card-image" src={imageURL} alt={name} />
+          )}
         </div>
-        {imageURL && (
-          <img className="product-card-image" src={imageURL} alt={name} />
-        )}
-      </div>
+      </Link>
     </div>
   );
 }
 
 ProductCard.propTypes = {
+  productID: PropTypes.string.isRequired,
   gtin: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   owner: PropTypes.string.isRequired,
@@ -51,22 +55,6 @@ ProductCard.propTypes = {
 
 ProductCard.defaultProps = {
   imageURL: null
-};
-
-function Property(props) {
-  const { label, value } = props;
-
-  return (
-    <div className="product-card-property">
-      <div className="label">{label}</div>
-      <div className="value">{value}</div>
-    </div>
-  );
-}
-
-Property.propTypes = {
-  label: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired
 };
 
 export default ProductCard;

--- a/grid-ui/saplings/product/src/components/ProductCard.scss
+++ b/grid-ui/saplings/product/src/components/ProductCard.scss
@@ -20,6 +20,7 @@
   border-radius: 5px;
   padding: 0.8rem;
   height: 12rem;
+  overflow: hidden;
 
   &:hover {
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
@@ -55,20 +56,6 @@
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-
-      .product-card-property {
-        display: flex;
-        flex-direction: column;
-
-        .label {
-          color: var(--color-grey);
-          font-weight: 300;
-        }
-
-        .value {
-          font-size: 1.3rem;
-        }
-      }
     }
 
     .product-card-image {

--- a/grid-ui/saplings/product/src/components/ProductInfo.js
+++ b/grid-ui/saplings/product/src/components/ProductInfo.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useParams, Link } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { getProperty } from '../data/property-parsing';
+import mockProducts from '../test/mock-products';
+import ProductProperty from './ProductProperty';
+import './ProductInfo.scss';
+
+function ProductInfo() {
+  const { id } = useParams();
+  const [product, setProduct] = useState({ properties: [] });
+
+  useEffect(() => {
+    const result = mockProducts.find(p => p.product_id === id);
+    if (result) {
+      setProduct(result);
+    }
+  }, [id]);
+
+  const imageURL = getProperty('image_url', product.properties);
+
+  return (
+    <div className="product-info-container">
+      {imageURL && (
+        <img src={imageURL} alt={product.id} className="product-image" />
+      )}
+      <ProductOverview
+        gtin={getProperty('gtin', product.properties) || 'Unknown'}
+        productName={
+          getProperty('product_name', product.properties) || 'Unknown'
+        }
+        owner={product.owner || 'Unknown'}
+      />
+      <ProductProperties propertiesList={product.properties} />
+    </div>
+  );
+}
+
+function ProductOverview(props) {
+  const { gtin, productName, owner } = props;
+
+  return (
+    <div className="product-overview-container">
+      <Link className="back-link" to="/product">
+        <FontAwesomeIcon icon="chevron-left" />
+        <span className="back-link-text">Back</span>
+      </Link>
+      <ProductProperty className="large light" label="GTIN" value={gtin} />
+      <ProductProperty
+        className="large light"
+        label="Product Name"
+        value={productName}
+      />
+      <ProductProperty className="large light" label="Owner" value={owner} />
+    </div>
+  );
+}
+
+ProductOverview.propTypes = {
+  gtin: PropTypes.string.isRequired,
+  productName: PropTypes.string.isRequired,
+  owner: PropTypes.string.isRequired
+};
+
+function ProductProperties(props) {
+  const { propertiesList } = props;
+
+  const primaryProperties = [
+    { name: 'brand_name', data_type: 'STRING', label: 'Brand Name' },
+    {
+      name: 'product_description',
+      data_type: 'STRING',
+      label: 'Product Description'
+    },
+    { name: 'gpc', label: 'GPC' },
+    { name: 'net_content', label: 'Net Content' },
+    { name: 'target_market', label: 'Target Market' }
+  ];
+
+  const productProperties = primaryProperties.map(property => {
+    const propertyValue = getProperty(property.name, propertiesList);
+
+    if (propertyValue) {
+      return (
+        <ProductProperty
+          className="large"
+          label={property.label}
+          value={propertyValue}
+        />
+      );
+    }
+    return <></>;
+  });
+
+  return (
+    <div className="product-properties-container">
+      <div className="product-properties-header">
+        <h5 className="title">Product Info</h5>
+        <hr />
+      </div>
+      <div className="product-properties-list">{productProperties}</div>
+      <button type="button" className="full-info-button">
+        VIEW FULL PRODUCT INFO
+      </button>
+    </div>
+  );
+}
+
+ProductProperties.propTypes = {
+  propertiesList: PropTypes.arrayOf(PropTypes.object).isRequired
+};
+
+export default ProductInfo;

--- a/grid-ui/saplings/product/src/components/ProductInfo.scss
+++ b/grid-ui/saplings/product/src/components/ProductInfo.scss
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.product-info-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+
+  .product-image {
+    position: absolute;
+    align-self: center;
+    object-fit: contain;
+    height: 15rem;
+    width: 15rem;
+    border-radius: 50%;
+    top: 50%;
+    left: 44%;
+    transform: translate(-50%, -50%);
+    background-color: white;
+    border: 5px solid var(--color-dark-grey);
+  }
+
+  .product-overview-container {
+    padding: 0rem 3rem 3rem 1rem;
+    padding-right: 8rem;
+    height: 100%;
+    width: 40%;
+    background-color: var(--color-dark-grey);
+
+    .back-link {
+      display: flex;
+      color: rgba(255, 255, 255, 0.7);
+      width: fit-content;
+      height: 3rem;
+      font-size: 1.25rem;
+      align-items: center;
+      text-decoration: none;
+
+      &:hover {
+        color: rgba(255, 255, 255, 0.9);
+      }
+
+      .back-link-text {
+        margin-left: 0.5rem;
+      }
+    }
+
+    .product-property {
+      margin-left: 2rem;
+
+      &:not(:last-child) {
+        margin-bottom: 1.5rem;
+      }
+    }
+  }
+
+  .product-properties-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 60%;
+    padding: 3rem;
+    padding-left: 8rem;
+
+    .product-properties-header {
+      margin-bottom: 2rem;
+
+      .title {
+        margin: 0;
+      }
+
+      hr {
+        border-top: 2px solid var(--color-dark-grey);
+        margin-left: 0;
+        margin-bottom: 1rem;
+        width: 12rem;
+      }
+    }
+
+    .product-properties-list {
+      display: flex;
+      flex-wrap: wrap;
+
+      .product-property {
+        min-width: 10rem;
+        margin-right: 4rem;
+
+        &:not(:last-child) {
+          margin-bottom: 1.5rem;
+        }
+      }
+    }
+
+    .full-info-button {
+      cursor: pointer;
+      margin-top: auto;
+      align-self: center;
+      width: 30rem;
+      height: 6rem;
+      border: 6px solid #f35f19;
+      border-radius: 4px;
+      font-size: 1.5rem;
+    }
+  }
+}

--- a/grid-ui/saplings/product/src/components/ProductProperty.js
+++ b/grid-ui/saplings/product/src/components/ProductProperty.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './ProductProperty.scss';
+
+function ProductProperty(props) {
+  const { label, value, className } = props;
+
+  return (
+    <div className={`product-property ${className}`}>
+      <div className="label">{label}</div>
+      <div className="value">{value}</div>
+    </div>
+  );
+}
+
+ProductProperty.defaultProps = {
+  className: ''
+};
+
+ProductProperty.propTypes = {
+  className: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired
+};
+
+export default ProductProperty;

--- a/grid-ui/saplings/product/src/components/ProductProperty.scss
+++ b/grid-ui/saplings/product/src/components/ProductProperty.scss
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.product-property {
+  display: flex;
+  flex-direction: column;
+
+  .label {
+    color: var(--color-grey);
+    font-weight: 300;
+    margin-bottom: 0.25rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .value {
+    color: var(--color-dark-grey);
+    font-size: 1.5rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &.large {
+    .label {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .value {
+      font-size: 2.25rem;
+    }
+  }
+
+  &.light {
+    .label {
+      color: rgba(255, 255, 255, 0.9);
+    }
+
+    .value {
+      color: rgba(255, 255, 255, 0.9);
+    }
+  }
+}

--- a/grid-ui/saplings/product/src/components/ProductsTable.js
+++ b/grid-ui/saplings/product/src/components/ProductsTable.js
@@ -20,6 +20,7 @@ import { useServiceState } from '../state/service-context';
 import './ProductsTable.scss';
 import ProductCard from './ProductCard';
 import mockProducts from '../test/mock-products';
+import { getProperty } from '../data/property-parsing';
 
 function ProductsTable() {
   const [products, setProducts] = useState(mockProducts);
@@ -36,18 +37,14 @@ function ProductsTable() {
   }, [selectedService]);
 
   const productCards = products.map(product => {
-    const findProperty = name => {
-      const property = product.properties.find(p => p.name === name);
-      return property ? property.string_value : null;
-    };
-
     return (
       <ProductCard
-        key={`${findProperty('gtin')}_${product.service_id}`}
-        gtin={findProperty('gtin')}
-        name={findProperty('product_name')}
+        key={product.product_id}
+        productID={product.product_id}
+        gtin={getProperty('gtin', product.properties)}
+        name={getProperty('product_name', product.properties)}
         owner={product.owner}
-        imageURL={findProperty('image_url')}
+        imageURL={getProperty('image_url', product.properties)}
       />
     );
   });

--- a/grid-ui/saplings/product/src/data/property-parsing.js
+++ b/grid-ui/saplings/product/src/data/property-parsing.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const getProperty = (name, propertyList) => {
+  const property = propertyList.find(p => p.name === name);
+  if (property === undefined) {
+    return null;
+  }
+
+  switch (property.data_type) {
+    case 'STRING':
+      return property.string_value;
+    case 'NUMBER':
+      return property.number_value;
+    default:
+      throw Error(`unsupported property type: ${property.data_type}`);
+  }
+};

--- a/grid-ui/saplings/product/src/test/mock-products.js
+++ b/grid-ui/saplings/product/src/test/mock-products.js
@@ -22,16 +22,44 @@ export default [
     properties: [
       {
         name: 'product_name',
+        data_type: 'STRING',
         string_value: 'Canola Oil'
       },
       {
         name: 'gtin',
-        string_value: '00012345600012'
+        data_type: 'NUMBER',
+        number_value: '00012345600012'
       },
       {
         name: 'image_url',
+        data_type: 'STRING',
         string_value:
           'https://target.scene7.com/is/image/Target/GUEST_e8106dc8-b312-49d3-b9f5-ae4f01553452?fmt=webp&wid=1400&qlt=80'
+      },
+      {
+        name: 'brand_name',
+        data_type: 'STRING',
+        string_value: 'Market Pantry'
+      },
+      {
+        name: 'product_description',
+        data_type: 'STRING',
+        string_value: 'Market Pantry Canola Oil 48oz'
+      },
+      {
+        name: 'gpc',
+        data_type: 'NUMBER',
+        number_value: '30002914'
+      },
+      {
+        name: 'net_content',
+        data_type: 'STRING',
+        string_value: '48oz'
+      },
+      {
+        name: 'target_market',
+        data_type: 'NUMBER',
+        number_value: '840'
       }
     ]
   },
@@ -42,16 +70,44 @@ export default [
     properties: [
       {
         name: 'product_name',
+        data_type: 'STRING',
         string_value: 'Truvia 80 ct.'
       },
       {
         name: 'gtin',
-        string_value: '00012345600099'
+        data_type: 'NUMBER',
+        number_value: '00012345600099'
       },
       {
         name: 'image_url',
+        data_type: 'STRING',
         string_value:
           'https://target.scene7.com/is/image/Target/GUEST_b7a6e983-b391-40a5-ad89-2f906bce5743?fmt=webp&wid=1400&qlt=80'
+      },
+      {
+        name: 'brand_name',
+        data_type: 'STRING',
+        string_value: 'Truvia'
+      },
+      {
+        name: 'product_description',
+        data_type: 'STRING',
+        string_value: 'Truvia Sugar 80CT'
+      },
+      {
+        name: 'gpc',
+        data_type: 'NUMBER',
+        number_value: '30016951'
+      },
+      {
+        name: 'net_content',
+        data_type: 'STRING',
+        string_value: '80CT'
+      },
+      {
+        name: 'target_market',
+        data_type: 'NUMBER',
+        number_value: '840'
       }
     ]
   },
@@ -62,11 +118,13 @@ export default [
     properties: [
       {
         name: 'product_name',
+        data_type: 'STRING',
         string_value: 'Anonymous Product'
       },
       {
         name: 'gtin',
-        string_value: '00000000000001'
+        data_type: 'NUMBER',
+        number_value: '00000000000001'
       }
     ]
   }

--- a/grid-ui/src/theme/typography.scss
+++ b/grid-ui/src/theme/typography.scss
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-@import url('https://fonts.googleapis.com/css?family=Roboto:400,400i,700|Roboto+Mono:400,700&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700|Roboto+Mono:400,700&display=swap');
 
 :root {
   --fontFamily-primary: 'Roboto', 'Helvetica', sans-serif;


### PR DESCRIPTION
Adds a product info view to the Product sapling. This view is accessible by clicking any of the product cards.

To test, run the following commands from the Grid repo:

`$ export 'CARGO_ARGS=-- --features experimental'`

`$ docker-compose -f grid-ui/docker/docker-compose.yaml up --build`

The UI is available on localhost:3030. The log in/register page should be visible. Try registering as a new user. Once you are logged in, the main Grid UI view will load.

Click the link to the product sapling on the nav bar. The UI should display several mock products. To access the product info view, click any of the product cards.