### PR TITLE
Update `circuit create` to `circuit propose`

### DIFF
--- a/examples/splinter/README.md
+++ b/examples/splinter/README.md
@@ -74,10 +74,10 @@ circuit is created.
    root@splinterd-alpha:/# echo "<public key>" > gridd.pub
    ```
 
-4. Propose a new circuit with the definition `circuit create` CLI command.
+4. Propose a new circuit with the definition `circuit propose` CLI command.
 
    ```
-   root@splinterd-alpha:/# splinter circuit create \
+   root@splinterd-alpha:/# splinter circuit propose \
       --key /key_registry_shared/alpha.priv \
       --url http://splinterd-alpha:8085  \
       --node alpha-node-000::tls://splinterd-alpha:8044 \


### PR DESCRIPTION
Updates the `circuit create` command to `circuit propose` in the
Grid-on-Splinter documentation, since this has been changed in the
Splinter CLI.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

This PR should not be merged until the corresponding change in splinter has been merged: https://github.com/Cargill/splinter/pull/609