### PR TITLE
Add delete product form

### DIFF
--- a/grid-ui/saplings/product/src/App.js
+++ b/grid-ui/saplings/product/src/App.js
@@ -25,7 +25,8 @@ import {
   faChevronLeft,
   faPlus,
   faTimes,
-  faSpinner
+  faSpinner,
+  faTrashAlt
 } from '@fortawesome/free-solid-svg-icons';
 import { ToastProvider } from 'react-toast-notifications';
 
@@ -35,6 +36,7 @@ import ProductsTable from './components/ProductsTable';
 import ProductInfo from './components/ProductInfo';
 import { AddProductForm } from './components/AddProductForm';
 import { EditProductForm } from './components/EditProductForm';
+import { DeleteProductForm } from './components/DeleteProductForm';
 import './App.scss';
 
 library.add(
@@ -45,7 +47,8 @@ library.add(
   faChevronLeft,
   faPlus,
   faTimes,
-  faSpinner
+  faSpinner,
+  faTrashAlt
 );
 
 function App() {
@@ -74,6 +77,15 @@ function App() {
     });
   }
 
+  function deleteProduct(gtin) {
+    setActiveForm({
+      formName: 'delete-product',
+      params: {
+        gtin
+      }
+    });
+  }
+
   function openForm(form) {
     const adata = { ...form.params } || {};
     switch (form.formName) {
@@ -91,6 +103,13 @@ function App() {
             service={adata.service}
           />
         );
+      case 'delete-product':
+        return (
+          <DeleteProductForm
+            closeFn={() => setActiveForm(initialFormState)}
+            gtin={adata.gtin}
+          />
+        );
       default:
     }
     return null;
@@ -104,7 +123,7 @@ function App() {
           <Router>
             <Switch>
               <Route exact path="/product">
-                <ProductsTable actions={{ addProduct, editProduct }} />
+                <ProductsTable actions={{ addProduct, editProduct, deleteProduct }} />
               </Route>
               <Route path="/product/products/:id">
                 <ProductInfo />

--- a/grid-ui/saplings/product/src/components/DeleteProductForm.js
+++ b/grid-ui/saplings/product/src/components/DeleteProductForm.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { SimpleForm } from './SimpleForm';
+import { Input } from './Input';
+
+import './DeleteProductForm.scss';
+import './forms.scss';
+
+export function DeleteProductForm({ closeFn, gtin }) {
+  const [confirmGtin, setConfirmGtin] = useState('');
+  const [valid, setValid] = useState(false);
+  const [errors, setErrors] = useState([]);
+
+  const gtinValidator = '\\b\\d{8}(?:\\d{4,6})?\\b';
+
+  const handleChange = e => {
+    const { value, validity } = e.target;
+    setConfirmGtin(value);
+    setValid(value === '' && validity.valid ? false : validity.valid);
+    setErrors(value === gtin ? [] : ['GTIN values do not match']);
+  };
+
+  const reset = () => {
+    setConfirmGtin('');
+    setValid(false);
+    setErrors([]);
+  };
+
+  const submit = () => {
+    reset();
+    closeFn();
+  };
+
+  return (
+    <div id="delete-product-form" className="modalForm">
+      <FontAwesomeIcon icon="times" className="close" onClick={closeFn} />
+      <div className="content">
+        <SimpleForm
+          formName="Delete Product"
+          handleSubmit={submit}
+          disabled={!valid || !!errors.length}
+        >
+          <div id="delete-warning">
+            <span>Are you sure you want to delete product:</span>
+            <span id="gtin-label">
+              GTIN: <span id="gtin">{gtin}</span>
+            </span>
+            <span>
+              You cannot undo this action. Please re-enter the GTIN below to
+              confirm.
+            </span>
+            <Input
+              type="text"
+              label="GTIN"
+              name="gtin"
+              value={confirmGtin}
+              pattern={gtinValidator}
+              onChange={handleChange}
+            />
+          </div>
+          {!!errors.length && (
+            <div className="error-messages">
+              {errors.map(error => (
+                <span>{error}</span>
+              ))}
+            </div>
+          )}
+        </SimpleForm>
+      </div>
+    </div>
+  );
+}
+
+DeleteProductForm.propTypes = {
+  closeFn: PropTypes.func.isRequired,
+  gtin: PropTypes.string.isRequired
+};

--- a/grid-ui/saplings/product/src/components/DeleteProductForm.scss
+++ b/grid-ui/saplings/product/src/components/DeleteProductForm.scss
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#product-sapling {
+  #delete-product-form {
+    #delete-warning {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      align-items: center;
+      width: 100%;
+      margin: 10% 0;
+      padding: 1rem;
+      border: 1px solid var(--color-failure);
+      border-radius: 5px;
+
+      > span {
+        padding: 1rem 0;
+      }
+
+      #gtin-label {
+        font-size: 1.5rem;
+
+        #gtin {
+          font-size: 2rem;
+          font-weight: bold;
+        }
+      }
+
+      .grid-input {
+        max-width: 550px;
+        padding-bottom: 24px;
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/product/src/components/ProductCard.js
+++ b/grid-ui/saplings/product/src/components/ProductCard.js
@@ -23,10 +23,17 @@ import ProductProperty from './ProductProperty';
 import './ProductCard.scss';
 
 function ProductCard(props) {
-  const { gtin, name, service, owner, imageURL, editFn, properties } = props;
+  const { gtin, name, service, owner, imageURL, editFn, deleteFn, properties } = props;
 
   return (
     <div className="product-card">
+      <button
+        type="button"
+        className="product-card-delete-button"
+        onClick={() => deleteFn(gtin)}
+      >
+        <FontAwesomeIcon className="icon" icon="trash-alt" />
+      </button>
       <button
         type="button"
         className="product-card-edit-button"
@@ -57,6 +64,7 @@ ProductCard.propTypes = {
   service: PropTypes.string.isRequired,
   imageURL: PropTypes.string,
   editFn: PropTypes.func.isRequired,
+  deleteFn: PropTypes.func.isRequired,
   properties: PropTypes.array.isRequired
 };
 

--- a/grid-ui/saplings/product/src/components/ProductCard.scss
+++ b/grid-ui/saplings/product/src/components/ProductCard.scss
@@ -26,6 +26,26 @@
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   }
 
+  .product-card-delete-button {
+    position: absolute;
+    padding: 0;
+    top: 0.8rem;
+    right: 2.4rem;
+    width: 1rem;
+    height: 1rem;
+    border: none;
+    color: var(--color-grey);
+
+    :hover {
+      color: var(--color-dark-grey);
+    }
+
+    .icon {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
+
   .product-card-edit-button {
     position: absolute;
     padding: 0;

--- a/grid-ui/saplings/product/src/components/ProductsTable.js
+++ b/grid-ui/saplings/product/src/components/ProductsTable.js
@@ -60,6 +60,7 @@ function ProductsTable({ actions }) {
         owner={product.owner}
         imageURL={getProperty('image_url', product.properties)}
         editFn={actions.editProduct}
+        deleteFn={actions.deleteProduct}
         properties={product.properties}
       />
     );

--- a/grid-ui/saplings/product/src/components/SimpleForm.js
+++ b/grid-ui/saplings/product/src/components/SimpleForm.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './SimpleForm.scss';
+
+export function SimpleForm({
+  formName,
+  handleSubmit,
+  style,
+  disabled,
+  error,
+  children
+}) {
+  return (
+    <div className="simpleForm" style={style}>
+      <div className="info">
+        <h5>{formName}</h5>
+      </div>
+      <div className="formWrapper">
+        <form>{children}</form>
+        <div className="actions">
+          <button
+            type="button"
+            onClick={handleSubmit}
+            className="submit"
+            disabled={disabled || error}
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+SimpleForm.propTypes = {
+  formName: PropTypes.string,
+  handleSubmit: PropTypes.func.isRequired,
+  style: PropTypes.object,
+  disabled: PropTypes.bool,
+  error: PropTypes.bool,
+  children: PropTypes.node
+};
+
+SimpleForm.defaultProps = {
+  formName: '',
+  style: undefined,
+  disabled: false,
+  error: false,
+  children: undefined
+};

--- a/grid-ui/saplings/product/src/components/SimpleForm.scss
+++ b/grid-ui/saplings/product/src/components/SimpleForm.scss
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#product-sapling {
+  .simpleForm {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: flex-start;
+    width: 100%;
+
+    .divider {
+      width: 100%;
+      background: var(--color-grey);
+      height: 2px;
+      margin: 2rem 0 0;
+    }
+
+    .info {
+      width: 30%;
+      min-width: 200px;
+      height: 100%;
+      padding: 0 48px;
+      display: flex;
+      flex-direction: column;
+      background: #333333;
+      color: #ffffff;
+      border-radius: 5px 0 0 5px;
+
+      > h5 {
+        display: inline-block;
+        width: 100%;
+        border-bottom: 1px solid #ffffff;
+        margin: 36px 0;
+      }
+    }
+
+    .formWrapper {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      flex: 0 1 100%;
+      align-items: center;
+      justify-content: space-between;
+
+      form {
+        display: flex;
+        flex-direction: column;
+        flex: 0 1 100%;
+        width: 100%;
+        padding: 0 5%;
+        overflow-y: auto;
+
+        .form-group {
+          width: 100%;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: wrap;
+
+          .grid-input {
+            flex: 0 1 40%;
+
+            &:not(:last-child) {
+              margin-right: 5%;
+            }
+          }
+
+          button {
+            height: 34px;
+            margin-top: 1.5rem;
+          }
+        }
+      }
+
+      .actions {
+        display: flex;
+        width: 90%;
+        flex-direction: row;
+        justify-content: flex-end;
+        padding: 1.5rem 0;
+        border-top: 1px solid #555555;
+
+        > * {
+          margin: 0 0.5rem;
+        }
+      }
+
+      h6 {
+        margin: 1rem 0;
+      }
+
+      button {
+        height: 38px;
+        width: fit-content;
+        border: 1px solid inset var(--color-grey);
+
+        &.confirm,
+        &.submit {
+          background: var(--color-secondary);
+          border: none;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the view for the form to delete a Grid Product. It is not yet hooked up the Grid daemon. This allows for a user to delete a Product after confirming by re-entering the product's GTIN.

## Testing

* Run `export 'CARGO_ARGS=-- --features experimental'` from the Grid directory
* Run `docker-compose -f grid-ui/docker/docker-compose.yaml build gridd grid-db splinter-db splinterd`
* Run `docker-compose -f grid-ui/docker/docker-compose.yaml up gridd grid-db splinter-db splinterd`
* Navigate to the `grid/grid-ui` directory
* Run `npm install`
* Navigate to any of the sapling directories that are required for testing, in this case `grid/grid-ui/saplings/product`, and run `npm install && npm run deploy` in them.
* Navigate back to the `grid/grid-ui` directory and run `npm run start`
* Once the app opens in the browser navigate to the profile sapling by clicking the icon in the bottom of the nav bar