### PR TITLE
Add product logo

### DIFF
--- a/grid-ui/sapling-dev-server/userSaplings
+++ b/grid-ui/sapling-dev-server/userSaplings
@@ -9,6 +9,6 @@
       "localhost:3030/sapling-dev-server/product/css/product.css"
     ],
     "workerFiles": [],
-    "icon": "https://via.placeholder.com/48/333333/FFFFFF?text=P"
+    "icon": "http://localhost:3030/sapling-dev-server/product/product_logo.svg"
   }
 ]

--- a/grid-ui/saplings/product/package.json
+++ b/grid-ui/saplings/product/package.json
@@ -9,7 +9,7 @@
     "eject": "react-scripts eject",
     "format": "prettier --write \"**/*.+(js|jsx|json|css|scss|md)\"",
     "lint": "eslint .",
-    "add-to-canopy": "mkdir -p ../../sapling-dev-server/product && cp -r ./build/static/* ../../sapling-dev-server/product",
+    "add-to-canopy": "mkdir -p ../../sapling-dev-server/product && cp -r ./build/static/* ../../sapling-dev-server/product && cp product_logo.svg ../../sapling-dev-server/product",
     "deploy": "npm run build && npm run add-to-canopy",
     "watch": "nodemon --ext js,scss,ts,css --watch src --exec npm run deploy"
   },

--- a/grid-ui/saplings/product/product_logo.svg
+++ b/grid-ui/saplings/product/product_logo.svg
@@ -1,0 +1,21 @@
+<!--
+Copyright 2018-2020 Cargill Incorporated
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<svg width="350" height="316" viewBox="0 0 350 316" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M327.955 68.5318L175.204 0.091601C175.074 0.0333247 174.926 0.0333263 174.796 0.0916026L22.045 68.5318C21.6468 68.7102 21.6522 69.2774 22.0538 69.4482L174.804 134.417C174.929 134.47 175.071 134.47 175.196 134.417L327.946 69.4482C328.348 69.2774 328.353 68.7102 327.955 68.5318Z" fill="#222325"/>
+<path d="M0.302708 246.13L162.303 315.701C162.633 315.842 163 315.6 163 315.241V156.331C163 156.13 162.88 155.949 162.695 155.871L0.694912 87.2942C0.365232 87.1546 0 87.3966 0 87.7546V245.671C0 245.87 0.119048 246.051 0.302708 246.13Z" fill="#222325"/>
+<path d="M350 245.671V87.7546C350 87.3966 349.635 87.1546 349.305 87.2942L187.305 155.871C187.12 155.949 187 156.13 187 156.331V315.241C187 315.6 187.367 315.842 187.697 315.701L349.697 246.13C349.881 246.051 350 245.87 350 245.671Z" fill="#F35F19"/>
+</svg>


### PR DESCRIPTION
This replaces the placeholder with an unofficial logo for Grid Product.

<img width="133" alt="Screen Shot 2020-04-06 at 3 23 38 PM" src="https://user-images.githubusercontent.com/27690938/78601578-a0c57780-781a-11ea-9a62-a795a4a86dbd.png">

Signed-off-by: Darian Plumb <dplumb@bitwise.io>


