### PR TITLE
Add properties modal

### DIFF
--- a/grid-ui/saplings/product/src/components/ProductInfo.js
+++ b/grid-ui/saplings/product/src/components/ProductInfo.js
@@ -25,6 +25,7 @@ import ProductProperty from './ProductProperty';
 import { fetchProduct } from '../api/grid';
 import NotFound from './NotFound';
 import Loading from './Loading';
+import PropertyDetailsModal from './PropertyDetailsModal';
 import './ProductInfo.scss';
 
 function ProductInfo() {
@@ -33,6 +34,15 @@ function ProductInfo() {
   const { selectedService } = useServiceState();
   const [loading, setLoading] = useState(false);
   const [notFound, setNotFound] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const closeModal = () => {
+    setModalOpen(false);
+  };
+
+  const openModal = () => {
+    setModalOpen(true);
+  };
 
   useEffect(() => {
     const getProduct = async () => {
@@ -75,12 +85,25 @@ function ProductInfo() {
           }
           owner={product.owner || 'Unknown'}
         />
-        <ProductProperties propertiesList={product.properties} />
+        <ProductProperties
+          propertiesList={product.properties}
+          openModal={openModal}
+        />
       </>
     );
   };
 
-  return <div className="product-info-container">{getContent()}</div>;
+  return (
+    <div className="product-info-container">
+      {modalOpen && (
+        <PropertyDetailsModal
+          closeFn={closeModal}
+          propertiesList={product.properties}
+        />
+      )}
+      {getContent()}
+    </div>
+  );
 }
 
 function ProductOverview(props) {
@@ -110,7 +133,7 @@ ProductOverview.propTypes = {
 };
 
 function ProductProperties(props) {
-  const { propertiesList } = props;
+  const { propertiesList, openModal } = props;
 
   const primaryProperties = [
     { name: 'brand_name', data_type: 'STRING', label: 'Brand Name' },
@@ -146,7 +169,7 @@ function ProductProperties(props) {
         <hr />
       </div>
       <div className="product-properties-list">{productProperties}</div>
-      <button type="button" className="full-info-button">
+      <button type="button" className="full-info-button" onClick={openModal}>
         VIEW FULL PRODUCT INFO
       </button>
     </div>
@@ -154,7 +177,8 @@ function ProductProperties(props) {
 }
 
 ProductProperties.propTypes = {
-  propertiesList: PropTypes.arrayOf(PropTypes.object).isRequired
+  propertiesList: PropTypes.arrayOf(PropTypes.object).isRequired,
+  openModal: PropTypes.func.isRequired
 };
 
 export default ProductInfo;

--- a/grid-ui/saplings/product/src/components/PropertyDetailsModal.js
+++ b/grid-ui/saplings/product/src/components/PropertyDetailsModal.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import PropTypes from 'prop-types';
+
+import { getPropertyValue, formatPropertyName } from '../data/property-parsing';
+import './PropertyDetailsModal.scss';
+
+function PropertyDetailsModal(props) {
+  const { closeFn, propertiesList } = props;
+
+  return (
+    <div className="modalForm">
+      <FontAwesomeIcon icon="times" className="close" onClick={closeFn} />
+      <div className="content propertiesTable-wrapper">
+        <table className="propertiesTable">
+          <tr className="propertiesTable-header">
+            <th>Attribute Name</th>
+            <th>Value</th>
+          </tr>
+          {propertiesList
+            .filter(property => property.name !== 'image_url')
+            .map(property => {
+              let value;
+              try {
+                value = getPropertyValue(property);
+              } catch (e) {
+                console.error(e);
+                value = 'unknown';
+              }
+              return (
+                <PropertyDetailsRow
+                  name={formatPropertyName(property.name)}
+                  value={value}
+                />
+              );
+            })}
+        </table>
+      </div>
+    </div>
+  );
+}
+
+PropertyDetailsModal.propTypes = {
+  closeFn: PropTypes.func.isRequired,
+  propertiesList: PropTypes.array.isRequired
+};
+
+function PropertyDetailsRow(props) {
+  const { name, value } = props;
+
+  return (
+    <tr className="propertiesTable-row">
+      <td>{name}</td>
+      <td>{value}</td>
+    </tr>
+  );
+}
+
+PropertyDetailsRow.propTypes = {
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired
+};
+
+export default PropertyDetailsModal;

--- a/grid-ui/saplings/product/src/components/PropertyDetailsModal.scss
+++ b/grid-ui/saplings/product/src/components/PropertyDetailsModal.scss
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.propertiesTable-wrapper {
+  overflow: auto;
+
+  .propertiesTable {
+    flex-direction: column;
+    border-collapse: collapse;
+    border-spacing: 0;
+    width: 100%;
+    table-layout: fixed;
+    font-size: 1.5rem;
+
+    .propertiesTable-header {
+      height: 5rem;
+      border-bottom: 1px solid var(--color-grey);
+
+      th {
+        font-weight: lighter;
+        text-align: left;
+        padding: 1.5rem;
+        border-right: 1px solid var(--color-grey);
+
+        &:last-child {
+          border: none;
+        }
+      }
+    }
+
+    .propertiesTable-row {
+      height: 4.5rem;
+      border-bottom: 1px solid var(--color-grey);
+
+      &:nth-child(even) {
+        background-color: #e8e8e8;
+      }
+
+      td {
+        font-weight: lighter;
+        text-align: left;
+        padding: 1.5rem;
+      }
+    }
+  }
+}

--- a/grid-ui/saplings/product/src/data/property-parsing.js
+++ b/grid-ui/saplings/product/src/data/property-parsing.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-export const getProperty = (name, propertyList) => {
-  const property = propertyList.find(p => p.name === name);
-  if (property === undefined) {
-    return null;
-  }
-
+/**
+ * Fetch the value of a property.
+ * @param {Object} property - The property object.
+ * @return {string} The value of the property.
+ */
+export const getPropertyValue = property => {
   switch (property.data_type.toLowerCase()) {
     case 'string':
       return property.string_value;
@@ -28,4 +28,28 @@ export const getProperty = (name, propertyList) => {
     default:
       throw Error(`unsupported property type: ${property.data_type}`);
   }
+};
+
+/**
+ * Fetch the value of a given property by name the property name.
+ * @param {string} name - The name of the property.
+ * @param {Array} propertyList - A list of product properties.
+ * @return {string} The value of the property.
+ */
+export const getProperty = (name, propertyList) => {
+  const property = propertyList.find(p => p.name === name);
+  if (property === undefined) {
+    return null;
+  }
+
+  return getPropertyValue(property);
+};
+
+/**
+ * Remove underscores and uppercase a given string.
+ * @param {string} name - The snake case name of a property.
+ * @return {string} The uppercase name of a property.
+ */
+export const formatPropertyName = name => {
+  return name.replace(/_/g, ' ').toUpperCase();
 };

--- a/grid-ui/saplings/product/src/state/service-context.js
+++ b/grid-ui/saplings/product/src/state/service-context.js
@@ -23,13 +23,31 @@ const ServiceDispatchContext = React.createContext();
 const serviceReducer = (state, action) => {
   switch (action.type) {
     case 'select': {
-      return { ...state, selectedService: action.payload.serviceID };
+      const updatedState = {
+        ...state,
+        selectedService: action.payload.serviceID
+      };
+      window.sessionStorage.setItem(
+        'SERVICE_STATE',
+        JSON.stringify(updatedState)
+      );
+      return updatedState;
     }
     case 'selectNone': {
-      return { ...state, selectedService: 'none' };
+      const updatedState = { ...state, selectedService: 'none' };
+      window.sessionStorage.setItem(
+        'SERVICE_STATE',
+        JSON.stringify(updatedState)
+      );
+      return updatedState;
     }
     case 'setServices': {
-      return { ...state, services: action.payload.services };
+      const updatedState = { ...state, services: action.payload.services };
+      window.sessionStorage.setItem(
+        'SERVICE_STATE',
+        JSON.stringify(updatedState)
+      );
+      return updatedState;
     }
     default:
       throw new Error(`unhandled action type: ${action.type}`);
@@ -37,10 +55,15 @@ const serviceReducer = (state, action) => {
 };
 
 function ServiceProvider({ children }) {
-  const [state, dispatch] = React.useReducer(serviceReducer, {
+  const sessionState = window.sessionStorage.getItem('SERVICE_STATE');
+  const defaultState = {
     selectedService: 'none',
     services: []
-  });
+  };
+  const [state, dispatch] = React.useReducer(
+    serviceReducer,
+    sessionState ? JSON.parse(sessionState) : defaultState
+  );
 
   return (
     <ServiceStateContext.Provider value={state}>


### PR DESCRIPTION
Add a modal showing the full view of product properties when the `VIEW FULL PRODUCT INFO` button is clicked.

To support this feature, the service state was added to sessionStorage. This means that you won't have to re-select a service when you refresh the page from a product info view. 