### PR TITLE
Update protocol prefix for TLS transport to tcps://

### DIFF
--- a/examples/splinter/README.md
+++ b/examples/splinter/README.md
@@ -80,8 +80,8 @@ circuit is created.
    root@splinterd-alpha:/# splinter circuit propose \
       --key /key_registry_shared/alpha.priv \
       --url http://splinterd-alpha:8085  \
-      --node alpha-node-000::tls://splinterd-alpha:8044 \
-      --node beta-node-000::tls://splinterd-beta:8044 \
+      --node alpha-node-000::tcps://splinterd-alpha:8044 \
+      --node beta-node-000::tcps://splinterd-beta:8044 \
       --service gsAA::alpha-node-000 \
       --service gsBB::beta-node-000 \
       --service-type *::scabbard \
@@ -113,7 +113,7 @@ circuit is created.
    Proposal to create: 01234-ABCDE
       Management Type: grid
 
-      alpha-node-000 (tls://splinterd-alpha:8044)
+      alpha-node-000 (tcps://splinterd-alpha:8044)
           Vote: ACCEPT (implied as requester):
               <alpha-public-key>
           Service (scabbard): gsAA
@@ -122,7 +122,7 @@ circuit is created.
               peer_services:
                   gsBB
 
-      beta-node-000 (tls://splinterd-beta:8044)
+      beta-node-000 (tcps://splinterd-beta:8044)
           Vote: PENDING
           Service (scabbard): gsBB
               admin_keys:
@@ -161,7 +161,7 @@ circuit is created.
    Proposal to create: 01234-ABCDE
       Management Type: grid
 
-      alpha-node-000 (tls://splinterd-alpha:8044)
+      alpha-node-000 (tcps://splinterd-alpha:8044)
           Vote: ACCEPT (implied as requester):
               <alpha-public-key>
           Service (scabbard): gsAA
@@ -170,7 +170,7 @@ circuit is created.
               peer_services:
                   gsBB
 
-      beta-node-000 (tls://splinterd-beta:8044)
+      beta-node-000 (tcps://splinterd-beta:8044)
           Vote: PENDING
           Service (scabbard): gsBB
               admin_keys:

--- a/examples/splinter/configs/nodes.yaml
+++ b/examples/splinter/configs/nodes.yaml
@@ -14,17 +14,17 @@
 # -----------------------------------------------------------------------------
 
 - identity: 'alpha-node-000'
-  endpoint: 'tls://splinterd-alpha:8044'
+  endpoint: 'tcps://splinterd-alpha:8044'
   display_name: 'Alpha - Node 0'
   metadata:
     organization: 'Alpha'
 - identity: 'beta-node-000'
-  endpoint: 'tls://splinterd-beta:8044'
+  endpoint: 'tcps://splinterd-beta:8044'
   display_name: 'Beta - Node 0'
   metadata:
     organization: 'Beta'
 - identity: 'gamma-node-000'
-  endpoint: 'tls://splinterd-gamma:8044'
+  endpoint: 'tcps://splinterd-gamma:8044'
   display_name: 'Gamma - Node 0'
   metadata:
     organization: 'Gamma'


### PR DESCRIPTION
Update the Grid on Splinter readme and configuration for
the change introduced in Cargill/splinter@a3ce928

This is being changed for consistency. For example when
we have ws:// and wss:// it will match tcp:// and tcps://.

The old prefix, tls://, is still supported but is considered
deprecated.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>