### PR TITLE
Reflect node endpoints change in splinter

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -53,7 +53,7 @@ url = "2.1"
 uuid = { version = "0.6", features = ["v4"] }
 
 [dependencies.splinter]
-version = "0.3"
+git = "https://github.com/Cargill/splinter"
 optional = true
 features = [ "events", "scabbard-client" ]
 

--- a/daemon/migrations/2020-04-17-190646_multiple_endpoints/down.sql
+++ b/daemon/migrations/2020-04-17-190646_multiple_endpoints/down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE grid_circuit_member ALTER COLUMN endpoints DROP DEFAULT;
+ALTER TABLE grid_circuit_member ALTER COLUMN endpoints
+  TYPE TEXT USING coalesce(endpoints[1],'');
+ALTER TABLE grid_circuit_member ALTER COLUMN endpoints SET DEFAULT '';
+ALTER TABLE grid_circuit_member RENAME COLUMN endpoints TO endpoint;

--- a/daemon/migrations/2020-04-17-190646_multiple_endpoints/up.sql
+++ b/daemon/migrations/2020-04-17-190646_multiple_endpoints/up.sql
@@ -1,0 +1,20 @@
+-- Copyright 2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE grid_circuit_member RENAME COLUMN endpoint TO endpoints;
+ALTER TABLE grid_circuit_member ALTER COLUMN endpoints DROP DEFAULT;
+ALTER TABLE grid_circuit_member ALTER COLUMN endpoints
+  TYPE TEXT[] USING array[endpoints];
+ALTER TABLE grid_circuit_member ALTER COLUMN endpoints SET DEFAULT '{}';

--- a/daemon/src/database/models.rs
+++ b/daemon/src/database/models.rs
@@ -523,7 +523,7 @@ pub struct GridCircuitMember {
     pub id: i64,
     pub circuit_id: String,
     pub node_id: String,
-    pub endpoint: String,
+    pub endpoints: Vec<String>,
     pub status: String,
     pub created_time: SystemTime,
     pub updated_time: SystemTime,
@@ -534,7 +534,7 @@ pub struct GridCircuitMember {
 pub struct NewGridCircuitMember {
     pub circuit_id: String,
     pub node_id: String,
-    pub endpoint: String,
+    pub endpoints: Vec<String>,
     pub status: String,
     pub created_time: SystemTime,
     pub updated_time: SystemTime,

--- a/daemon/src/database/schema.rs
+++ b/daemon/src/database/schema.rs
@@ -296,7 +296,7 @@ table! {
         id -> Int8,
         circuit_id -> Text,
         node_id -> Text,
-        endpoint -> Text,
+        endpoints -> Array<Text>,
         status -> Text,
         created_time -> Timestamp,
         updated_time -> Timestamp,

--- a/examples/splinter/README.md
+++ b/examples/splinter/README.md
@@ -29,11 +29,10 @@ have not been thoroughly tested or documented.
 
 Due to the rapid and ongoing development of Splinter and its experimental
 features, the images in this example can become stale very quickly. If you have
-used this procedure before, run the following commands to ensure that your
+used this procedure before, run the following command to ensure that your
 images are up to date:
 
 ```
-$ docker pull hyperledger/grid-dev
 $ docker-compose -f examples/splinter/docker-compose.yaml pull generate-key-registry db-alpha scabbard-cli-alpha splinterd-alpha
 ```
 
@@ -41,9 +40,13 @@ $ docker-compose -f examples/splinter/docker-compose.yaml pull generate-key-regi
 
 1. Clone the [Hyperledger Grid repository](https://github.com/hyperledger/grid)
    ([https://github.com/hyperledger/grid](https://github.com/hyperledger/grid)).
-2. Navigate to the grid root directory and start the Grid Docker containers.
+2. Navigate to the grid root directory and build the Grid Docker containers.
 
-   `$ docker-compose -f examples/splinter/docker-compose.yaml up --build`
+   `$ docker-compose -f examples/splinter/docker-compose.yaml build --pull`
+
+3. Start the Grid Docker containers.
+
+   `$ docker-compose -f examples/splinter/docker-compose.yaml up`
 
    This docker-compose file creates a network with two nodes (alpha and beta)
    that includes the Pike, Schema, and Product smart contracts.

--- a/examples/splinter/configs/nodes.yaml
+++ b/examples/splinter/configs/nodes.yaml
@@ -14,17 +14,20 @@
 # -----------------------------------------------------------------------------
 
 - identity: 'alpha-node-000'
-  endpoint: 'tcps://splinterd-alpha:8044'
+  endpoints:
+    - 'tcps://splinterd-alpha:8044'
   display_name: 'Alpha - Node 0'
   metadata:
     organization: 'Alpha'
 - identity: 'beta-node-000'
-  endpoint: 'tcps://splinterd-beta:8044'
+  endpoints:
+    - 'tcps://splinterd-beta:8044'
   display_name: 'Beta - Node 0'
   metadata:
     organization: 'Beta'
 - identity: 'gamma-node-000'
-  endpoint: 'tcps://splinterd-gamma:8044'
+  endpoints:
+    - 'tcps://splinterd-gamma:8044'
   display_name: 'Gamma - Node 0'
   metadata:
     organization: 'Gamma'


### PR DESCRIPTION
Updates Grid to reflect the change in splinter that makes node endpoints
plural. This includes updating the node registry file and adding a
database migration to update the column.

Signed-off-by: Logan Seeley <seeley@bitwise.io>