### PR TITLE
Update Grid for the removal of --transport in splinterd

### DIFF
--- a/docker-compose-splinter.yaml
+++ b/docker-compose-splinter.yaml
@@ -152,11 +152,10 @@ services:
         --registry-backend FILE \
         --registry-file /etc/splinter/nodes.yaml \
         --bind 0.0.0.0:8085 \
-        --network-endpoint 0.0.0.0:8044 \
+        --network-endpoint tcps://0.0.0.0:8044 \
         --node-id splinter-node \
-        --service-endpoint 0.0.0.0:8043 \
+        --service-endpoint tcp://0.0.0.0:8043 \
         --storage yaml \
-        --transport tls \
         --client-cert /etc/splinter/certs/client.crt \
         --client-key /etc/splinter/certs/private/client.key \
         --server-cert /etc/splinter/certs/server.crt \

--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -189,11 +189,10 @@ services:
         splinterd -vv \
         --registry file:///configs/nodes.yaml \
         --bind 0.0.0.0:8085 \
-        --network-endpoint 0.0.0.0:8044 \
+        --network-endpoint tcps://0.0.0.0:8044 \
         --node-id alpha-node-000 \
-        --service-endpoint 0.0.0.0:8043 \
+        --service-endpoint tcp://0.0.0.0:8043 \
         --storage yaml \
-        --transport tls \
         --client-cert /etc/splinter/certs/client.crt \
         --client-key /etc/splinter/certs/private/client.key \
         --server-cert /etc/splinter/certs/server.crt \
@@ -326,11 +325,10 @@ services:
         splinterd -vv \
         --registry file:///configs/nodes.yaml \
         --bind 0.0.0.0:8085 \
-        --network-endpoint 0.0.0.0:8044 \
+        --network-endpoint tcps://0.0.0.0:8044 \
         --node-id beta-node-000 \
-        --service-endpoint 0.0.0.0:8043 \
+        --service-endpoint tcp://0.0.0.0:8043 \
         --storage yaml \
-        --transport tls \
         --client-cert /etc/splinter/certs/client.crt \
         --client-key /etc/splinter/certs/private/client.key \
         --server-cert /etc/splinter/certs/server.crt \
@@ -456,11 +454,10 @@ services:
         splinterd -vv \
         --registry file:///configs/nodes.yaml \
         --bind 0.0.0.0:8085 \
-        --network-endpoint 0.0.0.0:8044 \
+        --network-endpoint tcps://0.0.0.0:8044 \
         --node-id gamma-node-000 \
-        --service-endpoint 0.0.0.0:8043 \
+        --service-endpoint tcp://0.0.0.0:8043 \
         --storage yaml \
-        --transport tls \
         --client-cert /etc/splinter/certs/client.crt \
         --client-key /etc/splinter/certs/private/client.key \
         --server-cert /etc/splinter/certs/server.crt \

--- a/grid-ui/docker/docker-compose.yaml
+++ b/grid-ui/docker/docker-compose.yaml
@@ -185,11 +185,10 @@
           --registry-backend FILE \
           --registry-file /configs/nodes.yaml \
           --bind 0.0.0.0:8085 \
-          --network-endpoint 0.0.0.0:8044 \
+          --network-endpoint tcps://0.0.0.0:8044 \
           --node-id alpha-node-000 \
-          --service-endpoint 0.0.0.0:8043 \
+          --service-endpoint tcp://0.0.0.0:8043 \
           --storage yaml \
-          --transport tls \
           --client-cert /etc/splinter/certs/client.crt \
           --client-key /etc/splinter/certs/private/client.key \
           --server-cert /etc/splinter/certs/server.crt \


### PR DESCRIPTION
Upgrades Grid to work with the new version of splinterd
after this change https://github.com/Cargill/splinter/pull/711

This should be merged after https://github.com/Cargill/splinter/pull/711.