### PR TITLE
Update for new version of splinterd which adds "tls-" prefix

### DIFF
--- a/docker-compose-splinter.yaml
+++ b/docker-compose-splinter.yaml
@@ -149,8 +149,7 @@ services:
         cp -a /splinter_shared/. /etc/splinter/certs && \
         mv /etc/splinter/nodes.yaml.example /etc/splinter/nodes.yaml && \
         splinterd -vv \
-        --registry-backend FILE \
-        --registry-file /etc/splinter/nodes.yaml \
+        --registry file:///etc/splinter/nodes.yaml\
         --bind 0.0.0.0:8085 \
         --network-endpoint tcps://0.0.0.0:8044 \
         --node-id splinter-node \

--- a/docker-compose-splinter.yaml
+++ b/docker-compose-splinter.yaml
@@ -156,9 +156,9 @@ services:
         --node-id splinter-node \
         --service-endpoint tcp://0.0.0.0:8043 \
         --storage yaml \
-        --client-cert /etc/splinter/certs/client.crt \
-        --client-key /etc/splinter/certs/private/client.key \
-        --server-cert /etc/splinter/certs/server.crt \
-        --server-key /etc/splinter/certs/private/server.key \
-        --insecure
+        --tls-client-cert /etc/splinter/certs/client.crt \
+        --tls-client-key /etc/splinter/certs/private/client.key \
+        --tls-server-cert /etc/splinter/certs/server.crt \
+        --tls-server-key /etc/splinter/certs/private/server.key \
+        --tls-insecure
       "

--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -193,13 +193,13 @@ services:
         --node-id alpha-node-000 \
         --service-endpoint tcp://0.0.0.0:8043 \
         --storage yaml \
-        --client-cert /etc/splinter/certs/client.crt \
-        --client-key /etc/splinter/certs/private/client.key \
-        --server-cert /etc/splinter/certs/server.crt \
-        --server-key /etc/splinter/certs/private/server.key \
+        --tls-client-cert /etc/splinter/certs/client.crt \
+        --tls-client-key /etc/splinter/certs/private/client.key \
+        --tls-server-cert /etc/splinter/certs/server.crt \
+        --tls-server-key /etc/splinter/certs/private/server.key \
         --enable-biome \
         --database postgres://admin:admin@splinter-db-alpha:5432/splinter \
-        --insecure
+        --tls-insecure
       "
 
   splinter-db-alpha:
@@ -329,13 +329,13 @@ services:
         --node-id beta-node-000 \
         --service-endpoint tcp://0.0.0.0:8043 \
         --storage yaml \
-        --client-cert /etc/splinter/certs/client.crt \
-        --client-key /etc/splinter/certs/private/client.key \
-        --server-cert /etc/splinter/certs/server.crt \
-        --server-key /etc/splinter/certs/private/server.key \
+        --tls-client-cert /etc/splinter/certs/client.crt \
+        --tls-client-key /etc/splinter/certs/private/client.key \
+        --tls-server-cert /etc/splinter/certs/server.crt \
+        --tls-server-key /etc/splinter/certs/private/server.key \
         --enable-biome \
         --database postgres://admin:admin@splinter-db-beta:5432/splinter \
-        --insecure
+        --tls-insecure
       "
 
   splinter-db-beta:
@@ -458,13 +458,13 @@ services:
         --node-id gamma-node-000 \
         --service-endpoint tcp://0.0.0.0:8043 \
         --storage yaml \
-        --client-cert /etc/splinter/certs/client.crt \
-        --client-key /etc/splinter/certs/private/client.key \
-        --server-cert /etc/splinter/certs/server.crt \
-        --server-key /etc/splinter/certs/private/server.key \
+        --tls-client-cert /etc/splinter/certs/client.crt \
+        --tls-client-key /etc/splinter/certs/private/client.key \
+        --tls-server-cert /etc/splinter/certs/server.crt \
+        --tls-server-key /etc/splinter/certs/private/server.key \
         --enable-biome \
         --database postgres://admin:admin@splinter-db-gamma:5432/splinter \
-        --insecure
+        --tls-insecure
       "
 
   splinter-db-gamma:

--- a/grid-ui/docker/docker-compose.yaml
+++ b/grid-ui/docker/docker-compose.yaml
@@ -189,13 +189,13 @@
           --node-id alpha-node-000 \
           --service-endpoint tcp://0.0.0.0:8043 \
           --storage yaml \
-          --client-cert /etc/splinter/certs/client.crt \
-          --client-key /etc/splinter/certs/private/client.key \
-          --server-cert /etc/splinter/certs/server.crt \
-          --server-key /etc/splinter/certs/private/server.key \
+          --tls-client-cert /etc/splinter/certs/client.crt \
+          --tls-client-key /etc/splinter/certs/private/client.key \
+          --tls-server-cert /etc/splinter/certs/server.crt \
+          --tls-server-key /etc/splinter/certs/private/server.key \
           --enable-biome \
           --database postgres://admin:admin@splinter-db:5432/splinter \
-          --insecure
+          --tls-insecure
         "
 
     splinter-db:


### PR DESCRIPTION
Update splinter tls options to match new splinterd

Update docker-compose for the changes in
Cargill/splinter#727

This should be merged after Cargill/splinter#727
