### PR TITLE
Fix routing issue with product sampling

### DIFF
--- a/grid-ui/saplings/product/src/index.js
+++ b/grid-ui/saplings/product/src/index.js
@@ -22,5 +22,7 @@ import './index.css';
 import App from './App';
 
 registerApp(domNode => {
-  ReactDOM.render(<App />, domNode);
+  if (/\/product*/.exec(window.location.pathname)) {
+    ReactDOM.render(<App />, domNode);
+  }
 });


### PR DESCRIPTION
Fixes bug that was causing the product sampling to not render the canopy
navbar when navigating directly to localhost:3033/products