### PR TITLE
Splinter/scabbard client dep update

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -46,7 +46,7 @@ protobuf = "2"
 reqwest = { version = "0.10.1", optional = true, features = ["json", "blocking"] }
 sabre-sdk = { version = "0.5", optional = true }
 sawtooth-sdk = { version = "0.4", features = ["transact-compat"] }
-scabbard = { git = "https://github.com/Cargill/splinter", optional = true, features = ["client", "events"] }
+scabbard = { version = "0.3", optional = true, features = ["client", "events"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 transact = { version = "0.2", optional = true }

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -54,7 +54,7 @@ url = "2.1"
 uuid = { version = "0.6", features = ["v4"] }
 
 [dependencies.splinter]
-git = "https://github.com/Cargill/splinter"
+version = "0.3"
 optional = true
 features = [ "events" ]
 


### PR DESCRIPTION
Reverts the Splinter dependency to use the published crate rather than git, and pulls the scabbard client from the scabbard crate (its new home).

This change is pending the next release of splinter/scabbard.