### PR TITLE
Pull scabbard client from scabbard crate

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -46,6 +46,7 @@ protobuf = "2"
 reqwest = { version = "0.10.1", optional = true, features = ["json", "blocking"] }
 sabre-sdk = { version = "0.5", optional = true }
 sawtooth-sdk = { version = "0.4", features = ["transact-compat"] }
+scabbard = { git = "https://github.com/Cargill/splinter", optional = true, features = ["client", "events"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 transact = { version = "0.2", optional = true }
@@ -55,7 +56,7 @@ uuid = { version = "0.6", features = ["v4"] }
 [dependencies.splinter]
 git = "https://github.com/Cargill/splinter"
 optional = true
-features = [ "events", "scabbard-client" ]
+features = [ "events" ]
 
 [features]
 default = ["sawtooth-support"]
@@ -65,7 +66,7 @@ stable = ["sawtooth-support"]
 experimental = ["splinter-support"]
 
 sawtooth-support = []
-splinter-support = ["splinter", "reqwest", "sabre-sdk", "transact", "transact/contract-archive"]
+splinter-support = ["scabbard", "splinter", "reqwest", "sabre-sdk", "transact", "transact/contract-archive"]
 test-api = []
 
 [package.metadata.deb]

--- a/daemon/src/splinter/app_auth_handler/error.rs
+++ b/daemon/src/splinter/app_auth_handler/error.rs
@@ -17,7 +17,8 @@
 
 use sabre_sdk::protocol::payload::{ActionBuildError, SabrePayloadBuildError};
 use sawtooth_sdk::signing::Error as SigningError;
-use splinter::{events, service::scabbard::client::ScabbardClientError};
+use scabbard::client::ScabbardClientError;
+use splinter::events;
 use std::error::Error;
 use std::fmt;
 

--- a/daemon/src/splinter/app_auth_handler/sabre.rs
+++ b/daemon/src/splinter/app_auth_handler/sabre.rs
@@ -26,7 +26,7 @@ use sawtooth_sdk::signing::{
     create_context, secp256k1::Secp256k1PrivateKey, transact::TransactSigner,
     Signer as SawtoothSigner,
 };
-use splinter::service::scabbard::client::{ScabbardClient, ServiceId};
+use scabbard::client::{ScabbardClient, ServiceId};
 use transact::{
     contract::archive::{default_scar_path, SmartContractArchive},
     protocol::{batch::BatchBuilder, transaction::Transaction},

--- a/daemon/src/splinter/event.rs
+++ b/daemon/src/splinter/event.rs
@@ -18,8 +18,8 @@
 use std::cell::RefCell;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};
 
+use scabbard::service::{StateChange as ScabbardStateChange, StateChangeEvent};
 use splinter::events::{Igniter, WebSocketClient, WebSocketError, WsResponse};
-use splinter::service::scabbard::{StateChange as ScabbardStateChange, StateChangeEvent};
 
 use crate::event::{
     CommitEvent, EventConnection, EventConnectionUnsubscriber, EventIoError, StateChange,


### PR DESCRIPTION
Updates gridd's dependencies to pull the scabbard client from the newly
created scabbard crate; the client is no longer provided by the splinter
crate.

Signed-off-by: Logan Seeley <seeley@bitwise.io>