### PR TITLE
Switch compose files to use Splinter 0.4 images

### DIFF
--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
       "
 
   generate-registry:
-    image: splintercommunity/splinter-cli:master
+    image: splintercommunity/splinter-cli:0.4-dev
     volumes:
       - registry:/registry
     command: |
@@ -191,14 +191,14 @@ services:
         "
 
   scabbard-cli-alpha:
-    image: splintercommunity/scabbard-cli:experimental
+    image: splintercommunity/scabbard-cli:0.4-experimental
     container_name: scabbard-cli-alpha
     hostname: scabbard-cli-alpha
     volumes:
       - gridd-alpha:/root/.splinter/keys
 
   splinterd-alpha:
-    image: splintercommunity/splinterd:experimental
+    image: splintercommunity/splinterd:0.4-experimental
     container_name: splinterd-alpha
     hostname: splinterd-alpha
     expose:
@@ -324,14 +324,14 @@ services:
         "
 
   scabbard-cli-beta:
-    image: splintercommunity/scabbard-cli:experimental
+    image: splintercommunity/scabbard-cli:0.4-experimental
     container_name: scabbard-cli-beta
     hostname: scabbard-cli-beta
     volumes:
       - gridd-beta:/root/.splinter/keys
 
   splinterd-beta:
-    image: splintercommunity/splinterd:experimental
+    image: splintercommunity/splinterd:0.4-experimental
     container_name: splinterd-beta
     hostname: splinterd-beta
     expose:
@@ -456,7 +456,7 @@ services:
         "
 
   splinterd-gamma:
-    image: splintercommunity/splinterd:experimental
+    image: splintercommunity/splinterd:0.4-experimental
     container_name: splinterd-gamma
     hostname: splinterd-gamma
     expose:

--- a/grid-ui/docker/docker-compose.yaml
+++ b/grid-ui/docker/docker-compose.yaml
@@ -128,14 +128,14 @@
           "
 
     scabbard-cli:
-      image: splintercommunity/scabbard-cli:experimental
+      image: splintercommunity/scabbard-cli:0.4-experimental
       container_name: scabbard-cli
       hostname: scabbard-cli
       volumes:
         - gridd:/root/.splinter/keys
 
     splinterd:
-      image: splintercommunity/splinterd:experimental
+      image: splintercommunity/splinterd:0.4-experimental
       container_name: splinterd
       hostname: splinterd
       expose:


### PR DESCRIPTION
Even numbered Splinter branches are considered "stable" so Grid should
use these instead of master.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>