### PR TITLE
Update docker-compose files to use stable 0.4 Splinter images

### DIFF
--- a/examples/splinter/README.md
+++ b/examples/splinter/README.md
@@ -24,13 +24,9 @@ This environment includes the Pike, Product, and Schema smart contracts.
 
 ## Important Notes
 
-The example `docker-compose.yaml` file uses experimental Splinter features that
-have not been thoroughly tested or documented.
-
-Due to the rapid and ongoing development of Splinter and its experimental
-features, the images in this example can become stale very quickly. If you have
-used this procedure before, run the following command to ensure that your
-images are up to date:
+Due to ongoing development of Splinter the images in this example can become
+stale. If you have used this procedure before, run the following command to
+ensure that your images are up to date:
 
 ```
 $ docker-compose -f examples/splinter/docker-compose.yaml pull generate-registry db-alpha scabbard-cli-alpha splinterd-alpha

--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
       "
 
   generate-registry:
-    image: splintercommunity/splinter-cli:0.4-dev
+    image: splintercommunity/splinter-cli:0.4
     volumes:
       - registry:/registry
     command: |
@@ -191,14 +191,14 @@ services:
         "
 
   scabbard-cli-alpha:
-    image: splintercommunity/scabbard-cli:0.4-experimental
+    image: splintercommunity/scabbard-cli:0.4
     container_name: scabbard-cli-alpha
     hostname: scabbard-cli-alpha
     volumes:
       - gridd-alpha:/root/.splinter/keys
 
   splinterd-alpha:
-    image: splintercommunity/splinterd:0.4-experimental
+    image: splintercommunity/splinterd:0.4
     container_name: splinterd-alpha
     hostname: splinterd-alpha
     expose:
@@ -324,14 +324,14 @@ services:
         "
 
   scabbard-cli-beta:
-    image: splintercommunity/scabbard-cli:0.4-experimental
+    image: splintercommunity/scabbard-cli:0.4
     container_name: scabbard-cli-beta
     hostname: scabbard-cli-beta
     volumes:
       - gridd-beta:/root/.splinter/keys
 
   splinterd-beta:
-    image: splintercommunity/splinterd:0.4-experimental
+    image: splintercommunity/splinterd:0.4
     container_name: splinterd-beta
     hostname: splinterd-beta
     expose:
@@ -456,7 +456,7 @@ services:
         "
 
   splinterd-gamma:
-    image: splintercommunity/splinterd:0.4-experimental
+    image: splintercommunity/splinterd:0.4
     container_name: splinterd-gamma
     hostname: splinterd-gamma
     expose:

--- a/grid-ui/docker/docker-compose.yaml
+++ b/grid-ui/docker/docker-compose.yaml
@@ -128,14 +128,14 @@
           "
 
     scabbard-cli:
-      image: splintercommunity/scabbard-cli:0.4-experimental
+      image: splintercommunity/scabbard-cli:0.4
       container_name: scabbard-cli
       hostname: scabbard-cli
       volumes:
         - gridd:/root/.splinter/keys
 
     splinterd:
-      image: splintercommunity/splinterd:0.4-experimental
+      image: splintercommunity/splinterd:0.4
       container_name: splinterd
       hostname: splinterd
       expose:


### PR DESCRIPTION
Grid no longer require the use of experimental Splinter images.
The Grid on Splinter examples has been updated to use 0.4 images.
Also updates the README to not mention experimental.

Also updates the grid-ui docker-compose.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>