### PR TITLE
Fix clippy error 'bind_instead_of_map'

### DIFF
--- a/cli/src/actions/keygen.rs
+++ b/cli/src/actions/keygen.rs
@@ -62,10 +62,10 @@ pub fn generate_keys(
                 .ok_or_else(|| {
                     CliError::UserError(String::from("Unable to determine home directory"))
                 })
-                .and_then(|mut p| {
+                .map(|mut p| {
                     p.push(".grid");
                     p.push("keys");
-                    Ok(p)
+                    p
                 })?;
             if !key_path.exists() {
                 fs::create_dir_all(key_path.clone())?;

--- a/cli/src/key.rs
+++ b/cli/src/key.rs
@@ -66,11 +66,11 @@ pub fn load_signing_key(name: Option<String>) -> Result<Secp256k1PrivateKey, Cli
                 "Could not load signing key: unable to determine home directory",
             ))
         })
-        .and_then(|mut p| {
+        .map(|mut p| {
             p.push(".grid");
             p.push("keys");
             p.push(format!("{}.priv", &username));
-            Ok(p)
+            p
         })?;
 
     if !private_key_filename.as_path().exists() {


### PR DESCRIPTION
Fixes instances where `.and_then(|x| Ok(x))` is used as it can be
more succinctly written as `.map(|x| x)`.

Signed-off-by: Shannyn Telander <telander@bitwise.io>