### PR TITLE
Handle PING_REQUEST

### DIFF
--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -188,6 +188,9 @@ impl<Conn: EventConnection + 'static> EventProcessor<Conn> {
                 loop {
                     match connection.recv() {
                         Ok(commit_event) => handle_message(commit_event, &event_handlers)?,
+                        Err(EventIoError::InvalidMessage(msg)) => {
+                            warn!("{}; ignoring...", msg);
+                        }
                         Err(err) => {
                             error!("Failed to receive events; aborting: {}", err);
                             break;


### PR DESCRIPTION
This change allows the grid daemon to safely handle the ping request, and any future, unrecognized messages.  It helps gridd support sawtooth 1.2.