### PR TITLE
Add sqlite dependency

### DIFF
--- a/ci/grid-dev
+++ b/ci/grid-dev
@@ -24,6 +24,7 @@ RUN apt-get update \
     libpq-dev \
     libssl-dev \
     libsasl2-dev \
+    libsqlite3-dev \
     libzmq3-dev \
     openssl \
     pkg-config \

--- a/ci/grid-dev.yaml
+++ b/ci/grid-dev.yaml
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   grid-dev:
-    image: hyperledger/grid-dev:v2
+    image: hyperledger/grid-dev:v3
     build:
       context: ..
       dockerfile: ci/grid-dev


### PR DESCRIPTION
This adds the libsqlite3-dev dependency to the grid-dev image and increments the version number from 2 to 3. This is done in support of refactoring the Grid database functionality.