### PR TITLE
Add organization store implementation

### DIFF
--- a/sdk/src/grid_db/mod.rs
+++ b/sdk/src/grid_db/mod.rs
@@ -28,4 +28,5 @@ pub use commits::store::CommitStore;
 
 #[cfg(feature = "diesel")]
 pub use organizations::store::diesel::DieselOrganizationStore;
+pub use organizations::store::memory::MemoryOrganizationStore;
 pub use organizations::store::OrganizationStore;

--- a/sdk/src/grid_db/organizations/mod.rs
+++ b/sdk/src/grid_db/organizations/mod.rs
@@ -12,20 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The grid_db submodule provides support for managing organizations,
-//! agents, commits, schemas, locations, products, and Track and Trace
-//! data.
-
-pub mod commits;
-pub mod organizations;
-
-pub mod migrations;
-
-#[cfg(feature = "diesel")]
-pub use commits::store::diesel::DieselCommitStore;
-pub use commits::store::memory::MemoryCommitStore;
-pub use commits::store::CommitStore;
-
-#[cfg(feature = "diesel")]
-pub use organizations::store::diesel::DieselOrganizationStore;
-pub use organizations::store::OrganizationStore;
+pub mod store;

--- a/sdk/src/grid_db/organizations/store/diesel/mod.rs
+++ b/sdk/src/grid_db/organizations/store/diesel/mod.rs
@@ -87,6 +87,46 @@ impl OrganizationStore for DieselOrganizationStore<diesel::pg::PgConnection> {
     }
 }
 
+#[cfg(feature = "sqlite")]
+impl OrganizationStore for DieselOrganizationStore<diesel::sqlite::SqliteConnection> {
+    fn add_organizations(&self, orgs: Vec<Organization>) -> Result<(), OrganizationStoreError> {
+        OrganizationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_organizations(Vec::from_iter(orgs.iter().map(|org| org.clone().into())))
+    }
+
+    fn list_organizations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Organization>, OrganizationStoreError> {
+        OrganizationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_organizations(service_id)
+    }
+
+    fn fetch_organization(
+        &self,
+        org_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Organization>, OrganizationStoreError> {
+        OrganizationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_organization(org_id, service_id)
+    }
+}
+
 impl From<OrganizationModel> for Organization {
     fn from(org: OrganizationModel) -> Self {
         Self {

--- a/sdk/src/grid_db/organizations/store/diesel/mod.rs
+++ b/sdk/src/grid_db/organizations/store/diesel/mod.rs
@@ -1,0 +1,116 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod models;
+mod operations;
+pub(in crate::grid_db) mod schema;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+use std::iter::FromIterator;
+
+use super::diesel::models::{NewOrganizationModel, OrganizationModel};
+use super::{Organization, OrganizationStore, OrganizationStoreError};
+use crate::database::DatabaseError;
+use operations::add_organizations::OrganizationStoreAddOrganizationsOperation as _;
+use operations::fetch_organization::OrganizationStoreFetchOrganizationOperation as _;
+use operations::list_organizations::OrganizationStoreListOrganizationsOperation as _;
+use operations::OrganizationStoreOperations;
+
+/// Manages creating organizations in the database
+#[derive(Clone)]
+pub struct DieselOrganizationStore<C: diesel::Connection + 'static> {
+    connection_pool: Pool<ConnectionManager<C>>,
+}
+
+#[cfg(feature = "diesel")]
+impl<C: diesel::Connection> DieselOrganizationStore<C> {
+    /// Creates a new DieselOrganizationStore
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool to the database
+    // Allow dead code if diesel feature is not enabled
+    #[allow(dead_code)]
+    pub fn new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        DieselOrganizationStore { connection_pool }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl OrganizationStore for DieselOrganizationStore<diesel::pg::PgConnection> {
+    fn add_organizations(&self, orgs: Vec<Organization>) -> Result<(), OrganizationStoreError> {
+        OrganizationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_organizations(Vec::from_iter(orgs.iter().map(|org| org.clone().into())))
+    }
+
+    fn list_organizations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Organization>, OrganizationStoreError> {
+        OrganizationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_organizations(service_id)
+    }
+
+    fn fetch_organization(
+        &self,
+        org_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Organization>, OrganizationStoreError> {
+        OrganizationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_organization(org_id, service_id)
+    }
+}
+
+impl From<OrganizationModel> for Organization {
+    fn from(org: OrganizationModel) -> Self {
+        Self {
+            org_id: org.org_id,
+            name: org.name,
+            address: org.address,
+            metadata: org.metadata,
+            start_commit_num: org.start_commit_num,
+            end_commit_num: org.end_commit_num,
+            service_id: org.service_id,
+        }
+    }
+}
+
+impl From<NewOrganizationModel> for Organization {
+    fn from(org: NewOrganizationModel) -> Self {
+        Self {
+            org_id: org.org_id,
+            name: org.name,
+            address: org.address,
+            metadata: org.metadata,
+            start_commit_num: org.start_commit_num,
+            end_commit_num: org.end_commit_num,
+            service_id: org.service_id,
+        }
+    }
+}

--- a/sdk/src/grid_db/organizations/store/diesel/models.rs
+++ b/sdk/src/grid_db/organizations/store/diesel/models.rs
@@ -1,0 +1,47 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::grid_db::organizations::store::diesel::schema::*;
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "organization"]
+pub struct NewOrganizationModel {
+    pub org_id: String,
+    pub name: String,
+    pub address: String,
+    pub metadata: Vec<u8>,
+
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+
+    pub service_id: Option<String>,
+}
+
+#[derive(Queryable, PartialEq, Identifiable, Debug)]
+#[table_name = "organization"]
+pub struct OrganizationModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
+    pub id: i64,
+    pub org_id: String,
+    pub name: String,
+    pub address: String,
+    pub metadata: Vec<u8>,
+
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+
+    pub service_id: Option<String>,
+}

--- a/sdk/src/grid_db/organizations/store/diesel/operations/add_organizations.rs
+++ b/sdk/src/grid_db/organizations/store/diesel/operations/add_organizations.rs
@@ -1,0 +1,74 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::OrganizationStoreOperations;
+use crate::grid_db::organizations::store::diesel::{schema::organization, OrganizationStoreError};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::organizations::store::diesel::models::{
+    NewOrganizationModel, OrganizationModel,
+};
+use diesel::{dsl::insert_into, prelude::*, result::Error::NotFound};
+
+pub(in crate::grid_db::organizations::store::diesel) trait OrganizationStoreAddOrganizationsOperation
+{
+    fn add_organizations(
+        &self,
+        orgs: Vec<NewOrganizationModel>,
+    ) -> Result<(), OrganizationStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> OrganizationStoreAddOrganizationsOperation
+    for OrganizationStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_organizations(
+        &self,
+        orgs: Vec<NewOrganizationModel>,
+    ) -> Result<(), OrganizationStoreError> {
+        for org in orgs {
+            let duplicate_org = organization::table
+                .filter(
+                    organization::org_id
+                        .eq(&org.org_id)
+                        .and(organization::service_id.eq(&org.service_id))
+                        .and(organization::end_commit_num.eq(MAX_COMMIT_NUM)),
+                )
+                .first::<OrganizationModel>(self.conn)
+                .map(Some)
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| OrganizationStoreError::QueryError {
+                    context: "Failed check for existing organization".to_string(),
+                    source: Box::new(err),
+                })?;
+            if duplicate_org.is_some() {
+                return Err(OrganizationStoreError::DuplicateError {
+                    context: "Organization already exists".to_string(),
+                    source: None,
+                });
+            }
+
+            insert_into(organization::table)
+                .values(org)
+                .execute(self.conn)
+                .map(|_| ())
+                .map_err(|err| OrganizationStoreError::OperationError {
+                    context: "Failed to add organization".to_string(),
+                    source: Some(Box::new(err)),
+                })?;
+        }
+
+        Ok(())
+    }
+}

--- a/sdk/src/grid_db/organizations/store/diesel/operations/add_organizations.rs
+++ b/sdk/src/grid_db/organizations/store/diesel/operations/add_organizations.rs
@@ -72,3 +72,47 @@ impl<'a> OrganizationStoreAddOrganizationsOperation
         Ok(())
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a> OrganizationStoreAddOrganizationsOperation
+    for OrganizationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_organizations(
+        &self,
+        orgs: Vec<NewOrganizationModel>,
+    ) -> Result<(), OrganizationStoreError> {
+        for org in orgs {
+            let duplicate_org = organization::table
+                .filter(
+                    organization::org_id
+                        .eq(&org.org_id)
+                        .and(organization::service_id.eq(&org.service_id))
+                        .and(organization::end_commit_num.eq(MAX_COMMIT_NUM)),
+                )
+                .first::<OrganizationModel>(self.conn)
+                .map(Some)
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| OrganizationStoreError::QueryError {
+                    context: "Failed check for existing organization".to_string(),
+                    source: Box::new(err),
+                })?;
+            if duplicate_org.is_some() {
+                return Err(OrganizationStoreError::DuplicateError {
+                    context: "Organization already exists".to_string(),
+                    source: None,
+                });
+            }
+
+            insert_into(organization::table)
+                .values(org)
+                .execute(self.conn)
+                .map(|_| ())
+                .map_err(|err| OrganizationStoreError::OperationError {
+                    context: "Failed to add organization".to_string(),
+                    source: Some(Box::new(err)),
+                })?;
+        }
+
+        Ok(())
+    }
+}

--- a/sdk/src/grid_db/organizations/store/diesel/operations/fetch_organization.rs
+++ b/sdk/src/grid_db/organizations/store/diesel/operations/fetch_organization.rs
@@ -1,0 +1,63 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::OrganizationStoreOperations;
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::organizations::store::diesel::models::OrganizationModel;
+use crate::grid_db::organizations::store::diesel::{schema::organization, OrganizationStoreError};
+use crate::grid_db::organizations::store::Organization;
+use diesel::{prelude::*, result::Error::NotFound};
+
+pub(in crate::grid_db::organizations::store::diesel) trait OrganizationStoreFetchOrganizationOperation
+{
+    fn fetch_organization(
+        &self,
+        org_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Organization>, OrganizationStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> OrganizationStoreFetchOrganizationOperation
+    for OrganizationStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn fetch_organization(
+        &self,
+        org_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Organization>, OrganizationStoreError> {
+        let org = organization::table
+            .filter(
+                organization::org_id
+                    .eq(&org_id)
+                    .and(organization::service_id.eq(&service_id))
+                    .and(organization::end_commit_num.eq(MAX_COMMIT_NUM)),
+            )
+            .first::<OrganizationModel>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| OrganizationStoreError::QueryError {
+                context: "Failed to fetch organization for org_id".to_string(),
+                source: Box::new(err),
+            })?
+            .ok_or_else(|| {
+                OrganizationStoreError::NotFoundError(format!(
+                    "Failed to find organization: {}",
+                    org_id,
+                ))
+            })?;
+
+        Ok(Some(Organization::from(org)))
+    }
+}

--- a/sdk/src/grid_db/organizations/store/diesel/operations/list_organizations.rs
+++ b/sdk/src/grid_db/organizations/store/diesel/operations/list_organizations.rs
@@ -59,3 +59,36 @@ impl<'a> OrganizationStoreListOrganizationsOperation
         Ok(orgs)
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a> OrganizationStoreListOrganizationsOperation
+    for OrganizationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn list_organizations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Organization>, OrganizationStoreError> {
+        let orgs = organization::table
+            .select(organization::all_columns)
+            .filter(
+                organization::service_id
+                    .eq(service_id)
+                    .and(organization::end_commit_num.eq(MAX_COMMIT_NUM)),
+            )
+            .load::<OrganizationModel>(self.conn)
+            .map(Some)
+            .map_err(|err| OrganizationStoreError::OperationError {
+                context: "Failed to fetch organizations".to_string(),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| {
+                OrganizationStoreError::NotFoundError(
+                    "Could not get all organizations from storage".to_string(),
+                )
+            })?
+            .into_iter()
+            .map(Organization::from)
+            .collect();
+        Ok(orgs)
+    }
+}

--- a/sdk/src/grid_db/organizations/store/diesel/operations/list_organizations.rs
+++ b/sdk/src/grid_db/organizations/store/diesel/operations/list_organizations.rs
@@ -1,0 +1,61 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::OrganizationStoreOperations;
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::organizations::store::diesel::models::OrganizationModel;
+use crate::grid_db::organizations::store::diesel::{schema::organization, OrganizationStoreError};
+use crate::grid_db::organizations::store::Organization;
+use diesel::prelude::*;
+
+pub(in crate::grid_db::organizations::store::diesel) trait OrganizationStoreListOrganizationsOperation
+{
+    fn list_organizations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Organization>, OrganizationStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> OrganizationStoreListOrganizationsOperation
+    for OrganizationStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_organizations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Organization>, OrganizationStoreError> {
+        let orgs = organization::table
+            .select(organization::all_columns)
+            .filter(
+                organization::service_id
+                    .eq(service_id)
+                    .and(organization::end_commit_num.eq(MAX_COMMIT_NUM)),
+            )
+            .load::<OrganizationModel>(self.conn)
+            .map(Some)
+            .map_err(|err| OrganizationStoreError::OperationError {
+                context: "Failed to fetch organizations".to_string(),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| {
+                OrganizationStoreError::NotFoundError(
+                    "Could not get all organizations from storage".to_string(),
+                )
+            })?
+            .into_iter()
+            .map(Organization::from)
+            .collect();
+        Ok(orgs)
+    }
+}

--- a/sdk/src/grid_db/organizations/store/diesel/operations/mod.rs
+++ b/sdk/src/grid_db/organizations/store/diesel/operations/mod.rs
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The grid_db submodule provides support for managing organizations,
-//! agents, commits, schemas, locations, products, and Track and Trace
-//! data.
+pub(super) mod add_organizations;
+pub(super) mod fetch_organization;
+pub(super) mod list_organizations;
 
-pub mod commits;
-pub mod organizations;
+pub(super) struct OrganizationStoreOperations<'a, C> {
+    conn: &'a C,
+}
 
-pub mod migrations;
-
-#[cfg(feature = "diesel")]
-pub use commits::store::diesel::DieselCommitStore;
-pub use commits::store::memory::MemoryCommitStore;
-pub use commits::store::CommitStore;
-
-#[cfg(feature = "diesel")]
-pub use organizations::store::diesel::DieselOrganizationStore;
-pub use organizations::store::OrganizationStore;
+impl<'a, C> OrganizationStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    pub fn new(conn: &'a C) -> Self {
+        OrganizationStoreOperations { conn }
+    }
+}

--- a/sdk/src/grid_db/organizations/store/diesel/schema.rs
+++ b/sdk/src/grid_db/organizations/store/diesel/schema.rs
@@ -12,20 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The grid_db submodule provides support for managing organizations,
-//! agents, commits, schemas, locations, products, and Track and Trace
-//! data.
-
-pub mod commits;
-pub mod organizations;
-
-pub mod migrations;
-
-#[cfg(feature = "diesel")]
-pub use commits::store::diesel::DieselCommitStore;
-pub use commits::store::memory::MemoryCommitStore;
-pub use commits::store::CommitStore;
-
-#[cfg(feature = "diesel")]
-pub use organizations::store::diesel::DieselOrganizationStore;
-pub use organizations::store::OrganizationStore;
+table! {
+    organization (id) {
+        id -> Int8,
+        org_id -> Varchar,
+        name -> Varchar,
+        address -> Varchar,
+        metadata -> Binary,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}

--- a/sdk/src/grid_db/organizations/store/error.rs
+++ b/sdk/src/grid_db/organizations/store/error.rs
@@ -1,0 +1,139 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+#[cfg(feature = "diesel")]
+use crate::database::error;
+
+/// Represents OrganizationStore errors
+#[derive(Debug)]
+pub enum OrganizationStoreError {
+    /// Represents CRUD operations failures
+    OperationError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    /// Represents database query failures
+    QueryError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents general failures in the database
+    StorageError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    DuplicateError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    /// Represents an issue connecting to the database
+    ConnectionError(Box<dyn Error>),
+    NotFoundError(String),
+}
+
+impl Error for OrganizationStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            OrganizationStoreError::OperationError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            OrganizationStoreError::OperationError { source: None, .. } => None,
+            OrganizationStoreError::QueryError { source, .. } => Some(&**source),
+            OrganizationStoreError::StorageError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            OrganizationStoreError::StorageError { source: None, .. } => None,
+            OrganizationStoreError::ConnectionError(err) => Some(&**err),
+            OrganizationStoreError::DuplicateError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            OrganizationStoreError::DuplicateError { source: None, .. } => None,
+            OrganizationStoreError::NotFoundError(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for OrganizationStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            OrganizationStoreError::OperationError {
+                context,
+                source: Some(source),
+            } => write!(f, "failed to perform operation: {}: {}", context, source),
+            OrganizationStoreError::OperationError {
+                context,
+                source: None,
+            } => write!(f, "failed to perform operation: {}", context),
+            OrganizationStoreError::QueryError { context, source } => {
+                write!(f, "failed query: {}: {}", context, source)
+            }
+            OrganizationStoreError::StorageError {
+                context,
+                source: Some(source),
+            } => write!(
+                f,
+                "the underlying storage returned an error: {}: {}",
+                context, source
+            ),
+            OrganizationStoreError::StorageError {
+                context,
+                source: None,
+            } => write!(f, "the underlying storage returned an error: {}", context),
+            OrganizationStoreError::ConnectionError(err) => {
+                write!(f, "failed to connect to underlying storage: {}", err)
+            }
+            OrganizationStoreError::DuplicateError {
+                context,
+                source: Some(source),
+            } => write!(f, "Organization already exists: {}: {}", context, source),
+            OrganizationStoreError::DuplicateError {
+                context,
+                source: None,
+            } => write!(f, "The organization already exists: {}", context),
+            OrganizationStoreError::NotFoundError(ref s) => {
+                write!(f, "Organization not found: {}", s)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<error::DatabaseError> for OrganizationStoreError {
+    fn from(err: error::DatabaseError) -> OrganizationStoreError {
+        OrganizationStoreError::ConnectionError(Box::new(err))
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<diesel::result::Error> for OrganizationStoreError {
+    fn from(err: diesel::result::Error) -> OrganizationStoreError {
+        OrganizationStoreError::QueryError {
+            context: "Diesel query failed".to_string(),
+            source: Box::new(err),
+        }
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<diesel::r2d2::PoolError> for OrganizationStoreError {
+    fn from(err: diesel::r2d2::PoolError) -> OrganizationStoreError {
+        OrganizationStoreError::ConnectionError(Box::new(err))
+    }
+}

--- a/sdk/src/grid_db/organizations/store/memory.rs
+++ b/sdk/src/grid_db/organizations/store/memory.rs
@@ -1,0 +1,106 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::iter::FromIterator;
+use std::sync::{Arc, Mutex};
+
+use super::OrganizationStore;
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::organizations::store::{error::OrganizationStoreError, Organization};
+
+/// Implementation of OrganizationStore that stores Organizations in memory. Useful for when
+/// persistence isn't necessary.
+#[derive(Clone, Default)]
+pub struct MemoryOrganizationStore {
+    inner_organization: Arc<Mutex<HashMap<String, Organization>>>,
+}
+
+impl MemoryOrganizationStore {
+    pub fn new() -> Self {
+        MemoryOrganizationStore {
+            inner_organization: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl OrganizationStore for MemoryOrganizationStore {
+    fn add_organizations(&self, orgs: Vec<Organization>) -> Result<(), OrganizationStoreError> {
+        let mut inner_organization =
+            self.inner_organization
+                .lock()
+                .map_err(|_| OrganizationStoreError::StorageError {
+                    context: "Cannot access organizations: mutex lock poisoned".to_string(),
+                    source: None,
+                })?;
+        for org in orgs {
+            inner_organization.insert(org.org_id.clone(), org);
+        }
+        Ok(())
+    }
+
+    fn list_organizations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Organization>, OrganizationStoreError> {
+        let inner_organization =
+            self.inner_organization
+                .lock()
+                .map_err(|_| OrganizationStoreError::StorageError {
+                    context: "Cannot access organizations: mutex lock poisoned".to_string(),
+                    source: None,
+                })?;
+        let filtered_orgs = inner_organization
+            .iter()
+            .filter(|(_, o)| o.service_id.eq(&service_id) && o.end_commit_num.eq(&MAX_COMMIT_NUM))
+            .map(|(_, o)| Organization {
+                org_id: o.org_id.clone(),
+                name: o.name.clone(),
+                address: o.address.clone(),
+                metadata: o.metadata.clone(),
+                start_commit_num: o.start_commit_num,
+                end_commit_num: o.end_commit_num,
+                service_id: o.service_id.clone(),
+            });
+        Ok(Vec::from_iter(filtered_orgs))
+    }
+
+    fn fetch_organization(
+        &self,
+        org_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Organization>, OrganizationStoreError> {
+        let inner_organization =
+            self.inner_organization
+                .lock()
+                .map_err(|_| OrganizationStoreError::StorageError {
+                    context: "Cannot access organizations: mutex lock poisoned".to_string(),
+                    source: None,
+                })?;
+
+        for (_, o) in inner_organization.iter() {
+            if o.service_id == service_id
+                && o.org_id == org_id
+                && o.end_commit_num == MAX_COMMIT_NUM
+            {
+                return Ok(Some(o.clone()));
+            }
+        }
+
+        Err(OrganizationStoreError::NotFoundError(format!(
+            "Organization with org_id {} not found.",
+            org_id,
+        )))
+    }
+}

--- a/sdk/src/grid_db/organizations/store/mod.rs
+++ b/sdk/src/grid_db/organizations/store/mod.rs
@@ -15,6 +15,7 @@
 #[cfg(feature = "diesel")]
 pub mod diesel;
 mod error;
+pub mod memory;
 
 pub use error::OrganizationStoreError;
 

--- a/sdk/src/grid_db/organizations/store/mod.rs
+++ b/sdk/src/grid_db/organizations/store/mod.rs
@@ -1,0 +1,110 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "diesel")]
+pub mod diesel;
+mod error;
+
+pub use error::OrganizationStoreError;
+
+use crate::hex::as_hex;
+
+#[cfg(feature = "diesel")]
+use self::diesel::models::NewOrganizationModel;
+
+/// Represents a Grid commit
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct Organization {
+    pub org_id: String,
+    pub name: String,
+    pub address: String,
+    #[serde(serialize_with = "as_hex")]
+    #[serde(deserialize_with = "deserialize_hex")]
+    #[serde(default)]
+    pub metadata: Vec<u8>,
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+pub trait OrganizationStore: Send + Sync {
+    /// Adds an organization to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `orgs` - The commit to be added
+    fn add_organizations(&self, orgs: Vec<Organization>) -> Result<(), OrganizationStoreError>;
+
+    ///  Lists organizations from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_id` - The service id to list organizations for
+    fn list_organizations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Organization>, OrganizationStoreError>;
+
+    /// Fetches an organization from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `org_id` - This organization id to fetch
+    ///  * `service_id` - The service id of the organization to fetch
+    fn fetch_organization(
+        &self,
+        org_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Organization>, OrganizationStoreError>;
+}
+
+#[cfg(feature = "diesel")]
+impl Into<NewOrganizationModel> for Organization {
+    fn into(self) -> NewOrganizationModel {
+        NewOrganizationModel {
+            org_id: self.org_id,
+            name: self.name,
+            address: self.address,
+            metadata: self.metadata,
+            start_commit_num: self.start_commit_num,
+            end_commit_num: self.end_commit_num,
+            service_id: self.service_id,
+        }
+    }
+}
+
+impl<OS> OrganizationStore for Box<OS>
+where
+    OS: OrganizationStore + ?Sized,
+{
+    fn add_organizations(&self, orgs: Vec<Organization>) -> Result<(), OrganizationStoreError> {
+        (**self).add_organizations(orgs)
+    }
+
+    fn list_organizations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Organization>, OrganizationStoreError> {
+        (**self).list_organizations(service_id)
+    }
+
+    fn fetch_organization(
+        &self,
+        org_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Organization>, OrganizationStoreError> {
+        (**self).fetch_organization(org_id, service_id)
+    }
+}

--- a/sdk/src/hex.rs
+++ b/sdk/src/hex.rs
@@ -1,0 +1,178 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt::{self, Write};
+
+use serde::de;
+use serde::{Deserializer, Serializer};
+
+/// Converts a byte array into a hex string
+///
+/// # Arguments
+///
+///  * `bytes`: the byte array to convert
+pub fn to_hex(bytes: &[u8]) -> String {
+    let mut buf = String::new();
+    for b in bytes {
+        write!(&mut buf, "{:02x}", b).expect("Unable to write to string");
+    }
+
+    buf
+}
+
+/// Parses a hex string into a byte array
+///
+/// # Arguments
+///
+///  * `hex`: the hex string to convert
+pub fn parse_hex(hex: &str) -> Result<Vec<u8>, HexError> {
+    if hex.len() % 2 != 0 {
+        return Err(HexError {
+            context: format!("{} is not valid hex: odd number of digits", hex),
+            source: None,
+        });
+    }
+
+    let mut res = vec![];
+    for i in (0..hex.len()).step_by(2) {
+        res.push(
+            u8::from_str_radix(&hex[i..i + 2], 16).map_err(|err| HexError {
+                context: format!("{} contains invalid hex", hex),
+                source: Some(Box::new(err)),
+            })?,
+        );
+    }
+
+    Ok(res)
+}
+
+/// Serializes a byte array as a hex string
+///
+/// # Arguments
+///
+///  * `data`: the byte array to convert
+///  * `serializer`: the serializer to use
+pub fn as_hex<S>(data: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&to_hex(data))
+}
+
+/// Deserializes a hex string into a byte array
+///
+/// # Arguments
+///
+///  * `deserializer`: the deserializer to use
+#[allow(dead_code)]
+pub fn deserialize_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct DeserializeHex;
+    impl<'de> de::Visitor<'de> for DeserializeHex {
+        /// Return type of this visitor. This visitor computes the max of a
+        /// sequence of values of type T, so the type of the maximum is T.
+        type Value = Vec<u8>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a hex string")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            match parse_hex(v) {
+                Ok(vec) => Ok(vec),
+                Err(err) => Err(de::Error::custom(err)),
+            }
+        }
+    }
+
+    // Create the visitor and ask the deserializer to drive it. The
+    // deserializer will call visitor.visit_seq() if a seq is present in
+    // the input data.
+    deserializer.deserialize_any(DeserializeHex)
+}
+
+#[derive(Debug)]
+pub struct HexError {
+    context: String,
+    source: Option<Box<dyn Error + Send>>,
+}
+
+impl Error for HexError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let Some(ref err) = self.source {
+            Some(&**err)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for HexError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref err) = self.source {
+            write!(f, "{}: {}", self.context, err)
+        } else {
+            f.write_str(&self.context)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test the parse_hex function.
+    ///
+    /// * test positive cases
+    /// * test error cases
+    /// * test round trip
+    /// * test empty
+    #[test]
+    fn test_parse_hex() {
+        assert_eq!(
+            vec![00u8, 10u8],
+            parse_hex("000a").expect("unable to parse 000a")
+        );
+        assert_eq!(
+            vec![01u8, 99u8, 255u8],
+            parse_hex("0163ff").expect("unable to parse 0163ff")
+        );
+
+        // check that odd number of digits fails
+        assert!(parse_hex("0").is_err());
+
+        // check that invalid digits fails
+        assert!(parse_hex("0G").is_err());
+
+        // check round trip
+        assert_eq!(
+            "abcdef",
+            &to_hex(&parse_hex("abcdef").expect("unable to parse hex for round trip"))
+        );
+        assert_eq!(
+            "012345",
+            &to_hex(&parse_hex("012345").expect("unable to parse hex for round trip"))
+        );
+
+        // check empty parses
+        let empty: Vec<u8> = Vec::with_capacity(0);
+        assert_eq!(empty, parse_hex("").expect("unable to parse empty"));
+    }
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -30,6 +30,7 @@ extern crate diesel_migrations;
 #[cfg(feature = "diesel")]
 pub mod database;
 pub mod grid_db;
+mod hex;
 #[macro_use]
 extern crate log;
 pub mod permissions;

--- a/sdk/src/store/memory.rs
+++ b/sdk/src/store/memory.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::grid_db::{CommitStore, MemoryCommitStore};
+use crate::grid_db::{CommitStore, MemoryCommitStore, MemoryOrganizationStore, OrganizationStore};
 
 use super::StoreFactory;
 
@@ -20,18 +20,27 @@ use super::StoreFactory;
 #[derive(Default)]
 pub struct MemoryStoreFactory {
     grid_commit_store: MemoryCommitStore,
+    grid_organization_store: MemoryOrganizationStore,
 }
 
 impl MemoryStoreFactory {
     pub fn new() -> Self {
         let grid_commit_store = MemoryCommitStore::new();
+        let grid_organization_store = MemoryOrganizationStore::new();
 
-        Self { grid_commit_store }
+        Self {
+            grid_commit_store,
+            grid_organization_store,
+        }
     }
 }
 
 impl StoreFactory for MemoryStoreFactory {
     fn get_grid_commit_store(&self) -> Box<dyn CommitStore> {
         Box::new(self.grid_commit_store.clone())
+    }
+
+    fn get_grid_organization_store(&self) -> Box<dyn OrganizationStore> {
+        Box::new(self.grid_organization_store.clone())
     }
 }

--- a/sdk/src/store/mod.rs
+++ b/sdk/src/store/mod.rs
@@ -27,6 +27,8 @@ use diesel::r2d2::{ConnectionManager, Pool};
 pub trait StoreFactory {
     /// Get a new `CommitStore`
     fn get_grid_commit_store(&self) -> Box<dyn crate::grid_db::CommitStore>;
+    /// Get a new `OrganizationStore`
+    fn get_grid_organization_store(&self) -> Box<dyn crate::grid_db::OrganizationStore>;
 }
 
 /// Creates a `StoreFactory` backed by the given connection

--- a/sdk/src/store/postgres.rs
+++ b/sdk/src/store/postgres.rs
@@ -34,4 +34,10 @@ impl StoreFactory for PgStoreFactory {
     fn get_grid_commit_store(&self) -> Box<dyn crate::grid_db::CommitStore> {
         Box::new(crate::grid_db::DieselCommitStore::new(self.pool.clone()))
     }
+
+    fn get_grid_organization_store(&self) -> Box<dyn crate::grid_db::OrganizationStore> {
+        Box::new(crate::grid_db::DieselOrganizationStore::new(
+            self.pool.clone(),
+        ))
+    }
 }

--- a/sdk/src/store/sqlite.rs
+++ b/sdk/src/store/sqlite.rs
@@ -34,4 +34,10 @@ impl StoreFactory for SqliteStoreFactory {
     fn get_grid_commit_store(&self) -> Box<dyn crate::grid_db::CommitStore> {
         Box::new(crate::grid_db::DieselCommitStore::new(self.pool.clone()))
     }
+
+    fn get_grid_organization_store(&self) -> Box<dyn crate::grid_db::OrganizationStore> {
+        Box::new(crate::grid_db::DieselOrganizationStore::new(
+            self.pool.clone(),
+        ))
+    }
 }


### PR DESCRIPTION
This adds the postgres, sqlite, and in-memory implementations of the organization store following the new pattern. This does not currently integrate the new store into the daemon but that integration will come in a later PR.