### PR TITLE
Add location store

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -28,6 +28,7 @@ license = "Apache-2.0"
 
 
 [dependencies]
+byteorder = "1"
 cfg-if = "0.1"
 diesel = { version = "1.0", features = ["r2d2", "serde_json"], optional = true }
 diesel_migrations = { version = "1.4", optional = true }

--- a/sdk/src/grid_db/locations/mod.rs
+++ b/sdk/src/grid_db/locations/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod store;

--- a/sdk/src/grid_db/locations/store/diesel/mod.rs
+++ b/sdk/src/grid_db/locations/store/diesel/mod.rs
@@ -1,0 +1,274 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod models;
+mod operations;
+pub(in crate::grid_db) mod schema;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use super::diesel::models::{
+    LocationAttributeModel, LocationModel, NewLocationAttributeModel, NewLocationModel,
+};
+use super::{LatLongValue, Location, LocationAttribute, LocationStore, LocationStoreError};
+use crate::database::DatabaseError;
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use operations::add_location::LocationStoreAddLocationOperation as _;
+use operations::fetch_location::LocationStoreFetchLocationOperation as _;
+use operations::list_locations::LocationStoreListLocationsOperation as _;
+use operations::update_location::LocationStoreUpdateLocationOperation as _;
+use operations::LocationStoreOperations;
+
+/// Manages creating organizations in the database
+#[derive(Clone)]
+pub struct DieselLocationStore<C: diesel::Connection + 'static> {
+    connection_pool: Pool<ConnectionManager<C>>,
+}
+
+impl<C: diesel::Connection> DieselLocationStore<C> {
+    /// Creates a new DieselLocationStore
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool to the database
+    // Allow dead code if diesel feature is not enabled
+    #[allow(dead_code)]
+    pub fn new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        DieselLocationStore { connection_pool }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl LocationStore for DieselLocationStore<diesel::pg::PgConnection> {
+    fn add_location(
+        &self,
+        location: Location,
+        attributes: Vec<LocationAttribute>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError> {
+        LocationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_location(
+            location.into(),
+            make_location_attribute_models(&attributes, None),
+            current_commit_num,
+        )
+    }
+
+    fn fetch_location(
+        &self,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Location>, LocationStoreError> {
+        LocationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_location(location_id, service_id)
+    }
+
+    fn list_locations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Location>, LocationStoreError> {
+        LocationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_locations(service_id)
+    }
+
+    fn update_location(
+        &self,
+        location: Location,
+        attributes: Vec<LocationAttribute>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError> {
+        LocationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .update_location(
+            location.into(),
+            make_location_attribute_models(&attributes, None),
+            current_commit_num,
+        )
+    }
+}
+
+impl Into<NewLocationModel> for Location {
+    fn into(self) -> NewLocationModel {
+        NewLocationModel {
+            location_id: self.location_id,
+            location_namespace: self.location_namespace,
+            owner: self.owner,
+            start_commit_num: self.start_commit_num,
+            end_commit_num: MAX_COMMIT_NUM,
+            service_id: self.service_id,
+        }
+    }
+}
+
+pub fn make_location_attribute_models(
+    attributes: &[LocationAttribute],
+    parent_property_name: Option<String>,
+) -> Vec<NewLocationAttributeModel> {
+    let mut attrs = Vec::new();
+
+    for attr in attributes {
+        attrs.push(NewLocationAttributeModel {
+            location_id: attr.location_id.to_string(),
+            location_address: attr.location_address.to_string(),
+            property_name: attr.property_name.to_string(),
+            parent_property_name: parent_property_name.clone(),
+            data_type: attr.data_type.to_string(),
+            bytes_value: attr.bytes_value.clone(),
+            boolean_value: attr.boolean_value,
+            number_value: attr.number_value,
+            string_value: attr.string_value.clone(),
+            enum_value: attr.enum_value,
+            latitude_value: attr.lat_long_value.clone().map(|lat_long| lat_long.0),
+            longitude_value: attr.lat_long_value.clone().map(|lat_long| lat_long.1),
+            start_commit_num: attr.start_commit_num,
+            end_commit_num: MAX_COMMIT_NUM,
+            service_id: attr.service_id.clone(),
+        });
+
+        if attr.struct_values.is_some() {
+            let vals = attr.struct_values.as_ref().unwrap();
+            if !vals.is_empty() {
+                attrs.append(&mut make_location_attribute_models(
+                    &vals,
+                    Some(attr.property_name.to_string()),
+                ));
+            }
+        }
+    }
+
+    attrs
+}
+
+impl From<(i64, i64)> for LatLongValue {
+    fn from((lat, long): (i64, i64)) -> Self {
+        Self(lat, long)
+    }
+}
+
+impl From<LocationAttributeModel> for LocationAttribute {
+    fn from(model: LocationAttributeModel) -> Self {
+        Self {
+            location_id: model.location_id,
+            location_address: model.location_address,
+            property_name: model.property_name,
+            parent_property_name: model.parent_property_name,
+            data_type: model.data_type,
+            bytes_value: model.bytes_value,
+            boolean_value: model.boolean_value,
+            number_value: model.number_value,
+            string_value: model.string_value,
+            enum_value: model.enum_value,
+            struct_values: None,
+            lat_long_value: create_lat_long_value(model.latitude_value, model.longitude_value),
+            start_commit_num: model.start_commit_num,
+            end_commit_num: model.end_commit_num,
+            service_id: model.service_id,
+        }
+    }
+}
+
+impl From<(LocationAttributeModel, Vec<LocationAttribute>)> for LocationAttribute {
+    fn from((model, children): (LocationAttributeModel, Vec<LocationAttribute>)) -> Self {
+        Self {
+            location_id: model.location_id,
+            location_address: model.location_address,
+            property_name: model.property_name,
+            parent_property_name: model.parent_property_name,
+            data_type: model.data_type,
+            bytes_value: model.bytes_value,
+            boolean_value: model.boolean_value,
+            number_value: model.number_value,
+            string_value: model.string_value,
+            enum_value: model.enum_value,
+            struct_values: Some(children),
+            lat_long_value: create_lat_long_value(model.latitude_value, model.longitude_value),
+            start_commit_num: model.start_commit_num,
+            end_commit_num: model.end_commit_num,
+            service_id: model.service_id,
+        }
+    }
+}
+
+impl From<(LocationModel, Vec<LocationAttribute>)> for Location {
+    fn from((location, attributes): (LocationModel, Vec<LocationAttribute>)) -> Self {
+        Self {
+            location_id: location.location_id,
+            location_namespace: location.location_namespace,
+            owner: location.owner,
+            attributes,
+            start_commit_num: location.start_commit_num,
+            end_commit_num: location.end_commit_num,
+            service_id: location.service_id,
+        }
+    }
+}
+
+impl From<LocationModel> for Location {
+    fn from(location: LocationModel) -> Self {
+        Self {
+            location_id: location.location_id,
+            location_namespace: location.location_namespace,
+            owner: location.owner,
+            attributes: Vec::new(),
+            start_commit_num: location.start_commit_num,
+            end_commit_num: location.end_commit_num,
+            service_id: location.service_id,
+        }
+    }
+}
+
+impl From<NewLocationModel> for Location {
+    fn from(location: NewLocationModel) -> Self {
+        Self {
+            location_id: location.location_id,
+            location_namespace: location.location_namespace,
+            owner: location.owner,
+            attributes: Vec::new(),
+            start_commit_num: location.start_commit_num,
+            end_commit_num: location.end_commit_num,
+            service_id: location.service_id,
+        }
+    }
+}
+
+pub fn create_lat_long_value(lat: Option<i64>, long: Option<i64>) -> Option<LatLongValue> {
+    if let Some(latitude) = lat {
+        if let Some(longitude) = long {
+            Some(LatLongValue::from((latitude, longitude)))
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}

--- a/sdk/src/grid_db/locations/store/diesel/mod.rs
+++ b/sdk/src/grid_db/locations/store/diesel/mod.rs
@@ -117,6 +117,75 @@ impl LocationStore for DieselLocationStore<diesel::pg::PgConnection> {
     }
 }
 
+#[cfg(feature = "sqlite")]
+impl LocationStore for DieselLocationStore<diesel::sqlite::SqliteConnection> {
+    fn add_location(
+        &self,
+        location: Location,
+        attributes: Vec<LocationAttribute>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError> {
+        LocationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_location(
+            location.into(),
+            make_location_attribute_models(&attributes, None),
+            current_commit_num,
+        )
+    }
+
+    fn fetch_location(
+        &self,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Location>, LocationStoreError> {
+        LocationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_location(location_id, service_id)
+    }
+
+    fn list_locations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Location>, LocationStoreError> {
+        LocationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_locations(service_id)
+    }
+
+    fn update_location(
+        &self,
+        location: Location,
+        attributes: Vec<LocationAttribute>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError> {
+        LocationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .update_location(
+            location.into(),
+            make_location_attribute_models(&attributes, None),
+            current_commit_num,
+        )
+    }
+}
+
+#[cfg(feature = "diesel")]
 impl Into<NewLocationModel> for Location {
     fn into(self) -> NewLocationModel {
         NewLocationModel {

--- a/sdk/src/grid_db/locations/store/diesel/models.rs
+++ b/sdk/src/grid_db/locations/store/diesel/models.rs
@@ -1,0 +1,91 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::grid_db::locations::store::diesel::schema::{location, location_attribute};
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "location"]
+pub struct NewLocationModel {
+    pub location_id: String,
+    pub location_namespace: String,
+    pub owner: String,
+
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "location"]
+pub struct LocationModel {
+    pub id: i64,
+    pub location_id: String,
+    pub location_namespace: String,
+    pub owner: String,
+
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "location_attribute"]
+pub struct NewLocationAttributeModel {
+    pub location_id: String,
+    pub location_address: String,
+    pub property_name: String,
+    pub parent_property_name: Option<String>,
+    pub data_type: String,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<i32>,
+    pub latitude_value: Option<i64>,
+    pub longitude_value: Option<i64>,
+
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "location_attribute"]
+pub struct LocationAttributeModel {
+    pub id: i64,
+    pub location_id: String,
+    pub location_address: String,
+    pub property_name: String,
+    pub parent_property_name: Option<String>,
+    pub data_type: String,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<i32>,
+    pub latitude_value: Option<i64>,
+    pub longitude_value: Option<i64>,
+
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+
+    pub service_id: Option<String>,
+}

--- a/sdk/src/grid_db/locations/store/diesel/operations/add_location.rs
+++ b/sdk/src/grid_db/locations/store/diesel/operations/add_location.rs
@@ -1,0 +1,143 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::LocationStoreOperations;
+use crate::grid_db::locations::store::diesel::{
+    schema::{location, location_attribute},
+    LocationStoreError,
+};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::locations::store::diesel::models::{
+    LocationAttributeModel, LocationModel, NewLocationAttributeModel, NewLocationModel,
+};
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error::NotFound,
+};
+
+pub(in crate::grid_db::locations::store::diesel) trait LocationStoreAddLocationOperation {
+    fn add_location(
+        &self,
+        location: NewLocationModel,
+        attributes: Vec<NewLocationAttributeModel>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> LocationStoreAddLocationOperation
+    for LocationStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_location(
+        &self,
+        location: NewLocationModel,
+        attributes: Vec<NewLocationAttributeModel>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, LocationStoreError, _>(|| {
+                let duplicate_loc = location::table
+                    .filter(
+                        location::location_id
+                            .eq(&location.location_id)
+                            .and(location::service_id.eq(&location.service_id))
+                            .and(location.end_commit_num.eq(&MAX_COMMIT_NUM)),
+                    )
+                    .first::<LocationModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                    .map_err(|err| LocationStoreError::QueryError {
+                        context: "Failed check for existing location".to_string(),
+                        source: Box::new(err),
+                    })?;
+
+                if duplicate_loc.is_some() {
+                    update(location::table)
+                        .filter(
+                            location::location_id
+                                .eq(&location.location_id)
+                                .and(location::service_id.eq(&location.service_id))
+                                .and(location::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(location::end_commit_num.eq(current_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| LocationStoreError::OperationError {
+                            context: "Failed to update location".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                insert_into(location::table)
+                    .values(&location)
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(|err| LocationStoreError::OperationError {
+                        context: "Failed to add location".to_string(),
+                        source: Some(Box::new(err)),
+                    })?;
+
+                for attr in attributes {
+                    let duplicate_attr = location_attribute::table
+                        .filter(
+                            location_attribute::location_id
+                                .eq(&attr.location_id)
+                                .and(location_attribute::property_name.eq(&attr.property_name))
+                                .and(location_attribute::service_id.eq(&attr.service_id))
+                                .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .first::<LocationAttributeModel>(self.conn)
+                        .map(Some)
+                        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                        .map_err(|err| LocationStoreError::QueryError {
+                            context: "Failed check for existing attribute".to_string(),
+                            source: Box::new(err),
+                        })?;
+
+                    if duplicate_attr.is_some() {
+                        update(location_attribute::table)
+                            .filter(
+                                location_attribute::location_id
+                                    .eq(&attr.location_id)
+                                    .and(location_attribute::property_name.eq(&attr.property_name))
+                                    .and(location_attribute::service_id.eq(&attr.service_id))
+                                    .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(location_attribute::end_commit_num.eq(current_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(|err| LocationStoreError::OperationError {
+                                context: "Failed to update location attribute".to_string(),
+                                source: Some(Box::new(err)),
+                            })?;
+                    }
+
+                    insert_into(location_attribute::table)
+                        .values(&attr)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| LocationStoreError::OperationError {
+                            context: "Failed to add location attribute".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/locations/store/diesel/operations/add_location.rs
+++ b/sdk/src/grid_db/locations/store/diesel/operations/add_location.rs
@@ -141,3 +141,106 @@ impl<'a> LocationStoreAddLocationOperation
             })
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a> LocationStoreAddLocationOperation
+    for LocationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_location(
+        &self,
+        location: NewLocationModel,
+        attributes: Vec<NewLocationAttributeModel>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError> {
+        self.conn
+            .immediate_transaction::<_, LocationStoreError, _>(|| {
+                let duplicate_loc = location::table
+                    .filter(
+                        location::location_id
+                            .eq(&location.location_id)
+                            .and(location::service_id.eq(&location.service_id))
+                            .and(location.end_commit_num.eq(&MAX_COMMIT_NUM)),
+                    )
+                    .first::<LocationModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                    .map_err(|err| LocationStoreError::QueryError {
+                        context: "Failed check for existing location".to_string(),
+                        source: Box::new(err),
+                    })?;
+
+                if duplicate_loc.is_some() {
+                    update(location::table)
+                        .filter(
+                            location::location_id
+                                .eq(&location.location_id)
+                                .and(location::service_id.eq(&location.service_id))
+                                .and(location::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(location::end_commit_num.eq(current_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| LocationStoreError::OperationError {
+                            context: "Failed to update location".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                insert_into(location::table)
+                    .values(&location)
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(|err| LocationStoreError::OperationError {
+                        context: "Failed to add location".to_string(),
+                        source: Some(Box::new(err)),
+                    })?;
+
+                for attr in attributes {
+                    let duplicate_attr = location_attribute::table
+                        .filter(
+                            location_attribute::location_id
+                                .eq(&attr.location_id)
+                                .and(location_attribute::property_name.eq(&attr.property_name))
+                                .and(location_attribute::service_id.eq(&attr.service_id))
+                                .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .first::<LocationAttributeModel>(self.conn)
+                        .map(Some)
+                        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                        .map_err(|err| LocationStoreError::QueryError {
+                            context: "Failed check for existing attribute".to_string(),
+                            source: Box::new(err),
+                        })?;
+
+                    if duplicate_attr.is_some() {
+                        update(location_attribute::table)
+                            .filter(
+                                location_attribute::location_id
+                                    .eq(&attr.location_id)
+                                    .and(location_attribute::property_name.eq(&attr.property_name))
+                                    .and(location_attribute::service_id.eq(&attr.service_id))
+                                    .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(location_attribute::end_commit_num.eq(current_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(|err| LocationStoreError::OperationError {
+                                context: "Failed to update location attribute".to_string(),
+                                source: Some(Box::new(err)),
+                            })?;
+                    }
+
+                    insert_into(location_attribute::table)
+                        .values(&attr)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| LocationStoreError::OperationError {
+                            context: "Failed to add location attribute".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/locations/store/diesel/operations/fetch_location.rs
+++ b/sdk/src/grid_db/locations/store/diesel/operations/fetch_location.rs
@@ -133,3 +133,92 @@ impl<'a> LocationStoreFetchLocationOperation<diesel::pg::PgConnection>
         Ok(attrs)
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a> LocationStoreFetchLocationOperation<diesel::sqlite::SqliteConnection>
+    for LocationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn fetch_location(
+        &self,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Location>, LocationStoreError> {
+        self.conn
+            .immediate_transaction::<_, LocationStoreError, _>(|| {
+                let loc = location::table
+                    .filter(
+                        location::location_id
+                            .eq(&location_id)
+                            .and(location::service_id.eq(&service_id))
+                            .and(location::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .first::<LocationModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                    .map_err(|err| LocationStoreError::QueryError {
+                        context: "Failed to fetch location for location_id".to_string(),
+                        source: Box::new(err),
+                    })?
+                    .ok_or_else(|| {
+                        LocationStoreError::NotFoundError(format!(
+                            "Failed to find location: {}",
+                            location_id,
+                        ))
+                    })?;
+
+                let roots =
+                    Self::get_root_attributes(&*self.conn, &location_id, service_id.clone())?;
+
+                let attrs = Self::get_attributes(&*self.conn, roots)?;
+
+                Ok(Some(Location::from((loc, attrs))))
+            })
+    }
+
+    fn get_root_attributes(
+        conn: &SqliteConnection,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> QueryResult<Vec<LocationAttributeModel>> {
+        location_attribute::table
+            .select(location_attribute::all_columns)
+            .filter(
+                location_attribute::location_id
+                    .eq(location_id)
+                    .and(location_attribute::parent_property_name.is_null())
+                    .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM))
+                    .and(location_attribute::service_id.eq(&service_id)),
+            )
+            .load::<LocationAttributeModel>(conn)
+    }
+
+    fn get_attributes(
+        conn: &SqliteConnection,
+        attributes: Vec<LocationAttributeModel>,
+    ) -> Result<Vec<LocationAttribute>, LocationStoreError> {
+        let mut attrs = Vec::new();
+
+        for attr in attributes {
+            let children = location_attribute::table
+                .select(location_attribute::all_columns)
+                .filter(
+                    location_attribute::parent_property_name
+                        .eq(&attr.parent_property_name)
+                        .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM))
+                        .and(location_attribute::service_id.eq(&attr.service_id)),
+                )
+                .load(conn)?;
+
+            if children.is_empty() {
+                attrs.push(LocationAttribute::from(attr));
+            } else {
+                attrs.push(LocationAttribute::from((
+                    attr,
+                    Self::get_attributes(&conn, children)?,
+                )));
+            }
+        }
+
+        Ok(attrs)
+    }
+}

--- a/sdk/src/grid_db/locations/store/diesel/operations/fetch_location.rs
+++ b/sdk/src/grid_db/locations/store/diesel/operations/fetch_location.rs
@@ -1,0 +1,135 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::LocationStoreOperations;
+use crate::grid_db::locations::store::diesel::{
+    schema::{location, location_attribute},
+    LocationStoreError,
+};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::locations::store::diesel::models::{LocationAttributeModel, LocationModel};
+use crate::grid_db::locations::store::{Location, LocationAttribute};
+use diesel::{prelude::*, result::Error::NotFound, QueryResult};
+
+pub(in crate::grid_db::locations::store::diesel) trait LocationStoreFetchLocationOperation<
+    C: Connection,
+>
+{
+    fn fetch_location(
+        &self,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Location>, LocationStoreError>;
+    fn get_root_attributes(
+        conn: &C,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> QueryResult<Vec<LocationAttributeModel>>;
+    fn get_attributes(
+        conn: &C,
+        attributes: Vec<LocationAttributeModel>,
+    ) -> Result<Vec<LocationAttribute>, LocationStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> LocationStoreFetchLocationOperation<diesel::pg::PgConnection>
+    for LocationStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn fetch_location(
+        &self,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Location>, LocationStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, LocationStoreError, _>(|| {
+                let loc = location::table
+                    .filter(
+                        location::location_id
+                            .eq(&location_id)
+                            .and(location::service_id.eq(&service_id))
+                            .and(location::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .first::<LocationModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                    .map_err(|err| LocationStoreError::QueryError {
+                        context: "Failed to fetch location for location_id".to_string(),
+                        source: Box::new(err),
+                    })?
+                    .ok_or_else(|| {
+                        LocationStoreError::NotFoundError(format!(
+                            "Failed to find location: {}",
+                            location_id,
+                        ))
+                    })?;
+
+                let roots =
+                    Self::get_root_attributes(&*self.conn, &location_id, service_id.clone())?;
+
+                let attrs = Self::get_attributes(&*self.conn, roots)?;
+
+                Ok(Some(Location::from((loc, attrs))))
+            })
+    }
+
+    fn get_root_attributes(
+        conn: &PgConnection,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> QueryResult<Vec<LocationAttributeModel>> {
+        location_attribute::table
+            .select(location_attribute::all_columns)
+            .filter(
+                location_attribute::location_id
+                    .eq(location_id)
+                    .and(location_attribute::parent_property_name.is_null())
+                    .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM))
+                    .and(location_attribute::service_id.eq(&service_id)),
+            )
+            .load::<LocationAttributeModel>(conn)
+    }
+
+    fn get_attributes(
+        conn: &PgConnection,
+        attributes: Vec<LocationAttributeModel>,
+    ) -> Result<Vec<LocationAttribute>, LocationStoreError> {
+        let mut attrs = Vec::new();
+
+        for attr in attributes {
+            let children = location_attribute::table
+                .select(location_attribute::all_columns)
+                .filter(
+                    location_attribute::parent_property_name
+                        .eq(&attr.parent_property_name)
+                        .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM))
+                        .and(location_attribute::service_id.eq(&attr.service_id)),
+                )
+                .load(conn)?;
+
+            if children.is_empty() {
+                attrs.push(LocationAttribute::from(attr));
+            } else {
+                attrs.push(LocationAttribute::from((
+                    attr,
+                    Self::get_attributes(&conn, children)?,
+                )));
+            }
+        }
+
+        Ok(attrs)
+    }
+}

--- a/sdk/src/grid_db/locations/store/diesel/operations/list_locations.rs
+++ b/sdk/src/grid_db/locations/store/diesel/operations/list_locations.rs
@@ -1,0 +1,143 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::LocationStoreOperations;
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::locations::store::diesel::{
+    schema::{location, location_attribute},
+    LocationStoreError,
+};
+
+use crate::grid_db::locations::store::diesel::models::{LocationAttributeModel, LocationModel};
+use crate::grid_db::locations::store::{Location, LocationAttribute};
+use diesel::prelude::*;
+
+pub(in crate::grid_db::locations::store::diesel) trait LocationStoreListLocationsOperation<
+    C: Connection,
+>
+{
+    fn list_locations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Location>, LocationStoreError>;
+    fn get_root_attributes(
+        conn: &C,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> QueryResult<Vec<LocationAttributeModel>>;
+    fn get_attributes(
+        conn: &C,
+        attributes: Vec<LocationAttributeModel>,
+    ) -> Result<Vec<LocationAttribute>, LocationStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> LocationStoreListLocationsOperation<diesel::pg::PgConnection>
+    for LocationStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_locations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Location>, LocationStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, LocationStoreError, _>(|| {
+                let locs: Vec<LocationModel> = location::table
+                    .select(location::all_columns)
+                    .filter(
+                        location::service_id
+                            .eq(&service_id)
+                            .and(location::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .load::<LocationModel>(self.conn)
+                    .map(Some)
+                    .map_err(|err| LocationStoreError::OperationError {
+                        context: "Failed to fetch locations".to_string(),
+                        source: Some(Box::new(err)),
+                    })?
+                    .ok_or_else(|| {
+                        LocationStoreError::NotFoundError(
+                            "Could not get all locations from storage".to_string(),
+                        )
+                    })?
+                    .into_iter()
+                    .collect();
+
+                let mut locations = Vec::new();
+
+                for l in locs {
+                    let loc: LocationModel = l;
+                    let roots = Self::get_root_attributes(
+                        &*self.conn,
+                        &loc.location_id,
+                        service_id.clone(),
+                    )?;
+
+                    let attrs = Self::get_attributes(&*self.conn, roots)?;
+
+                    locations.push(Location::from((loc, attrs)));
+                }
+
+                Ok(locations)
+            })
+    }
+
+    fn get_root_attributes(
+        conn: &PgConnection,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> QueryResult<Vec<LocationAttributeModel>> {
+        location_attribute::table
+            .select(location_attribute::all_columns)
+            .filter(
+                location_attribute::location_id
+                    .eq(location_id)
+                    .and(location_attribute::parent_property_name.is_null())
+                    .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM))
+                    .and(location_attribute::service_id.eq(&service_id)),
+            )
+            .load::<LocationAttributeModel>(conn)
+    }
+
+    fn get_attributes(
+        conn: &PgConnection,
+        attributes: Vec<LocationAttributeModel>,
+    ) -> Result<Vec<LocationAttribute>, LocationStoreError> {
+        let mut attrs = Vec::new();
+
+        for attr in attributes {
+            let children = location_attribute::table
+                .select(location_attribute::all_columns)
+                .filter(
+                    location_attribute::parent_property_name
+                        .eq(&attr.parent_property_name)
+                        .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM))
+                        .and(location_attribute::service_id.eq(&attr.service_id)),
+                )
+                .load(conn)?;
+
+            if children.is_empty() {
+                attrs.push(LocationAttribute::from(attr));
+            } else {
+                attrs.push(LocationAttribute::from((
+                    attr,
+                    Self::get_attributes(&conn, children)?,
+                )));
+            }
+        }
+
+        Ok(attrs)
+    }
+}

--- a/sdk/src/grid_db/locations/store/diesel/operations/list_locations.rs
+++ b/sdk/src/grid_db/locations/store/diesel/operations/list_locations.rs
@@ -141,3 +141,101 @@ impl<'a> LocationStoreListLocationsOperation<diesel::pg::PgConnection>
         Ok(attrs)
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a> LocationStoreListLocationsOperation<diesel::sqlite::SqliteConnection>
+    for LocationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn list_locations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Location>, LocationStoreError> {
+        self.conn
+            .immediate_transaction::<_, LocationStoreError, _>(|| {
+                let locs: Vec<LocationModel> = location::table
+                    .select(location::all_columns)
+                    .filter(
+                        location::service_id
+                            .eq(&service_id)
+                            .and(location::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .load::<LocationModel>(self.conn)
+                    .map(Some)
+                    .map_err(|err| LocationStoreError::OperationError {
+                        context: "Failed to fetch locations".to_string(),
+                        source: Some(Box::new(err)),
+                    })?
+                    .ok_or_else(|| {
+                        LocationStoreError::NotFoundError(
+                            "Could not get all locations from storage".to_string(),
+                        )
+                    })?
+                    .into_iter()
+                    .collect();
+
+                let mut locations = Vec::new();
+
+                for l in locs {
+                    let loc: LocationModel = l;
+                    let roots = Self::get_root_attributes(
+                        &*self.conn,
+                        &loc.location_id,
+                        service_id.clone(),
+                    )?;
+
+                    let attrs = Self::get_attributes(&*self.conn, roots)?;
+
+                    locations.push(Location::from((loc, attrs)));
+                }
+
+                Ok(locations)
+            })
+    }
+
+    fn get_root_attributes(
+        conn: &SqliteConnection,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> QueryResult<Vec<LocationAttributeModel>> {
+        location_attribute::table
+            .select(location_attribute::all_columns)
+            .filter(
+                location_attribute::location_id
+                    .eq(location_id)
+                    .and(location_attribute::parent_property_name.is_null())
+                    .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM))
+                    .and(location_attribute::service_id.eq(&service_id)),
+            )
+            .load::<LocationAttributeModel>(conn)
+    }
+
+    fn get_attributes(
+        conn: &SqliteConnection,
+        attributes: Vec<LocationAttributeModel>,
+    ) -> Result<Vec<LocationAttribute>, LocationStoreError> {
+        let mut attrs = Vec::new();
+
+        for attr in attributes {
+            let children = location_attribute::table
+                .select(location_attribute::all_columns)
+                .filter(
+                    location_attribute::parent_property_name
+                        .eq(&attr.parent_property_name)
+                        .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM))
+                        .and(location_attribute::service_id.eq(&attr.service_id)),
+                )
+                .load(conn)?;
+
+            if children.is_empty() {
+                attrs.push(LocationAttribute::from(attr));
+            } else {
+                attrs.push(LocationAttribute::from((
+                    attr,
+                    Self::get_attributes(&conn, children)?,
+                )));
+            }
+        }
+
+        Ok(attrs)
+    }
+}

--- a/sdk/src/grid_db/locations/store/diesel/operations/mod.rs
+++ b/sdk/src/grid_db/locations/store/diesel/operations/mod.rs
@@ -1,0 +1,31 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) mod add_location;
+pub(super) mod fetch_location;
+pub(super) mod list_locations;
+pub(super) mod update_location;
+
+pub(super) struct LocationStoreOperations<'a, C> {
+    conn: &'a C,
+}
+
+impl<'a, C> LocationStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    pub fn new(conn: &'a C) -> Self {
+        LocationStoreOperations { conn }
+    }
+}

--- a/sdk/src/grid_db/locations/store/diesel/operations/update_location.rs
+++ b/sdk/src/grid_db/locations/store/diesel/operations/update_location.rs
@@ -1,0 +1,123 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::LocationStoreOperations;
+use crate::grid_db::locations::store::diesel::{
+    schema::{location, location_attribute},
+    LocationStoreError,
+};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::locations::store::diesel::models::{
+    LocationModel, NewLocationAttributeModel, NewLocationModel,
+};
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error::NotFound,
+};
+
+pub(in crate::grid_db::locations::store::diesel) trait LocationStoreUpdateLocationOperation {
+    fn update_location(
+        &self,
+        location: NewLocationModel,
+        attributes: Vec<NewLocationAttributeModel>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> LocationStoreUpdateLocationOperation
+    for LocationStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn update_location(
+        &self,
+        location: NewLocationModel,
+        attributes: Vec<NewLocationAttributeModel>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, LocationStoreError, _>(|| {
+                let loc = location::table
+                    .filter(
+                        location::location_id
+                            .eq(&location.location_id)
+                            .and(location::service_id.eq(&location.service_id)),
+                    )
+                    .first::<LocationModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                    .map_err(|err| LocationStoreError::QueryError {
+                        context: "Failed check for existing location".to_string(),
+                        source: Box::new(err),
+                    })?;
+
+                if loc.is_some() {
+                    update(location::table)
+                        .filter(
+                            location::location_id
+                                .eq(&location.location_id)
+                                .and(location::service_id.eq(&location.service_id))
+                                .and(location::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(location::end_commit_num.eq(current_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| LocationStoreError::OperationError {
+                            context: "Failed to update location".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                insert_into(location::table)
+                    .values(&location)
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(|err| LocationStoreError::OperationError {
+                        context: "Failed to add location".to_string(),
+                        source: Some(Box::new(err)),
+                    })?;
+
+                update(location_attribute::table)
+                    .filter(
+                        location_attribute::location_id
+                            .eq(&location.location_id)
+                            .and(location_attribute::service_id.eq(&location.service_id))
+                            .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(location_attribute::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(|err| LocationStoreError::OperationError {
+                        context: "Failed to update location".to_string(),
+                        source: Some(Box::new(err)),
+                    })?;
+
+                for attribute in attributes {
+                    insert_into(location_attribute::table)
+                        .values(&attribute)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| LocationStoreError::OperationError {
+                            context: "Failed to add location attribute".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/locations/store/diesel/operations/update_location.rs
+++ b/sdk/src/grid_db/locations/store/diesel/operations/update_location.rs
@@ -121,3 +121,86 @@ impl<'a> LocationStoreUpdateLocationOperation
             })
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a> LocationStoreUpdateLocationOperation
+    for LocationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn update_location(
+        &self,
+        location: NewLocationModel,
+        attributes: Vec<NewLocationAttributeModel>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError> {
+        self.conn
+            .immediate_transaction::<_, LocationStoreError, _>(|| {
+                let loc = location::table
+                    .filter(
+                        location::location_id
+                            .eq(&location.location_id)
+                            .and(location::service_id.eq(&location.service_id)),
+                    )
+                    .first::<LocationModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                    .map_err(|err| LocationStoreError::QueryError {
+                        context: "Failed check for existing location".to_string(),
+                        source: Box::new(err),
+                    })?;
+
+                if loc.is_some() {
+                    update(location::table)
+                        .filter(
+                            location::location_id
+                                .eq(&location.location_id)
+                                .and(location::service_id.eq(&location.service_id))
+                                .and(location::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(location::end_commit_num.eq(current_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| LocationStoreError::OperationError {
+                            context: "Failed to update location".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                insert_into(location::table)
+                    .values(&location)
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(|err| LocationStoreError::OperationError {
+                        context: "Failed to add location".to_string(),
+                        source: Some(Box::new(err)),
+                    })?;
+
+                update(location_attribute::table)
+                    .filter(
+                        location_attribute::location_id
+                            .eq(&location.location_id)
+                            .and(location_attribute::service_id.eq(&location.service_id))
+                            .and(location_attribute::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(location_attribute::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(|err| LocationStoreError::OperationError {
+                        context: "Failed to update location".to_string(),
+                        source: Some(Box::new(err)),
+                    })?;
+
+                for attribute in attributes {
+                    insert_into(location_attribute::table)
+                        .values(&attribute)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| LocationStoreError::OperationError {
+                            context: "Failed to add location attribute".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/locations/store/diesel/schema.rs
+++ b/sdk/src/grid_db/locations/store/diesel/schema.rs
@@ -1,0 +1,47 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+table! {
+    location (id) {
+        id -> Int8,
+        location_id -> Varchar,
+        location_namespace -> Text,
+        owner -> Varchar,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+    location_attribute (id) {
+        id -> Int8,
+        location_id -> Varchar,
+        location_address -> Text,
+        property_name -> Text,
+        parent_property_name -> Nullable<Text>,
+        data_type -> Text,
+        bytes_value -> Nullable<Bytea>,
+        boolean_value -> Nullable<Bool>,
+        number_value -> Nullable<Int8>,
+        string_value -> Nullable<Text>,
+        enum_value -> Nullable<Int4>,
+        latitude_value -> Nullable<Int8>,
+        longitude_value -> Nullable<Int8>,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}

--- a/sdk/src/grid_db/locations/store/error.rs
+++ b/sdk/src/grid_db/locations/store/error.rs
@@ -1,0 +1,137 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+#[cfg(feature = "diesel")]
+use crate::database::error;
+
+/// Represents LocationStore errors
+#[derive(Debug)]
+pub enum LocationStoreError {
+    /// Represents CRUD operations failures
+    OperationError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    /// Represents database query failures
+    QueryError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents general failures in the database
+    StorageError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    DuplicateError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    /// Represents an issue connecting to the database
+    ConnectionError(Box<dyn Error>),
+    NotFoundError(String),
+}
+
+impl Error for LocationStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            LocationStoreError::OperationError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            LocationStoreError::OperationError { source: None, .. } => None,
+            LocationStoreError::QueryError { source, .. } => Some(&**source),
+            LocationStoreError::StorageError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            LocationStoreError::StorageError { source: None, .. } => None,
+            LocationStoreError::ConnectionError(err) => Some(&**err),
+            LocationStoreError::DuplicateError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            LocationStoreError::DuplicateError { source: None, .. } => None,
+            LocationStoreError::NotFoundError(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for LocationStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LocationStoreError::OperationError {
+                context,
+                source: Some(source),
+            } => write!(f, "failed to perform operation: {}: {}", context, source),
+            LocationStoreError::OperationError {
+                context,
+                source: None,
+            } => write!(f, "failed to perform operation: {}", context),
+            LocationStoreError::QueryError { context, source } => {
+                write!(f, "failed query: {}: {}", context, source)
+            }
+            LocationStoreError::StorageError {
+                context,
+                source: Some(source),
+            } => write!(
+                f,
+                "the underlying storage returned an error: {}: {}",
+                context, source
+            ),
+            LocationStoreError::StorageError {
+                context,
+                source: None,
+            } => write!(f, "the underlying storage returned an error: {}", context),
+            LocationStoreError::ConnectionError(err) => {
+                write!(f, "failed to connect to underlying storage: {}", err)
+            }
+            LocationStoreError::DuplicateError {
+                context,
+                source: Some(source),
+            } => write!(f, "Commit already exists: {}: {}", context, source),
+            LocationStoreError::DuplicateError {
+                context,
+                source: None,
+            } => write!(f, "The commit already exists: {}", context),
+            LocationStoreError::NotFoundError(ref s) => write!(f, "Commit not found: {}", s),
+        }
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<error::DatabaseError> for LocationStoreError {
+    fn from(err: error::DatabaseError) -> LocationStoreError {
+        LocationStoreError::ConnectionError(Box::new(err))
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<diesel::result::Error> for LocationStoreError {
+    fn from(err: diesel::result::Error) -> LocationStoreError {
+        LocationStoreError::QueryError {
+            context: "Diesel query failed".to_string(),
+            source: Box::new(err),
+        }
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<diesel::r2d2::PoolError> for LocationStoreError {
+    fn from(err: diesel::r2d2::PoolError) -> LocationStoreError {
+        LocationStoreError::ConnectionError(Box::new(err))
+    }
+}

--- a/sdk/src/grid_db/locations/store/mod.rs
+++ b/sdk/src/grid_db/locations/store/mod.rs
@@ -1,0 +1,145 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "diesel")]
+pub mod diesel;
+mod error;
+
+pub use error::LocationStoreError;
+
+/// Represents a Grid Location
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct Location {
+    pub location_id: String,
+    pub location_namespace: String,
+    pub owner: String,
+    pub attributes: Vec<LocationAttribute>,
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+/// Represents a Grid Location Attribute
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct LocationAttribute {
+    pub location_id: String,
+    pub location_address: String,
+    pub property_name: String,
+    pub parent_property_name: Option<String>,
+    pub data_type: String,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<i32>,
+    pub struct_values: Option<Vec<LocationAttribute>>,
+    pub lat_long_value: Option<LatLongValue>,
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct LatLong;
+
+#[derive(Debug, PartialEq, Clone, Serialize)]
+pub struct LatLongValue(pub i64, pub i64);
+
+pub trait LocationStore: Send + Sync {
+    /// Adds a location to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `location` - The location to be added
+    fn add_location(
+        &self,
+        location: Location,
+        attributes: Vec<LocationAttribute>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError>;
+
+    /// Fetches a location from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `location_id` - The ID of the location to be fetched
+    ///  * `service_id` - optional - The service ID to fetch the location from
+    fn fetch_location(
+        &self,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Location>, LocationStoreError>;
+
+    /// Gets locations from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_id` - optional - The service ID to get the locations for
+    fn list_locations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Location>, LocationStoreError>;
+
+    /// Gets locations from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `location` - The updated location
+    fn update_location(
+        &self,
+        location: Location,
+        attributes: Vec<LocationAttribute>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError>;
+}
+
+impl<LS> LocationStore for Box<LS>
+where
+    LS: LocationStore + ?Sized,
+{
+    fn add_location(
+        &self,
+        location: Location,
+        attributes: Vec<LocationAttribute>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError> {
+        (**self).add_location(location, attributes, current_commit_num)
+    }
+
+    fn fetch_location(
+        &self,
+        location_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Location>, LocationStoreError> {
+        (**self).fetch_location(location_id, service_id)
+    }
+
+    fn list_locations(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Location>, LocationStoreError> {
+        (**self).list_locations(service_id)
+    }
+
+    fn update_location(
+        &self,
+        location: Location,
+        attributes: Vec<LocationAttribute>,
+        current_commit_num: i64,
+    ) -> Result<(), LocationStoreError> {
+        (**self).update_location(location, attributes, current_commit_num)
+    }
+}

--- a/sdk/src/grid_db/mod.rs
+++ b/sdk/src/grid_db/mod.rs
@@ -17,6 +17,7 @@
 //! data.
 
 pub mod commits;
+pub mod locations;
 pub mod organizations;
 
 pub mod migrations;
@@ -30,3 +31,7 @@ pub use commits::store::CommitStore;
 pub use organizations::store::diesel::DieselOrganizationStore;
 pub use organizations::store::memory::MemoryOrganizationStore;
 pub use organizations::store::OrganizationStore;
+
+#[cfg(feature = "diesel")]
+pub use locations::store::diesel::DieselLocationStore;
+pub use locations::store::LocationStore;

--- a/sdk/src/store/memory.rs
+++ b/sdk/src/store/memory.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::grid_db::{CommitStore, MemoryCommitStore, MemoryOrganizationStore, OrganizationStore};
+use crate::grid_db::{
+    CommitStore, LocationStore, MemoryCommitStore, MemoryOrganizationStore, OrganizationStore,
+};
 
 use super::StoreFactory;
 
@@ -42,5 +44,9 @@ impl StoreFactory for MemoryStoreFactory {
 
     fn get_grid_organization_store(&self) -> Box<dyn OrganizationStore> {
         Box::new(self.grid_organization_store.clone())
+    }
+
+    fn get_grid_location_store(&self) -> Box<dyn LocationStore> {
+        unimplemented!()
     }
 }

--- a/sdk/src/store/mod.rs
+++ b/sdk/src/store/mod.rs
@@ -29,6 +29,8 @@ pub trait StoreFactory {
     fn get_grid_commit_store(&self) -> Box<dyn crate::grid_db::CommitStore>;
     /// Get a new `OrganizationStore`
     fn get_grid_organization_store(&self) -> Box<dyn crate::grid_db::OrganizationStore>;
+    /// Get a new `LocationStore`
+    fn get_grid_location_store(&self) -> Box<dyn crate::grid_db::LocationStore>;
 }
 
 /// Creates a `StoreFactory` backed by the given connection

--- a/sdk/src/store/postgres.rs
+++ b/sdk/src/store/postgres.rs
@@ -40,4 +40,8 @@ impl StoreFactory for PgStoreFactory {
             self.pool.clone(),
         ))
     }
+
+    fn get_grid_location_store(&self) -> Box<dyn crate::grid_db::LocationStore> {
+        Box::new(crate::grid_db::DieselLocationStore::new(self.pool.clone()))
+    }
 }

--- a/sdk/src/store/sqlite.rs
+++ b/sdk/src/store/sqlite.rs
@@ -40,4 +40,8 @@ impl StoreFactory for SqliteStoreFactory {
             self.pool.clone(),
         ))
     }
+
+    fn get_grid_location_store(&self) -> Box<dyn crate::grid_db::LocationStore> {
+        Box::new(crate::grid_db::DieselLocationStore::new(self.pool.clone()))
+    }
 }


### PR DESCRIPTION
This adds the postgres and sqlite store implementations and stubs the in-memory implementation (to make it compile) for the location store following the new pattern. This does not currently integrate the new store into the daemon but that integration will come in a later PR.