### PR TITLE
Add agent store

### DIFF
--- a/sdk/src/grid_db/agents/mod.rs
+++ b/sdk/src/grid_db/agents/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod store;

--- a/sdk/src/grid_db/agents/store/diesel/mod.rs
+++ b/sdk/src/grid_db/agents/store/diesel/mod.rs
@@ -1,0 +1,176 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod models;
+mod operations;
+pub(in crate::grid_db) mod schema;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use super::diesel::models::{AgentModel, NewAgentModel, NewRoleModel, RoleModel};
+use super::{Agent, AgentStore, AgentStoreError, Role};
+use crate::database::DatabaseError;
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use operations::add_agent::AgentStoreAddAgentOperation as _;
+use operations::fetch_agent::AgentStoreFetchAgentOperation as _;
+use operations::list_agents::AgentStoreListAgentsOperation as _;
+use operations::update_agent::AgentStoreUpdateAgentOperation as _;
+use operations::AgentStoreOperations;
+
+/// Manages creating agents in the database
+#[derive(Clone)]
+pub struct DieselAgentStore<C: diesel::Connection + 'static> {
+    connection_pool: Pool<ConnectionManager<C>>,
+}
+
+impl<C: diesel::Connection> DieselAgentStore<C> {
+    /// Creates a new DieselAgentStore
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool to the database
+    // Allow dead code if diesel feature is not enabled
+    #[allow(dead_code)]
+    pub fn new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        DieselAgentStore { connection_pool }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl AgentStore for DieselAgentStore<diesel::pg::PgConnection> {
+    fn add_agent(&self, agent: Agent) -> Result<(), AgentStoreError> {
+        AgentStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_agent(agent.clone().into(), make_role_models(&agent))
+    }
+
+    fn list_agents(&self, service_id: Option<String>) -> Result<Vec<Agent>, AgentStoreError> {
+        AgentStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_agents(service_id)
+    }
+
+    fn fetch_agent(
+        &self,
+        pub_key: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Agent>, AgentStoreError> {
+        AgentStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_agent(pub_key, service_id)
+    }
+
+    fn update_agent(&self, agent: Agent) -> Result<(), AgentStoreError> {
+        AgentStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .update_agent(agent.clone().into(), make_role_models(&agent))
+    }
+}
+
+impl From<RoleModel> for Role {
+    fn from(role: RoleModel) -> Self {
+        Self {
+            public_key: role.public_key,
+            role_name: role.role_name,
+            start_commit_num: role.start_commit_num,
+            end_commit_num: role.end_commit_num,
+            service_id: role.service_id,
+        }
+    }
+}
+
+impl From<(AgentModel, Vec<RoleModel>)> for Agent {
+    fn from((agent_model, role_models): (AgentModel, Vec<RoleModel>)) -> Self {
+        Self {
+            public_key: agent_model.public_key,
+            org_id: agent_model.org_id,
+            active: agent_model.active,
+            metadata: agent_model.metadata,
+            roles: role_models
+                .iter()
+                .map(|role| role.role_name.to_string())
+                .collect(),
+            start_commit_num: agent_model.start_commit_num,
+            end_commit_num: agent_model.end_commit_num,
+            service_id: agent_model.service_id,
+        }
+    }
+}
+
+impl Into<NewAgentModel> for Agent {
+    fn into(self) -> NewAgentModel {
+        NewAgentModel {
+            public_key: self.public_key,
+            org_id: self.org_id,
+            active: self.active,
+            metadata: self.metadata,
+            start_commit_num: self.start_commit_num,
+            end_commit_num: MAX_COMMIT_NUM,
+            service_id: self.service_id,
+        }
+    }
+}
+
+pub fn make_role_models(agent: &Agent) -> Vec<NewRoleModel> {
+    let mut roles = Vec::new();
+
+    for role in &agent.roles {
+        roles.push(NewRoleModel {
+            public_key: agent.public_key.to_string(),
+            role_name: role.to_string(),
+            start_commit_num: agent.start_commit_num,
+            end_commit_num: agent.end_commit_num,
+            service_id: agent.service_id.clone(),
+        })
+    }
+
+    roles
+}
+
+impl From<DatabaseError> for AgentStoreError {
+    fn from(err: DatabaseError) -> AgentStoreError {
+        AgentStoreError::ConnectionError(Box::new(err))
+    }
+}
+
+impl From<diesel::result::Error> for AgentStoreError {
+    fn from(err: diesel::result::Error) -> AgentStoreError {
+        AgentStoreError::QueryError {
+            context: "Diesel query failed".to_string(),
+            source: Box::new(err),
+        }
+    }
+}
+
+impl From<diesel::r2d2::PoolError> for AgentStoreError {
+    fn from(err: diesel::r2d2::PoolError) -> AgentStoreError {
+        AgentStoreError::ConnectionError(Box::new(err))
+    }
+}

--- a/sdk/src/grid_db/agents/store/diesel/mod.rs
+++ b/sdk/src/grid_db/agents/store/diesel/mod.rs
@@ -94,6 +94,53 @@ impl AgentStore for DieselAgentStore<diesel::pg::PgConnection> {
     }
 }
 
+#[cfg(feature = "sqlite")]
+impl AgentStore for DieselAgentStore<diesel::sqlite::SqliteConnection> {
+    fn add_agent(&self, agent: Agent) -> Result<(), AgentStoreError> {
+        AgentStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_agent(agent.clone().into(), make_role_models(&agent))
+    }
+
+    fn list_agents(&self, service_id: Option<String>) -> Result<Vec<Agent>, AgentStoreError> {
+        AgentStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_agents(service_id)
+    }
+
+    fn fetch_agent(
+        &self,
+        pub_key: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Agent>, AgentStoreError> {
+        AgentStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_agent(pub_key, service_id)
+    }
+
+    fn update_agent(&self, agent: Agent) -> Result<(), AgentStoreError> {
+        AgentStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .update_agent(agent.clone().into(), make_role_models(&agent))
+    }
+}
+
 impl From<RoleModel> for Role {
     fn from(role: RoleModel) -> Self {
         Self {

--- a/sdk/src/grid_db/agents/store/diesel/models.rs
+++ b/sdk/src/grid_db/agents/store/diesel/models.rs
@@ -1,0 +1,74 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::grid_db::agents::store::diesel::schema::*;
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "agent"]
+pub struct NewAgentModel {
+    pub public_key: String,
+    pub org_id: String,
+    pub active: bool,
+    pub metadata: Vec<u8>,
+
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "agent"]
+pub struct AgentModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
+    pub id: i64,
+    pub public_key: String,
+    pub org_id: String,
+    pub active: bool,
+    pub metadata: Vec<u8>,
+
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "role"]
+pub struct NewRoleModel {
+    pub public_key: String,
+    pub role_name: String,
+
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "role"]
+pub struct RoleModel {
+    pub id: i64,
+    pub public_key: String,
+    pub role_name: String,
+
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+
+    pub service_id: Option<String>,
+}

--- a/sdk/src/grid_db/agents/store/diesel/operations/add_agent.rs
+++ b/sdk/src/grid_db/agents/store/diesel/operations/add_agent.rs
@@ -1,0 +1,139 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::AgentStoreOperations;
+use crate::grid_db::agents::store::diesel::{
+    schema::{agent, role},
+    AgentStoreError,
+};
+
+use crate::grid_db::agents::store::diesel::models::{
+    AgentModel, NewAgentModel, NewRoleModel, RoleModel,
+};
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error::NotFound,
+};
+
+pub(in crate::grid_db::agents::store::diesel) trait AgentStoreAddAgentOperation {
+    fn add_agent(
+        &self,
+        agent: NewAgentModel,
+        roles: Vec<NewRoleModel>,
+    ) -> Result<(), AgentStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> AgentStoreAddAgentOperation for AgentStoreOperations<'a, diesel::pg::PgConnection> {
+    fn add_agent(
+        &self,
+        agent: NewAgentModel,
+        roles: Vec<NewRoleModel>,
+    ) -> Result<(), AgentStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, AgentStoreError, _>(|| {
+                let duplicate_agent = agent::table
+                    .filter(
+                        agent::public_key
+                            .eq(&agent.public_key)
+                            .and(agent::service_id.eq(&agent.service_id))
+                            .and(agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .first::<AgentModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                    .map_err(|err| AgentStoreError::QueryError {
+                        context: "Failed check for existing agent".to_string(),
+                        source: Box::new(err),
+                    })?;
+
+                if duplicate_agent.is_some() {
+                    update(agent::table)
+                        .filter(
+                            agent::public_key
+                                .eq(&agent.public_key)
+                                .and(agent::service_id.eq(&agent.service_id))
+                                .and(agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(agent::end_commit_num.eq(agent.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| AgentStoreError::OperationError {
+                            context: "Failed to update agent".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                insert_into(agent::table)
+                    .values(&agent)
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(|err| AgentStoreError::OperationError {
+                        context: "Failed to add agent".to_string(),
+                        source: Some(Box::new(err)),
+                    })?;
+
+                for role in roles {
+                    let duplicate_role = role::table
+                        .filter(
+                            role::public_key
+                                .eq(&role.public_key)
+                                .and(role::role_name.eq(&role.role_name))
+                                .and(role::service_id.eq(&role.service_id))
+                                .and(role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .first::<RoleModel>(self.conn)
+                        .map(Some)
+                        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                        .map_err(|err| AgentStoreError::QueryError {
+                            context: "Failed check for existing role".to_string(),
+                            source: Box::new(err),
+                        })?;
+
+                    if duplicate_role.is_some() {
+                        update(role::table)
+                            .filter(
+                                role::public_key
+                                    .eq(&role.public_key)
+                                    .and(role::role_name.eq(&role.role_name))
+                                    .and(role::service_id.eq(&role.service_id))
+                                    .and(role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(role::end_commit_num.eq(role.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(|err| AgentStoreError::OperationError {
+                                context: "Failed to update agent role".to_string(),
+                                source: Some(Box::new(err)),
+                            })?;
+                    }
+
+                    insert_into(role::table)
+                        .values(&role)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| AgentStoreError::OperationError {
+                            context: "Failed to add agent role".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/agents/store/diesel/operations/fetch_agent.rs
+++ b/sdk/src/grid_db/agents/store/diesel/operations/fetch_agent.rs
@@ -1,0 +1,87 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::AgentStoreOperations;
+use crate::grid_db::agents::store::diesel::{
+    schema::{agent, role},
+    Agent, AgentStoreError,
+};
+
+use crate::grid_db::agents::store::diesel::models::{AgentModel, RoleModel};
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use diesel::{prelude::*, result::Error::NotFound};
+
+pub(in crate::grid_db::agents::store::diesel) trait AgentStoreFetchAgentOperation {
+    fn fetch_agent(
+        &self,
+        pub_key: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Agent>, AgentStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> AgentStoreFetchAgentOperation for AgentStoreOperations<'a, diesel::pg::PgConnection> {
+    fn fetch_agent(
+        &self,
+        pub_key: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Agent>, AgentStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, AgentStoreError, _>(|| {
+                let agent = agent::table
+                    .filter(
+                        agent::public_key
+                            .eq(&pub_key)
+                            .and(agent::service_id.eq(&service_id))
+                            .and(agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .first::<AgentModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                    .map_err(|err| AgentStoreError::QueryError {
+                        context: "Failed to fetch agent for pub_key".to_string(),
+                        source: Box::new(err),
+                    })?
+                    .ok_or_else(|| {
+                        AgentStoreError::NotFoundError(
+                            format!("Failed to find agent: {}", pub_key,),
+                        )
+                    })?;
+
+                let roles = role::table
+                    .select(role::all_columns)
+                    .filter(
+                        role::public_key
+                            .eq(&pub_key)
+                            .and(role::service_id.eq(&service_id))
+                            .and(role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .load::<RoleModel>(self.conn)
+                    .map(Some)
+                    .map_err(|err| AgentStoreError::OperationError {
+                        context: "Failed to fetch roles".to_string(),
+                        source: Some(Box::new(err)),
+                    })?
+                    .ok_or_else(|| {
+                        AgentStoreError::NotFoundError(
+                            "Could not get all roles from storage".to_string(),
+                        )
+                    })?;
+
+                Ok(Some(Agent::from((agent, roles))))
+            })
+    }
+}

--- a/sdk/src/grid_db/agents/store/diesel/operations/list_agents.rs
+++ b/sdk/src/grid_db/agents/store/diesel/operations/list_agents.rs
@@ -86,3 +86,64 @@ impl<'a> AgentStoreListAgentsOperation for AgentStoreOperations<'a, diesel::pg::
             })
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a> AgentStoreListAgentsOperation
+    for AgentStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn list_agents(&self, service_id: Option<String>) -> Result<Vec<Agent>, AgentStoreError> {
+        self.conn
+            .immediate_transaction::<_, AgentStoreError, _>(|| {
+                let agent_models: Vec<AgentModel> = agent::table
+                    .select(agent::all_columns)
+                    .filter(
+                        agent::service_id
+                            .eq(&service_id)
+                            .and(agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .load::<AgentModel>(self.conn)
+                    .map(Some)
+                    .map_err(|err| AgentStoreError::OperationError {
+                        context: "Failed to fetch agents".to_string(),
+                        source: Some(Box::new(err)),
+                    })?
+                    .ok_or_else(|| {
+                        AgentStoreError::NotFoundError(
+                            "Could not get all agents from storage".to_string(),
+                        )
+                    })?
+                    .into_iter()
+                    .collect();
+
+                let mut agents = Vec::new();
+
+                for a in agent_models {
+                    let roles: Vec<RoleModel> = role::table
+                        .select(role::all_columns)
+                        .filter(
+                            role::service_id
+                                .eq(&service_id)
+                                .and(role::public_key.eq(&a.public_key))
+                                .and(role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .load::<RoleModel>(self.conn)
+                        .map(Some)
+                        .map_err(|err| AgentStoreError::OperationError {
+                            context: "Failed to fetch roles".to_string(),
+                            source: Some(Box::new(err)),
+                        })?
+                        .ok_or_else(|| {
+                            AgentStoreError::NotFoundError(
+                                "Could not get all roles from storage".to_string(),
+                            )
+                        })?
+                        .into_iter()
+                        .collect();
+
+                    agents.push(Agent::from((a, roles)));
+                }
+
+                Ok(agents)
+            })
+    }
+}

--- a/sdk/src/grid_db/agents/store/diesel/operations/list_agents.rs
+++ b/sdk/src/grid_db/agents/store/diesel/operations/list_agents.rs
@@ -1,0 +1,88 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::AgentStoreOperations;
+use crate::grid_db::agents::store::diesel::{
+    schema::{agent, role},
+    Agent, AgentStoreError,
+};
+
+use crate::grid_db::agents::store::diesel::models::{AgentModel, RoleModel};
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use diesel::prelude::*;
+
+pub(in crate::grid_db::agents::store::diesel) trait AgentStoreListAgentsOperation {
+    fn list_agents(&self, service_id: Option<String>) -> Result<Vec<Agent>, AgentStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> AgentStoreListAgentsOperation for AgentStoreOperations<'a, diesel::pg::PgConnection> {
+    fn list_agents(&self, service_id: Option<String>) -> Result<Vec<Agent>, AgentStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, AgentStoreError, _>(|| {
+                let agent_models: Vec<AgentModel> = agent::table
+                    .select(agent::all_columns)
+                    .filter(
+                        agent::service_id
+                            .eq(&service_id)
+                            .and(agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .load::<AgentModel>(self.conn)
+                    .map(Some)
+                    .map_err(|err| AgentStoreError::OperationError {
+                        context: "Failed to fetch agents".to_string(),
+                        source: Some(Box::new(err)),
+                    })?
+                    .ok_or_else(|| {
+                        AgentStoreError::NotFoundError(
+                            "Could not get all agents from storage".to_string(),
+                        )
+                    })?
+                    .into_iter()
+                    .collect();
+
+                let mut agents = Vec::new();
+
+                for a in agent_models {
+                    let roles: Vec<RoleModel> = role::table
+                        .select(role::all_columns)
+                        .filter(
+                            role::service_id
+                                .eq(&service_id)
+                                .and(role::public_key.eq(&a.public_key))
+                                .and(role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .load::<RoleModel>(self.conn)
+                        .map(Some)
+                        .map_err(|err| AgentStoreError::OperationError {
+                            context: "Failed to fetch roles".to_string(),
+                            source: Some(Box::new(err)),
+                        })?
+                        .ok_or_else(|| {
+                            AgentStoreError::NotFoundError(
+                                "Could not get all roles from storage".to_string(),
+                            )
+                        })?
+                        .into_iter()
+                        .collect();
+
+                    agents.push(Agent::from((a, roles)));
+                }
+
+                Ok(agents)
+            })
+    }
+}

--- a/sdk/src/grid_db/agents/store/diesel/operations/mod.rs
+++ b/sdk/src/grid_db/agents/store/diesel/operations/mod.rs
@@ -1,0 +1,31 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) mod add_agent;
+pub(super) mod fetch_agent;
+pub(super) mod list_agents;
+pub(super) mod update_agent;
+
+pub(super) struct AgentStoreOperations<'a, C> {
+    conn: &'a C,
+}
+
+impl<'a, C> AgentStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    pub fn new(conn: &'a C) -> Self {
+        AgentStoreOperations { conn }
+    }
+}

--- a/sdk/src/grid_db/agents/store/diesel/operations/update_agent.rs
+++ b/sdk/src/grid_db/agents/store/diesel/operations/update_agent.rs
@@ -117,3 +117,86 @@ impl<'a> AgentStoreUpdateAgentOperation for AgentStoreOperations<'a, diesel::pg:
             })
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a> AgentStoreUpdateAgentOperation
+    for AgentStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn update_agent(
+        &self,
+        agent: NewAgentModel,
+        roles: Vec<NewRoleModel>,
+    ) -> Result<(), AgentStoreError> {
+        self.conn
+            .immediate_transaction::<_, AgentStoreError, _>(|| {
+                let agt = agent::table
+                    .filter(
+                        agent::public_key
+                            .eq(&agent.public_key)
+                            .and(agent::service_id.eq(&agent.service_id))
+                            .and(agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .first::<AgentModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                    .map_err(|err| AgentStoreError::QueryError {
+                        context: "Failed to fetch agent for pub_key".to_string(),
+                        source: Box::new(err),
+                    })?;
+
+                if agt.is_some() {
+                    update(agent::table)
+                        .filter(
+                            agent::public_key
+                                .eq(&agent.public_key)
+                                .and(agent::service_id.eq(&agent.service_id))
+                                .and(agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(agent::end_commit_num.eq(&agent.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| AgentStoreError::OperationError {
+                            context: "Failed to update agent".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                insert_into(agent::table)
+                    .values(&agent)
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(|err| AgentStoreError::OperationError {
+                        context: "Failed to add agent".to_string(),
+                        source: Some(Box::new(err)),
+                    })?;
+
+                update(role::table)
+                    .filter(
+                        role::public_key
+                            .eq(&agent.public_key)
+                            .and(role::service_id.eq(&agent.service_id))
+                            .and(role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(role::end_commit_num.eq(&agent.start_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(|err| AgentStoreError::OperationError {
+                        context: "Failed to update role".to_string(),
+                        source: Some(Box::new(err)),
+                    })?;
+
+                for role in roles {
+                    insert_into(role::table)
+                        .values(&role)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| AgentStoreError::OperationError {
+                            context: "Failed to add agent attribute".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/agents/store/diesel/operations/update_agent.rs
+++ b/sdk/src/grid_db/agents/store/diesel/operations/update_agent.rs
@@ -1,0 +1,119 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::AgentStoreOperations;
+use crate::grid_db::agents::store::diesel::{
+    schema::{agent, role},
+    AgentStoreError,
+};
+
+use crate::grid_db::agents::store::diesel::models::{AgentModel, NewAgentModel, NewRoleModel};
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error::NotFound,
+};
+
+pub(in crate::grid_db::agents) trait AgentStoreUpdateAgentOperation {
+    fn update_agent(
+        &self,
+        agent: NewAgentModel,
+        roles: Vec<NewRoleModel>,
+    ) -> Result<(), AgentStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> AgentStoreUpdateAgentOperation for AgentStoreOperations<'a, diesel::pg::PgConnection> {
+    fn update_agent(
+        &self,
+        agent: NewAgentModel,
+        roles: Vec<NewRoleModel>,
+    ) -> Result<(), AgentStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, AgentStoreError, _>(|| {
+                let agt = agent::table
+                    .filter(
+                        agent::public_key
+                            .eq(&agent.public_key)
+                            .and(agent::service_id.eq(&agent.service_id))
+                            .and(agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .first::<AgentModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                    .map_err(|err| AgentStoreError::QueryError {
+                        context: "Failed to fetch agent for pub_key".to_string(),
+                        source: Box::new(err),
+                    })?;
+
+                if agt.is_some() {
+                    update(agent::table)
+                        .filter(
+                            agent::public_key
+                                .eq(&agent.public_key)
+                                .and(agent::service_id.eq(&agent.service_id))
+                                .and(agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(agent::end_commit_num.eq(&agent.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| AgentStoreError::OperationError {
+                            context: "Failed to update agent".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                insert_into(agent::table)
+                    .values(&agent)
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(|err| AgentStoreError::OperationError {
+                        context: "Failed to add agent".to_string(),
+                        source: Some(Box::new(err)),
+                    })?;
+
+                update(role::table)
+                    .filter(
+                        role::public_key
+                            .eq(&agent.public_key)
+                            .and(role::service_id.eq(&agent.service_id))
+                            .and(role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(role::end_commit_num.eq(&agent.start_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(|err| AgentStoreError::OperationError {
+                        context: "Failed to update role".to_string(),
+                        source: Some(Box::new(err)),
+                    })?;
+
+                for role in roles {
+                    insert_into(role::table)
+                        .values(&role)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| AgentStoreError::OperationError {
+                            context: "Failed to add agent attribute".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/agents/store/diesel/schema.rs
+++ b/sdk/src/grid_db/agents/store/diesel/schema.rs
@@ -1,0 +1,37 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+table! {
+    agent (id) {
+        id -> Int8,
+        public_key -> Varchar,
+        org_id -> Varchar,
+        active -> Bool,
+        metadata -> Binary,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}
+
+table! {
+    role (id) {
+        id -> Int8,
+        public_key -> Varchar,
+        role_name -> Text,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}

--- a/sdk/src/grid_db/agents/store/error.rs
+++ b/sdk/src/grid_db/agents/store/error.rs
@@ -1,0 +1,110 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+/// Represents AgentStore errors
+#[derive(Debug)]
+pub enum AgentStoreError {
+    /// Represents CRUD operations failures
+    OperationError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    /// Represents database query failures
+    QueryError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents general failures in the database
+    StorageError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    DuplicateError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    /// Represents an issue connecting to the database
+    ConnectionError(Box<dyn Error>),
+    NotFoundError(String),
+}
+
+impl Error for AgentStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            AgentStoreError::OperationError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            AgentStoreError::OperationError { source: None, .. } => None,
+            AgentStoreError::QueryError { source, .. } => Some(&**source),
+            AgentStoreError::StorageError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            AgentStoreError::StorageError { source: None, .. } => None,
+            AgentStoreError::ConnectionError(err) => Some(&**err),
+            AgentStoreError::DuplicateError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            AgentStoreError::DuplicateError { source: None, .. } => None,
+            AgentStoreError::NotFoundError(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for AgentStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AgentStoreError::OperationError {
+                context,
+                source: Some(source),
+            } => write!(f, "failed to perform operation: {}: {}", context, source),
+            AgentStoreError::OperationError {
+                context,
+                source: None,
+            } => write!(f, "failed to perform operation: {}", context),
+            AgentStoreError::QueryError { context, source } => {
+                write!(f, "failed query: {}: {}", context, source)
+            }
+            AgentStoreError::StorageError {
+                context,
+                source: Some(source),
+            } => write!(
+                f,
+                "the underlying storage returned an error: {}: {}",
+                context, source
+            ),
+            AgentStoreError::StorageError {
+                context,
+                source: None,
+            } => write!(f, "the underlying storage returned an error: {}", context),
+            AgentStoreError::ConnectionError(err) => {
+                write!(f, "failed to connect to underlying storage: {}", err)
+            }
+            AgentStoreError::DuplicateError {
+                context,
+                source: Some(source),
+            } => write!(f, "Agent already exists: {}: {}", context, source),
+            AgentStoreError::DuplicateError {
+                context,
+                source: None,
+            } => write!(f, "The agent already exists: {}", context),
+            AgentStoreError::NotFoundError(ref s) => write!(f, "Agent not found: {}", s),
+        }
+    }
+}

--- a/sdk/src/grid_db/agents/store/mod.rs
+++ b/sdk/src/grid_db/agents/store/mod.rs
@@ -1,0 +1,105 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "diesel")]
+pub mod diesel;
+mod error;
+
+pub use error::AgentStoreError;
+
+/// Represents a Grid Agent
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct Agent {
+    pub public_key: String,
+    pub org_id: String,
+    pub active: bool,
+    pub metadata: Vec<u8>,
+    pub roles: Vec<String>,
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+
+    pub service_id: Option<String>,
+}
+
+/// Represents a Grid Agent Role
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct Role {
+    pub public_key: String,
+    pub role_name: String,
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+pub trait AgentStore: Send + Sync {
+    /// Adds an agent to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `agent` - The agent to be added
+    fn add_agent(&self, agent: Agent) -> Result<(), AgentStoreError>;
+
+    ///  Lists agents from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_id` - The service id to list agents for
+    fn list_agents(&self, service_id: Option<String>) -> Result<Vec<Agent>, AgentStoreError>;
+
+    /// Fetches an agent from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `pub_key` - This public key of the agent to fetch
+    ///  * `service_id` - The service id of the agent to fetch
+    fn fetch_agent(
+        &self,
+        pub_key: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Agent>, AgentStoreError>;
+
+    ///  Updates an agent in the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `agent` - The updated agent to add
+    fn update_agent(&self, agent: Agent) -> Result<(), AgentStoreError>;
+}
+
+impl<AS> AgentStore for Box<AS>
+where
+    AS: AgentStore + ?Sized,
+{
+    fn add_agent(&self, agent: Agent) -> Result<(), AgentStoreError> {
+        (**self).add_agent(agent)
+    }
+
+    fn list_agents(&self, service_id: Option<String>) -> Result<Vec<Agent>, AgentStoreError> {
+        (**self).list_agents(service_id)
+    }
+
+    fn fetch_agent(
+        &self,
+        pub_key: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Agent>, AgentStoreError> {
+        (**self).fetch_agent(pub_key, service_id)
+    }
+
+    fn update_agent(&self, agent: Agent) -> Result<(), AgentStoreError> {
+        (**self).update_agent(agent)
+    }
+}

--- a/sdk/src/grid_db/mod.rs
+++ b/sdk/src/grid_db/mod.rs
@@ -16,11 +16,16 @@
 //! agents, commits, schemas, locations, products, and Track and Trace
 //! data.
 
+pub mod agents;
 pub mod commits;
 pub mod locations;
 pub mod organizations;
 
 pub mod migrations;
+
+#[cfg(feature = "diesel")]
+pub use agents::store::diesel::DieselAgentStore;
+pub use agents::store::AgentStore;
 
 #[cfg(feature = "diesel")]
 pub use commits::store::diesel::DieselCommitStore;

--- a/sdk/src/store/memory.rs
+++ b/sdk/src/store/memory.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use crate::grid_db::{
-    CommitStore, LocationStore, MemoryCommitStore, MemoryOrganizationStore, OrganizationStore,
+    AgentStore, CommitStore, LocationStore, MemoryCommitStore, MemoryOrganizationStore,
+    OrganizationStore,
 };
 
 use super::StoreFactory;
@@ -38,6 +39,10 @@ impl MemoryStoreFactory {
 }
 
 impl StoreFactory for MemoryStoreFactory {
+    fn get_grid_agent_store(&self) -> Box<dyn AgentStore> {
+        unimplemented!()
+    }
+
     fn get_grid_commit_store(&self) -> Box<dyn CommitStore> {
         Box::new(self.grid_commit_store.clone())
     }

--- a/sdk/src/store/mod.rs
+++ b/sdk/src/store/mod.rs
@@ -25,6 +25,8 @@ use diesel::r2d2::{ConnectionManager, Pool};
 
 /// An abstract factory for creating Grid stores backed by the same storage
 pub trait StoreFactory {
+    /// Get a new `AgentStore`
+    fn get_grid_agent_store(&self) -> Box<dyn crate::grid_db::AgentStore>;
     /// Get a new `CommitStore`
     fn get_grid_commit_store(&self) -> Box<dyn crate::grid_db::CommitStore>;
     /// Get a new `OrganizationStore`

--- a/sdk/src/store/postgres.rs
+++ b/sdk/src/store/postgres.rs
@@ -31,6 +31,10 @@ impl PgStoreFactory {
 }
 
 impl StoreFactory for PgStoreFactory {
+    fn get_grid_agent_store(&self) -> Box<dyn crate::grid_db::AgentStore> {
+        Box::new(crate::grid_db::DieselAgentStore::new(self.pool.clone()))
+    }
+
     fn get_grid_commit_store(&self) -> Box<dyn crate::grid_db::CommitStore> {
         Box::new(crate::grid_db::DieselCommitStore::new(self.pool.clone()))
     }

--- a/sdk/src/store/sqlite.rs
+++ b/sdk/src/store/sqlite.rs
@@ -31,6 +31,10 @@ impl SqliteStoreFactory {
 }
 
 impl StoreFactory for SqliteStoreFactory {
+    fn get_grid_agent_store(&self) -> Box<dyn crate::grid_db::AgentStore> {
+        Box::new(crate::grid_db::DieselAgentStore::new(self.pool.clone()))
+    }
+
     fn get_grid_commit_store(&self) -> Box<dyn crate::grid_db::CommitStore> {
         Box::new(crate::grid_db::DieselCommitStore::new(self.pool.clone()))
     }


### PR DESCRIPTION
This adds the postgres and sqlite store implementations and stubs the in-memory implementation (to make it compile) for the agent store following the new pattern. This does not currently integrate the new store into the daemon but that integration will come in a later PR.