### PR TITLE
Move organization and commit store implementations into diesel modules

### DIFF
--- a/sdk/src/grid_db/commits/store/error.rs
+++ b/sdk/src/grid_db/commits/store/error.rs
@@ -15,9 +15,6 @@
 use std::error::Error;
 use std::fmt;
 
-#[cfg(feature = "diesel")]
-use crate::database::error;
-
 /// Represents CommitStore errors
 #[derive(Debug)]
 pub enum CommitStoreError {
@@ -112,30 +109,6 @@ impl fmt::Display for CommitStoreError {
     }
 }
 
-#[cfg(feature = "diesel")]
-impl From<error::DatabaseError> for CommitStoreError {
-    fn from(err: error::DatabaseError) -> CommitStoreError {
-        CommitStoreError::ConnectionError(Box::new(err))
-    }
-}
-
-#[cfg(feature = "diesel")]
-impl From<diesel::result::Error> for CommitStoreError {
-    fn from(err: diesel::result::Error) -> CommitStoreError {
-        CommitStoreError::QueryError {
-            context: "Diesel query failed".to_string(),
-            source: Box::new(err),
-        }
-    }
-}
-
-#[cfg(feature = "diesel")]
-impl From<diesel::r2d2::PoolError> for CommitStoreError {
-    fn from(err: diesel::r2d2::PoolError) -> CommitStoreError {
-        CommitStoreError::ConnectionError(Box::new(err))
-    }
-}
-
 /// Represents CommitEvent errors
 #[derive(Debug)]
 pub enum CommitEventError {
@@ -146,13 +119,6 @@ pub enum CommitEventError {
     },
     /// Represents an issue receiving events
     ConnectionError(String),
-}
-
-#[cfg(feature = "diesel")]
-impl From<error::DatabaseError> for CommitEventError {
-    fn from(err: error::DatabaseError) -> CommitEventError {
-        CommitEventError::ConnectionError(format!("{}", err))
-    }
 }
 
 impl Error for CommitEventError {

--- a/sdk/src/grid_db/organizations/store/diesel/mod.rs
+++ b/sdk/src/grid_db/organizations/store/diesel/mod.rs
@@ -33,7 +33,6 @@ pub struct DieselOrganizationStore<C: diesel::Connection + 'static> {
     connection_pool: Pool<ConnectionManager<C>>,
 }
 
-#[cfg(feature = "diesel")]
 impl<C: diesel::Connection> DieselOrganizationStore<C> {
     /// Creates a new DieselOrganizationStore
     ///
@@ -152,5 +151,40 @@ impl From<NewOrganizationModel> for Organization {
             end_commit_num: org.end_commit_num,
             service_id: org.service_id,
         }
+    }
+}
+
+impl Into<NewOrganizationModel> for Organization {
+    fn into(self) -> NewOrganizationModel {
+        NewOrganizationModel {
+            org_id: self.org_id,
+            name: self.name,
+            address: self.address,
+            metadata: self.metadata,
+            start_commit_num: self.start_commit_num,
+            end_commit_num: self.end_commit_num,
+            service_id: self.service_id,
+        }
+    }
+}
+
+impl From<DatabaseError> for OrganizationStoreError {
+    fn from(err: DatabaseError) -> OrganizationStoreError {
+        OrganizationStoreError::ConnectionError(Box::new(err))
+    }
+}
+
+impl From<diesel::result::Error> for OrganizationStoreError {
+    fn from(err: diesel::result::Error) -> OrganizationStoreError {
+        OrganizationStoreError::QueryError {
+            context: "Diesel query failed".to_string(),
+            source: Box::new(err),
+        }
+    }
+}
+
+impl From<diesel::r2d2::PoolError> for OrganizationStoreError {
+    fn from(err: diesel::r2d2::PoolError) -> OrganizationStoreError {
+        OrganizationStoreError::ConnectionError(Box::new(err))
     }
 }

--- a/sdk/src/grid_db/organizations/store/error.rs
+++ b/sdk/src/grid_db/organizations/store/error.rs
@@ -15,9 +15,6 @@
 use std::error::Error;
 use std::fmt;
 
-#[cfg(feature = "diesel")]
-use crate::database::error;
-
 /// Represents OrganizationStore errors
 #[derive(Debug)]
 pub enum OrganizationStoreError {
@@ -111,29 +108,5 @@ impl fmt::Display for OrganizationStoreError {
                 write!(f, "Organization not found: {}", s)
             }
         }
-    }
-}
-
-#[cfg(feature = "diesel")]
-impl From<error::DatabaseError> for OrganizationStoreError {
-    fn from(err: error::DatabaseError) -> OrganizationStoreError {
-        OrganizationStoreError::ConnectionError(Box::new(err))
-    }
-}
-
-#[cfg(feature = "diesel")]
-impl From<diesel::result::Error> for OrganizationStoreError {
-    fn from(err: diesel::result::Error) -> OrganizationStoreError {
-        OrganizationStoreError::QueryError {
-            context: "Diesel query failed".to_string(),
-            source: Box::new(err),
-        }
-    }
-}
-
-#[cfg(feature = "diesel")]
-impl From<diesel::r2d2::PoolError> for OrganizationStoreError {
-    fn from(err: diesel::r2d2::PoolError) -> OrganizationStoreError {
-        OrganizationStoreError::ConnectionError(Box::new(err))
     }
 }

--- a/sdk/src/grid_db/organizations/store/mod.rs
+++ b/sdk/src/grid_db/organizations/store/mod.rs
@@ -21,9 +21,6 @@ pub use error::OrganizationStoreError;
 
 use crate::hex::as_hex;
 
-#[cfg(feature = "diesel")]
-use self::diesel::models::NewOrganizationModel;
-
 /// Represents a Grid commit
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct Organization {
@@ -69,21 +66,6 @@ pub trait OrganizationStore: Send + Sync {
         org_id: &str,
         service_id: Option<String>,
     ) -> Result<Option<Organization>, OrganizationStoreError>;
-}
-
-#[cfg(feature = "diesel")]
-impl Into<NewOrganizationModel> for Organization {
-    fn into(self) -> NewOrganizationModel {
-        NewOrganizationModel {
-            org_id: self.org_id,
-            name: self.name,
-            address: self.address,
-            metadata: self.metadata,
-            start_commit_num: self.start_commit_num,
-            end_commit_num: self.end_commit_num,
-            service_id: self.service_id,
-        }
-    }
 }
 
 impl<OS> OrganizationStore for Box<OS>


### PR DESCRIPTION
Move several `impl` statements that use the diesel feature flag in the organization and commit modules into their respective diesel modules.