### PR TITLE
Add track and Trace store

### DIFF
--- a/sdk/src/grid_db/mod.rs
+++ b/sdk/src/grid_db/mod.rs
@@ -22,6 +22,7 @@ pub mod locations;
 pub mod organizations;
 pub mod products;
 pub mod schemas;
+pub mod track_and_trace;
 
 pub mod migrations;
 
@@ -51,3 +52,7 @@ pub use products::store::ProductStore;
 pub use schemas::store::diesel::DieselSchemaStore;
 pub use schemas::store::memory::MemorySchemaStore;
 pub use schemas::store::SchemaStore;
+
+#[cfg(feature = "diesel")]
+pub use track_and_trace::store::diesel::DieselTrackAndTraceStore;
+pub use track_and_trace::store::TrackAndTraceStore;

--- a/sdk/src/grid_db/track_and_trace/mod.rs
+++ b/sdk/src/grid_db/track_and_trace/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod store;

--- a/sdk/src/grid_db/track_and_trace/store/diesel/mod.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/mod.rs
@@ -1,0 +1,596 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod models;
+mod operations;
+pub(in crate::grid_db) mod schema;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use super::diesel::models::{
+    AssociatedAgentModel, NewAssociatedAgentModel, NewPropertyModel, NewProposalModel,
+    NewRecordModel, NewReportedValueModel, NewReporterModel, PropertyModel, ProposalModel,
+    RecordModel, ReportedValueReporterToAgentMetadataModel, ReporterModel,
+};
+use super::{
+    AssociatedAgent, LatLongValue, Property, Proposal, Record, ReportedValue,
+    ReportedValueReporterToAgentMetadata, Reporter, TrackAndTraceStore, TrackAndTraceStoreError,
+};
+use crate::database::DatabaseError;
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use operations::add_associated_agents::TrackAndTraceStoreAddAssociatedAgentsOperation as _;
+use operations::add_properties::TrackAndTraceStoreAddPropertiesOperation as _;
+use operations::add_proposals::TrackAndTraceStoreAddProposalsOperation as _;
+use operations::add_records::TrackAndTraceStoreAddRecordsOperation as _;
+use operations::add_reported_values::TrackAndTraceStoreAddReportedValuesOperation as _;
+use operations::add_reporters::TrackAndTraceStoreAddReportersOperation as _;
+use operations::fetch_property_with_data_type::TrackAndTraceStoreFetchPropertyWithDataTypeOperation as _;
+use operations::fetch_record::TrackAndTraceStoreFetchRecordOperation as _;
+use operations::fetch_reported_value_reporter_to_agent_metadata::TrackAndTraceStoreFetchReportedValueReporterToAgentMetadataOperation as _;
+use operations::list_associated_agents::TrackAndTraceStoreListAssociatedAgentsOperation as _;
+use operations::list_properties_with_data_type::TrackAndTraceStoreListPropertiesWithDataTypeOperation as _;
+use operations::list_proposals::TrackAndTraceStoreListProposalsOperation as _;
+use operations::list_records::TrackAndTraceStoreListRecordsOperation as _;
+use operations::list_reported_value_reporter_to_agent_metadata::TrackAndTraceStoreListReportedValueReporterToAgentMetadataOperation as _;
+use operations::list_reporters::TrackAndTraceStoreListReportersOperation as _;
+use operations::TrackAndTraceStoreOperations;
+
+/// Manages creating track and trace elements in the database
+#[derive(Clone)]
+pub struct DieselTrackAndTraceStore<C: diesel::Connection + 'static> {
+    connection_pool: Pool<ConnectionManager<C>>,
+}
+
+#[cfg(feature = "diesel")]
+impl<C: diesel::Connection> DieselTrackAndTraceStore<C> {
+    /// Creates a new DieselTrackAndTraceStore
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool to the database
+    // Allow dead code if diesel feature is not enabled
+    #[allow(dead_code)]
+    pub fn new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        DieselTrackAndTraceStore { connection_pool }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl TrackAndTraceStore for DieselTrackAndTraceStore<diesel::pg::PgConnection> {
+    fn add_associated_agents(
+        &self,
+        agents: Vec<AssociatedAgent>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_associated_agents(agents.iter().map(|a| a.clone().into()).collect())
+    }
+
+    fn add_properties(&self, properties: Vec<Property>) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_properties(properties.into_iter().map(|p| p.into()).collect())
+    }
+
+    fn add_proposals(&self, proposals: Vec<Proposal>) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_proposals(proposals.into_iter().map(|p| p.into()).collect())
+    }
+
+    fn add_records(&self, records: Vec<Record>) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_records(records.into_iter().map(|r| r.into()).collect())
+    }
+
+    fn add_reported_values(
+        &self,
+        values: Vec<ReportedValue>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_reported_values(make_reported_value_models(&values, None))
+    }
+
+    fn add_reporters(&self, reporters: Vec<Reporter>) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_reporters(reporters.into_iter().map(|r| r.into()).collect())
+    }
+
+    fn fetch_property_with_data_type(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<(Property, Option<String>)>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_property_with_data_type(record_id, property_name, service_id)
+    }
+
+    fn fetch_record(
+        &self,
+        record_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Record>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_record(record_id, service_id)
+    }
+
+    fn fetch_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        commit_height: Option<i64>,
+        service_id: Option<String>,
+    ) -> Result<Option<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_reported_value_reporter_to_agent_metadata(
+            record_id,
+            property_name,
+            commit_height,
+            service_id,
+        )
+    }
+
+    fn list_associated_agents(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<AssociatedAgent>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_associated_agents(record_ids, service_id)
+    }
+
+    fn list_properties_with_data_type(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<(Property, Option<String>)>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_properties_with_data_type(record_ids, service_id)
+    }
+
+    fn list_proposals(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<Proposal>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_proposals(record_ids, service_id)
+    }
+
+    fn list_records(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Record>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_records(service_id)
+    }
+
+    fn list_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_reported_value_reporter_to_agent_metadata(
+            record_id,
+            property_name,
+            service_id,
+        )
+    }
+
+    fn list_reporters(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<Reporter>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_reporters(record_id, property_name, service_id)
+    }
+}
+
+impl From<(i64, i64)> for LatLongValue {
+    fn from((lat, long): (i64, i64)) -> Self {
+        Self(lat, long)
+    }
+}
+
+impl Into<NewAssociatedAgentModel> for AssociatedAgent {
+    fn into(self) -> NewAssociatedAgentModel {
+        NewAssociatedAgentModel {
+            record_id: self.record_id,
+            role: self.role,
+            agent_id: self.agent_id,
+            timestamp: self.timestamp,
+            start_commit_num: self.start_commit_num,
+            end_commit_num: self.end_commit_num,
+            service_id: self.service_id,
+        }
+    }
+}
+
+impl Into<NewPropertyModel> for Property {
+    fn into(self) -> NewPropertyModel {
+        NewPropertyModel {
+            name: self.name,
+            record_id: self.record_id,
+            property_definition: self.property_definition,
+            current_page: self.current_page,
+            wrapped: self.wrapped,
+            start_commit_num: self.start_commit_num,
+            end_commit_num: self.end_commit_num,
+            service_id: self.service_id,
+        }
+    }
+}
+
+impl Into<NewProposalModel> for Proposal {
+    fn into(self) -> NewProposalModel {
+        NewProposalModel {
+            record_id: self.record_id,
+            timestamp: self.timestamp,
+            issuing_agent: self.issuing_agent,
+            receiving_agent: self.receiving_agent,
+            role: self.role,
+            properties: self.properties.join(","),
+            status: self.status,
+            terms: self.terms,
+            start_commit_num: self.start_commit_num,
+            end_commit_num: self.end_commit_num,
+            service_id: self.service_id,
+        }
+    }
+}
+
+impl Into<NewRecordModel> for Record {
+    fn into(self) -> NewRecordModel {
+        NewRecordModel {
+            record_id: self.record_id,
+            schema: self.schema,
+            final_: self.final_,
+            owners: self.owners.join(","),
+            custodians: self.custodians.join(","),
+            start_commit_num: self.start_commit_num,
+            end_commit_num: self.end_commit_num,
+            service_id: self.service_id,
+        }
+    }
+}
+
+impl Into<NewReporterModel> for Reporter {
+    fn into(self) -> NewReporterModel {
+        NewReporterModel {
+            property_name: self.property_name,
+            record_id: self.record_id,
+            public_key: self.public_key,
+            authorized: self.authorized,
+            reporter_index: self.reporter_index,
+            start_commit_num: self.start_commit_num,
+            end_commit_num: self.end_commit_num,
+            service_id: self.service_id,
+        }
+    }
+}
+
+fn make_reported_value_models(
+    values: &[ReportedValue],
+    parent_name: Option<String>,
+) -> Vec<NewReportedValueModel> {
+    let mut vals = Vec::new();
+
+    for val in values {
+        vals.push(NewReportedValueModel {
+            property_name: val.property_name.to_string(),
+            record_id: val.record_id.to_string(),
+            reporter_index: val.reporter_index,
+            timestamp: val.timestamp,
+            data_type: val.data_type.to_string(),
+            bytes_value: val.bytes_value.clone(),
+            boolean_value: val.boolean_value,
+            number_value: val.number_value,
+            string_value: val.string_value.clone(),
+            enum_value: val.enum_value,
+            parent_name: parent_name.clone(),
+            latitude_value: val.lat_long_value.clone().map(|lat_long| lat_long.0),
+            longitude_value: val.lat_long_value.clone().map(|lat_long| lat_long.1),
+            start_commit_num: val.start_commit_num,
+            end_commit_num: MAX_COMMIT_NUM,
+            service_id: val.service_id.clone(),
+        });
+
+        if val.struct_values.is_some() {
+            let vs = val.struct_values.as_ref().unwrap();
+            if !vals.is_empty() {
+                vals.append(&mut make_reported_value_models(
+                    vs,
+                    Some(val.property_name.clone()),
+                ));
+            }
+        }
+    }
+
+    vals
+}
+
+impl From<AssociatedAgentModel> for AssociatedAgent {
+    fn from(model: AssociatedAgentModel) -> Self {
+        Self {
+            id: model.id,
+            record_id: model.record_id,
+            role: model.role,
+            agent_id: model.agent_id,
+            timestamp: model.timestamp,
+            start_commit_num: model.start_commit_num,
+            end_commit_num: model.end_commit_num,
+            service_id: model.service_id,
+        }
+    }
+}
+
+impl From<AssociatedAgent> for AssociatedAgentModel {
+    fn from(agent: AssociatedAgent) -> Self {
+        Self {
+            id: agent.id,
+            record_id: agent.record_id,
+            role: agent.role,
+            agent_id: agent.agent_id,
+            timestamp: agent.timestamp,
+            start_commit_num: agent.start_commit_num,
+            end_commit_num: agent.end_commit_num,
+            service_id: agent.service_id,
+        }
+    }
+}
+
+impl From<PropertyModel> for Property {
+    fn from(model: PropertyModel) -> Self {
+        Self {
+            id: model.id,
+            name: model.name,
+            record_id: model.record_id,
+            property_definition: model.property_definition,
+            current_page: model.current_page,
+            wrapped: model.wrapped,
+            start_commit_num: model.start_commit_num,
+            end_commit_num: model.end_commit_num,
+            service_id: model.service_id,
+        }
+    }
+}
+
+impl From<ProposalModel> for Proposal {
+    fn from(model: ProposalModel) -> Self {
+        Self {
+            id: model.id,
+            record_id: model.record_id,
+            timestamp: model.timestamp,
+            issuing_agent: model.issuing_agent,
+            receiving_agent: model.receiving_agent,
+            role: model.role,
+            properties: model.properties.split(',').map(String::from).collect(),
+            status: model.status,
+            terms: model.terms,
+            start_commit_num: model.start_commit_num,
+            end_commit_num: model.end_commit_num,
+            service_id: model.service_id,
+        }
+    }
+}
+
+impl From<RecordModel> for Record {
+    fn from(model: RecordModel) -> Self {
+        Self {
+            id: model.id,
+            record_id: model.record_id,
+            schema: model.schema,
+            final_: model.final_,
+            owners: model.owners.split(',').map(String::from).collect(),
+            custodians: model.custodians.split(',').map(String::from).collect(),
+            start_commit_num: model.start_commit_num,
+            end_commit_num: model.end_commit_num,
+            service_id: model.service_id,
+        }
+    }
+}
+
+impl From<ReporterModel> for Reporter {
+    fn from(model: ReporterModel) -> Self {
+        Self {
+            id: model.id,
+            property_name: model.property_name,
+            record_id: model.record_id,
+            public_key: model.public_key,
+            authorized: model.authorized,
+            reporter_index: model.reporter_index,
+            start_commit_num: model.start_commit_num,
+            end_commit_num: model.end_commit_num,
+            service_id: model.service_id,
+        }
+    }
+}
+
+impl From<ReportedValueReporterToAgentMetadataModel> for ReportedValueReporterToAgentMetadata {
+    fn from(model: ReportedValueReporterToAgentMetadataModel) -> Self {
+        Self {
+            id: model.id,
+            property_name: model.property_name,
+            record_id: model.record_id,
+            reporter_index: model.reporter_index,
+            timestamp: model.timestamp,
+            data_type: model.data_type,
+            bytes_value: model.bytes_value,
+            boolean_value: model.boolean_value,
+            number_value: model.number_value,
+            string_value: model.string_value,
+            enum_value: model.enum_value,
+            struct_values: Vec::new(),
+            lat_long_value: create_lat_long_value(model.latitude_value, model.longitude_value),
+            public_key: model.public_key,
+            authorized: model.authorized,
+            metadata: model.metadata,
+            reported_value_end_commit_num: model.reported_value_end_commit_num,
+            reporter_end_commit_num: model.reporter_end_commit_num,
+            service_id: model.service_id,
+        }
+    }
+}
+
+impl
+    From<(
+        ReportedValueReporterToAgentMetadataModel,
+        Vec<ReportedValueReporterToAgentMetadata>,
+    )> for ReportedValueReporterToAgentMetadata
+{
+    fn from(
+        (model, values): (
+            ReportedValueReporterToAgentMetadataModel,
+            Vec<ReportedValueReporterToAgentMetadata>,
+        ),
+    ) -> Self {
+        Self {
+            id: model.id,
+            property_name: model.property_name,
+            record_id: model.record_id,
+            reporter_index: model.reporter_index,
+            timestamp: model.timestamp,
+            data_type: model.data_type,
+            bytes_value: model.bytes_value,
+            boolean_value: model.boolean_value,
+            number_value: model.number_value,
+            string_value: model.string_value,
+            enum_value: model.enum_value,
+            struct_values: values,
+            lat_long_value: create_lat_long_value(model.latitude_value, model.longitude_value),
+            public_key: model.public_key,
+            authorized: model.authorized,
+            metadata: model.metadata,
+            reported_value_end_commit_num: model.reported_value_end_commit_num,
+            reporter_end_commit_num: model.reporter_end_commit_num,
+            service_id: model.service_id,
+        }
+    }
+}
+
+pub fn make_property_with_data_type(
+    (model, data_type): (PropertyModel, Option<String>),
+) -> (Property, Option<String>) {
+    (Property::from(model), data_type)
+}
+
+pub fn create_lat_long_value(lat: Option<i64>, long: Option<i64>) -> Option<LatLongValue> {
+    if let Some(latitude) = lat {
+        if let Some(longitude) = long {
+            Some(LatLongValue::from((latitude, longitude)))
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+impl From<DatabaseError> for TrackAndTraceStoreError {
+    fn from(err: DatabaseError) -> TrackAndTraceStoreError {
+        TrackAndTraceStoreError::ConnectionError(Box::new(err))
+    }
+}
+
+impl From<diesel::result::Error> for TrackAndTraceStoreError {
+    fn from(err: diesel::result::Error) -> TrackAndTraceStoreError {
+        TrackAndTraceStoreError::QueryError {
+            context: "Diesel query failed".to_string(),
+            source: Box::new(err),
+        }
+    }
+}
+
+impl From<diesel::r2d2::PoolError> for TrackAndTraceStoreError {
+    fn from(err: diesel::r2d2::PoolError) -> TrackAndTraceStoreError {
+        TrackAndTraceStoreError::ConnectionError(Box::new(err))
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/mod.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/mod.rs
@@ -274,6 +274,214 @@ impl TrackAndTraceStore for DieselTrackAndTraceStore<diesel::pg::PgConnection> {
     }
 }
 
+#[cfg(feature = "sqlite")]
+impl TrackAndTraceStore for DieselTrackAndTraceStore<diesel::sqlite::SqliteConnection> {
+    fn add_associated_agents(
+        &self,
+        agents: Vec<AssociatedAgent>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_associated_agents(agents.iter().map(|a| a.clone().into()).collect())
+    }
+
+    fn add_properties(&self, properties: Vec<Property>) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_properties(properties.into_iter().map(|p| p.into()).collect())
+    }
+
+    fn add_proposals(&self, proposals: Vec<Proposal>) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_proposals(proposals.into_iter().map(|p| p.into()).collect())
+    }
+
+    fn add_records(&self, records: Vec<Record>) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_records(records.into_iter().map(|r| r.into()).collect())
+    }
+
+    fn add_reported_values(
+        &self,
+        values: Vec<ReportedValue>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_reported_values(make_reported_value_models(&values, None))
+    }
+
+    fn add_reporters(&self, reporters: Vec<Reporter>) -> Result<(), TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .add_reporters(reporters.into_iter().map(|r| r.into()).collect())
+    }
+
+    fn fetch_property_with_data_type(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<(Property, Option<String>)>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_property_with_data_type(record_id, property_name, service_id)
+    }
+
+    fn fetch_record(
+        &self,
+        record_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Record>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_record(record_id, service_id)
+    }
+
+    fn fetch_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        commit_height: Option<i64>,
+        service_id: Option<String>,
+    ) -> Result<Option<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .fetch_reported_value_reporter_to_agent_metadata(
+            record_id,
+            property_name,
+            commit_height,
+            service_id,
+        )
+    }
+
+    fn list_associated_agents(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<AssociatedAgent>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_associated_agents(record_ids, service_id)
+    }
+
+    fn list_properties_with_data_type(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<(Property, Option<String>)>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_properties_with_data_type(record_ids, service_id)
+    }
+
+    fn list_proposals(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<Proposal>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_proposals(record_ids, service_id)
+    }
+
+    fn list_records(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Record>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_records(service_id)
+    }
+
+    fn list_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_reported_value_reporter_to_agent_metadata(
+            record_id,
+            property_name,
+            service_id,
+        )
+    }
+
+    fn list_reporters(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<Reporter>, TrackAndTraceStoreError> {
+        TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            DatabaseError::ConnectionError {
+                context: "Could not get connection pool".to_string(),
+                source: Box::new(err),
+            }
+        })?)
+        .list_reporters(record_id, property_name, service_id)
+    }
+}
+
 impl From<(i64, i64)> for LatLongValue {
     fn from((lat, long): (i64, i64)) -> Self {
         Self(lat, long)

--- a/sdk/src/grid_db/track_and_trace/store/diesel/models.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/models.rs
@@ -1,0 +1,288 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::grid_db::track_and_trace::store::diesel::schema::*;
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "associated_agent"]
+pub struct NewAssociatedAgentModel {
+    pub record_id: String,
+    pub role: String,
+    pub agent_id: String,
+    pub timestamp: i64,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "associated_agent"]
+pub struct AssociatedAgentModel {
+    pub id: i64,
+    pub record_id: String,
+    pub role: String,
+    pub agent_id: String,
+    pub timestamp: i64,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "grid_property_definition"]
+pub struct NewGridPropertyDefinitionModel {
+    pub name: String,
+    pub schema_name: String,
+    pub data_type: String,
+    pub required: bool,
+    pub description: String,
+    pub number_exponent: i64,
+    // comma separated list of enums
+    pub enum_options: String,
+    pub parent_name: Option<String>,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "grid_property_definition"]
+pub struct GridPropertyDefinitionModel {
+    pub id: i64,
+    pub name: String,
+    pub schema_name: String,
+    pub data_type: String,
+    pub required: bool,
+    pub description: String,
+    pub number_exponent: i64,
+    // comma separated list of enums
+    pub enum_options: String,
+    pub parent_name: Option<String>,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "property"]
+pub struct NewPropertyModel {
+    pub name: String,
+    pub record_id: String,
+    pub property_definition: String,
+    pub current_page: i32,
+    pub wrapped: bool,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "property"]
+pub struct PropertyModel {
+    pub id: i64,
+    pub name: String,
+    pub record_id: String,
+    pub property_definition: String,
+    pub current_page: i32,
+    pub wrapped: bool,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "proposal"]
+pub struct NewProposalModel {
+    pub record_id: String,
+    pub timestamp: i64,
+    pub issuing_agent: String,
+    pub receiving_agent: String,
+    pub role: String,
+    // comma separated list of properties
+    pub properties: String,
+    pub status: String,
+    // comma separated list of terms
+    pub terms: String,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "proposal"]
+pub struct ProposalModel {
+    pub id: i64,
+    pub record_id: String,
+    pub timestamp: i64,
+    pub issuing_agent: String,
+    pub receiving_agent: String,
+    pub role: String,
+    // comma separated list of properties
+    pub properties: String,
+    pub status: String,
+    pub terms: String,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "record"]
+pub struct NewRecordModel {
+    pub record_id: String,
+    pub schema: String,
+    pub final_: bool,
+    // comma separated list of owners
+    pub owners: String,
+    // comma separated list of custodians
+    pub custodians: String,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "record"]
+pub struct RecordModel {
+    pub id: i64,
+    pub record_id: String,
+    pub schema: String,
+    pub final_: bool,
+    // comma separated list of owners
+    pub owners: String,
+    // comma separated list of custodians
+    pub custodians: String,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "reported_value"]
+pub struct NewReportedValueModel {
+    pub property_name: String,
+    pub record_id: String,
+    pub reporter_index: i32,
+    pub timestamp: i64,
+    pub data_type: String,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<i32>,
+    pub parent_name: Option<String>,
+    pub latitude_value: Option<i64>,
+    pub longitude_value: Option<i64>,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "reported_value"]
+pub struct ReportedValueModel {
+    pub id: i64,
+    pub property_name: String,
+    pub record_id: String,
+    pub reporter_index: i32,
+    pub timestamp: i64,
+    pub data_type: String,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<i32>,
+    pub parent_name: Option<String>,
+    pub latitude_value: Option<i64>,
+    pub longitude_value: Option<i64>,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "reported_value_reporter_to_agent_metadata"]
+pub struct NewReportedValueReporterToAgentMetadataModel {
+    pub property_name: String,
+    pub record_id: String,
+    pub reporter_index: i32,
+    pub timestamp: i64,
+    pub data_type: String,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<i32>,
+    pub parent_name: Option<String>,
+    pub latitude_value: Option<i64>,
+    pub longitude_value: Option<i64>,
+    pub public_key: Option<String>,
+    pub authorized: Option<bool>,
+    pub metadata: Option<Vec<u8>>,
+    pub reported_value_end_commit_num: i64,
+    pub reporter_end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "reported_value_reporter_to_agent_metadata"]
+pub struct ReportedValueReporterToAgentMetadataModel {
+    pub id: i64,
+    pub property_name: String,
+    pub record_id: String,
+    pub reporter_index: i32,
+    pub timestamp: i64,
+    pub data_type: String,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<i32>,
+    pub parent_name: Option<String>,
+    pub latitude_value: Option<i64>,
+    pub longitude_value: Option<i64>,
+    pub public_key: Option<String>,
+    pub authorized: Option<bool>,
+    pub metadata: Option<Vec<u8>>,
+    pub reported_value_end_commit_num: i64,
+    pub reporter_end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "reporter"]
+pub struct NewReporterModel {
+    pub property_name: String,
+    pub record_id: String,
+    pub public_key: String,
+    pub authorized: bool,
+    pub reporter_index: i32,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "reporter"]
+pub struct ReporterModel {
+    pub id: i64,
+    pub property_name: String,
+    pub record_id: String,
+    pub public_key: String,
+    pub authorized: bool,
+    pub reporter_index: i32,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_associated_agents.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_associated_agents.rs
@@ -1,0 +1,99 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{
+    schema::associated_agent, TrackAndTraceStoreError,
+};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::{
+    AssociatedAgentModel, NewAssociatedAgentModel,
+};
+
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error::NotFound,
+};
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreAddAssociatedAgentsOperation
+{
+    fn add_associated_agents(
+        &self,
+        agents: Vec<NewAssociatedAgentModel>,
+    ) -> Result<(), TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreAddAssociatedAgentsOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_associated_agents(
+        &self,
+        agents: Vec<NewAssociatedAgentModel>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, TrackAndTraceStoreError, _>(|| {
+                for agent in agents {
+                    let duplicate = associated_agent::table
+                        .filter(
+                            associated_agent::agent_id
+                                .eq(&agent.agent_id)
+                                .and(associated_agent::record_id.eq(&agent.record_id))
+                                .and(associated_agent::end_commit_num.eq(MAX_COMMIT_NUM))
+                                .and(associated_agent::service_id.eq(&agent.service_id)),
+                        )
+                        .first::<AssociatedAgentModel>(self.conn)
+                        .map(Some)
+                        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                        .map_err(|err| TrackAndTraceStoreError::QueryError {
+                            context: "Failed check for existing record".to_string(),
+                            source: Box::new(err),
+                        })?;
+
+                    if duplicate.is_some() {
+                        update(associated_agent::table)
+                            .filter(
+                                associated_agent::agent_id
+                                    .eq(&agent.agent_id)
+                                    .and(associated_agent::record_id.eq(&agent.record_id))
+                                    .and(associated_agent::end_commit_num.eq(MAX_COMMIT_NUM))
+                                    .and(associated_agent::service_id.eq(&agent.service_id)),
+                            )
+                            .set(associated_agent::end_commit_num.eq(&agent.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                                context: "Failed to update record".to_string(),
+                                source: Some(Box::new(err)),
+                            })?;
+                    }
+
+                    insert_into(associated_agent::table)
+                        .values(&agent)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| TrackAndTraceStoreError::OperationError {
+                            context: "Failed to add record".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_properties.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_properties.rs
@@ -93,3 +93,63 @@ impl<'a> TrackAndTraceStoreAddPropertiesOperation
             })
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a> TrackAndTraceStoreAddPropertiesOperation
+    for TrackAndTraceStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_properties(
+        &self,
+        properties: Vec<NewPropertyModel>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        self.conn
+            .immediate_transaction::<_, TrackAndTraceStoreError, _>(|| {
+                for prop in properties {
+                    let duplicate = property::table
+                        .filter(
+                            property::name
+                                .eq(&prop.name)
+                                .and(property::record_id.eq(&prop.record_id))
+                                .and(property::end_commit_num.eq(MAX_COMMIT_NUM))
+                                .and(property::service_id.eq(&prop.service_id)),
+                        )
+                        .first::<PropertyModel>(self.conn)
+                        .map(Some)
+                        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                        .map_err(|err| TrackAndTraceStoreError::QueryError {
+                            context: "Failed check for existing record".to_string(),
+                            source: Box::new(err),
+                        })?;
+
+                    if duplicate.is_some() {
+                        update(property::table)
+                            .filter(
+                                property::name
+                                    .eq(&prop.name)
+                                    .and(property::record_id.eq(&prop.record_id))
+                                    .and(property::end_commit_num.eq(MAX_COMMIT_NUM))
+                                    .and(property::service_id.eq(&prop.service_id)),
+                            )
+                            .set(property::end_commit_num.eq(&prop.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                                context: "Failed to update record".to_string(),
+                                source: Some(Box::new(err)),
+                            })?;
+                    }
+
+                    insert_into(property::table)
+                        .values(&prop)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| TrackAndTraceStoreError::OperationError {
+                            context: "Failed to add record".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_properties.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_properties.rs
@@ -1,0 +1,95 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{schema::property, TrackAndTraceStoreError};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::{NewPropertyModel, PropertyModel};
+
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error::NotFound,
+};
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreAddPropertiesOperation
+{
+    fn add_properties(
+        &self,
+        properties: Vec<NewPropertyModel>,
+    ) -> Result<(), TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreAddPropertiesOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_properties(
+        &self,
+        properties: Vec<NewPropertyModel>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, TrackAndTraceStoreError, _>(|| {
+                for prop in properties {
+                    let duplicate = property::table
+                        .filter(
+                            property::name
+                                .eq(&prop.name)
+                                .and(property::record_id.eq(&prop.record_id))
+                                .and(property::end_commit_num.eq(MAX_COMMIT_NUM))
+                                .and(property::service_id.eq(&prop.service_id)),
+                        )
+                        .first::<PropertyModel>(self.conn)
+                        .map(Some)
+                        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                        .map_err(|err| TrackAndTraceStoreError::QueryError {
+                            context: "Failed check for existing record".to_string(),
+                            source: Box::new(err),
+                        })?;
+
+                    if duplicate.is_some() {
+                        update(property::table)
+                            .filter(
+                                property::name
+                                    .eq(&prop.name)
+                                    .and(property::record_id.eq(&prop.record_id))
+                                    .and(property::end_commit_num.eq(MAX_COMMIT_NUM))
+                                    .and(property::service_id.eq(&prop.service_id)),
+                            )
+                            .set(property::end_commit_num.eq(&prop.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                                context: "Failed to update record".to_string(),
+                                source: Some(Box::new(err)),
+                            })?;
+                    }
+
+                    insert_into(property::table)
+                        .values(&prop)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| TrackAndTraceStoreError::OperationError {
+                            context: "Failed to add record".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_proposals.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_proposals.rs
@@ -1,0 +1,97 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{schema::proposal, TrackAndTraceStoreError};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::{NewProposalModel, ProposalModel};
+
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error::NotFound,
+};
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreAddProposalsOperation
+{
+    fn add_proposals(
+        &self,
+        proposals: Vec<NewProposalModel>,
+    ) -> Result<(), TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreAddProposalsOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_proposals(
+        &self,
+        proposals: Vec<NewProposalModel>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, TrackAndTraceStoreError, _>(|| {
+                for prop in proposals {
+                    let duplicate = proposal::table
+                        .filter(
+                            proposal::record_id
+                                .eq(&prop.record_id)
+                                .and(proposal::receiving_agent.eq(&prop.receiving_agent))
+                                .and(proposal::service_id.eq(&prop.service_id))
+                                .and(proposal::role.eq(&prop.role))
+                                .and(proposal::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .first::<ProposalModel>(self.conn)
+                        .map(Some)
+                        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                        .map_err(|err| TrackAndTraceStoreError::QueryError {
+                            context: "Failed check for existing record".to_string(),
+                            source: Box::new(err),
+                        })?;
+
+                    if duplicate.is_some() {
+                        update(proposal::table)
+                            .filter(
+                                proposal::record_id
+                                    .eq(&prop.record_id)
+                                    .and(proposal::receiving_agent.eq(&prop.receiving_agent))
+                                    .and(proposal::service_id.eq(&prop.service_id))
+                                    .and(proposal::role.eq(&prop.role))
+                                    .and(proposal::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(proposal::end_commit_num.eq(&prop.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                                context: "Failed to update record".to_string(),
+                                source: Some(Box::new(err)),
+                            })?;
+                    }
+
+                    insert_into(proposal::table)
+                        .values(prop)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| TrackAndTraceStoreError::OperationError {
+                            context: "Failed to add record".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_records.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_records.rs
@@ -1,0 +1,86 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{schema::record, TrackAndTraceStoreError};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::{NewRecordModel, RecordModel};
+
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error::NotFound,
+};
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreAddRecordsOperation {
+    fn add_records(&self, records: Vec<NewRecordModel>) -> Result<(), TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreAddRecordsOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_records(&self, records: Vec<NewRecordModel>) -> Result<(), TrackAndTraceStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, TrackAndTraceStoreError, _>(|| {
+                for rec in records {
+                    let duplicate = record::table
+                        .filter(
+                            record::record_id
+                                .eq(&rec.record_id)
+                                .and(record::service_id.eq(&rec.service_id))
+                                .and(record::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .first::<RecordModel>(self.conn)
+                        .map(Some)
+                        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                        .map_err(|err| TrackAndTraceStoreError::QueryError {
+                            context: "Failed check for existing record".to_string(),
+                            source: Box::new(err),
+                        })?;
+
+                    if duplicate.is_some() {
+                        update(record::table)
+                            .filter(
+                                record::record_id
+                                    .eq(&rec.record_id)
+                                    .and(record::service_id.eq(&rec.service_id))
+                                    .and(record::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(record::end_commit_num.eq(&rec.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                                context: "Failed to update record".to_string(),
+                                source: Some(Box::new(err)),
+                            })?;
+                    }
+
+                    insert_into(record::table)
+                        .values(&rec)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| TrackAndTraceStoreError::OperationError {
+                            context: "Failed to add record".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_reported_values.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_reported_values.rs
@@ -1,0 +1,99 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{
+    schema::reported_value, TrackAndTraceStoreError,
+};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::{
+    NewReportedValueModel, ReportedValueModel,
+};
+
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error::NotFound,
+};
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreAddReportedValuesOperation
+{
+    fn add_reported_values(
+        &self,
+        values: Vec<NewReportedValueModel>,
+    ) -> Result<(), TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreAddReportedValuesOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_reported_values(
+        &self,
+        values: Vec<NewReportedValueModel>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, TrackAndTraceStoreError, _>(|| {
+                for val in values {
+                    let duplicate = reported_value::table
+                        .filter(
+                            reported_value::record_id
+                                .eq(&val.record_id)
+                                .and(reported_value::property_name.eq(&val.property_name))
+                                .and(reported_value::service_id.eq(&val.service_id))
+                                .and(reported_value::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .first::<ReportedValueModel>(self.conn)
+                        .map(Some)
+                        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                        .map_err(|err| TrackAndTraceStoreError::QueryError {
+                            context: "Failed check for existing record".to_string(),
+                            source: Box::new(err),
+                        })?;
+
+                    if duplicate.is_some() {
+                        update(reported_value::table)
+                            .filter(
+                                reported_value::record_id
+                                    .eq(&val.record_id)
+                                    .and(reported_value::property_name.eq(&val.property_name))
+                                    .and(reported_value::service_id.eq(&val.service_id))
+                                    .and(reported_value::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(reported_value::end_commit_num.eq(&val.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                                context: "Failed to update record".to_string(),
+                                source: Some(Box::new(err)),
+                            })?;
+                    }
+
+                    insert_into(reported_value::table)
+                        .values(&val)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| TrackAndTraceStoreError::OperationError {
+                            context: "Failed to add record".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_reporters.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/add_reporters.rs
@@ -1,0 +1,97 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{schema::reporter, TrackAndTraceStoreError};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::{NewReporterModel, ReporterModel};
+
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error::NotFound,
+};
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreAddReportersOperation
+{
+    fn add_reporters(
+        &self,
+        reporters: Vec<NewReporterModel>,
+    ) -> Result<(), TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreAddReportersOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_reporters(
+        &self,
+        reporters: Vec<NewReporterModel>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        self.conn
+            .build_transaction()
+            .read_write()
+            .run::<_, TrackAndTraceStoreError, _>(|| {
+                for rep in reporters {
+                    let duplicate = reporter::table
+                        .filter(
+                            reporter::record_id
+                                .eq(&rep.record_id)
+                                .and(reporter::property_name.eq(&rep.property_name))
+                                .and(reporter::public_key.eq(&rep.public_key))
+                                .and(reporter::service_id.eq(&rep.service_id))
+                                .and(reporter::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .first::<ReporterModel>(self.conn)
+                        .map(Some)
+                        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                        .map_err(|err| TrackAndTraceStoreError::QueryError {
+                            context: "Failed check for existing record".to_string(),
+                            source: Box::new(err),
+                        })?;
+
+                    if duplicate.is_some() {
+                        update(reporter::table)
+                            .filter(
+                                reporter::record_id
+                                    .eq(&rep.record_id)
+                                    .and(reporter::property_name.eq(&rep.property_name))
+                                    .and(reporter::public_key.eq(&rep.public_key))
+                                    .and(reporter::service_id.eq(&rep.service_id))
+                                    .and(reporter::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(reporter::end_commit_num.eq(&rep.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                                context: "Failed to update record".to_string(),
+                                source: Some(Box::new(err)),
+                            })?;
+                    }
+
+                    insert_into(reporter::table)
+                        .values(&rep)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(|err| TrackAndTraceStoreError::OperationError {
+                            context: "Failed to add record".to_string(),
+                            source: Some(Box::new(err)),
+                        })?;
+                }
+
+                Ok(())
+            })
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/fetch_property_with_data_type.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/fetch_property_with_data_type.rs
@@ -87,3 +87,56 @@ impl<'a> TrackAndTraceStoreFetchPropertyWithDataTypeOperation
         Ok(Some(make_property_with_data_type(prop.unwrap())))
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a> TrackAndTraceStoreFetchPropertyWithDataTypeOperation
+    for TrackAndTraceStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn fetch_property_with_data_type(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<(Property, Option<String>)>, TrackAndTraceStoreError> {
+        let mut query = property::table
+            .into_boxed()
+            .left_join(
+                record::table.on(property::record_id
+                    .eq(record::record_id)
+                    .and(property::end_commit_num.eq(record::end_commit_num))),
+            )
+            .left_join(
+                grid_property_definition::table.on(record::schema
+                    .eq(grid_property_definition::schema_name)
+                    .and(property::name.eq(grid_property_definition::name))
+                    .and(property::end_commit_num.eq(record::end_commit_num))),
+            )
+            .filter(
+                property::name
+                    .eq(property_name)
+                    .and(property::record_id.eq(record_id))
+                    .and(property::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+        if let Some(service_id) = service_id {
+            query = query.filter(property::service_id.eq(service_id));
+        } else {
+            query = query.filter(property::service_id.is_null());
+        }
+
+        let prop = query
+            .select((
+                property::all_columns,
+                grid_property_definition::data_type.nullable(),
+            ))
+            .first::<(PropertyModel, Option<String>)>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| TrackAndTraceStoreError::QueryError {
+                context: "Failed to fetch existing record".to_string(),
+                source: Box::new(err),
+            })?;
+
+        Ok(Some(make_property_with_data_type(prop.unwrap())))
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/fetch_property_with_data_type.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/fetch_property_with_data_type.rs
@@ -1,0 +1,89 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{
+    make_property_with_data_type,
+    schema::{grid_property_definition, property, record},
+    TrackAndTraceStoreError,
+};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::PropertyModel;
+use crate::grid_db::track_and_trace::store::Property;
+
+use diesel::{prelude::*, result::Error::NotFound};
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreFetchPropertyWithDataTypeOperation
+{
+    fn fetch_property_with_data_type(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<(Property, Option<String>)>, TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreFetchPropertyWithDataTypeOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn fetch_property_with_data_type(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<(Property, Option<String>)>, TrackAndTraceStoreError> {
+        let mut query = property::table
+            .into_boxed()
+            .left_join(
+                record::table.on(property::record_id
+                    .eq(record::record_id)
+                    .and(property::end_commit_num.eq(record::end_commit_num))),
+            )
+            .left_join(
+                grid_property_definition::table.on(record::schema
+                    .eq(grid_property_definition::schema_name)
+                    .and(property::name.eq(grid_property_definition::name))
+                    .and(property::end_commit_num.eq(record::end_commit_num))),
+            )
+            .filter(
+                property::name
+                    .eq(property_name)
+                    .and(property::record_id.eq(record_id))
+                    .and(property::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+        if let Some(service_id) = service_id {
+            query = query.filter(property::service_id.eq(service_id));
+        } else {
+            query = query.filter(property::service_id.is_null());
+        }
+
+        let prop = query
+            .select((
+                property::all_columns,
+                grid_property_definition::data_type.nullable(),
+            ))
+            .first::<(PropertyModel, Option<String>)>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| TrackAndTraceStoreError::QueryError {
+                context: "Failed to fetch existing record".to_string(),
+                source: Box::new(err),
+            })?;
+
+        Ok(Some(make_property_with_data_type(prop.unwrap())))
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/fetch_record.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/fetch_record.rs
@@ -1,0 +1,68 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{schema::record, TrackAndTraceStoreError};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::RecordModel;
+use crate::grid_db::track_and_trace::store::Record;
+
+use diesel::{prelude::*, result::Error::NotFound};
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreFetchRecordOperation
+{
+    fn fetch_record(
+        &self,
+        record_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Record>, TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreFetchRecordOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn fetch_record(
+        &self,
+        record_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Record>, TrackAndTraceStoreError> {
+        let mut query = record::table
+            .into_boxed()
+            .select(record::all_columns)
+            .filter(
+                record::record_id
+                    .eq(record_id)
+                    .and(record::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+        if let Some(service_id) = service_id {
+            query = query.filter(record::service_id.eq(service_id));
+        } else {
+            query = query.filter(record::service_id.is_null());
+        }
+
+        let rec = query
+            .first::<RecordModel>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| TrackAndTraceStoreError::QueryError {
+                context: "Failed to fetch existing record".to_string(),
+                source: Box::new(err),
+            })?;
+
+        Ok(Some(Record::from(rec.unwrap())))
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/fetch_reported_value_reporter_to_agent_metadata.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/fetch_reported_value_reporter_to_agent_metadata.rs
@@ -1,0 +1,188 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{
+    schema::reported_value_reporter_to_agent_metadata, TrackAndTraceStoreError,
+};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::ReportedValueReporterToAgentMetadataModel;
+use crate::grid_db::track_and_trace::store::ReportedValueReporterToAgentMetadata;
+
+use diesel::{prelude::*, result::Error::NotFound};
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreFetchReportedValueReporterToAgentMetadataOperation<
+    C: Connection,
+>
+{
+    fn fetch_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        commit_height: Option<i64>,
+        service_id: Option<String>,
+    ) -> Result<Option<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError>;
+    fn get_root_rvs(
+        conn: &C,
+        record_id: &str,
+        property_name: &str,
+        commit_height: Option<i64>,
+        service_id: Option<String>,
+    ) -> QueryResult<Vec<ReportedValueReporterToAgentMetadataModel>>;
+    fn get_rvs_for_rv(
+        conn: &C,
+        rvs: Vec<ReportedValueReporterToAgentMetadataModel>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a>
+    TrackAndTraceStoreFetchReportedValueReporterToAgentMetadataOperation<diesel::pg::PgConnection>
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn fetch_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        commit_height: Option<i64>,
+        service_id: Option<String>,
+    ) -> Result<Option<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        let height = commit_height.unwrap_or(MAX_COMMIT_NUM);
+        let mut query = reported_value_reporter_to_agent_metadata::table
+            .into_boxed()
+            .filter(
+                reported_value_reporter_to_agent_metadata::property_name
+                    .eq(property_name)
+                    .and(reported_value_reporter_to_agent_metadata::record_id.eq(record_id))
+                    .and(
+                        reported_value_reporter_to_agent_metadata::reported_value_end_commit_num
+                            .eq(height),
+                    ),
+            );
+
+        if let Some(service_id) = service_id.clone() {
+            query =
+                query.filter(reported_value_reporter_to_agent_metadata::service_id.eq(service_id));
+        } else {
+            query = query.filter(reported_value_reporter_to_agent_metadata::service_id.is_null());
+        }
+
+        let val = query
+            .first::<ReportedValueReporterToAgentMetadataModel>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| TrackAndTraceStoreError::QueryError {
+                context: "Failed to fetch existing record".to_string(),
+                source: Box::new(err),
+            })?;
+
+        let roots = Self::get_root_rvs(
+            &*self.conn,
+            &record_id,
+            &property_name,
+            commit_height,
+            service_id,
+        )?;
+
+        let rvs = Self::get_rvs_for_rv(&*self.conn, roots)?;
+
+        Ok(Some(ReportedValueReporterToAgentMetadata::from((
+            val.unwrap(),
+            rvs,
+        ))))
+    }
+
+    fn get_root_rvs(
+        conn: &PgConnection,
+        record_id: &str,
+        property_name: &str,
+        commit_height: Option<i64>,
+        service_id: Option<String>,
+    ) -> QueryResult<Vec<ReportedValueReporterToAgentMetadataModel>> {
+        let mut query = reported_value_reporter_to_agent_metadata::table
+            .into_boxed()
+            .select(reported_value_reporter_to_agent_metadata::all_columns)
+            .filter(
+                reported_value_reporter_to_agent_metadata::record_id
+                    .eq(record_id)
+                    .and(reported_value_reporter_to_agent_metadata::parent_name.is_null())
+                    .and(
+                        reported_value_reporter_to_agent_metadata::property_name.eq(property_name),
+                    ),
+            );
+
+        if let Some(service_id) = service_id {
+            query =
+                query.filter(reported_value_reporter_to_agent_metadata::service_id.eq(service_id));
+        } else {
+            query = query.filter(reported_value_reporter_to_agent_metadata::service_id.is_null());
+        }
+
+        if let Some(commit_height) = commit_height {
+            query = query.filter(
+                reported_value_reporter_to_agent_metadata::reported_value_end_commit_num
+                    .eq(commit_height),
+            );
+        } else {
+            query = query.filter(
+                reported_value_reporter_to_agent_metadata::reported_value_end_commit_num
+                    .eq(MAX_COMMIT_NUM),
+            );
+        }
+
+        query.load::<ReportedValueReporterToAgentMetadataModel>(conn)
+    }
+
+    fn get_rvs_for_rv(
+        conn: &PgConnection,
+        rvs: Vec<ReportedValueReporterToAgentMetadataModel>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        let mut values = Vec::new();
+
+        for rv in rvs {
+            let mut query = reported_value_reporter_to_agent_metadata::table
+                .into_boxed()
+                .select(reported_value_reporter_to_agent_metadata::all_columns)
+                .filter(
+                    reported_value_reporter_to_agent_metadata::parent_name
+                        .eq(&rv.property_name)
+                        .and(
+                            reported_value_reporter_to_agent_metadata::record_id.eq(&rv.record_id),
+                        ),
+                );
+
+            if let Some(service_id) = &rv.service_id {
+                query = query
+                    .filter(reported_value_reporter_to_agent_metadata::service_id.eq(service_id));
+            } else {
+                query =
+                    query.filter(reported_value_reporter_to_agent_metadata::service_id.is_null());
+            }
+
+            let children = query.load::<ReportedValueReporterToAgentMetadataModel>(conn)?;
+
+            if children.is_empty() {
+                values.push(ReportedValueReporterToAgentMetadata::from(rv))
+            } else {
+                values.push(ReportedValueReporterToAgentMetadata::from((
+                    rv,
+                    Self::get_rvs_for_rv(conn, children)?,
+                )));
+            }
+        }
+
+        Ok(values)
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_associated_agents.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_associated_agents.rs
@@ -1,0 +1,76 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{
+    schema::associated_agent, TrackAndTraceStoreError,
+};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::AssociatedAgentModel;
+use crate::grid_db::track_and_trace::store::AssociatedAgent;
+
+use diesel::prelude::*;
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreListAssociatedAgentsOperation
+{
+    fn list_associated_agents(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<AssociatedAgent>, TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreListAssociatedAgentsOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_associated_agents(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<AssociatedAgent>, TrackAndTraceStoreError> {
+        let mut query = associated_agent::table
+            .into_boxed()
+            .select(associated_agent::all_columns)
+            .filter(
+                associated_agent::end_commit_num
+                    .eq(MAX_COMMIT_NUM)
+                    .and(associated_agent::record_id.eq_any(record_ids)),
+            );
+
+        if let Some(service_id) = service_id {
+            query = query.filter(associated_agent::service_id.eq(service_id));
+        } else {
+            query = query.filter(associated_agent::service_id.is_null());
+        }
+
+        let models: Vec<AssociatedAgentModel> = query
+            .load::<AssociatedAgentModel>(self.conn)
+            .map(Some)
+            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                context: "Failed to fetch records".to_string(),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| {
+                TrackAndTraceStoreError::NotFoundError(
+                    "Could not get all records from storage".to_string(),
+                )
+            })?
+            .into_iter()
+            .collect();
+
+        Ok(models.into_iter().map(AssociatedAgent::from).collect())
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_properties_with_data_type.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_properties_with_data_type.rs
@@ -1,0 +1,95 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{
+    make_property_with_data_type,
+    schema::{grid_property_definition, property, record},
+    TrackAndTraceStoreError,
+};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::PropertyModel;
+use crate::grid_db::track_and_trace::store::Property;
+
+use diesel::prelude::*;
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreListPropertiesWithDataTypeOperation
+{
+    fn list_properties_with_data_type(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<(Property, Option<String>)>, TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreListPropertiesWithDataTypeOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_properties_with_data_type(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<(Property, Option<String>)>, TrackAndTraceStoreError> {
+        let mut query = property::table
+            .into_boxed()
+            .left_join(
+                record::table.on(property::record_id
+                    .eq(record::record_id)
+                    .and(property::end_commit_num.eq(record::end_commit_num))),
+            )
+            .left_join(
+                grid_property_definition::table.on(record::schema
+                    .eq(grid_property_definition::schema_name)
+                    .and(property::name.eq(grid_property_definition::name))
+                    .and(property::end_commit_num.eq(record::end_commit_num))),
+            )
+            .filter(
+                property::record_id
+                    .eq_any(record_ids)
+                    .and(property::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+        if let Some(service_id) = service_id {
+            query = query.filter(property::service_id.eq(service_id));
+        } else {
+            query = query.filter(property::service_id.is_null());
+        }
+
+        let models: Vec<(PropertyModel, Option<String>)> = query
+            .select((
+                property::all_columns,
+                grid_property_definition::data_type.nullable(),
+            ))
+            .load::<(PropertyModel, Option<String>)>(self.conn)
+            .map(Some)
+            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                context: "Failed to fetch records".to_string(),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| {
+                TrackAndTraceStoreError::NotFoundError(
+                    "Could not get all records from storage".to_string(),
+                )
+            })?
+            .into_iter()
+            .collect();
+
+        Ok(models
+            .into_iter()
+            .map(make_property_with_data_type)
+            .collect())
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_proposals.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_proposals.rs
@@ -1,0 +1,74 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{schema::proposal, TrackAndTraceStoreError};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::ProposalModel;
+use crate::grid_db::track_and_trace::store::Proposal;
+
+use diesel::prelude::*;
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreListProposalsOperation
+{
+    fn list_proposals(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<Proposal>, TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreListProposalsOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_proposals(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<Proposal>, TrackAndTraceStoreError> {
+        let mut query = proposal::table
+            .into_boxed()
+            .select(proposal::all_columns)
+            .filter(
+                proposal::end_commit_num
+                    .eq(MAX_COMMIT_NUM)
+                    .and(proposal::record_id.eq_any(record_ids)),
+            );
+
+        if let Some(service_id) = service_id {
+            query = query.filter(proposal::service_id.eq(service_id));
+        } else {
+            query = query.filter(proposal::service_id.is_null());
+        }
+
+        let models: Vec<ProposalModel> = query
+            .load::<ProposalModel>(self.conn)
+            .map(Some)
+            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                context: "Failed to fetch records".to_string(),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| {
+                TrackAndTraceStoreError::NotFoundError(
+                    "Could not get all records from storage".to_string(),
+                )
+            })?
+            .into_iter()
+            .collect();
+
+        Ok(models.into_iter().map(Proposal::from).collect())
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_proposals.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_proposals.rs
@@ -72,3 +72,46 @@ impl<'a> TrackAndTraceStoreListProposalsOperation
         Ok(models.into_iter().map(Proposal::from).collect())
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a> TrackAndTraceStoreListProposalsOperation
+    for TrackAndTraceStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn list_proposals(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<Proposal>, TrackAndTraceStoreError> {
+        let mut query = proposal::table
+            .into_boxed()
+            .select(proposal::all_columns)
+            .filter(
+                proposal::end_commit_num
+                    .eq(MAX_COMMIT_NUM)
+                    .and(proposal::record_id.eq_any(record_ids)),
+            );
+
+        if let Some(service_id) = service_id {
+            query = query.filter(proposal::service_id.eq(service_id));
+        } else {
+            query = query.filter(proposal::service_id.is_null());
+        }
+
+        let models: Vec<ProposalModel> = query
+            .load::<ProposalModel>(self.conn)
+            .map(Some)
+            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                context: "Failed to fetch records".to_string(),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| {
+                TrackAndTraceStoreError::NotFoundError(
+                    "Could not get all records from storage".to_string(),
+                )
+            })?
+            .into_iter()
+            .collect();
+
+        Ok(models.into_iter().map(Proposal::from).collect())
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_records.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_records.rs
@@ -1,0 +1,68 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{schema::record, TrackAndTraceStoreError};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::RecordModel;
+use crate::grid_db::track_and_trace::store::Record;
+
+use diesel::prelude::*;
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreListRecordsOperation
+{
+    fn list_records(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Record>, TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreListRecordsOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_records(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Record>, TrackAndTraceStoreError> {
+        let mut query = record::table
+            .into_boxed()
+            .select(record::all_columns)
+            .filter(record::end_commit_num.eq(MAX_COMMIT_NUM));
+
+        if let Some(service_id) = service_id {
+            query = query.filter(record::service_id.eq(service_id));
+        } else {
+            query = query.filter(record::service_id.is_null());
+        }
+
+        let models: Vec<RecordModel> = query
+            .load::<RecordModel>(self.conn)
+            .map(Some)
+            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                context: "Failed to fetch records".to_string(),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| {
+                TrackAndTraceStoreError::NotFoundError(
+                    "Could not get all records from storage".to_string(),
+                )
+            })?
+            .into_iter()
+            .collect();
+
+        Ok(models.into_iter().map(Record::from).collect())
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_reported_value_reporter_to_agent_metadata.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_reported_value_reporter_to_agent_metadata.rs
@@ -1,0 +1,170 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{
+    schema::reported_value_reporter_to_agent_metadata, TrackAndTraceStoreError,
+};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::ReportedValueReporterToAgentMetadataModel;
+use crate::grid_db::track_and_trace::store::ReportedValueReporterToAgentMetadata;
+
+use diesel::prelude::*;
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreListReportedValueReporterToAgentMetadataOperation<
+    C: Connection,
+>
+{
+    fn list_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError>;
+    fn get_root_rvs(
+        conn: &C,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> QueryResult<Vec<ReportedValueReporterToAgentMetadataModel>>;
+    fn get_rvs_for_rv(
+        conn: &C,
+        rvs: Vec<ReportedValueReporterToAgentMetadataModel>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a>
+    TrackAndTraceStoreListReportedValueReporterToAgentMetadataOperation<diesel::pg::PgConnection>
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        let query: Vec<ReportedValueReporterToAgentMetadataModel> = reported_value_reporter_to_agent_metadata::table
+            .filter(
+                reported_value_reporter_to_agent_metadata::property_name
+                    .eq(property_name)
+                    .and(reported_value_reporter_to_agent_metadata::record_id.eq(record_id))
+                    .and(
+                        reported_value_reporter_to_agent_metadata::reported_value_end_commit_num
+                            .le(MAX_COMMIT_NUM),
+                    ),
+            )
+            .load::<ReportedValueReporterToAgentMetadataModel>(self.conn)
+            .map(Some)
+            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                context: "Failed to fetch records".to_string(),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| {
+                TrackAndTraceStoreError::NotFoundError(
+                    "Could not get all records from storage".to_string(),
+                )
+            })?
+            .into_iter()
+            .collect();
+
+        let mut rvs = Vec::new();
+
+        for model in query {
+            let rv: ReportedValueReporterToAgentMetadataModel = model;
+            let roots =
+                Self::get_root_rvs(&*self.conn, &record_id, &property_name, service_id.clone())?;
+
+            let children = Self::get_rvs_for_rv(&*self.conn, roots)?;
+
+            rvs.push(ReportedValueReporterToAgentMetadata::from((rv, children)));
+        }
+
+        Ok(rvs)
+    }
+
+    fn get_root_rvs(
+        conn: &PgConnection,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> QueryResult<Vec<ReportedValueReporterToAgentMetadataModel>> {
+        let mut query = reported_value_reporter_to_agent_metadata::table
+            .into_boxed()
+            .select(reported_value_reporter_to_agent_metadata::all_columns)
+            .filter(
+                reported_value_reporter_to_agent_metadata::record_id
+                    .eq(record_id)
+                    .and(reported_value_reporter_to_agent_metadata::parent_name.is_null())
+                    .and(
+                        reported_value_reporter_to_agent_metadata::reported_value_end_commit_num
+                            .le(MAX_COMMIT_NUM),
+                    )
+                    .and(
+                        reported_value_reporter_to_agent_metadata::property_name.eq(property_name),
+                    ),
+            );
+
+        if let Some(service_id) = service_id {
+            query =
+                query.filter(reported_value_reporter_to_agent_metadata::service_id.eq(service_id));
+        } else {
+            query = query.filter(reported_value_reporter_to_agent_metadata::service_id.is_null());
+        }
+
+        query.load::<ReportedValueReporterToAgentMetadataModel>(conn)
+    }
+
+    fn get_rvs_for_rv(
+        conn: &PgConnection,
+        rvs: Vec<ReportedValueReporterToAgentMetadataModel>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        let mut values = Vec::new();
+
+        for rv in rvs {
+            let mut query = reported_value_reporter_to_agent_metadata::table
+                .into_boxed()
+                .select(reported_value_reporter_to_agent_metadata::all_columns)
+                .filter(
+                    reported_value_reporter_to_agent_metadata::parent_name
+                        .eq(&rv.property_name)
+                        .and(
+                            reported_value_reporter_to_agent_metadata::record_id.eq(&rv.record_id),
+                        ),
+                );
+
+            if let Some(service_id) = &rv.service_id {
+                query = query
+                    .filter(reported_value_reporter_to_agent_metadata::service_id.eq(service_id));
+            } else {
+                query =
+                    query.filter(reported_value_reporter_to_agent_metadata::service_id.is_null());
+            }
+
+            let children = query.load::<ReportedValueReporterToAgentMetadataModel>(conn)?;
+
+            if children.is_empty() {
+                values.push(ReportedValueReporterToAgentMetadata::from(rv))
+            } else {
+                values.push(ReportedValueReporterToAgentMetadata::from((
+                    rv,
+                    Self::get_rvs_for_rv(conn, children)?,
+                )));
+            }
+        }
+
+        Ok(values)
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_reported_value_reporter_to_agent_metadata.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_reported_value_reporter_to_agent_metadata.rs
@@ -168,3 +168,128 @@ impl<'a>
         Ok(values)
     }
 }
+
+#[cfg(feature = "sqlite")]
+impl<'a>
+    TrackAndTraceStoreListReportedValueReporterToAgentMetadataOperation<
+        diesel::sqlite::SqliteConnection,
+    > for TrackAndTraceStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn list_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        let query: Vec<ReportedValueReporterToAgentMetadataModel> = reported_value_reporter_to_agent_metadata::table
+            .filter(
+                reported_value_reporter_to_agent_metadata::property_name
+                    .eq(property_name)
+                    .and(reported_value_reporter_to_agent_metadata::record_id.eq(record_id))
+                    .and(
+                        reported_value_reporter_to_agent_metadata::reported_value_end_commit_num
+                            .le(MAX_COMMIT_NUM),
+                    ),
+            )
+            .load::<ReportedValueReporterToAgentMetadataModel>(self.conn)
+            .map(Some)
+            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                context: "Failed to fetch records".to_string(),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| {
+                TrackAndTraceStoreError::NotFoundError(
+                    "Could not get all records from storage".to_string(),
+                )
+            })?
+            .into_iter()
+            .collect();
+
+        let mut rvs = Vec::new();
+
+        for model in query {
+            let rv: ReportedValueReporterToAgentMetadataModel = model;
+            let roots =
+                Self::get_root_rvs(&*self.conn, &record_id, &property_name, service_id.clone())?;
+
+            let children = Self::get_rvs_for_rv(&*self.conn, roots)?;
+
+            rvs.push(ReportedValueReporterToAgentMetadata::from((rv, children)));
+        }
+
+        Ok(rvs)
+    }
+
+    fn get_root_rvs(
+        conn: &SqliteConnection,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> QueryResult<Vec<ReportedValueReporterToAgentMetadataModel>> {
+        let mut query = reported_value_reporter_to_agent_metadata::table
+            .into_boxed()
+            .select(reported_value_reporter_to_agent_metadata::all_columns)
+            .filter(
+                reported_value_reporter_to_agent_metadata::record_id
+                    .eq(record_id)
+                    .and(reported_value_reporter_to_agent_metadata::parent_name.is_null())
+                    .and(
+                        reported_value_reporter_to_agent_metadata::reported_value_end_commit_num
+                            .le(MAX_COMMIT_NUM),
+                    )
+                    .and(
+                        reported_value_reporter_to_agent_metadata::property_name.eq(property_name),
+                    ),
+            );
+
+        if let Some(service_id) = service_id {
+            query =
+                query.filter(reported_value_reporter_to_agent_metadata::service_id.eq(service_id));
+        } else {
+            query = query.filter(reported_value_reporter_to_agent_metadata::service_id.is_null());
+        }
+
+        query.load::<ReportedValueReporterToAgentMetadataModel>(conn)
+    }
+
+    fn get_rvs_for_rv(
+        conn: &SqliteConnection,
+        rvs: Vec<ReportedValueReporterToAgentMetadataModel>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        let mut values = Vec::new();
+
+        for rv in rvs {
+            let mut query = reported_value_reporter_to_agent_metadata::table
+                .into_boxed()
+                .select(reported_value_reporter_to_agent_metadata::all_columns)
+                .filter(
+                    reported_value_reporter_to_agent_metadata::parent_name
+                        .eq(&rv.property_name)
+                        .and(
+                            reported_value_reporter_to_agent_metadata::record_id.eq(&rv.record_id),
+                        ),
+                );
+
+            if let Some(service_id) = &rv.service_id {
+                query = query
+                    .filter(reported_value_reporter_to_agent_metadata::service_id.eq(service_id));
+            } else {
+                query =
+                    query.filter(reported_value_reporter_to_agent_metadata::service_id.is_null());
+            }
+
+            let children = query.load::<ReportedValueReporterToAgentMetadataModel>(conn)?;
+
+            if children.is_empty() {
+                values.push(ReportedValueReporterToAgentMetadata::from(rv))
+            } else {
+                values.push(ReportedValueReporterToAgentMetadata::from((
+                    rv,
+                    Self::get_rvs_for_rv(conn, children)?,
+                )));
+            }
+        }
+
+        Ok(values)
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_reporters.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/list_reporters.rs
@@ -1,0 +1,77 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TrackAndTraceStoreOperations;
+use crate::grid_db::track_and_trace::store::diesel::{schema::reporter, TrackAndTraceStoreError};
+
+use crate::grid_db::commits::MAX_COMMIT_NUM;
+use crate::grid_db::track_and_trace::store::diesel::models::ReporterModel;
+use crate::grid_db::track_and_trace::store::Reporter;
+
+use diesel::prelude::*;
+
+pub(in crate::grid_db::track_and_trace::store::diesel) trait TrackAndTraceStoreListReportersOperation
+{
+    fn list_reporters(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<Reporter>, TrackAndTraceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> TrackAndTraceStoreListReportersOperation
+    for TrackAndTraceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_reporters(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<Reporter>, TrackAndTraceStoreError> {
+        let mut query = reporter::table
+            .into_boxed()
+            .select(reporter::all_columns)
+            .filter(
+                reporter::property_name
+                    .eq(property_name)
+                    .and(reporter::record_id.eq(record_id))
+                    .and(reporter::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+        if let Some(service_id) = service_id {
+            query = query.filter(reporter::service_id.eq(service_id));
+        } else {
+            query = query.filter(reporter::service_id.is_null());
+        }
+
+        let model: Vec<ReporterModel> = query
+            .load::<ReporterModel>(self.conn)
+            .map(Some)
+            .map_err(|err| TrackAndTraceStoreError::OperationError {
+                context: "Failed to fetch records".to_string(),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| {
+                TrackAndTraceStoreError::NotFoundError(
+                    "Could not get all records from storage".to_string(),
+                )
+            })?
+            .into_iter()
+            .collect();
+
+        Ok(model.into_iter().map(Reporter::from).collect())
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/operations/mod.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/operations/mod.rs
@@ -1,0 +1,42 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) mod add_associated_agents;
+pub(super) mod add_properties;
+pub(super) mod add_proposals;
+pub(super) mod add_records;
+pub(super) mod add_reported_values;
+pub(super) mod add_reporters;
+pub(super) mod fetch_property_with_data_type;
+pub(super) mod fetch_record;
+pub(super) mod fetch_reported_value_reporter_to_agent_metadata;
+pub(super) mod list_associated_agents;
+pub(super) mod list_properties_with_data_type;
+pub(super) mod list_proposals;
+pub(super) mod list_records;
+pub(super) mod list_reported_value_reporter_to_agent_metadata;
+pub(super) mod list_reporters;
+
+pub(super) struct TrackAndTraceStoreOperations<'a, C> {
+    conn: &'a C,
+}
+
+impl<'a, C> TrackAndTraceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    pub fn new(conn: &'a C) -> Self {
+        TrackAndTraceStoreOperations { conn }
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/diesel/schema.rs
+++ b/sdk/src/grid_db/track_and_trace/store/diesel/schema.rs
@@ -1,0 +1,161 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+table! {
+    associated_agent (id) {
+        id -> Int8,
+        record_id -> Text,
+        role -> Text,
+        agent_id -> Text,
+        timestamp -> Int8,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}
+
+table! {
+    grid_property_definition (id) {
+        id -> Int8,
+        name -> Text,
+        schema_name -> Text,
+        data_type -> Text,
+        required -> Bool,
+        description -> Text,
+        number_exponent -> Int8,
+        enum_options -> Text,
+        parent_name -> Nullable<Text>,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}
+
+table! {
+    property (id) {
+        id -> Int8,
+        name -> Text,
+        record_id -> Text,
+        property_definition -> Text,
+        current_page -> Int4,
+        wrapped -> Bool,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}
+
+table! {
+    proposal (id) {
+        id -> Int8,
+        record_id -> Text,
+        timestamp -> Int8,
+        issuing_agent -> Text,
+        receiving_agent -> Text,
+        role -> Text,
+        properties -> Text,
+        status -> Text,
+        terms -> Text,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}
+
+table! {
+    record (id) {
+        id -> Int8,
+        record_id -> Text,
+        schema -> Text,
+        #[sql_name = "final"]
+        final_ -> Bool,
+        owners -> Text,
+        custodians -> Text,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}
+
+table! {
+    reported_value (id) {
+        id -> Int8,
+        property_name -> Text,
+        record_id -> Text,
+        reporter_index -> Int4,
+        timestamp -> Int8,
+        data_type -> Text,
+        bytes_value -> Nullable<Bytea>,
+        boolean_value -> Nullable<Bool>,
+        number_value -> Nullable<Int8>,
+        string_value -> Nullable<Text>,
+        enum_value -> Nullable<Int4>,
+        parent_name -> Nullable<Text>,
+        latitude_value -> Nullable<Int8>,
+        longitude_value -> Nullable<Int8>,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+    reported_value_reporter_to_agent_metadata (id) {
+        id -> Int8,
+        property_name -> Text,
+        record_id -> Text,
+        reporter_index -> Int4,
+        timestamp -> Int8,
+        data_type -> Text,
+        bytes_value ->  Nullable<Bytea>,
+        boolean_value ->  Nullable<Bool>,
+        number_value ->  Nullable<Int8>,
+        string_value ->  Nullable<Text>,
+        enum_value ->  Nullable<Int4>,
+        parent_name ->  Nullable<Text>,
+        latitude_value -> Nullable<Int8>,
+        longitude_value -> Nullable<Int8>,
+        public_key ->  Nullable<Text>,
+        authorized ->  Nullable<Bool>,
+        metadata ->  Nullable<Binary>,
+        reported_value_end_commit_num -> Int8,
+        reporter_end_commit_num ->  Int8,
+        service_id -> Nullable<Text>,
+    }
+}
+
+table! {
+    reporter (id) {
+        id -> Int8,
+        property_name -> Text,
+        record_id -> Text,
+        public_key -> Text,
+        authorized -> Bool,
+        reporter_index -> Int4,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}
+
+allow_tables_to_appear_in_same_query!(
+    associated_agent,
+    grid_property_definition,
+    property,
+    proposal,
+    record,
+    reported_value,
+    reporter,
+);

--- a/sdk/src/grid_db/track_and_trace/store/error.rs
+++ b/sdk/src/grid_db/track_and_trace/store/error.rs
@@ -1,0 +1,110 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+/// Represents TrackAndTraceStore errors
+#[derive(Debug)]
+pub enum TrackAndTraceStoreError {
+    /// Represents CRUD operations failures
+    OperationError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    /// Represents database query failures
+    QueryError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents general failures in the database
+    StorageError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    DuplicateError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    /// Represents an issue connecting to the database
+    ConnectionError(Box<dyn Error>),
+    NotFoundError(String),
+}
+
+impl Error for TrackAndTraceStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            TrackAndTraceStoreError::OperationError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            TrackAndTraceStoreError::OperationError { source: None, .. } => None,
+            TrackAndTraceStoreError::QueryError { source, .. } => Some(&**source),
+            TrackAndTraceStoreError::StorageError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            TrackAndTraceStoreError::StorageError { source: None, .. } => None,
+            TrackAndTraceStoreError::ConnectionError(err) => Some(&**err),
+            TrackAndTraceStoreError::DuplicateError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            TrackAndTraceStoreError::DuplicateError { source: None, .. } => None,
+            TrackAndTraceStoreError::NotFoundError(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for TrackAndTraceStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TrackAndTraceStoreError::OperationError {
+                context,
+                source: Some(source),
+            } => write!(f, "failed to perform operation: {}: {}", context, source),
+            TrackAndTraceStoreError::OperationError {
+                context,
+                source: None,
+            } => write!(f, "failed to perform operation: {}", context),
+            TrackAndTraceStoreError::QueryError { context, source } => {
+                write!(f, "failed query: {}: {}", context, source)
+            }
+            TrackAndTraceStoreError::StorageError {
+                context,
+                source: Some(source),
+            } => write!(
+                f,
+                "the underlying storage returned an error: {}: {}",
+                context, source
+            ),
+            TrackAndTraceStoreError::StorageError {
+                context,
+                source: None,
+            } => write!(f, "the underlying storage returned an error: {}", context),
+            TrackAndTraceStoreError::ConnectionError(err) => {
+                write!(f, "failed to connect to underlying storage: {}", err)
+            }
+            TrackAndTraceStoreError::DuplicateError {
+                context,
+                source: Some(source),
+            } => write!(f, "Element already exists: {}: {}", context, source),
+            TrackAndTraceStoreError::DuplicateError {
+                context,
+                source: None,
+            } => write!(f, "The element already exists: {}", context),
+            TrackAndTraceStoreError::NotFoundError(ref s) => write!(f, "Element not found: {}", s),
+        }
+    }
+}

--- a/sdk/src/grid_db/track_and_trace/store/mod.rs
+++ b/sdk/src/grid_db/track_and_trace/store/mod.rs
@@ -1,0 +1,421 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "diesel")]
+pub mod diesel;
+mod error;
+
+pub use error::TrackAndTraceStoreError;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssociatedAgent {
+    pub id: i64,
+    pub record_id: String,
+    pub role: String,
+    pub agent_id: String,
+    pub timestamp: i64,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Property {
+    pub id: i64,
+    pub name: String,
+    pub record_id: String,
+    pub property_definition: String,
+    pub current_page: i32,
+    pub wrapped: bool,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Proposal {
+    pub id: i64,
+    pub record_id: String,
+    pub timestamp: i64,
+    pub issuing_agent: String,
+    pub receiving_agent: String,
+    pub role: String,
+    pub properties: Vec<String>,
+    pub status: String,
+    pub terms: String,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Record {
+    pub id: i64,
+    pub record_id: String,
+    pub schema: String,
+    pub final_: bool,
+    pub owners: Vec<String>,
+    pub custodians: Vec<String>,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReportedValue {
+    pub id: i64,
+    pub property_name: String,
+    pub record_id: String,
+    pub reporter_index: i32,
+    pub timestamp: i64,
+    pub data_type: String,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<i32>,
+    pub struct_values: Option<Vec<ReportedValue>>,
+    pub lat_long_value: Option<LatLongValue>,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Reporter {
+    pub id: i64,
+    pub property_name: String,
+    pub record_id: String,
+    pub public_key: String,
+    pub authorized: bool,
+    pub reporter_index: i32,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReportedValueReporterToAgentMetadata {
+    pub id: i64,
+    pub property_name: String,
+    pub record_id: String,
+    pub reporter_index: i32,
+    pub timestamp: i64,
+    pub data_type: String,
+    pub bytes_value: Option<Vec<u8>>,
+    pub boolean_value: Option<bool>,
+    pub number_value: Option<i64>,
+    pub string_value: Option<String>,
+    pub enum_value: Option<i32>,
+    pub struct_values: Vec<ReportedValueReporterToAgentMetadata>,
+    pub lat_long_value: Option<LatLongValue>,
+    pub public_key: Option<String>,
+    pub authorized: Option<bool>,
+    pub metadata: Option<Vec<u8>>,
+    pub reported_value_end_commit_num: i64,
+    pub reporter_end_commit_num: i64,
+    pub service_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct LatLong;
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct LatLongValue(pub i64, pub i64);
+
+pub trait TrackAndTraceStore: Send + Sync {
+    /// Adds an associated agent to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `agents` - The agents to be added
+    fn add_associated_agents(
+        &self,
+        agents: Vec<AssociatedAgent>,
+    ) -> Result<(), TrackAndTraceStoreError>;
+
+    /// Adds properties to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `properties` - The properties to be added
+    fn add_properties(&self, properties: Vec<Property>) -> Result<(), TrackAndTraceStoreError>;
+
+    /// Adds proposals to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `proposals` - The proposals to be added
+    fn add_proposals(&self, proposals: Vec<Proposal>) -> Result<(), TrackAndTraceStoreError>;
+
+    /// Adds records to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `records` - The records to be added
+    fn add_records(&self, records: Vec<Record>) -> Result<(), TrackAndTraceStoreError>;
+
+    /// Adds reported values to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `values` - The reported values to be added
+    fn add_reported_values(
+        &self,
+        values: Vec<ReportedValue>,
+    ) -> Result<(), TrackAndTraceStoreError>;
+
+    /// Adds reporters to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `reporters` - The reporters to be added
+    fn add_reporters(&self, reporters: Vec<Reporter>) -> Result<(), TrackAndTraceStoreError>;
+
+    /// Fetches a property and its data type from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `record_id` - The record ID to fetch for
+    ///  * `property_name` - The property name to fetch
+    ///  * `service_id` - The service ID to fetch for
+    fn fetch_property_with_data_type(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<(Property, Option<String>)>, TrackAndTraceStoreError>;
+
+    /// Fetches a record from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `record_id` - The record ID to fetch for
+    ///  * `service_id` - The service ID to fetch for
+    fn fetch_record(
+        &self,
+        record_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Record>, TrackAndTraceStoreError>;
+
+    /// Fetches a reported value reported to agent metadata object from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `record_id` - The record ID to fetch for
+    ///  * `property_name` - The property name to fetch
+    ///  * `commit_height` - The commit height of the reported value to fetch
+    ///  * `service_id` - The service ID to fetch for
+    fn fetch_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        commit_height: Option<i64>,
+        service_id: Option<String>,
+    ) -> Result<Option<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError>;
+
+    /// Fetches a list of associated agents from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `record_ids` - The record IDs to fetch for
+    ///  * `service_id` - The service ID to fetch for
+    fn list_associated_agents(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<AssociatedAgent>, TrackAndTraceStoreError>;
+
+    /// Fetches a list of properties and their data types from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `record_ids` - The list of record IDs to fetch for
+    ///  * `service_id` - The service ID to fetch for
+    fn list_properties_with_data_type(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<(Property, Option<String>)>, TrackAndTraceStoreError>;
+
+    /// Fetches a list of proposals from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `record_ids` - The list of record IDs to fetch for
+    ///  * `service_id` - The service ID to fetch for
+    fn list_proposals(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<Proposal>, TrackAndTraceStoreError>;
+
+    /// Fetches a list of records from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_id` - The service ID to fetch for
+    fn list_records(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Record>, TrackAndTraceStoreError>;
+
+    /// Fetches a list of reported value reported to agent metadata objects from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `record_id` - The record ID to fetch for
+    ///  * `property_name` - The property name to fetch
+    ///  * `service_id` - The service ID to fetch for
+    fn list_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError>;
+
+    /// Fetches a list of reporters from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `record_id` - The record ID to fetch for
+    ///  * `property_name` - The property name to fetch
+    ///  * `service_id` - The service ID to fetch for
+    fn list_reporters(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<Reporter>, TrackAndTraceStoreError>;
+}
+
+impl<TS> TrackAndTraceStore for Box<TS>
+where
+    TS: TrackAndTraceStore + ?Sized,
+{
+    fn add_associated_agents(
+        &self,
+        agents: Vec<AssociatedAgent>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        (**self).add_associated_agents(agents)
+    }
+
+    fn add_properties(&self, properties: Vec<Property>) -> Result<(), TrackAndTraceStoreError> {
+        (**self).add_properties(properties)
+    }
+
+    fn add_proposals(&self, proposals: Vec<Proposal>) -> Result<(), TrackAndTraceStoreError> {
+        (**self).add_proposals(proposals)
+    }
+
+    fn add_records(&self, records: Vec<Record>) -> Result<(), TrackAndTraceStoreError> {
+        (**self).add_records(records)
+    }
+
+    fn add_reported_values(
+        &self,
+        values: Vec<ReportedValue>,
+    ) -> Result<(), TrackAndTraceStoreError> {
+        (**self).add_reported_values(values)
+    }
+
+    fn add_reporters(&self, reporters: Vec<Reporter>) -> Result<(), TrackAndTraceStoreError> {
+        (**self).add_reporters(reporters)
+    }
+
+    fn fetch_property_with_data_type(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<(Property, Option<String>)>, TrackAndTraceStoreError> {
+        (**self).fetch_property_with_data_type(record_id, property_name, service_id)
+    }
+
+    fn fetch_record(
+        &self,
+        record_id: &str,
+        service_id: Option<String>,
+    ) -> Result<Option<Record>, TrackAndTraceStoreError> {
+        (**self).fetch_record(record_id, service_id)
+    }
+
+    fn fetch_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        commit_height: Option<i64>,
+        service_id: Option<String>,
+    ) -> Result<Option<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        (**self).fetch_reported_value_reporter_to_agent_metadata(
+            record_id,
+            property_name,
+            commit_height,
+            service_id,
+        )
+    }
+
+    fn list_associated_agents(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<AssociatedAgent>, TrackAndTraceStoreError> {
+        (**self).list_associated_agents(record_ids, service_id)
+    }
+
+    fn list_properties_with_data_type(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<(Property, Option<String>)>, TrackAndTraceStoreError> {
+        (**self).list_properties_with_data_type(record_ids, service_id)
+    }
+
+    fn list_proposals(
+        &self,
+        record_ids: &[String],
+        service_id: Option<String>,
+    ) -> Result<Vec<Proposal>, TrackAndTraceStoreError> {
+        (**self).list_proposals(record_ids, service_id)
+    }
+
+    fn list_records(
+        &self,
+        service_id: Option<String>,
+    ) -> Result<Vec<Record>, TrackAndTraceStoreError> {
+        (**self).list_records(service_id)
+    }
+
+    fn list_reported_value_reporter_to_agent_metadata(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<ReportedValueReporterToAgentMetadata>, TrackAndTraceStoreError> {
+        (**self).list_reported_value_reporter_to_agent_metadata(
+            record_id,
+            property_name,
+            service_id,
+        )
+    }
+
+    fn list_reporters(
+        &self,
+        record_id: &str,
+        property_name: &str,
+        service_id: Option<String>,
+    ) -> Result<Vec<Reporter>, TrackAndTraceStoreError> {
+        (**self).list_reporters(record_id, property_name, service_id)
+    }
+}

--- a/sdk/src/store/memory.rs
+++ b/sdk/src/store/memory.rs
@@ -14,7 +14,7 @@
 
 use crate::grid_db::{
     AgentStore, CommitStore, LocationStore, MemoryCommitStore, MemoryOrganizationStore,
-    MemorySchemaStore, OrganizationStore, SchemaStore,
+    MemorySchemaStore, OrganizationStore, SchemaStore, TrackAndTraceStore,
 };
 
 use super::StoreFactory;
@@ -64,5 +64,9 @@ impl StoreFactory for MemoryStoreFactory {
 
     fn get_grid_schema_store(&self) -> Box<dyn SchemaStore> {
         Box::new(self.grid_schema_store.clone())
+    }
+
+    fn get_grid_track_and_trace_store(&self) -> Box<dyn TrackAndTraceStore> {
+        unimplemented!()
     }
 }

--- a/sdk/src/store/mod.rs
+++ b/sdk/src/store/mod.rs
@@ -37,6 +37,8 @@ pub trait StoreFactory {
     fn get_grid_product_store(&self) -> Box<dyn crate::grid_db::ProductStore>;
     /// Get a new `SchemaStore`
     fn get_grid_schema_store(&self) -> Box<dyn crate::grid_db::SchemaStore>;
+    /// Get a new `TrackAndTraceStore`
+    fn get_grid_track_and_trace_store(&self) -> Box<dyn crate::grid_db::TrackAndTraceStore>;
 }
 
 /// Creates a `StoreFactory` backed by the given connection

--- a/sdk/src/store/postgres.rs
+++ b/sdk/src/store/postgres.rs
@@ -56,4 +56,10 @@ impl StoreFactory for PgStoreFactory {
     fn get_grid_schema_store(&self) -> Box<dyn crate::grid_db::SchemaStore> {
         Box::new(crate::grid_db::DieselSchemaStore::new(self.pool.clone()))
     }
+
+    fn get_grid_track_and_trace_store(&self) -> Box<dyn crate::grid_db::TrackAndTraceStore> {
+        Box::new(crate::grid_db::DieselTrackAndTraceStore::new(
+            self.pool.clone(),
+        ))
+    }
 }

--- a/sdk/src/store/sqlite.rs
+++ b/sdk/src/store/sqlite.rs
@@ -56,4 +56,10 @@ impl StoreFactory for SqliteStoreFactory {
     fn get_grid_schema_store(&self) -> Box<dyn crate::grid_db::SchemaStore> {
         Box::new(crate::grid_db::DieselSchemaStore::new(self.pool.clone()))
     }
+
+    fn get_grid_track_and_trace_store(&self) -> Box<dyn crate::grid_db::TrackAndTraceStore> {
+        Box::new(crate::grid_db::DieselTrackAndTraceStore::new(
+            self.pool.clone(),
+        ))
+    }
 }


### PR DESCRIPTION
This adds the postgres and sqlite store implementations and stubs the in-memory implementation (to make it compile) for the track and trace store following the new pattern. This does not currently integrate the new store into the daemon but that integration will come in a later PR.