### PR TITLE
Add shared circuit-template volume

### DIFF
--- a/daemon/packaging/ubuntu/postinst
+++ b/daemon/packaging/ubuntu/postinst
@@ -36,6 +36,12 @@ case "$1" in
         chown -R root:$group /etc/grid
         chmod 775 /etc/grid
         chmod 750 /etc/grid/keys
+
+        if [ ! -d /usr/share/splinter/circuit-templates ]; then
+          mkdir -p /usr/share/splinter/circuit-templates
+        fi
+        chmod 755 /usr/share/splinter/circuit-templates
+
     else
         true
     fi

--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -20,6 +20,7 @@ volumes:
   gridd-alpha:
   gridd-beta:
   gridd-gamma:
+  templates-shared:
 
 services:
 
@@ -184,6 +185,7 @@ services:
     volumes:
       - contracts-shared:/usr/share/scar
       - gridd-alpha:/etc/grid/keys
+      - templates-shared:/usr/share/splinter/circuit-templates
     expose:
       - 8080
     ports:
@@ -226,6 +228,7 @@ services:
     volumes:
       - contracts-shared:/usr/share/scar
       - registry:/registry
+      - templates-shared:/usr/share/splinter/circuit-templates
     entrypoint: |
       bash -c "
         until PGPASSWORD=admin psql -h splinter-db-alpha -U admin -d splinter -c '\q'; do
@@ -318,6 +321,7 @@ services:
     volumes:
       - contracts-shared:/usr/share/scar
       - gridd-beta:/etc/grid/keys
+      - templates-shared:/usr/share/splinter/circuit-templates
     expose:
       - 8080
     ports:
@@ -359,6 +363,7 @@ services:
     volumes:
       - contracts-shared:/usr/share/scar
       - registry:/registry
+      - templates-shared:/usr/share/splinter/circuit-templates
     entrypoint: |
       bash -c "
         until PGPASSWORD=admin psql -h splinter-db-beta -U admin -d splinter -c '\q'; do
@@ -451,6 +456,7 @@ services:
     volumes:
       - contracts-shared:/usr/share/scar
       - gridd-gamma:/etc/grid/keys
+      - templates-shared:/usr/share/splinter/circuit-templates
     expose:
       - 8080
     ports:
@@ -484,6 +490,7 @@ services:
     volumes:
       - contracts-shared:/usr/share/scar
       - registry:/registry
+      - templates-shared:/usr/share/splinter/circuit-templates
     entrypoint: |
       bash -c "
         until PGPASSWORD=admin psql -h splinter-db-gamma -U admin -d splinter -c '\q'; do


### PR DESCRIPTION
Adds a shared-volume to the Splinter example's docker-compose file
amongst the gridd and splinterd containers to store any circuit template
files, so both the Grid daemon and Splinter daemon have access to these
files.

Signed-off-by: Shannyn Telander <telander@bitwise.io>