### PR TITLE
Add location deployment to app auth handler

### DIFF
--- a/daemon/src/splinter/app_auth_handler/sabre.rs
+++ b/daemon/src/splinter/app_auth_handler/sabre.rs
@@ -52,6 +52,11 @@ const SCHEMA_PREFIX: &str = "621dee01";
 const SCHEMA_CONTRACT_NAME: &str = "grid-schema";
 const SCHEMA_CONTRACT_VERSION_REQ: &str = "0.1.0-dev";
 
+// Location constants
+const LOCATION_PREFIX: &str = "621dee04";
+const LOCATION_CONTRACT_NAME: &str = "grid-location";
+const LOCATION_CONTRACT_VERSION_REQ: &str = "0.1.0-dev";
+
 pub fn setup_grid(
     scabbard_admin_key: &str,
     proposed_admin_pubkeys: Vec<String>,
@@ -102,6 +107,24 @@ pub fn setup_grid(
     let product_schema_namespace_permissions_txn =
         make_namespace_permissions_txn(&signer, &product_contract, SCHEMA_PREFIX)?;
 
+    // Make Location transactions
+    let location_contract = SmartContractArchive::from_scar_file(
+        LOCATION_CONTRACT_NAME,
+        LOCATION_CONTRACT_VERSION_REQ,
+        &default_scar_path(),
+    )?;
+    let location_contract_registry_txn =
+        make_contract_registry_txn(&signer, &location_contract.metadata.name)?;
+    let location_contract_txn =
+        make_upload_contract_txn(&signer, &location_contract, LOCATION_PREFIX)?;
+    let location_namespace_registry_txn = make_namespace_registry_txn(&signer, LOCATION_PREFIX)?;
+    let location_namespace_permissions_txn =
+        make_namespace_permissions_txn(&signer, &location_contract, LOCATION_PREFIX)?;
+    let location_pike_namespace_permissions_txn =
+        make_namespace_permissions_txn(&signer, &location_contract, PIKE_PREFIX)?;
+    let location_schema_namespace_permissions_txn =
+        make_namespace_permissions_txn(&signer, &location_contract, SCHEMA_PREFIX)?;
+
     // Make schema transactions
     let schema_contract = SmartContractArchive::from_scar_file(
         SCHEMA_CONTRACT_NAME,
@@ -133,6 +156,12 @@ pub fn setup_grid(
         product_schema_namespace_permissions_txn,
         schema_pike_namespace_permissions_txn,
         schema_namespace_permissions_txn,
+        location_contract_registry_txn,
+        location_contract_txn,
+        location_namespace_registry_txn,
+        location_namespace_permissions_txn,
+        location_pike_namespace_permissions_txn,
+        location_schema_namespace_permissions_txn,
     ];
     let batch = BatchBuilder::new().with_transactions(txns).build(&signer)?;
 

--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -211,6 +211,7 @@ services:
     hostname: scabbard-cli-alpha
     volumes:
       - gridd-alpha:/root/.splinter/keys
+    command: tail -f /dev/null
 
   splinterd-alpha:
     image: splintercommunity/splinterd:0.4
@@ -344,6 +345,7 @@ services:
     hostname: scabbard-cli-beta
     volumes:
       - gridd-beta:/root/.splinter/keys
+    command: tail -f /dev/null
 
   splinterd-beta:
     image: splintercommunity/splinterd:0.4


### PR DESCRIPTION
This PR adds the Grid Location contract to the list of contracts that is automatically deployed when setting up a new Grid circuit. Since location is a foundational capability for Grid, it should be auto deployed. I also added a `tail -f /dev/null` command to the scabbard CLI so it can be used to see what contracts are deployed.


To test:

1. Follow the Grid on Splinter README instructions up to step 10 in "Create a Circuit"
2. `$ docker-compose -f examples/splinter/docker-compose.yaml exec scabbard-cli-alpha bash`
3. `# scabbard contract list --service-id <service-id> --url http://splinterd-alpha:8085`

Ensure that the CLI command in step 3 shows the location contract