### PR TITLE
Add man pages for grid product commands

### DIFF
--- a/cli/man/grid-product-create.md
+++ b/cli/man/grid-product-create.md
@@ -1,0 +1,147 @@
+% GRID-PRODUCT-CREATE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-product-create** — Create products from a YAML file
+
+SYNOPSIS
+========
+
+**grid product create** \[**FLAGS**\] \[**OPTIONS**\] <**product_id**>
+
+DESCRIPTION
+===========
+
+Create new products from a YAML file. This command requires the `--path` option to
+specify a path to a YAML file containing the list of products.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+OPTIONS
+=======
+
+`--owner`
+: Organization ID of the owner
+
+`--namespace`
+: Namespace of the product (default: "GS1")
+
+`--property`
+: A product property (format: key=value)
+
+`--file, -f`
+: Path or URL to a YAML file containing a list of products
+
+ARGS
+====
+
+`<product_id>`
+: Unique identifier of the product
+
+EXAMPLES
+========
+
+Products can be created by using the `create` command
+
+Using a YAML file
+```
+$ grid product create \
+    --file products.yaml
+```
+
+Using command-line arguments
+```
+$ grid product create 762111177704 \
+    --owner cgl
+    --property width=10
+    --property length=10
+    --property depth=10
+```
+
+Sample YAML file describing a list of products.
+
+```
+- product_namespace: "GS1"
+  product_id: "762111177704"
+  owner: "314156"
+  properties:
+    - name: "length"
+      data_type: "NUMBER"
+      number_value: 8
+    - name: "width"
+      data_type: "NUMBER"
+      number_value: 11
+    - name: "height"
+      data_type: "NUMBER"
+      number_value: 1
+- product_namespace: "GS1"
+  product_id: "881334009880"
+  owner: "314156"
+  properties:
+    - name: "length"
+      data_type: "NUMBER"
+      number_value: 8
+    - name: "width"
+      data_type: "NUMBER"
+      number_value: 11
+    - name: "height"
+      data_type: "NUMBER"
+      number_value: 11
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/cli/man/grid-product-delete.md
+++ b/cli/man/grid-product-delete.md
@@ -1,0 +1,97 @@
+% GRID-PRODUCT-DELETE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-product-delete** — Delete an existing product
+
+SYNOPSIS
+========
+
+**grid product delete** \[**FLAGS**\] \[**OPTIONS**\] <**product_id**>
+
+DESCRIPTION
+===========
+
+Delete an existing product. This command requires the `--product_id` option
+to specify the unique identifier of the product that is to be deleted. The
+`--product_namespace` option must also be specified (e.g. GS1).
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+OPTIONS
+=======
+
+`--namespace`
+: Product namespace (e.g. `GS1`)
+
+ARGS
+====
+
+`<product_id>`
+: Unique identifier of the product
+
+EXAMPLES
+========
+
+Delete an existing product.
+
+```
+$ grid product delete --product_id 762111177704 --product_namespace GS1
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/cli/man/grid-product-list.md
+++ b/cli/man/grid-product-list.md
@@ -1,0 +1,99 @@
+% GRID-PRODUCT-LIST(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-product-list** — List all products
+
+SYNOPSIS
+========
+
+**grid product list** \[**FLAGS**\]
+
+DESCRIPTION
+===========
+
+List all products in grid. If the `service_id` flag is specified, only
+products corresponding to that `service_id` will be shown.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+EXAMPLES
+========
+
+The command
+
+```
+$ grid product list
+```
+
+Will list all products and their properties
+
+```
+Product ID: 762111177704
+Product Namespace: GS1
+Owner: 314156
+Properties:
+    length: 8
+    width: 11
+    height: 1
+Product ID: 881334009880
+Product Namespace: GS1
+Owner: 314156
+Properties:
+    length: 8
+    width: 11
+    height: 11
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/cli/man/grid-product-show.md
+++ b/cli/man/grid-product-show.md
@@ -1,0 +1,99 @@
+% GRID-PRODUCT-SHOW(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-product-show** — Show the details of a specific product
+
+SYNOPSIS
+========
+
+**grid product show** \[**FLAGS**\] <**product_id**>
+
+DESCRIPTION
+===========
+
+Show the complete details of a specific product. This command requires the
+`<product_id>` argument to specify the unique identifier for the product that
+is to be retrieved.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+ARGS
+====
+
+`<product_id>`
+: Unique identifier of the product
+
+EXAMPLES
+========
+
+The command
+
+```
+$ grid product show --product_id 762111177704
+```
+
+Will show the details of the specified product
+
+```
+Product ID: 762111177704
+Product Namespace: GS1
+Owner: 314156
+Properties:
+    length: 8
+    width: 11
+    height: 1
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/cli/man/grid-product-update.md
+++ b/cli/man/grid-product-update.md
@@ -1,0 +1,144 @@
+% GRID-PRODUCT-UPDATE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-product-update** — Updates existing products
+
+SYNOPSIS
+========
+
+**grid product update** \[**FLAGS**\] \[**OPTIONS**\] <**product_id**>
+
+DESCRIPTION
+===========
+
+Updates existing products. This command requires the `--path` option
+to specify the path to a YAML file containing a list of products.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+OPTIONS
+=======
+
+`--owner`
+: Organization ID of the owner
+
+`--namespace`
+: Namespace of the product (default: "GS1")
+
+`--property`
+: A product property (format: key=value)
+
+`--file, -f`
+: Path or URL to a YAML file containing a list of products
+
+ARGS
+====
+
+`<product_id>`
+: Unique identifier of the product
+
+EXAMPLES
+========
+
+Products can be updated by using the `update` command
+
+Using a YAML file
+```
+$ grid product update \
+    --file products.yaml
+```
+
+Using command-line arguments
+```
+$ grid product update 762111177704 \
+    --property width=10
+    --property length=10
+    --property depth=10
+```
+
+Sample YAML file describing products.
+
+```
+- product_namespace: "GS1"
+  product_id: "762111177704"
+  properties:
+    - name: "length"
+      data_type: "NUMBER"
+      number_value: 8
+    - name: "width"
+      data_type: "NUMBER"
+      number_value: 12
+    - name: "height"
+      data_type: "NUMBER"
+      number_value: 4
+- product_namespace: "GS1"
+  product_id: "881334009880"
+  properties:
+    - name: "length"
+      data_type: "NUMBER"
+      number_value: 8
+    - name: "width"
+      data_type: "NUMBER"
+      number_value: 12
+    - name: "height"
+      data_type: "NUMBER"
+      number_value: 12
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/cli/man/grid-product.md
+++ b/cli/man/grid-product.md
@@ -1,0 +1,93 @@
+% GRID-PRODUCT(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-product** — Create, update, or delete Grid Products
+
+SYNOPSIS
+========
+
+**grid product** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+
+This command allows for the creation and management of Grid Products.
+Commands to list and display Product data are also available.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SUBCOMMANDS
+===========
+
+`create`
+: Create new products
+
+`update`
+: Update existing products
+
+`delete`
+: Delete a product
+
+`show`
+: Show details of a specified product
+
+`list`
+: List details of all existing products
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/cli/man/grid.1.md
+++ b/cli/man/grid.1.md
@@ -1,0 +1,119 @@
+% GRID(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid** — Command-line interface for Grid
+
+SYNOPSIS
+========
+
+**grid** \[**FLAGS**\] \[**OPTIONS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+
+The `grid` utility is the command-line interface for Grid.
+
+* Run `grid --help` to see the list of subcommands.
+
+* Run `grid *SUBCOMMAND* --help` to see information about a specific
+  subcommand (for example, `grid location create --help`).
+
+* To view the man page for a Grid subcommand, use the "dashed form" of the
+  name, where each space is replaced with a hyphen. For example, run
+  `man grid-location-create` to see the man page for `grid location create`.
+
+SUBCOMMANDS
+===========
+
+`admin`
+: Administrative commands for grid
+
+`agent`
+: Update or create an agent
+
+`database`
+: Manage Grid Daemon database
+
+`keygen`
+: Generate keys with which the user can sign transactions and batches
+
+`location`
+: Provides commands for creating, updating, and deleting locations
+
+`organization`
+: Update or create an organization
+
+`product`
+: Create, update or delete products
+
+`schema`
+: Update or create schemas
+
+FLAGS
+=====
+
+Most `grid` subcommands accept the following common flags:
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+OPTIONS
+=======
+
+`-k`, `--key`
+: Base name for private key file
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+ENVIRONMENT VARIABLES
+=====================
+
+Many `grid` subcommands accept the following environment variable:
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| `grid(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/


### PR DESCRIPTION
This adds man pages for the grid product subcommands. The subcommands
documented are: `grid product create`, `grid product delete`, `grid
product list`, `grid product show`, and `grid product update`.

Signed-off-by: Davey Newhall <newhall@bitwise.io>