### PR TITLE
Add grid options to subcommand help

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -73,12 +73,12 @@ fn run() -> Result<(), CliError> {
         (version: VERSION)
         (author: "Contributors to Hyperledger Grid")
         (about: "Command line for Hyperledger Grid")
-        (@arg url: --url  +takes_value "URL for the REST API")
-        (@arg wait: --wait +takes_value "How long to wait for transaction to be committed")
-        (@arg key: -k +takes_value "base name for private key file")
+        (@arg url: --url +global +takes_value "URL for the REST API")
+        (@arg wait: --wait +global +takes_value "How long to wait for transaction to be committed")
+        (@arg key: -k +global +takes_value "base name for private key file")
         (@arg verbose: -v +multiple +global "Log verbosely")
         (@arg quiet: -q --quiet +global conflicts_with[verbose] "Do not display output")
-        (@arg service_id: --("service-id") +takes_value "The ID of the service the payload should be \
+        (@arg service_id: --("service-id") +global +takes_value "The ID of the service the payload should be \
             sent to; required if running on Splinter. Format <circuit-id>::<service-id>")
         (@subcommand agent =>
             (about: "Update or create agent")


### PR DESCRIPTION
This adds the global Grid CLI options to the help output for the
Grid subcommands.

Signed-off-by: Davey Newhall <newhall@bitwise.io>