### PR TITLE
Add Davey Newhall as a maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @chenette @davececchi @dcmiddle @dplumb94 @eloaverona @jsmitchell @peterschwarz @rberg2 @rbuysse @RyanLassigBanks @shannynalayna @vaporos
+*       @agunde406 @chenette @davececchi @dcmiddle @dnewh @dplumb94 @eloaverona @jsmitchell @peterschwarz @rberg2 @rbuysse @RyanLassigBanks @shannynalayna @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,7 @@
 | Dan Middleton | dcmiddle | Dan |
 | Darian Plumb | dplumb94 | dplumb |
 | Dave Cecchi | davececchi | cecchi |
+| Davey Newhall | dnewh | newhall |
 | Eloá Franca Verona | eloaverona | eloafran |
 | James Mitchell | jsmitchell | jsmitchell |
 | Peter Schwarz | peterschwarz | pschwarz |


### PR DESCRIPTION
As demonstrated by the commit history, Davey has been consistently
contributing to Grid for quite a while.
