### PR TITLE
Fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,6 @@ contributors who can:
 * Improve documentation
 
 For more information, please see
-[Contributing](https://grid.hyperledger.org/community/contributing/)
+[Contributing to Grid](https://grid.hyperledger.org/community/contributing.html)
 on the Hyperledger Grid website.
 


### PR DESCRIPTION
Update link text and URL to point to current topic:
Contributing to Grid at grid.hyperledger.org/community/contributing.html

Signed-off-by: Anne Chenette <chenette@bitwise.io>