### PR TITLE
Add protos to UI directory and add to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,6 @@ tests/sawtooth_sc_test/protobuf/
 **/sapling-dev-server/profile
 **/sapling-dev-server/register-login.js
 
-**/saplings/product/src/compiled_protos.json
-
 # misc
 .DS_Store
 .env.local

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -37,6 +37,7 @@ RUN npm config set unsafe-perm true
 
 COPY saplings saplings
 COPY sapling-dev-server sapling-dev-server
+COPY protos protos
 
 ARG PUBLIC_URL_PARTIAL
 ENV PUBLIC_URL $PUBLIC_URL_PARTIAL

--- a/ui/protos/location_payload.proto
+++ b/ui/protos/location_payload.proto
@@ -1,0 +1,62 @@
+// Copyright 2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+import "schema_state.proto";
+
+message LocationPayload {
+    enum Action {
+      UNSET_ACTION = 0;
+      LOCATION_CREATE = 1;
+      LOCATION_UPDATE = 2;
+      LOCATION_DELETE = 3;
+    }
+
+    Action action = 1;
+
+    // Approximately when transaction was submitted, as a Unix UTC
+    // timestamp
+    uint64 timestamp = 2;
+
+    LocationCreateAction location_create = 3;
+    LocationUpdateAction location_update = 4;
+    LocationDeleteAction location_delete = 5;
+}
+
+enum LocationNamespace {
+    UNSET_TYPE = 0;
+    GS1 = 1;
+}
+
+message LocationCreateAction {
+    LocationNamespace namespace = 1;
+    string location_id = 2;
+    string owner = 3;
+    repeated PropertyValue properties = 4;
+}
+
+message LocationUpdateAction {
+    // Not modified. Only used to find location object in state
+    LocationNamespace namespace = 1;
+    // Not modified. Only used to find location object in state
+    string location_id = 2;
+    // This will replace all properties currently defined
+    repeated PropertyValue properties = 3;
+}
+
+message LocationDeleteAction {
+    LocationNamespace namespace = 1;
+    string location_id = 2;
+}

--- a/ui/protos/location_state.proto
+++ b/ui/protos/location_state.proto
@@ -1,0 +1,38 @@
+// Copyright 2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+import "schema_state.proto";
+
+message Location {
+    enum LocationNamespace {
+        UNSET_TYPE = 0;
+        GS1 = 1;
+    }
+    // Global Location Number as defined by GS1 specification
+    string location_id = 1;
+
+    LocationNamespace namespace = 2;
+
+    // Who owns this product (pike organization id)
+    string owner = 3;
+
+    // Addition attributes for custom configurations 
+    repeated PropertyValue properties = 4;
+}
+
+message LocationList {
+    repeated Location entries = 1;
+}

--- a/ui/protos/pike_payload.proto
+++ b/ui/protos/pike_payload.proto
@@ -1,0 +1,67 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+import "pike_state.proto";
+
+message PikePayload {
+  enum Action {
+    ACTION_UNSET = 0;
+
+    CREATE_AGENT = 1;
+    UPDATE_AGENT = 2;
+
+    CREATE_ORGANIZATION = 3;
+    UPDATE_ORGANIZATION = 4;
+  }
+
+  Action action = 1;
+
+  CreateAgentAction create_agent = 2;
+  UpdateAgentAction update_agent = 3;
+
+  CreateOrganizationAction create_organization = 4;
+  UpdateOrganizationAction update_organization = 5;
+}
+
+message CreateAgentAction {
+  string org_id = 1;
+  string public_key = 2;
+  bool active = 3;
+  repeated string roles = 4;
+  repeated KeyValueEntry metadata = 5;
+}
+
+message UpdateAgentAction {
+  string org_id = 1;
+  string public_key = 2;
+  bool active = 3;
+  repeated string roles = 4;
+  repeated KeyValueEntry metadata = 5;
+}
+
+message CreateOrganizationAction {
+  string id = 1;
+  string name = 2;
+  string address = 3;
+  repeated KeyValueEntry metadata = 4;
+}
+
+message UpdateOrganizationAction {
+  string id = 1;
+  string name = 2;
+  string address = 3;
+  repeated KeyValueEntry metadata = 4;
+}

--- a/ui/protos/pike_state.proto
+++ b/ui/protos/pike_state.proto
@@ -1,0 +1,44 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message Agent {
+  string org_id = 1;
+  string public_key = 2;
+  bool active = 3;
+  repeated string roles = 4;
+  repeated KeyValueEntry metadata = 5;
+}
+
+message AgentList {
+  repeated Agent agents = 1;
+}
+
+message KeyValueEntry {
+  string key = 1;
+  string value = 2;
+}
+
+message Organization {
+  string org_id = 1;
+  string name = 2;
+  string address = 3;
+  repeated KeyValueEntry metadata = 4;
+}
+
+message OrganizationList {
+  repeated Organization organizations = 1;
+}

--- a/ui/protos/product_payload.proto
+++ b/ui/protos/product_payload.proto
@@ -1,0 +1,59 @@
+// Copyright (c) 2019 Target Brands, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+import "product_state.proto";
+import "schema_state.proto";
+
+message ProductPayload {
+    enum Action {
+        UNSET_ACTION = 0;
+        PRODUCT_CREATE = 1;
+        PRODUCT_UPDATE = 2;
+        PRODUCT_DELETE = 3;
+    }
+
+    Action action = 1;
+
+    // Approximately when transaction was submitted, as a Unix UTC
+    // timestamp
+    uint64 timestamp = 2;
+
+    ProductCreateAction product_create = 3;
+    ProductUpdateAction product_update = 4;
+    ProductDeleteAction product_delete = 5;
+}
+
+message ProductCreateAction {
+    // product_namespace and product_id are used in deriving the state address
+    Product.ProductNamespace product_namespace = 1;
+    string product_id = 2;
+    string owner = 3;
+    repeated PropertyValue properties = 4;
+}
+
+message ProductUpdateAction {
+    // product_namespace and product_id are used in deriving the state address
+    Product.ProductNamespace product_namespace = 1;
+    string product_id = 2;
+    // this will replace all properties currently defined
+    repeated PropertyValue properties = 3;
+}
+
+message ProductDeleteAction {
+    // product_namespace and product_id are used in deriving the state address
+    Product.ProductNamespace product_namespace = 1;
+    string product_id = 2;
+ }

--- a/ui/protos/product_state.proto
+++ b/ui/protos/product_state.proto
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Target Brands, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+import "schema_state.proto";
+
+message Product {
+  enum ProductNamespace {
+      UNSET_TYPE = 0;
+      GS1 = 1;
+  }
+
+  // product_id for products (gtin)
+  string product_id = 1;
+
+  // What namespace of product is this (GS1)
+  ProductNamespace product_namespace = 2;
+
+  // Who owns this product (pike organization id)
+  string owner = 3;
+
+  // Addition attributes for custom configurations 
+  repeated PropertyValue properties = 4;
+}
+
+message ProductList {
+  repeated Product entries = 1;
+}

--- a/ui/protos/schema_payload.proto
+++ b/ui/protos/schema_payload.proto
@@ -1,0 +1,55 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "schema_state.proto";
+
+// SchemaPayload contains an action enum and the associated action payload.
+message SchemaPayload {
+    enum Action {
+        UNSET_ACTION = 0;
+        SCHEMA_CREATE = 1;
+        SCHEMA_UPDATE = 2;
+    }
+
+    Action action = 1;
+
+    // The smart contract will read from just one of these fields
+    // according to the Action. Only one of these should be set and must match
+    // the corresponding Action.
+    SchemaCreateAction schema_create = 2;
+    SchemaUpdateAction schema_update = 3;
+}
+
+// SchemaCreateAction adds a new Schema to state.
+message SchemaCreateAction {
+    // The name of the Schema.  This is also the unique identifier for the
+    // new Schema.
+    string schema_name = 1;
+     // An optional description of the schema.
+    string description = 2;
+    // The property definitions that make up the Schema; must not be empty.
+    repeated PropertyDefinition properties = 10;
+}
+
+// SchemaUpdateAction updates an existing Schema. The new properties will
+// be added to the Schema definitions.
+message SchemaUpdateAction {
+    // The name of the Schema to be updated.
+    string schema_name = 1;
+    // The property definitions to be added to the Schema; must not be empty.
+    repeated PropertyDefinition properties = 2;
+}

--- a/ui/protos/schema_state.proto
+++ b/ui/protos/schema_state.proto
@@ -1,0 +1,86 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message PropertyDefinition {
+    enum DataType {
+        UNSET_DATA_TYPE = 0;
+        BYTES = 1;
+        BOOLEAN = 2;
+        NUMBER = 3;
+        STRING = 4;
+        ENUM = 5;
+        STRUCT = 6;
+        LAT_LONG = 7;
+    }
+    // The name of the property
+    string name = 1;
+    // The data type of the value; must not be set to UNSET_DATA_TYPE.
+    DataType data_type = 2;
+    // Indicates that this is a required property in the Schema
+    bool required = 3;
+    // An optional description of the field.
+    string description = 4;
+    // The exponent for a NUMBER property
+    sint32 number_exponent = 10;
+    // The list of values for an ENUM property; must not be empty/ for
+    // properties of that type.
+    repeated string enum_options = 11;
+    // The list of property definitions for a STRUCT property; must  not be
+    // empty for properties of that type.
+    repeated PropertyDefinition struct_properties = 12;
+}
+
+message Schema {
+    // The name of the Schema.  This is also the unique identifier for the
+    // Schema.
+    string name = 1;
+    // An optional description of the schema.
+    string description = 2;
+    // The Pike organization that has rights to modify the schema.
+    string owner = 3;
+    // The property definitions that make up the Schema; must not be empty.
+    repeated PropertyDefinition properties = 10;
+}
+
+message SchemaList {
+    // Schemas are stored in a list to handle any hash collisions
+    repeated Schema schemas = 1;
+}
+
+message LatLong {
+    // Coordinates are expected to be in millionths of a degree
+    sint64 latitude = 1;
+    sint64 longitude = 2;
+}
+
+message PropertyValue {
+    // The name of the property value.  Used to validate the property against a
+    // Schema.
+    string name = 1;
+    // The data type of the property.  Indicates which value field the actual
+    // value may be found.  Must not be set to `UNSET_DATA_TYPE`.
+    PropertyDefinition.DataType data_type = 2;
+    // The value fields for the possible data types.  Only one of these will
+    // contain a value, determined by the value of `data_type`
+    bytes bytes_value = 10;
+    bool boolean_value = 11;
+    sint64 number_value = 12;
+    string string_value = 13;
+    uint32 enum_value = 14;
+    repeated PropertyValue struct_values = 15;
+    LatLong lat_long_value = 16;
+}

--- a/ui/protos/track_and_trace_payload.proto
+++ b/ui/protos/track_and_trace_payload.proto
@@ -1,0 +1,119 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "track_and_trace_state.proto";
+import "schema_state.proto";
+
+message TrackAndTracePayload {
+  enum Action {
+    UNSET_ACTION = 0;
+    CREATE_RECORD = 1;
+    FINALIZE_RECORD = 2;
+    UPDATE_PROPERTIES = 3;
+    CREATE_PROPOSAL = 4;
+    ANSWER_PROPOSAL = 5;
+    REVOKE_REPORTER = 6;
+  }
+
+  Action action = 1;
+
+  // The approximate time this payload was submitted, as a Unix UTC timestamp.
+  uint64 timestamp = 2;
+
+  // The transaction handler will read from just one of these fields
+  // according to the Action.
+  CreateRecordAction create_record = 3;
+  FinalizeRecordAction finalize_record = 4;
+  UpdatePropertiesAction update_properties = 6;
+  CreateProposalAction create_proposal = 7;
+  AnswerProposalAction answer_proposal = 8;
+  RevokeReporterAction revoke_reporter = 9;
+}
+
+message CreateRecordAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  // The name of the Schema this Record belongs to
+  string schema = 2;
+
+  repeated PropertyValue properties = 3;
+}
+
+
+message FinalizeRecordAction {
+  // The natural key of the Record
+  string record_id = 1;
+}
+
+message UpdatePropertiesAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  repeated PropertyValue properties = 2;
+}
+
+
+message CreateProposalAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  // the public key of the Agent to whom the Proposal is sent
+  // (must be different from the Agent creating the Proposal)
+  string receiving_agent = 2;
+
+  Proposal.Role role = 3;
+
+  repeated string properties = 4;
+
+  // The human-readable terms of transfer.
+  string terms = 5;
+}
+
+
+message AnswerProposalAction {
+  enum Response {
+    ACCEPT = 0;
+    REJECT = 1;
+    CANCEL = 2;
+  }
+
+  // The natural key of the Record
+  string record_id = 1;
+
+  // The public key of the Agent to whom the proposal is sent
+  string receiving_agent = 2;
+
+  // The role being proposed (owner, custodian, or reporter)
+  Proposal.Role role = 3;
+
+  // The respose to the Proposal (accept, reject, or cancel)
+  Response response = 4;
+}
+
+
+message RevokeReporterAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  // The reporter's public key
+  string reporter_id = 2;
+
+  // The names of the Properties for which the reporter's
+  // authorization is revoked
+  repeated string properties = 3;
+}

--- a/ui/protos/track_and_trace_state.proto
+++ b/ui/protos/track_and_trace_state.proto
@@ -1,0 +1,174 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "schema_state.proto";
+
+message Property {
+  message Reporter {
+    // The public key of the Agent authorized to report updates.
+    string public_key = 1;
+
+    // A flag indicating whether the reporter is authorized to send updates.
+    // When a reporter is added, this is set to true, and a `RevokeReporter`
+    // transaction sets it to false.
+    bool authorized = 2;
+
+    // An update must be stored with some way of identifying which
+    // Agent sent it. Storing a full public key for each update would
+    // be wasteful, so instead Reporters are identified by their index
+    // in the `reporters` field.
+    uint32 index = 3;
+  }
+
+  // The name of the Property, e.g. "temperature". This must be unique among
+  // Properties.
+  string name = 1;
+
+  // The natural key of the Property's associated Record.
+  string record_id = 2;
+
+  // The name of the PropertyDefinition that defines this record.
+  PropertyDefinition property_definition = 3;
+
+  // The Reporters authorized to send updates, sorted by index. New
+  // Reporters should be given an index equal to the number of
+  // Reporters already authorized.
+  repeated Reporter reporters = 4;
+
+  // The page to which new updates are added. This number represents
+  // the last 4 hex characters of the page's address. Consequently,
+  // it should not exceed 16^4 = 65536.
+  uint32 current_page = 5;
+
+  // A flag indicating whether the first 16^4 pages have been filled.
+  // This is used to calculate the last four hex characters of the
+  // address of the page containing the earliest updates. When it is
+  // false, the earliest page's address will end in "0001". When it is
+  // true, the earliest page's address will be one more than the
+  // current_page, or "0001" if the current_page is "ffff".
+  bool wrapped = 6;
+}
+
+message PropertyList {
+  repeated Property entries = 1;
+}
+
+message PropertyPage {
+  message ReportedValue {
+    // The index of the reporter id in reporters field.
+    uint32 reporter_index = 1;
+
+    // The approximate time this value was reported, as a Unix UTC timestamp.
+    uint64 timestamp = 2;
+
+    PropertyValue value = 3;
+  }
+
+  // The name of the page's associated Property and the record_id of
+  // its associated Record. These are required to distinguish pages
+  // with colliding addresses.
+  string name = 1;
+  string record_id = 2;
+
+  // ReportedValues are sorted first by timestamp, then by reporter_index.
+  repeated ReportedValue reported_values = 3;
+}
+
+
+message PropertyPageList {
+  repeated PropertyPage entries = 1;
+}
+
+message Proposal {
+  enum Role {
+    OWNER = 0;
+    CUSTODIAN = 1;
+    REPORTER = 2;
+  }
+
+  enum Status {
+    OPEN = 0;
+    ACCEPTED = 1;
+    REJECTED = 2;
+    CANCELED = 3;
+  }
+
+  // The Record that this proposal applies to.
+  string record_id = 1;
+
+  // The approximate time this proposal was created, as a Unix UTC timestamp.
+  uint64 timestamp = 2;
+
+  // The public key of the Agent sending the Proposal. This Agent must
+  // be the owner of the Record (or the custodian, if the Proposal is
+  // to transfer custodianship).
+  string issuing_agent = 3;
+
+  // The public key of the Agent to whom the Proposal is sent.
+  string receiving_agent = 4;
+
+  // What the Proposal is for -- transferring ownership, transferring
+  // custodianship, or authorizing a reporter.
+  Role role = 5;
+
+  // The names of properties for which the reporter is being authorized
+  // (empty for owner or custodian transfers).
+  repeated string properties = 6;
+
+  // The status of the Proposal. For a given Record and receiving
+  // Agent, there can be only one open Proposal at a time for each
+  // role.
+  Status status = 7;
+
+  // The human-readable terms of transfer.
+  string terms = 8;
+}
+
+
+message ProposalList {
+  repeated Proposal entries = 1;
+}
+
+message Record {
+  message AssociatedAgent {
+    // Agent's public key.
+    string agent_id = 1;
+
+    // The approximate time this agent was associated, as a Unix UTC timestamp.
+    uint64 timestamp = 2;
+  }
+
+  // User-defined natural key which identifies the object in the real world
+  // (for example a serial number).
+  string record_id = 1;
+
+  // Name of the schema used by the record.
+  string schema = 2;
+
+  // Ordered oldest to newest by timestamp.
+  repeated AssociatedAgent owners = 3;
+  repeated AssociatedAgent custodians = 4;
+
+  // Flag indicating whether the Record can be updated. If it is set
+  // to true, then the record has been finalized and no further
+  // changes can be made to it or its Properties.
+  bool final = 5;
+}
+
+message RecordList {
+  repeated Record entries = 1;
+}

--- a/ui/saplings/product/package.json
+++ b/ui/saplings/product/package.json
@@ -10,9 +10,9 @@
     "format": "prettier --write \"**/*.+(js|jsx|json|css|scss|md)\"",
     "lint": "eslint .",
     "add-to-canopy": "mkdir -p ../../sapling-dev-server/product && cp -r ./build/static/* ../../sapling-dev-server/product && cp product_logo.svg ../../sapling-dev-server/product",
-    "deploy": "npm run build && npm run add-to-canopy",
+    "deploy": "npm run generate-proto-files && npm run build && npm run add-to-canopy",
     "watch": "nodemon --ext js,scss,ts,css --watch src --exec npm run deploy",
-    "generate-proto-files": "node scripts/compile_protobuf.js > src/compiled_protos.json"
+    "generate-proto-files": "node scripts/compile_protobuf.js ../../protos > src/compiled_protos.json"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/ui/saplings/product/test/Dockerfile
+++ b/ui/saplings/product/test/Dockerfile
@@ -25,9 +25,8 @@ RUN apk add git
 RUN npm config set unsafe-perm true && npm install
 
 COPY ./ui/saplings/product /ui/saplings/product
-
-COPY ./sdk/protos /ui/saplings/product/protos
+COPY ./ui/protos /ui/protos
 
 RUN cd /ui/saplings/product && \
   npm install && \
-  npm run generate-proto-files ./protos
+  npm run generate-proto-files ../../protos


### PR DESCRIPTION
The protos have to be added to the ui directory since it is used as the
context directory for Grid UI builds. This also fixes the protogen
script to use these files.

This commit also fixes the gitignore since it was ignoring the artifact
of the generate proto files script twice.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>