### PR TITLE
Fix GTIN length bug

### DIFF
--- a/contracts/product/src/addressing.rs
+++ b/contracts/product/src/addressing.rs
@@ -27,8 +27,10 @@ pub fn get_product_prefix() -> String {
 pub fn compute_gs1_product_address(gtin: &str) -> String {
     // 621ddee (grid namespace) + 02 (product namespace) + 01 (gs1 namespace)
     String::from(GRID_NAMESPACE)
-        + "02010000000000000000000000000000000000000000000000"
-        + gtin
+        + "02"
+        + "01"
+        + "00000000000000000000000000000000000000000000"
+        + &format!("{:0>14}", gtin)
         + "00"
 }
 

--- a/ui/saplings/product/src/App.js
+++ b/ui/saplings/product/src/App.js
@@ -123,7 +123,9 @@ function App() {
           <Router>
             <Switch>
               <Route exact path="/product">
-                <ProductsTable actions={{ addProduct, editProduct, deleteProduct }} />
+                <ProductsTable
+                  actions={{ addProduct, editProduct, deleteProduct }}
+                />
               </Route>
               <Route path="/product/products/:id">
                 <ProductInfo />

--- a/ui/saplings/product/src/api/transactions.js
+++ b/ui/saplings/product/src/api/transactions.js
@@ -55,7 +55,10 @@ function buildProductAddress(productId, productNamespace) {
     default:
       prefix = productTypeNamespaces.GS1;
   }
-  return `${prefix}00000000000000000000000000000000000000000000${productId}00`;
+  return `${prefix}"00000000000000000000000000000000000000000000"${productId.padStart(
+    14,
+    '0'
+  )}00`;
 }
 
 function buildOrganizationAddess(orgName) {

--- a/ui/saplings/product/src/components/ProductCard.js
+++ b/ui/saplings/product/src/components/ProductCard.js
@@ -23,7 +23,16 @@ import ProductProperty from './ProductProperty';
 import './ProductCard.scss';
 
 function ProductCard(props) {
-  const { gtin, name, service, owner, imageURL, editFn, deleteFn, properties } = props;
+  const {
+    gtin,
+    name,
+    service,
+    owner,
+    imageURL,
+    editFn,
+    deleteFn,
+    properties
+  } = props;
 
   return (
     <div className="product-card">


### PR DESCRIPTION
This adds support for GTIN-8, GTIN-13, and GTIN-14. Previously, only
GTIN-12 was supported and other GTIN lengths would cause errors to be
thrown.