### PR TITLE
Have location show command correctly consume location_id

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -238,7 +238,7 @@ fn run() -> Result<(), CliError> {
             )
             (@subcommand show =>
                 (about: "Show location specified by ID argument")
-                (@arg location_id: +required +takes_value "Unique identifier for location")
+                (@arg location_id: +required "Unique identifier for location")
             )
         )
 
@@ -639,7 +639,7 @@ fn run() -> Result<(), CliError> {
                 locations::do_delete_location(&url, key, wait, action, service_id.as_deref())?
             }
             ("list", Some(_)) => locations::do_list_locations(&url, service_id.as_deref())?,
-            ("show", Some(_)) => locations::do_show_location(
+            ("show", Some(m)) => locations::do_show_location(
                 &url,
                 m.value_of("location_id").unwrap(),
                 service_id.as_deref(),


### PR DESCRIPTION
Fixes small bug that was causing the location_id being passed to the
show command to not be read.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>