### PR TITLE
Remove quotes from keygen output

### DIFF
--- a/cli/src/actions/admin.rs
+++ b/cli/src/actions/admin.rs
@@ -99,9 +99,9 @@ pub fn do_keygen(
     let public_key = context.get_public_key(&*private_key)?;
 
     if public_key_path.exists() {
-        info!("Overwriting file: {:?}", public_key_path);
+        info!("Overwriting file: {}", &public_key_path.display());
     } else {
-        info!("Writing file: {:?}", public_key_path);
+        info!("Writing file: {}", &public_key_path.display());
     }
     let public_key_file = OpenOptions::new()
         .write(true)
@@ -112,9 +112,9 @@ pub fn do_keygen(
     writeln!(&public_key_file, "{}", &public_key.as_hex())?;
 
     if private_key_path.exists() {
-        info!("Overwriting file: {:?}", private_key_path);
+        info!("Overwriting file: {}", &private_key_path.display());
     } else {
-        info!("Writing file: {:?}", private_key_path);
+        info!("Writing file: {}", &private_key_path.display());
     }
     let private_key_file = OpenOptions::new()
         .write(true)

--- a/cli/src/actions/keygen.rs
+++ b/cli/src/actions/keygen.rs
@@ -93,9 +93,9 @@ pub fn generate_keys(
     let public_key = context.get_public_key(&*private_key)?;
 
     if public_key_path.exists() {
-        info!("Overwriting file: {:?}", public_key_path);
+        info!("Overwriting file: {}", &public_key_path.display());
     } else {
-        info!("Writing file: {:?}", public_key_path);
+        info!("Writing file: {}", &public_key_path.display());
     }
     let public_key_file = OpenOptions::new()
         .write(true)
@@ -106,9 +106,9 @@ pub fn generate_keys(
     writeln!(&public_key_file, "{}", public_key.as_hex())?;
 
     if private_key_path.exists() {
-        info!("Overwriting file: {:?}", private_key_path);
+        info!("Overwriting file: {}", &private_key_path.display());
     } else {
-        info!("Writing file: {:?}", private_key_path);
+        info!("Writing file: {}", &private_key_path.display());
     }
     let private_key_file = OpenOptions::new()
         .write(true)


### PR DESCRIPTION
This removes the quotation marks from around the file path output in the
`grid keygen` and `grid admin keygen` commands. This is a more standard
output format.

Signed-off-by: Davey Newhall <newhall@bitwise.io>