### PR TITLE
Add schemaspy docs generation

### DIFF
--- a/examples/database/postgres/README.md
+++ b/examples/database/postgres/README.md
@@ -1,0 +1,23 @@
+# Generating Database Schema Documentation
+
+This document outlines a procedure for generating the Grid database
+documentation and updating the Grid website.
+
+The docker-compose file builds the documentation website and serves it locally
+at [localhost:9001](http://localhost:9001).
+
+Run the following command to run and build the website:
+
+```
+$ docker-compose -f examples/database/postgres/docker-compose.yaml up --build
+```
+
+## Copy Generated Site to Grid Docs
+
+1. Clone the [Hyperledger Grid Website repository](https://github.com/hyperledger/grid-website)
+   ([https://github.com/hyperledger/grid](https://github.com/hyperledger/grid-website)).
+1. Navigate to the `grid-website/docs/<release_number>/database/postgres` directory
+1. Run the command:
+```
+$ docker cp griddb-console:/usr/local/apache2/htdocs/* .
+```

--- a/examples/database/postgres/docker-compose.yaml
+++ b/examples/database/postgres/docker-compose.yaml
@@ -1,0 +1,151 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+version: "3.6"
+
+volumes:
+  contracts:
+  db_console:
+  registry:
+  gridd:
+  templates:
+
+services:
+  db:
+    image: postgres
+    container_name: db
+    hostname: db
+    restart: always
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: grid
+      POSTGRES_PASSWORD: grid_example
+      POSTGRES_DB: grid
+
+  griddb-console-builder:
+    image: griddb-console-builder
+    environment:
+      HOST: db
+      PORT: 5432
+      DATABASE: grid
+      USER: grid
+      PASSWORD: grid_example
+    build:
+      context: .
+      dockerfile: schemaspy/Dockerfile
+    volumes:
+      - db_console:/output
+    container_name: griddb-console-builder
+    depends_on:
+      - db
+
+  griddb-console:
+    image: httpd:2.4
+    container_name: griddb-console
+    volumes:
+      - db_console:/usr/local/apache2/htdocs
+    expose:
+      - 80
+    ports:
+      - 9001:80
+    command: "apachectl -D FOREGROUND"
+
+  gridd:
+    image: gridd
+    container_name: gridd
+    hostname: gridd
+    build:
+      context: ../../..
+      dockerfile: daemon/Dockerfile
+      args:
+        - REPO_VERSION=${REPO_VERSION}
+        - CARGO_ARGS=-- --features experimental
+    volumes:
+      - contracts:/usr/share/scar
+      - gridd:/etc/grid/keys
+      - templates:/usr/share/splinter/circuit-templates
+    expose:
+      - 8080
+    ports:
+      - "8080:8080"
+    environment:
+      GRID_DAEMON_KEY: "alpha-agent"
+      GRID_DAEMON_ENDPOINT: "http://gridd:8080"
+    entrypoint: |
+      bash -c "
+        # we need to wait for the db to have started.
+        until PGPASSWORD=grid_example psql -h db -U grid -c '\q' > /dev/null 2>&1; do
+            >&2 echo \"Database is unavailable - sleeping\"
+            sleep 1
+        done
+        grid -vv admin keygen --skip && \
+        grid -vv database migrate \
+            --database-url postgres://grid:grid_example@db/grid &&
+        gridd -vv -b 0.0.0.0:8080 -C splinter:http://splinterd:8085 \
+            --database-url postgres://grid:grid_example@db/grid
+      "
+
+  splinterd:
+    image: splintercommunity/splinterd:0.4
+    container_name: splinterd
+    hostname: splinterd
+    expose:
+      - 8044
+      - 8085
+    ports:
+      - "8044:8044"
+      - "8085:8085"
+    volumes:
+      - contracts:/usr/share/scar
+      - registry:/registry
+      - templates:/usr/share/splinter/circuit-templates
+    entrypoint: |
+      bash -c "
+        until PGPASSWORD=admin psql -h splinter-db -U admin -d splinter -c '\q'; do
+          >&2 echo \"Database is unavailable - sleeping\"
+          sleep 1
+        done
+        if [ ! -f /etc/splinter/certs/private/server.key ]
+        then
+          splinter-cli cert generate --force
+        fi && \
+        splinter database migrate -C postgres://admin:admin@splinter-db:5432/splinter && \
+        splinterd -vv \
+        --registries http://registry-server:80/registry.yaml \
+        --rest-api-endpoint 0.0.0.0:8085 \
+        --network-endpoints tcps://0.0.0.0:8044 \
+        --advertised-endpoint tcps://splinterd:8044 \
+        --node-id node-000 \
+        --service-endpoint tcp://0.0.0.0:8043 \
+        --storage yaml \
+        --tls-client-cert /etc/splinter/certs/client.crt \
+        --tls-client-key /etc/splinter/certs/private/client.key \
+        --tls-server-cert /etc/splinter/certs/server.crt \
+        --tls-server-key /etc/splinter/certs/private/server.key \
+        --enable-biome \
+        --database postgres://admin:admin@splinter-db:5432/splinter \
+        --tls-insecure
+      "
+
+  splinter-db:
+    image: postgres
+    container_name: splinter-db
+    restart: always
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: splinter

--- a/examples/database/postgres/schemaspy/Dockerfile
+++ b/examples/database/postgres/schemaspy/Dockerfile
@@ -1,0 +1,46 @@
+# Copyright 2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+FROM schemaspy/schemaspy:snapshot as SCHEMASPY
+
+FROM ubuntu:bionic as TARGET
+
+RUN apt-get update \
+    && apt-get install -y -q \
+        build-essential \
+        openjdk-8-jre \
+        libpq-dev \
+        postgresql-client \
+        graphviz \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /output && \
+    mkdir -p /org/schemaspy/drivers && \
+    mkdir /schemaspy
+
+COPY schemaspy/generate .
+COPY schemaspy/pgsql11.properties /schemaspy
+
+RUN chmod a+x generate
+
+FROM TARGET
+
+COPY --from=schemaspy /usr/local/lib/schemaspy/schemaspy-6.1.1-SNAPSHOT.jar /schemaspy/schemaSpy.jar
+
+COPY --from=schemaspy /drivers_inc/ /org/schemaspy/drivers
+
+RUN chmod a+x schemaspy/schemaSpy.jar
+
+ENTRYPOINT ["./generate"]

--- a/examples/database/postgres/schemaspy/generate
+++ b/examples/database/postgres/schemaspy/generate
@@ -1,0 +1,25 @@
+# Copyright 2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+#!/bin/bash
+
+until PGPASSWORD=$PASSWORD psql -h $HOST -d $DATABASE -U $USER -c '\q'; do
+  >&2 echo "Database is unavailable - sleeping"
+  sleep 1
+done
+
+java -jar schemaspy/schemaSpy.jar \
+    -t pgsql11 -host $HOST -port $PORT \
+    -db $DATABASE -u $USER -p $PASSWORD -o /output \
+    -dp /org/schemaspy/drivers/postgresql-42.1.1.jre7.jar

--- a/examples/database/postgres/schemaspy/pgsql11.properties
+++ b/examples/database/postgres/schemaspy/pgsql11.properties
@@ -1,0 +1,18 @@
+# Copyright 2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+extends=pgsql
+selectRoutinesSql=select r.routine_name, case p.prokind when 'f' then 'FUNCTION' when 'p' then 'PROCEDURE' when 'a' then 'AGGREGATE' when 'w' then 'WINDOW' else 'UNKNOWN' end as routine_type, case when p.proretset then 'SETOF ' else '' end || case when r.data_type = 'USER-DEFINED' then r.type_udt_name else r.data_type end as dtd_identifier, r.external_language as routine_body, r.routine_definition, r.sql_data_access, r.security_type, r.is_deterministic, d.description as routine_comment from information_schema.routines r left join pg_namespace ns on r.routine_schema = ns.nspname left join pg_proc p on ns.oid = p.pronamespace and r.routine_name = p.proname left join pg_description d on d.objoid = p.oid where r.routine_schema = :schema
+selectRoutineParametersSql=select r.routine_name as specific_name, coalesce(p.parameter_name, '$' || p.ordinal_position) as parameter_name, p.data_type as dtd_identifier, p.parameter_mode from information_schema.parameters p left join information_schema.routines r on r.specific_name = p.specific_name where p.specific_schema = :schema order by p.specific_name, p.ordinal_position


### PR DESCRIPTION
This adds a docker-compose file and associated utility files to
generate a website documenting the postgres database documentation using
schemaspy. This also adds a README file that describes the process of
moving the generated site to the grid-website repo for hosting as a
release task.

Signed-off-by: Davey Newhall <newhall@bitwise.io>