### PR TITLE
Grid daemon feature guards

### DIFF
--- a/bin/run_integration_tests
+++ b/bin/run_integration_tests
@@ -21,7 +21,7 @@ exitcode=0
 
 cd $top_dir/daemon/test
 
-docker-compose up --abort-on-container-exit --exit-code-from daemon
+CARGO_ARGS="-- --features experimental" docker-compose up --abort-on-container-exit --exit-code-from daemon
 test_exit=$?
 
 if [[ $test_exit != 0 ]]; then
@@ -36,7 +36,7 @@ clean_up
 
 cd $top_dir/integration
 
-docker-compose up --abort-on-container-exit --exit-code-from gridd
+CARGO_ARGS="-- --features experimental" docker-compose up --abort-on-container-exit --exit-code-from gridd
 test_exit=$?
 
 if [[ $test_exit != 0 ]]; then

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -63,16 +63,27 @@ default = ["sawtooth-support"]
 
 stable = [
     "sawtooth-support",
+    "pike",
+    "schema",
+    "product",
+    "location"
 ]
 
 experimental = [
     "stable",
     "splinter-support",
+    "track-and-trace"
 ]
 
 sawtooth-support = []
 splinter-support = ["scabbard", "splinter", "reqwest", "sabre-sdk", "transact", "transact/contract-archive"]
 test-api = []
+pike = []
+schema = ["pike"]
+product = ["pike", "schema"]
+location = ["pike", "schema"]
+track-and-trace = []
+
 
 [package.metadata.deb]
 maintainer = "The Hyperledger Grid Team"

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -27,21 +27,37 @@ use grid_sdk::grid_db::commits::store::{
 
 pub use self::error::{EventError, EventIoError, EventProcessorError};
 
+#[cfg(feature = "pike")]
 const PIKE_NAMESPACE: &str = "cad11d";
+#[cfg(feature = "pike")]
 const PIKE_AGENT: &str = "cad11d00";
+#[cfg(feature = "pike")]
 const PIKE_ORG: &str = "cad11d01";
 
 const GRID_NAMESPACE: &str = "621dee";
+#[cfg(feature = "schema")]
 const GRID_SCHEMA: &str = "621dee01";
+#[cfg(feature = "product")]
 const GRID_PRODUCT: &str = "621dee02";
+#[cfg(feature = "location")]
 const GRID_LOCATION: &str = "621dee04";
 
+#[cfg(feature = "track-and-trace")]
 const TRACK_AND_TRACE_NAMESPACE: &str = "a43b46";
+#[cfg(feature = "track-and-trace")]
 const TRACK_AND_TRACE_PROPERTY: &str = "a43b46ea";
+#[cfg(feature = "track-and-trace")]
 const TRACK_AND_TRACE_PROPOSAL: &str = "a43b46aa";
+#[cfg(feature = "track-and-trace")]
 const TRACK_AND_TRACE_RECORD: &str = "a43b46ec";
 
-const ALL_GRID_NAMESPACES: &[&str] = &[PIKE_NAMESPACE, GRID_NAMESPACE, TRACK_AND_TRACE_NAMESPACE];
+const ALL_GRID_NAMESPACES: &[&str] = &[
+    #[cfg(feature = "pike")]
+    PIKE_NAMESPACE,
+    GRID_NAMESPACE,
+    #[cfg(feature = "track-and-trace")]
+    TRACK_AND_TRACE_NAMESPACE,
+];
 
 const SABRE_NAMESPACE: &str = "00ec";
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -21,6 +21,12 @@ extern crate diesel;
 extern crate diesel_migrations;
 #[macro_use]
 extern crate log;
+#[cfg(any(
+    feature = "pike",
+    feature = "schema",
+    feature = "product",
+    feature = "location"
+))]
 #[macro_use]
 extern crate serde_json;
 #[cfg(feature = "splinter-support")]

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -20,20 +20,32 @@ use grid_sdk::grid_db::{
     SchemaStore, TrackAndTraceStore,
 };
 
+#[cfg(feature = "pike")]
 mod agents;
 mod batches;
+#[cfg(feature = "location")]
 mod locations;
+#[cfg(feature = "pike")]
 mod organizations;
+#[cfg(feature = "product")]
 mod products;
+#[cfg(feature = "track-and-trace")]
 mod records;
+#[cfg(feature = "schema")]
 mod schemas;
 
+#[cfg(feature = "pike")]
 pub use agents::*;
 pub use batches::*;
+#[cfg(feature = "location")]
 pub use locations::*;
+#[cfg(feature = "pike")]
 pub use organizations::*;
+#[cfg(feature = "product")]
 pub use products::*;
+#[cfg(feature = "track-and-trace")]
 pub use records::*;
+#[cfg(feature = "schema")]
 pub use schemas::*;
 
 use crate::database::ConnectionPool;

--- a/daemon/src/sawtooth/event.rs
+++ b/daemon/src/sawtooth/event.rs
@@ -395,9 +395,7 @@ mod tests {
 
     use sawtooth_sdk::messages::events::Event_Attribute;
 
-    const PIKE_NAMESPACE: &str = "cad11d";
     const GRID_NAMESPACE: &str = "621dee";
-    const TRACK_AND_TRACE_NAMESPACE: &str = "a43b46";
 
     /// Verify that a valid set of Sawtooth events can be converted to a `CommitEvent`.
     #[test]
@@ -406,9 +404,9 @@ mod tests {
         let block_num = 1;
 
         let grid_state_changes = vec![
-            create_state_change(format!("{}01", PIKE_NAMESPACE), Some(vec![0x01])),
+            create_state_change(format!("{}01", GRID_NAMESPACE), Some(vec![0x01])),
             create_state_change(format!("{}02", GRID_NAMESPACE), Some(vec![0x02])),
-            create_state_change(format!("{}03", TRACK_AND_TRACE_NAMESPACE), None),
+            create_state_change(format!("{}03", GRID_NAMESPACE), None),
         ];
         let non_grid_state_changes = vec![create_state_change("ef".into(), None)];
 

--- a/daemon/src/splinter/app_auth_handler/sabre.rs
+++ b/daemon/src/splinter/app_auth_handler/sabre.rs
@@ -38,8 +38,11 @@ use crate::splinter::app_auth_handler::error::AppAuthHandlerError;
 const SCABBARD_SUBMISSION_WAIT_SECS: u64 = 10;
 
 // Pike constants
+#[cfg(feature = "pike")]
 const PIKE_PREFIX: &str = "cad11d";
+#[cfg(feature = "pike")]
 const PIKE_CONTRACT_NAME: &str = "grid-pike";
+#[cfg(feature = "pike")]
 const PIKE_CONTRACT_VERSION_REQ: &str = "0.1.0-dev";
 
 // Product constants
@@ -77,90 +80,136 @@ pub fn setup_grid(
     }
 
     // Make Pike transactions
+    #[cfg(feature = "pike")]
     let pike_contract = SmartContractArchive::from_scar_file(
         PIKE_CONTRACT_NAME,
         PIKE_CONTRACT_VERSION_REQ,
         &default_scar_path(),
     )?;
+    #[cfg(feature = "pike")]
     let pike_contract_registry_txn =
         make_contract_registry_txn(&signer, &pike_contract.metadata.name)?;
+    #[cfg(feature = "pike")]
     let pike_contract_txn = make_upload_contract_txn(&signer, &pike_contract, PIKE_PREFIX)?;
+    #[cfg(feature = "pike")]
     let pike_namespace_registry_txn = make_namespace_registry_txn(&signer, PIKE_PREFIX)?;
+    #[cfg(feature = "pike")]
     let pike_namespace_permissions_txn =
         make_namespace_permissions_txn(&signer, &pike_contract, PIKE_PREFIX)?;
 
     // Make Product transactions
+    #[cfg(feature = "product")]
     let product_contract = SmartContractArchive::from_scar_file(
         PRODUCT_CONTRACT_NAME,
         PRODUCT_CONTRACT_VERSION_REQ,
         &default_scar_path(),
     )?;
+    #[cfg(feature = "product")]
     let product_contract_registry_txn =
         make_contract_registry_txn(&signer, &product_contract.metadata.name)?;
+    #[cfg(feature = "product")]
     let product_contract_txn =
         make_upload_contract_txn(&signer, &product_contract, PRODUCT_PREFIX)?;
+    #[cfg(feature = "product")]
     let product_namespace_registry_txn = make_namespace_registry_txn(&signer, PRODUCT_PREFIX)?;
+    #[cfg(feature = "product")]
     let product_namespace_permissions_txn =
         make_namespace_permissions_txn(&signer, &product_contract, PRODUCT_PREFIX)?;
+    #[cfg(feature = "product")]
     let product_pike_namespace_permissions_txn =
         make_namespace_permissions_txn(&signer, &product_contract, PIKE_PREFIX)?;
+    #[cfg(feature = "product")]
     let product_schema_namespace_permissions_txn =
         make_namespace_permissions_txn(&signer, &product_contract, SCHEMA_PREFIX)?;
 
     // Make Location transactions
+    #[cfg(feature = "location")]
     let location_contract = SmartContractArchive::from_scar_file(
         LOCATION_CONTRACT_NAME,
         LOCATION_CONTRACT_VERSION_REQ,
         &default_scar_path(),
     )?;
+    #[cfg(feature = "location")]
     let location_contract_registry_txn =
         make_contract_registry_txn(&signer, &location_contract.metadata.name)?;
+    #[cfg(feature = "location")]
     let location_contract_txn =
         make_upload_contract_txn(&signer, &location_contract, LOCATION_PREFIX)?;
+    #[cfg(feature = "location")]
     let location_namespace_registry_txn = make_namespace_registry_txn(&signer, LOCATION_PREFIX)?;
+    #[cfg(feature = "location")]
     let location_namespace_permissions_txn =
         make_namespace_permissions_txn(&signer, &location_contract, LOCATION_PREFIX)?;
+    #[cfg(feature = "location")]
     let location_pike_namespace_permissions_txn =
         make_namespace_permissions_txn(&signer, &location_contract, PIKE_PREFIX)?;
+    #[cfg(feature = "location")]
     let location_schema_namespace_permissions_txn =
         make_namespace_permissions_txn(&signer, &location_contract, SCHEMA_PREFIX)?;
 
     // Make schema transactions
+    #[cfg(feature = "schema")]
     let schema_contract = SmartContractArchive::from_scar_file(
         SCHEMA_CONTRACT_NAME,
         SCHEMA_CONTRACT_VERSION_REQ,
         &default_scar_path(),
     )?;
+    #[cfg(feature = "schema")]
     let schema_contract_registry_txn =
         make_contract_registry_txn(&signer, &schema_contract.metadata.name)?;
+    #[cfg(feature = "schema")]
     let schema_contract_txn = make_upload_contract_txn(&signer, &schema_contract, SCHEMA_PREFIX)?;
+    #[cfg(feature = "schema")]
     let schema_namespace_registry_txn = make_namespace_registry_txn(&signer, SCHEMA_PREFIX)?;
+    #[cfg(feature = "schema")]
     let schema_namespace_permissions_txn =
         make_namespace_permissions_txn(&signer, &schema_contract, SCHEMA_PREFIX)?;
+    #[cfg(feature = "schema")]
     let schema_pike_namespace_permissions_txn =
         make_namespace_permissions_txn(&signer, &schema_contract, PIKE_PREFIX)?;
 
     let txns = vec![
+        #[cfg(feature = "pike")]
         pike_contract_registry_txn,
+        #[cfg(feature = "pike")]
         pike_contract_txn,
+        #[cfg(feature = "pike")]
         pike_namespace_registry_txn,
+        #[cfg(feature = "pike")]
         pike_namespace_permissions_txn,
+        #[cfg(feature = "product")]
         product_contract_registry_txn,
+        #[cfg(feature = "product")]
         product_contract_txn,
+        #[cfg(feature = "product")]
         product_namespace_registry_txn,
+        #[cfg(feature = "product")]
         product_pike_namespace_permissions_txn,
+        #[cfg(feature = "product")]
         product_namespace_permissions_txn,
+        #[cfg(feature = "schema")]
         schema_contract_registry_txn,
+        #[cfg(feature = "schema")]
         schema_contract_txn,
+        #[cfg(feature = "schema")]
         schema_namespace_registry_txn,
+        #[cfg(feature = "product")]
         product_schema_namespace_permissions_txn,
+        #[cfg(feature = "schema")]
         schema_pike_namespace_permissions_txn,
+        #[cfg(feature = "schema")]
         schema_namespace_permissions_txn,
+        #[cfg(feature = "location")]
         location_contract_registry_txn,
+        #[cfg(feature = "location")]
         location_contract_txn,
+        #[cfg(feature = "location")]
         location_namespace_registry_txn,
+        #[cfg(feature = "location")]
         location_namespace_permissions_txn,
+        #[cfg(feature = "location")]
         location_pike_namespace_permissions_txn,
+        #[cfg(feature = "location")]
         location_schema_namespace_permissions_txn,
     ];
     let batch = BatchBuilder::new().with_transactions(txns).build(&signer)?;
@@ -194,6 +243,7 @@ fn make_contract_registry_txn(
         .build(signer)?)
 }
 
+#[cfg(feature = "pike")]
 fn make_upload_contract_txn(
     signer: &dyn Signer,
     contract: &SmartContractArchive,

--- a/daemon/test/docker-compose.yaml
+++ b/daemon/test/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
             sleep 1
         done
         cd daemon
-        cargo test --features test-api --  --test-threads=1
+        cargo test --features test-api,experimental --  --test-threads=1
         cd ../cli
         cargo test actions -- --test-threads=1
         cargo test yaml_parser -- --test-threads=1

--- a/integration/docker-compose.yaml
+++ b/integration/docker-compose.yaml
@@ -202,8 +202,11 @@ services:
       - ..:/project/grid
     entrypoint: |
       bash -c "
-        cargo build -p grid-daemon  && \
-        cargo build -p grid-cli  && \
+        cd daemon && \
+        cargo build --features experimental && \
+        cd ../cli && \
+        cargo build --features experimental -p grid-cli  && \
+        cd .. && \
         # we need to wait for the db to have started.
         until PGPASSWORD=grid_example psql -h db -U grid -c '\q'; do
             >&2 echo \"Database is unavailable - sleeping\"


### PR DESCRIPTION
The grid daemon's feature set is now guarded by the following features:

    - pike
    - product
    - schema
    - location
    - track-and-trace

When these features are enabled the corresponding rest api routes will
be active, the app auth handler will upload corresponding smart
contracts to created circuits and the database handler will listen for
corresponding events. Pike, product, schema, and location are considered
stable features and will be included by default or if the daemon is
compiled with the stabled flag. Track and trace is considered
experimental and will only be included if the daemon is compiled with
the experimental flag.

When only location and product are enabled, pike and schema will be
included as well because those features are  required to properly use
product and location. Similarly, if schema is enabled pike will also be
included for the same reason.