### PR TITLE
Standardize protocol version in smart contracts

### DIFF
--- a/contracts/pike/packaging/scar/manifest.yaml
+++ b/contracts/pike/packaging/scar/manifest.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: pike
-version: '0.1'
+version: '1'
 inputs:
   - 'cad11d'
 outputs:

--- a/contracts/pike/src/handler.rs
+++ b/contracts/pike/src/handler.rs
@@ -215,7 +215,7 @@ impl PikeTransactionHandler {
     pub fn new() -> PikeTransactionHandler {
         PikeTransactionHandler {
             family_name: "pike".to_string(),
-            family_versions: vec!["0.1".to_string()],
+            family_versions: vec!["1".to_string()],
             namespaces: vec![NAMESPACE.to_string()],
         }
     }

--- a/contracts/product/packaging/scar/manifest.yaml
+++ b/contracts/product/packaging/scar/manifest.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: grid_product
-version: '1.0'
+version: '1'
 inputs:
   - '621dee01'
   - '621dee02'

--- a/contracts/product/product.yaml
+++ b/contracts/product/product.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: grid_product
-version: '1.0'
+version: '1'
 wasm: /tmp/grid-product-tp.wasm
 inputs:
   - '621dee01'

--- a/contracts/product/src/handler.rs
+++ b/contracts/product/src/handler.rs
@@ -73,7 +73,7 @@ impl ProductTransactionHandler {
     pub fn new() -> ProductTransactionHandler {
         ProductTransactionHandler {
             family_name: "grid_product".to_string(),
-            family_versions: vec!["1.0".to_string()],
+            family_versions: vec!["1".to_string()],
             namespaces: vec![get_product_prefix()],
         }
     }

--- a/contracts/schema/packaging/scar/manifest.yaml
+++ b/contracts/schema/packaging/scar/manifest.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: grid_schema
-version: '1.0'
+version: '1'
 inputs:
   - '621dee01'
   - 'cad11d'

--- a/contracts/schema/schema.yaml
+++ b/contracts/schema/schema.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: grid_schema
-version: '1.0'
+version: '1'
 wasm: /tmp/grid-schema-tp.wasm
 inputs:
   - '621dee01'

--- a/contracts/schema/src/handler.rs
+++ b/contracts/schema/src/handler.rs
@@ -73,7 +73,7 @@ impl GridSchemaTransactionHandler {
     pub fn new() -> Self {
         GridSchemaTransactionHandler {
             family_name: "grid_schema".to_string(),
-            family_versions: vec!["1.0".to_string()],
+            family_versions: vec!["1".to_string()],
             namespaces: vec![GRID_NAMESPACE.to_string()],
         }
     }

--- a/contracts/track_and_trace/packaging/scar/manifest.yaml
+++ b/contracts/track_and_trace/packaging/scar/manifest.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: grid_track_and_trace
-version: '1.0'
+version: '1'
 inputs:
   - 'a43b46'
   - '621dee01'

--- a/contracts/track_and_trace/src/handler.rs
+++ b/contracts/track_and_trace/src/handler.rs
@@ -59,7 +59,7 @@ impl TrackAndTraceTransactionHandler {
     pub fn new() -> TrackAndTraceTransactionHandler {
         TrackAndTraceTransactionHandler {
             family_name: "grid_track_and_trace".to_string(),
-            family_versions: vec!["1.0".to_string()],
+            family_versions: vec!["1".to_string()],
             namespaces: vec![
                 get_track_and_trace_prefix(),
                 get_pike_prefix(),

--- a/contracts/track_and_trace/track_and_trace.yaml
+++ b/contracts/track_and_trace/track_and_trace.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: grid_track_and_trace
-version: '1.0'
+version: '1'
 wasm: /tmp/grid-track-and-trace-tp.wasm
 inputs:
   - 'a43b46'


### PR DESCRIPTION
Changing this to a non-semver value makes it more clear than this value
specifies the protocol version and is separate from the repository's
packaging version.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>