### PR TITLE
SDK Feature Guards

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -40,7 +40,7 @@ diesel = { version = "1.0.0", features = ["r2d2", "serde_json"] }
 diesel_migrations = "1.4"
 flexi_logger = "0.14"
 futures = "0.3"
-grid-sdk = { path = "../sdk", features = ["database"] }
+grid-sdk = { path = "../sdk", features = ["database", "experimental"] }
 log = "0.4"
 protobuf = "2"
 reqwest = { version = "0.10.1", optional = true, features = ["json", "blocking"] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -54,13 +54,19 @@ glob = "0.2"
 [features]
 default = []
 
-stable = []
+stable = [
+    "pike",
+    "schema",
+    "product",
+    "location"
+]
 
 experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
-    "database"
+    "database",
+    "track-and-trace"
 ]
 
 database = [
@@ -71,6 +77,12 @@ database = [
     "postgres",
     "sqlite"
 ]
+
+pike = []
+schema = ["pike"]
+product = ["pike", "schema"]
+location = ["pike", "schema"]
+track-and-trace = []
 
 grid_db = ["sawtooth-compat"]
 postgres = ["diesel/postgres", "diesel_migrations"]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -29,17 +29,23 @@ extern crate diesel_migrations;
 #[macro_use]
 extern crate log;
 
+#[cfg(feature = "pike")]
 pub mod agents;
 pub mod commits;
 pub mod error;
 mod hex;
+#[cfg(feature = "location")]
 pub mod locations;
 pub mod migrations;
+#[cfg(feature = "pike")]
 pub mod organizations;
 pub mod permissions;
+#[cfg(feature = "product")]
 pub mod products;
 pub mod protocol;
 pub mod protos;
+#[cfg(feature = "schema")]
 pub mod schemas;
 pub mod store;
+#[cfg(feature = "track-and-trace")]
 pub mod track_and_trace;

--- a/sdk/src/migrations/diesel/postgres/mod.rs
+++ b/sdk/src/migrations/diesel/postgres/mod.rs
@@ -14,19 +14,25 @@
 
 //! Defines methods and utilities to interact with user tables in the database.
 
+#[cfg(feature = "location")]
+use crate::locations::store::diesel::schema::{location::dsl::*, location_attribute::dsl::*};
+#[cfg(feature = "product")]
+use crate::products::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*};
+#[cfg(feature = "pike")]
 use crate::{
     agents::store::diesel::schema::{agent::dsl::*, role::dsl::role},
-    commits::store::diesel::schema::{chain_record::dsl::*, commit::dsl::*},
-    locations::store::diesel::schema::{location::dsl::*, location_attribute::dsl::*},
     organizations::store::diesel::schema::organization::dsl::*,
-    products::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*},
-    schemas::store::diesel::schema::{
-        grid_property_definition::dsl::grid_property_definition, grid_schema::dsl::*,
-    },
-    track_and_trace::store::diesel::schema::{
-        associated_agent::dsl::*, property::dsl::*, proposal::dsl::*, record::dsl::*,
-        reported_value::dsl::*, reporter::dsl::*,
-    },
+};
+
+use crate::commits::store::diesel::schema::{chain_record::dsl::*, commit::dsl::*};
+#[cfg(feature = "schema")]
+use crate::schemas::store::diesel::schema::{
+    grid_property_definition::dsl::grid_property_definition, grid_schema::dsl::*,
+};
+#[cfg(feature = "track-and-trace")]
+use crate::track_and_trace::store::diesel::schema::{
+    associated_agent::dsl::*, property::dsl::*, proposal::dsl::*, record::dsl::*,
+    reported_value::dsl::*, reporter::dsl::*,
 };
 
 use diesel::RunQueryDsl;
@@ -60,23 +66,38 @@ pub fn run_migrations(conn: &PgConnection) -> Result<(), MigrationsError> {
 #[cfg(all(feature = "postgres", feature = "diesel"))]
 pub fn clear_database(conn: &PgConnection) -> Result<(), MigrationsError> {
     conn.transaction::<_, MigrationsError, _>(|| {
-        diesel::delete(agent).execute(conn)?;
-        diesel::delete(role).execute(conn)?;
+        #[cfg(feature = "pike")]
+        {
+            diesel::delete(agent).execute(conn)?;
+            diesel::delete(organization).execute(conn)?;
+            diesel::delete(role).execute(conn)?;
+        }
+        #[cfg(feature = "location")]
+        {
+            diesel::delete(location_attribute).execute(conn)?;
+            diesel::delete(location).execute(conn)?;
+        }
+        #[cfg(feature = "product")]
+        {
+            diesel::delete(product).execute(conn)?;
+            diesel::delete(product_property_value).execute(conn)?;
+        }
+        #[cfg(feature = "schema")]
+        {
+            diesel::delete(grid_property_definition).execute(conn)?;
+            diesel::delete(grid_schema).execute(conn)?;
+        }
+        #[cfg(feature = "track-and-trace")]
+        {
+            diesel::delete(associated_agent).execute(conn)?;
+            diesel::delete(property).execute(conn)?;
+            diesel::delete(proposal).execute(conn)?;
+            diesel::delete(record).execute(conn)?;
+            diesel::delete(reported_value).execute(conn)?;
+            diesel::delete(reporter).execute(conn)?;
+        }
         diesel::delete(chain_record).execute(conn)?;
         diesel::delete(commit).execute(conn)?;
-        diesel::delete(location).execute(conn)?;
-        diesel::delete(location_attribute).execute(conn)?;
-        diesel::delete(organization).execute(conn)?;
-        diesel::delete(product).execute(conn)?;
-        diesel::delete(product_property_value).execute(conn)?;
-        diesel::delete(grid_schema).execute(conn)?;
-        diesel::delete(grid_property_definition).execute(conn)?;
-        diesel::delete(associated_agent).execute(conn)?;
-        diesel::delete(property).execute(conn)?;
-        diesel::delete(proposal).execute(conn)?;
-        diesel::delete(record).execute(conn)?;
-        diesel::delete(reported_value).execute(conn)?;
-        diesel::delete(reporter).execute(conn)?;
 
         Ok(())
     })?;

--- a/sdk/src/migrations/diesel/sqlite/mod.rs
+++ b/sdk/src/migrations/diesel/sqlite/mod.rs
@@ -12,19 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "location")]
+use crate::locations::store::diesel::schema::{location::dsl::*, location_attribute::dsl::*};
+#[cfg(feature = "product")]
+use crate::products::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*};
+#[cfg(feature = "pike")]
 use crate::{
     agents::store::diesel::schema::{agent::dsl::*, role::dsl::role},
-    commits::store::diesel::schema::{chain_record::dsl::*, commit::dsl::*},
-    locations::store::diesel::schema::{location::dsl::*, location_attribute::dsl::*},
     organizations::store::diesel::schema::organization::dsl::*,
-    products::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*},
-    schemas::store::diesel::schema::{
-        grid_property_definition::dsl::grid_property_definition, grid_schema::dsl::*,
-    },
-    track_and_trace::store::diesel::schema::{
-        associated_agent::dsl::*, property::dsl::*, proposal::dsl::*, record::dsl::*,
-        reported_value::dsl::*, reporter::dsl::*,
-    },
+};
+
+use crate::commits::store::diesel::schema::{chain_record::dsl::*, commit::dsl::*};
+#[cfg(feature = "schema")]
+use crate::schemas::store::diesel::schema::{
+    grid_property_definition::dsl::grid_property_definition, grid_schema::dsl::*,
+};
+#[cfg(feature = "track-and-trace")]
+use crate::track_and_trace::store::diesel::schema::{
+    associated_agent::dsl::*, property::dsl::*, proposal::dsl::*, record::dsl::*,
+    reported_value::dsl::*, reporter::dsl::*,
 };
 
 use diesel::RunQueryDsl;
@@ -58,23 +64,38 @@ pub fn run_migrations(conn: &SqliteConnection) -> Result<(), MigrationsError> {
 #[cfg(all(feature = "sqlite", feature = "diesel"))]
 pub fn clear_database(conn: &SqliteConnection) -> Result<(), MigrationsError> {
     conn.transaction::<_, MigrationsError, _>(|| {
-        diesel::delete(agent).execute(conn)?;
-        diesel::delete(role).execute(conn)?;
+        #[cfg(feature = "pike")]
+        {
+            diesel::delete(agent).execute(conn)?;
+            diesel::delete(organization).execute(conn)?;
+            diesel::delete(role).execute(conn)?;
+        }
+        #[cfg(feature = "location")]
+        {
+            diesel::delete(location_attribute).execute(conn)?;
+            diesel::delete(location).execute(conn)?;
+        }
+        #[cfg(feature = "product")]
+        {
+            diesel::delete(product).execute(conn)?;
+            diesel::delete(product_property_value).execute(conn)?;
+        }
+        #[cfg(feature = "schema")]
+        {
+            diesel::delete(grid_property_definition).execute(conn)?;
+            diesel::delete(grid_schema).execute(conn)?;
+        }
+        #[cfg(feature = "track-and-trace")]
+        {
+            diesel::delete(associated_agent).execute(conn)?;
+            diesel::delete(property).execute(conn)?;
+            diesel::delete(proposal).execute(conn)?;
+            diesel::delete(record).execute(conn)?;
+            diesel::delete(reported_value).execute(conn)?;
+            diesel::delete(reporter).execute(conn)?;
+        }
         diesel::delete(chain_record).execute(conn)?;
         diesel::delete(commit).execute(conn)?;
-        diesel::delete(location).execute(conn)?;
-        diesel::delete(location_attribute).execute(conn)?;
-        diesel::delete(organization).execute(conn)?;
-        diesel::delete(product).execute(conn)?;
-        diesel::delete(product_property_value).execute(conn)?;
-        diesel::delete(grid_schema).execute(conn)?;
-        diesel::delete(grid_property_definition).execute(conn)?;
-        diesel::delete(associated_agent).execute(conn)?;
-        diesel::delete(property).execute(conn)?;
-        diesel::delete(proposal).execute(conn)?;
-        diesel::delete(record).execute(conn)?;
-        diesel::delete(reported_value).execute(conn)?;
-        diesel::delete(reporter).execute(conn)?;
 
         Ok(())
     })?;

--- a/sdk/src/store/memory.rs
+++ b/sdk/src/store/memory.rs
@@ -12,11 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "location")]
+use crate::locations::LocationStore;
+#[cfg(feature = "schema")]
+use crate::schemas::SchemaStore;
+#[cfg(feature = "track-and-trace")]
+use crate::track_and_trace::TrackAndTraceStore;
+#[cfg(feature = "pike")]
 use crate::{
-    agents::AgentStore, commits::CommitStore, commits::MemoryCommitStore, locations::LocationStore,
-    organizations::MemoryOrganizationStore, organizations::OrganizationStore, schemas::SchemaStore,
-    track_and_trace::TrackAndTraceStore,
+    agents::AgentStore, organizations::MemoryOrganizationStore, organizations::OrganizationStore,
 };
+use crate::{commits::CommitStore, commits::MemoryCommitStore};
 
 use super::StoreFactory;
 
@@ -24,22 +30,26 @@ use super::StoreFactory;
 #[derive(Default)]
 pub struct MemoryStoreFactory {
     grid_commit_store: MemoryCommitStore,
+    #[cfg(feature = "pike")]
     grid_organization_store: MemoryOrganizationStore,
 }
 
 impl MemoryStoreFactory {
     pub fn new() -> Self {
         let grid_commit_store = MemoryCommitStore::new();
+        #[cfg(feature = "pike")]
         let grid_organization_store = MemoryOrganizationStore::new();
 
         Self {
             grid_commit_store,
+            #[cfg(feature = "pike")]
             grid_organization_store,
         }
     }
 }
 
 impl StoreFactory for MemoryStoreFactory {
+    #[cfg(feature = "pike")]
     fn get_grid_agent_store(&self) -> Box<dyn AgentStore> {
         unimplemented!()
     }
@@ -48,22 +58,27 @@ impl StoreFactory for MemoryStoreFactory {
         Box::new(self.grid_commit_store.clone())
     }
 
+    #[cfg(feature = "pike")]
     fn get_grid_organization_store(&self) -> Box<dyn OrganizationStore> {
         Box::new(self.grid_organization_store.clone())
     }
 
+    #[cfg(feature = "location")]
     fn get_grid_location_store(&self) -> Box<dyn LocationStore> {
         unimplemented!()
     }
 
+    #[cfg(feature = "product")]
     fn get_grid_product_store(&self) -> Box<dyn crate::products::ProductStore> {
         unimplemented!()
     }
 
+    #[cfg(feature = "schema")]
     fn get_grid_schema_store(&self) -> Box<dyn SchemaStore> {
         unimplemented!()
     }
 
+    #[cfg(feature = "track-and-trace")]
     fn get_grid_track_and_trace_store(&self) -> Box<dyn TrackAndTraceStore> {
         unimplemented!()
     }

--- a/sdk/src/store/mod.rs
+++ b/sdk/src/store/mod.rs
@@ -26,18 +26,24 @@ use diesel::r2d2::{ConnectionManager, Pool};
 /// An abstract factory for creating Grid stores backed by the same storage
 pub trait StoreFactory {
     /// Get a new `AgentStore`
+    #[cfg(feature = "pike")]
     fn get_grid_agent_store(&self) -> Box<dyn crate::agents::AgentStore>;
     /// Get a new `CommitStore`
     fn get_grid_commit_store(&self) -> Box<dyn crate::commits::CommitStore>;
     /// Get a new `OrganizationStore`
+    #[cfg(feature = "pike")]
     fn get_grid_organization_store(&self) -> Box<dyn crate::organizations::OrganizationStore>;
     /// Get a new `LocationStore`
+    #[cfg(feature = "location")]
     fn get_grid_location_store(&self) -> Box<dyn crate::locations::LocationStore>;
     /// Get a new `ProductStore`
+    #[cfg(feature = "product")]
     fn get_grid_product_store(&self) -> Box<dyn crate::products::ProductStore>;
     /// Get a new `SchemaStore`
+    #[cfg(feature = "schema")]
     fn get_grid_schema_store(&self) -> Box<dyn crate::schemas::SchemaStore>;
     /// Get a new `TrackAndTraceStore`
+    #[cfg(feature = "track-and-trace")]
     fn get_grid_track_and_trace_store(&self)
         -> Box<dyn crate::track_and_trace::TrackAndTraceStore>;
 }

--- a/sdk/src/store/postgres.rs
+++ b/sdk/src/store/postgres.rs
@@ -31,6 +31,7 @@ impl PgStoreFactory {
 }
 
 impl StoreFactory for PgStoreFactory {
+    #[cfg(feature = "pike")]
     fn get_grid_agent_store(&self) -> Box<dyn crate::agents::AgentStore> {
         Box::new(crate::agents::DieselAgentStore::new(self.pool.clone()))
     }
@@ -39,26 +40,31 @@ impl StoreFactory for PgStoreFactory {
         Box::new(crate::commits::DieselCommitStore::new(self.pool.clone()))
     }
 
+    #[cfg(feature = "pike")]
     fn get_grid_organization_store(&self) -> Box<dyn crate::organizations::OrganizationStore> {
         Box::new(crate::organizations::DieselOrganizationStore::new(
             self.pool.clone(),
         ))
     }
 
+    #[cfg(feature = "location")]
     fn get_grid_location_store(&self) -> Box<dyn crate::locations::LocationStore> {
         Box::new(crate::locations::DieselLocationStore::new(
             self.pool.clone(),
         ))
     }
 
+    #[cfg(feature = "product")]
     fn get_grid_product_store(&self) -> Box<dyn crate::products::ProductStore> {
         Box::new(crate::products::DieselProductStore::new(self.pool.clone()))
     }
 
+    #[cfg(feature = "schema")]
     fn get_grid_schema_store(&self) -> Box<dyn crate::schemas::SchemaStore> {
         Box::new(crate::schemas::DieselSchemaStore::new(self.pool.clone()))
     }
 
+    #[cfg(feature = "track-and-trace")]
     fn get_grid_track_and_trace_store(
         &self,
     ) -> Box<dyn crate::track_and_trace::TrackAndTraceStore> {

--- a/sdk/src/store/sqlite.rs
+++ b/sdk/src/store/sqlite.rs
@@ -31,6 +31,7 @@ impl SqliteStoreFactory {
 }
 
 impl StoreFactory for SqliteStoreFactory {
+    #[cfg(feature = "pike")]
     fn get_grid_agent_store(&self) -> Box<dyn crate::agents::AgentStore> {
         Box::new(crate::agents::DieselAgentStore::new(self.pool.clone()))
     }
@@ -39,26 +40,31 @@ impl StoreFactory for SqliteStoreFactory {
         Box::new(crate::commits::DieselCommitStore::new(self.pool.clone()))
     }
 
+    #[cfg(feature = "pike")]
     fn get_grid_organization_store(&self) -> Box<dyn crate::organizations::OrganizationStore> {
         Box::new(crate::organizations::DieselOrganizationStore::new(
             self.pool.clone(),
         ))
     }
 
+    #[cfg(feature = "location")]
     fn get_grid_location_store(&self) -> Box<dyn crate::locations::LocationStore> {
         Box::new(crate::locations::DieselLocationStore::new(
             self.pool.clone(),
         ))
     }
 
+    #[cfg(feature = "product")]
     fn get_grid_product_store(&self) -> Box<dyn crate::products::ProductStore> {
         Box::new(crate::products::DieselProductStore::new(self.pool.clone()))
     }
 
+    #[cfg(feature = "schema")]
     fn get_grid_schema_store(&self) -> Box<dyn crate::schemas::SchemaStore> {
         Box::new(crate::schemas::DieselSchemaStore::new(self.pool.clone()))
     }
 
+    #[cfg(feature = "track-and-trace")]
     fn get_grid_track_and_trace_store(
         &self,
     ) -> Box<dyn crate::track_and_trace::TrackAndTraceStore> {


### PR DESCRIPTION
Adds the following features to the grid sdk

    - pike
    - product
    - schema
    - location
    - track-and-trace

Pike, product, schema, and location are considered
stable features and will be included if the sdk is compiled with the stabled
flag. Track and trace is considered experimental and will only be included if
the sdk is compiled with
the experimental flag.

When only location and product are enabled, pike and schema will be
included as well because those features are  required to properly use
product and location. Similarly, if schema is enabled pike will also be
included for the same reason.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>