### PR TITLE
Fix Pike version in Grid CLI

### DIFF
--- a/cli/src/transaction.rs
+++ b/cli/src/transaction.rs
@@ -37,7 +37,7 @@ use crate::CliError;
 
 pub const PIKE_NAMESPACE: &str = "cad11d";
 const PIKE_FAMILY_NAME: &str = "pike";
-const PIKE_FAMILY_VERSION: &str = "0.1";
+const PIKE_FAMILY_VERSION: &str = "1";
 
 pub const GRID_SCHEMA_NAMESPACE: &str = "621dee01";
 const GRID_SCHEMA_FAMILY_NAME: &str = "grid_schema";

--- a/cli/tests/product.rs
+++ b/cli/tests/product.rs
@@ -28,8 +28,8 @@ mod integration {
     static KEY_DIR: &str = "/root";
     static PUB_KEY_FILE: &str = "/root/.grid/keys/root.pub";
 
-    static ORG_ID: &str = "cgl";
-    static ORG_NAME: &str = "Cargill";
+    static ORG_ID: &str = "762";
+    static ORG_NAME: &str = "MyOrg";
     static ORG_ADDRESS: &str = "hq";
 
     static SCHEMA_CREATE_FILE: &str = "tests/products/test_product_schema.yaml";

--- a/cli/tests/products/create_product.yaml
+++ b/cli/tests/products/create_product.yaml
@@ -15,7 +15,7 @@
 
 - product_namespace: "GS1"
   product_id: "762111177704"
-  owner: cgl
+  owner: 762
   properties:
     length: 8
     width: 11

--- a/contracts/pike/pike.yaml
+++ b/contracts/pike/pike.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: pike
-version: '0.1'
+version: '1'
 wasm: /tmp/grid-pike-tp.wasm
 inputs:
   - 'cad11d'


### PR DESCRIPTION
These version numbers were changed to be integers so the Pike version
should just be "1".

Signed-off-by: Darian Plumb <dplumb@bitwise.io>