### PR TITLE
Use Message::parse_from_bytes instead of protobuf::parse_from_bytes

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,7 @@ sawtooth-sdk = "0.4"
 sabre-sdk = "0.5"
 grid-sdk = { path = "../sdk", features = ["database"] }
 rust-crypto = "0.2"
-protobuf = "2"
+protobuf = "2.19"
 users = "0.9"
 reqwest = "0.9"
 dirs = "1"

--- a/contracts/location/Cargo.toml
+++ b/contracts/location/Cargo.toml
@@ -25,7 +25,7 @@ clap = "2"
 grid-sdk = { path = "../../sdk" }
 cfg-if = "0.1"
 hex = "0.3.1"
-protobuf = "2"
+protobuf = "2.19"
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/contracts/pike/Cargo.toml
+++ b/contracts/pike/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.1.0"
 authors = ["Cargill Incorporated"]
 
 [dependencies]
-protobuf = "2"
+protobuf = "2.19"
 cfg-if = "0.1"
 hex = "0.3.1"
 grid-sdk = {path = "../../sdk"}

--- a/contracts/pike/src/handler.rs
+++ b/contracts/pike/src/handler.rs
@@ -67,7 +67,8 @@ impl<'a> PikeState<'a> {
         let d = self.context.get_state_entry(&address)?;
         match d {
             Some(packed) => {
-                let agents: AgentList = match protobuf::parse_from_bytes(packed.as_slice()) {
+                let agents: AgentList = match protobuf::Message::parse_from_bytes(packed.as_slice())
+                {
                     Ok(agents) => agents,
                     Err(err) => {
                         return Err(ApplyError::InternalError(format!(
@@ -92,7 +93,7 @@ impl<'a> PikeState<'a> {
         let address = compute_address(public_key, Resource::AGENT);
         let d = self.context.get_state_entry(&address)?;
         let mut agent_list = match d {
-            Some(packed) => match protobuf::parse_from_bytes(packed.as_slice()) {
+            Some(packed) => match protobuf::Message::parse_from_bytes(packed.as_slice()) {
                 Ok(agents) => agents,
                 Err(err) => {
                     return Err(ApplyError::InternalError(format!(
@@ -137,15 +138,16 @@ impl<'a> PikeState<'a> {
         let d = self.context.get_state_entry(&address)?;
         match d {
             Some(packed) => {
-                let orgs: OrganizationList = match protobuf::parse_from_bytes(packed.as_slice()) {
-                    Ok(orgs) => orgs,
-                    Err(err) => {
-                        return Err(ApplyError::InternalError(format!(
-                            "Cannot deserialize organization list: {:?}",
-                            err,
-                        )))
-                    }
-                };
+                let orgs: OrganizationList =
+                    match protobuf::Message::parse_from_bytes(packed.as_slice()) {
+                        Ok(orgs) => orgs,
+                        Err(err) => {
+                            return Err(ApplyError::InternalError(format!(
+                                "Cannot deserialize organization list: {:?}",
+                                err,
+                            )))
+                        }
+                    };
 
                 for org in orgs.get_organizations() {
                     if org.org_id == id {
@@ -166,7 +168,7 @@ impl<'a> PikeState<'a> {
         let address = compute_address(id, Resource::ORG);
         let d = self.context.get_state_entry(&address)?;
         let mut organization_list = match d {
-            Some(packed) => match protobuf::parse_from_bytes(packed.as_slice()) {
+            Some(packed) => match protobuf::Message::parse_from_bytes(packed.as_slice()) {
                 Ok(orgs) => orgs,
                 Err(err) => {
                     return Err(ApplyError::InternalError(format!(
@@ -239,7 +241,7 @@ impl TransactionHandler for PikeTransactionHandler {
         request: &TpProcessRequest,
         context: &mut dyn TransactionContext,
     ) -> Result<(), ApplyError> {
-        let payload = protobuf::parse_from_bytes::<PikePayload>(request.get_payload())
+        let payload: PikePayload = protobuf::Message::parse_from_bytes(request.get_payload())
             .map_err(|_| ApplyError::InternalError("Failed to parse payload".into()))?;
 
         let signer = request.get_header().get_signer_public_key();

--- a/contracts/product/Cargo.toml
+++ b/contracts/product/Cargo.toml
@@ -25,7 +25,7 @@ clap = "2"
 grid-sdk = { path = "../../sdk" }
 cfg-if = "0.1"
 hex = "0.3.1"
-protobuf = "2"
+protobuf = "2.19"
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/contracts/track_and_trace/Cargo.toml
+++ b/contracts/track_and_trace/Cargo.toml
@@ -25,7 +25,7 @@ clap = "2"
 grid-sdk = { path = "../../sdk" }
 cfg-if = "0.1"
 hex = "0.3.1"
-protobuf = "2"
+protobuf = "2.19"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rust-crypto-wasm = "0.3"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -42,7 +42,7 @@ flexi_logger = "0.14"
 futures = "0.3"
 grid-sdk = { path = "../sdk", features = ["database", "experimental"] }
 log = "0.4"
-protobuf = "2"
+protobuf = "2.19"
 reqwest = { version = "0.10.1", optional = true, features = ["json", "blocking"] }
 sabre-sdk = { version = "0.5", optional = true }
 sawtooth-sdk = { version = "0.4", features = ["transact-compat"] }

--- a/daemon/src/rest_api/routes/batches.rs
+++ b/daemon/src/rest_api/routes/batches.rs
@@ -29,7 +29,7 @@ pub async fn submit_batches(
     query_service_id: web::Query<QueryServiceId>,
     _: AcceptServiceIdParam,
 ) -> Result<HttpResponse, RestApiResponseError> {
-    let batch_list: BatchList = match protobuf::parse_from_bytes(&*body) {
+    let batch_list: BatchList = match protobuf::Message::parse_from_bytes(&*body) {
         Ok(batch_list) => batch_list,
         Err(err) => {
             return Err(RestApiResponseError::BadRequest(format!(

--- a/daemon/src/sawtooth/batch_submitter.rs
+++ b/daemon/src/sawtooth/batch_submitter.rs
@@ -141,7 +141,7 @@ pub fn query_validator<T: protobuf::Message, C: protobuf::Message, MS: MessageSe
             ))
         })?;
 
-    protobuf::parse_from_bytes(
+    protobuf::Message::parse_from_bytes(
         response_future
             .get_timeout(Duration::new(DEFAULT_TIME_OUT.into(), 0))
             .map_err(|err| RestApiResponseError::RequestHandlerError(err.to_string()))?

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -33,7 +33,7 @@ cfg-if = "0.1"
 diesel = { version = "1.0", features = ["r2d2", "serde_json"], optional = true }
 diesel_migrations = { version = "1.4", optional = true }
 log = "0.4"
-protobuf = "2"
+protobuf = "2.19"
 sabre-sdk = { version = "0.5", optional = true }
 sawtooth-sdk = { version = "0.4", features = ["transact-compat"], optional=true }
 serde = { version = "1.0", features = ["derive"] }

--- a/sdk/src/protocol/location/payload.rs
+++ b/sdk/src/protocol/location/payload.rs
@@ -141,7 +141,7 @@ impl FromNative<LocationPayload> for protos::location_payload::LocationPayload {
 impl FromBytes<LocationPayload> for LocationPayload {
     fn from_bytes(bytes: &[u8]) -> Result<LocationPayload, ProtoConversionError> {
         let proto: location_payload::LocationPayload =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get LocationPayload from bytes".into(),
                 )
@@ -287,7 +287,7 @@ impl FromNative<LocationCreateAction> for location_payload::LocationCreateAction
 impl FromBytes<LocationCreateAction> for LocationCreateAction {
     fn from_bytes(bytes: &[u8]) -> Result<LocationCreateAction, ProtoConversionError> {
         let proto: protos::location_payload::LocationCreateAction =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get LocationCreateAction from bytes".to_string(),
                 )
@@ -421,7 +421,7 @@ impl FromNative<LocationUpdateAction> for protos::location_payload::LocationUpda
 impl FromBytes<LocationUpdateAction> for LocationUpdateAction {
     fn from_bytes(bytes: &[u8]) -> Result<LocationUpdateAction, ProtoConversionError> {
         let proto: protos::location_payload::LocationUpdateAction =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get LocationUpdateAction from bytes".to_string(),
                 )
@@ -540,7 +540,7 @@ impl FromNative<LocationDeleteAction> for protos::location_payload::LocationDele
 impl FromBytes<LocationDeleteAction> for LocationDeleteAction {
     fn from_bytes(bytes: &[u8]) -> Result<LocationDeleteAction, ProtoConversionError> {
         let proto: protos::location_payload::LocationDeleteAction =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get LocationDeleteAction from bytes".to_string(),
                 )

--- a/sdk/src/protocol/location/state.rs
+++ b/sdk/src/protocol/location/state.rs
@@ -287,7 +287,7 @@ impl FromNative<LocationList> for protos::location_state::LocationList {
 
 impl FromBytes<LocationList> for LocationList {
     fn from_bytes(bytes: &[u8]) -> Result<LocationList, ProtoConversionError> {
-        let proto: protos::location_state::LocationList = protobuf::parse_from_bytes(bytes)
+        let proto: protos::location_state::LocationList = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get LocationList from bytes".to_string(),

--- a/sdk/src/protocol/pike/payload.rs
+++ b/sdk/src/protocol/pike/payload.rs
@@ -148,7 +148,7 @@ impl FromNative<CreateAgentAction> for protos::pike_payload::CreateAgentAction {
 
 impl FromBytes<CreateAgentAction> for CreateAgentAction {
     fn from_bytes(bytes: &[u8]) -> Result<CreateAgentAction, ProtoConversionError> {
-        let proto: protos::pike_payload::CreateAgentAction = protobuf::parse_from_bytes(bytes)
+        let proto: protos::pike_payload::CreateAgentAction = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get CreateAgentAction from bytes".to_string(),
@@ -339,7 +339,7 @@ impl FromNative<UpdateAgentAction> for protos::pike_payload::UpdateAgentAction {
 
 impl FromBytes<UpdateAgentAction> for UpdateAgentAction {
     fn from_bytes(bytes: &[u8]) -> Result<UpdateAgentAction, ProtoConversionError> {
-        let proto: protos::pike_payload::UpdateAgentAction = protobuf::parse_from_bytes(bytes)
+        let proto: protos::pike_payload::UpdateAgentAction = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get UpdateAgentAction from bytes".to_string(),
@@ -523,7 +523,7 @@ impl FromNative<CreateOrganizationAction> for protos::pike_payload::CreateOrgani
 impl FromBytes<CreateOrganizationAction> for CreateOrganizationAction {
     fn from_bytes(bytes: &[u8]) -> Result<CreateOrganizationAction, ProtoConversionError> {
         let proto: protos::pike_payload::CreateOrganizationAction =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get CreateOrganizationAction from bytes".to_string(),
                 )
@@ -710,7 +710,7 @@ impl FromNative<UpdateOrganizationAction> for protos::pike_payload::UpdateOrgani
 impl FromBytes<UpdateOrganizationAction> for UpdateOrganizationAction {
     fn from_bytes(bytes: &[u8]) -> Result<UpdateOrganizationAction, ProtoConversionError> {
         let proto: protos::pike_payload::UpdateOrganizationAction =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get UpdateOrganizationAction from bytes".to_string(),
                 )
@@ -889,7 +889,7 @@ impl FromNative<PikePayload> for protos::pike_payload::PikePayload {
 impl FromBytes<PikePayload> for PikePayload {
     fn from_bytes(bytes: &[u8]) -> Result<PikePayload, ProtoConversionError> {
         let proto: protos::pike_payload::PikePayload =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get PikePayload from bytes".to_string(),
                 )

--- a/sdk/src/protocol/pike/state.rs
+++ b/sdk/src/protocol/pike/state.rs
@@ -64,7 +64,7 @@ impl FromNative<KeyValueEntry> for protos::pike_state::KeyValueEntry {
 impl FromBytes<KeyValueEntry> for KeyValueEntry {
     fn from_bytes(bytes: &[u8]) -> Result<KeyValueEntry, ProtoConversionError> {
         let proto: protos::pike_state::KeyValueEntry =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get KeyValueEntry from bytes".to_string(),
                 )
@@ -224,7 +224,7 @@ impl FromNative<Agent> for protos::pike_state::Agent {
 
 impl FromBytes<Agent> for Agent {
     fn from_bytes(bytes: &[u8]) -> Result<Agent, ProtoConversionError> {
-        let proto: protos::pike_state::Agent = protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: protos::pike_state::Agent = Message::parse_from_bytes(bytes).map_err(|_| {
             ProtoConversionError::SerializationError("Unable to get Agent from bytes".to_string())
         })?;
         proto.into_native()
@@ -379,7 +379,7 @@ impl FromNative<AgentList> for protos::pike_state::AgentList {
 impl FromBytes<AgentList> for AgentList {
     fn from_bytes(bytes: &[u8]) -> Result<AgentList, ProtoConversionError> {
         let proto: protos::pike_state::AgentList =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get AgentList from bytes".to_string(),
                 )
@@ -527,7 +527,7 @@ impl FromNative<Organization> for protos::pike_state::Organization {
 impl FromBytes<Organization> for Organization {
     fn from_bytes(bytes: &[u8]) -> Result<Organization, ProtoConversionError> {
         let proto: protos::pike_state::Organization =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Organization from bytes".to_string(),
                 )
@@ -682,7 +682,7 @@ impl FromNative<OrganizationList> for protos::pike_state::OrganizationList {
 
 impl FromBytes<OrganizationList> for OrganizationList {
     fn from_bytes(bytes: &[u8]) -> Result<OrganizationList, ProtoConversionError> {
-        let proto: protos::pike_state::OrganizationList = protobuf::parse_from_bytes(bytes)
+        let proto: protos::pike_state::OrganizationList = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get OrganizationList from bytes".to_string(),

--- a/sdk/src/protocol/product/payload.rs
+++ b/sdk/src/protocol/product/payload.rs
@@ -105,7 +105,7 @@ impl FromNative<ProductPayload> for protos::product_payload::ProductPayload {
 impl FromBytes<ProductPayload> for ProductPayload {
     fn from_bytes(bytes: &[u8]) -> Result<ProductPayload, ProtoConversionError> {
         let proto: product_payload::ProductPayload =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get ProductPayload from bytes".into(),
                 )
@@ -252,7 +252,7 @@ impl FromNative<ProductCreateAction> for product_payload::ProductCreateAction {
 
 impl FromBytes<ProductCreateAction> for ProductCreateAction {
     fn from_bytes(bytes: &[u8]) -> Result<ProductCreateAction, ProtoConversionError> {
-        let proto: protos::product_payload::ProductCreateAction = protobuf::parse_from_bytes(bytes)
+        let proto: protos::product_payload::ProductCreateAction = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get ProductCreateAction from bytes".to_string(),
@@ -387,7 +387,7 @@ impl FromNative<ProductUpdateAction> for protos::product_payload::ProductUpdateA
 
 impl FromBytes<ProductUpdateAction> for ProductUpdateAction {
     fn from_bytes(bytes: &[u8]) -> Result<ProductUpdateAction, ProtoConversionError> {
-        let proto: protos::product_payload::ProductUpdateAction = protobuf::parse_from_bytes(bytes)
+        let proto: protos::product_payload::ProductUpdateAction = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get ProductUpdateAction from bytes".to_string(),
@@ -506,7 +506,7 @@ impl FromNative<ProductDeleteAction> for protos::product_payload::ProductDeleteA
 
 impl FromBytes<ProductDeleteAction> for ProductDeleteAction {
     fn from_bytes(bytes: &[u8]) -> Result<ProductDeleteAction, ProtoConversionError> {
-        let proto: protos::product_payload::ProductDeleteAction = protobuf::parse_from_bytes(bytes)
+        let proto: protos::product_payload::ProductDeleteAction = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get ProductDeleteAction from bytes".to_string(),

--- a/sdk/src/protocol/product/state.rs
+++ b/sdk/src/protocol/product/state.rs
@@ -135,7 +135,7 @@ impl FromNative<Product> for protos::product_state::Product {
 impl FromBytes<Product> for Product {
     fn from_bytes(bytes: &[u8]) -> Result<Product, ProtoConversionError> {
         let proto: protos::product_state::Product =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Product from bytes".to_string(),
                 )
@@ -300,7 +300,7 @@ impl FromNative<ProductList> for protos::product_state::ProductList {
 impl FromBytes<ProductList> for ProductList {
     fn from_bytes(bytes: &[u8]) -> Result<ProductList, ProtoConversionError> {
         let proto: protos::product_state::ProductList =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get ProductList from bytes".to_string(),
                 )

--- a/sdk/src/protocol/schema/payload.rs
+++ b/sdk/src/protocol/schema/payload.rs
@@ -84,7 +84,7 @@ impl FromNative<SchemaPayload> for protos::schema_payload::SchemaPayload {
 
 impl FromBytes<SchemaPayload> for SchemaPayload {
     fn from_bytes(bytes: &[u8]) -> Result<SchemaPayload, ProtoConversionError> {
-        let proto: protos::schema_payload::SchemaPayload = protobuf::parse_from_bytes(bytes)
+        let proto: protos::schema_payload::SchemaPayload = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get SchemaPayload from bytes".to_string(),
@@ -217,12 +217,12 @@ impl FromNative<SchemaCreateAction> for protos::schema_payload::SchemaCreateActi
 
 impl FromBytes<SchemaCreateAction> for SchemaCreateAction {
     fn from_bytes(bytes: &[u8]) -> Result<SchemaCreateAction, ProtoConversionError> {
-        let proto: protos::schema_payload::SchemaCreateAction = protobuf::parse_from_bytes(bytes)
+        let proto: protos::schema_payload::SchemaCreateAction = Message::parse_from_bytes(bytes)
             .map_err(|_| {
-            ProtoConversionError::SerializationError(
-                "Unable to get SchemaCreateAction from bytes".to_string(),
-            )
-        })?;
+                ProtoConversionError::SerializationError(
+                    "Unable to get SchemaCreateAction from bytes".to_string(),
+                )
+            })?;
         proto.into_native()
     }
 }
@@ -372,12 +372,12 @@ impl FromNative<SchemaUpdateAction> for protos::schema_payload::SchemaUpdateActi
 
 impl FromBytes<SchemaUpdateAction> for SchemaUpdateAction {
     fn from_bytes(bytes: &[u8]) -> Result<SchemaUpdateAction, ProtoConversionError> {
-        let proto: protos::schema_payload::SchemaUpdateAction = protobuf::parse_from_bytes(bytes)
+        let proto: protos::schema_payload::SchemaUpdateAction = Message::parse_from_bytes(bytes)
             .map_err(|_| {
-            ProtoConversionError::SerializationError(
-                "Unable to get SchemaUpdateAction from bytes".to_string(),
-            )
-        })?;
+                ProtoConversionError::SerializationError(
+                    "Unable to get SchemaUpdateAction from bytes".to_string(),
+                )
+            })?;
         proto.into_native()
     }
 }

--- a/sdk/src/protocol/schema/state.rs
+++ b/sdk/src/protocol/schema/state.rs
@@ -257,7 +257,7 @@ impl FromNative<PropertyDefinition> for protos::schema_state::PropertyDefinition
 
 impl FromBytes<PropertyDefinition> for PropertyDefinition {
     fn from_bytes(bytes: &[u8]) -> Result<PropertyDefinition, ProtoConversionError> {
-        let proto: protos::schema_state::PropertyDefinition = protobuf::parse_from_bytes(bytes)
+        let proto: protos::schema_state::PropertyDefinition = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get PropertyDefinition from bytes".to_string(),
@@ -496,7 +496,7 @@ impl FromNative<Schema> for protos::schema_state::Schema {
 impl FromBytes<Schema> for Schema {
     fn from_bytes(bytes: &[u8]) -> Result<Schema, ProtoConversionError> {
         let proto: protos::schema_state::Schema =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Schema from bytes".to_string(),
                 )
@@ -655,7 +655,7 @@ impl FromNative<SchemaList> for protos::schema_state::SchemaList {
 impl FromBytes<SchemaList> for SchemaList {
     fn from_bytes(bytes: &[u8]) -> Result<SchemaList, ProtoConversionError> {
         let proto: protos::schema_state::SchemaList =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get SchemaList from bytes".to_string(),
                 )
@@ -839,8 +839,8 @@ impl FromNative<PropertyValue> for protos::schema_state::PropertyValue {
 
 impl FromBytes<PropertyValue> for PropertyValue {
     fn from_bytes(bytes: &[u8]) -> Result<PropertyValue, ProtoConversionError> {
-        let proto: protos::schema_state::PropertyValue = protobuf::parse_from_bytes(bytes)
-            .map_err(|_| {
+        let proto: protos::schema_state::PropertyValue =
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get PropertyValue from bytes".to_string(),
                 )

--- a/sdk/src/protocol/track_and_trace/payload.rs
+++ b/sdk/src/protocol/track_and_trace/payload.rs
@@ -125,12 +125,12 @@ impl FromNative<CreateRecordAction> for track_and_trace_payload::CreateRecordAct
 
 impl FromBytes<CreateRecordAction> for CreateRecordAction {
     fn from_bytes(bytes: &[u8]) -> Result<CreateRecordAction, ProtoConversionError> {
-        let proto: track_and_trace_payload::CreateRecordAction = protobuf::parse_from_bytes(bytes)
+        let proto: track_and_trace_payload::CreateRecordAction = Message::parse_from_bytes(bytes)
             .map_err(|_| {
-                ProtoConversionError::SerializationError(
-                    "Unable to get CreateRecordAction from bytes".into(),
-                )
-            })?;
+            ProtoConversionError::SerializationError(
+                "Unable to get CreateRecordAction from bytes".into(),
+            )
+        })?;
         proto.into_native()
     }
 }
@@ -200,8 +200,8 @@ impl FromNative<FinalizeRecordAction> for track_and_trace_payload::FinalizeRecor
 
 impl FromBytes<FinalizeRecordAction> for FinalizeRecordAction {
     fn from_bytes(bytes: &[u8]) -> Result<FinalizeRecordAction, ProtoConversionError> {
-        let proto: track_and_trace_payload::FinalizeRecordAction =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: track_and_trace_payload::FinalizeRecordAction = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get CreateFinalizeAction from bytes".into(),
                 )
@@ -306,7 +306,7 @@ impl FromNative<UpdatePropertiesAction> for track_and_trace_payload::UpdatePrope
 impl FromBytes<UpdatePropertiesAction> for UpdatePropertiesAction {
     fn from_bytes(bytes: &[u8]) -> Result<UpdatePropertiesAction, ProtoConversionError> {
         let proto: track_and_trace_payload::UpdatePropertiesAction =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get UpdatePropertiesAction from bytes".into(),
                 )
@@ -447,8 +447,8 @@ impl FromNative<CreateProposalAction> for track_and_trace_payload::CreateProposa
 
 impl FromBytes<CreateProposalAction> for CreateProposalAction {
     fn from_bytes(bytes: &[u8]) -> Result<CreateProposalAction, ProtoConversionError> {
-        let proto: track_and_trace_payload::CreateProposalAction =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: track_and_trace_payload::CreateProposalAction = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get CreateProposalAction from bytes".into(),
                 )
@@ -608,8 +608,8 @@ impl FromNative<AnswerProposalAction> for track_and_trace_payload::AnswerProposa
 
 impl FromBytes<AnswerProposalAction> for AnswerProposalAction {
     fn from_bytes(bytes: &[u8]) -> Result<AnswerProposalAction, ProtoConversionError> {
-        let proto: track_and_trace_payload::AnswerProposalAction =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: track_and_trace_payload::AnswerProposalAction = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get AnswerProposalAction from bytes".into(),
                 )
@@ -721,8 +721,8 @@ impl FromNative<RevokeReporterAction> for track_and_trace_payload::RevokeReporte
 
 impl FromBytes<RevokeReporterAction> for RevokeReporterAction {
     fn from_bytes(bytes: &[u8]) -> Result<RevokeReporterAction, ProtoConversionError> {
-        let proto: track_and_trace_payload::RevokeReporterAction =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: track_and_trace_payload::RevokeReporterAction = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get RevokeReporterAction from bytes".into(),
                 )
@@ -874,8 +874,8 @@ impl FromNative<TrackAndTracePayload> for track_and_trace_payload::TrackAndTrace
 
 impl FromBytes<TrackAndTracePayload> for TrackAndTracePayload {
     fn from_bytes(bytes: &[u8]) -> Result<TrackAndTracePayload, ProtoConversionError> {
-        let proto: track_and_trace_payload::TrackAndTracePayload =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: track_and_trace_payload::TrackAndTracePayload = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get TrackAndTracePaylaod from bytes".into(),
                 )

--- a/sdk/src/protocol/track_and_trace/state.rs
+++ b/sdk/src/protocol/track_and_trace/state.rs
@@ -112,7 +112,7 @@ impl FromNative<Reporter> for track_and_trace_state::Property_Reporter {
 
 impl FromBytes<Reporter> for Reporter {
     fn from_bytes(bytes: &[u8]) -> Result<Reporter, ProtoConversionError> {
-        let proto: track_and_trace_state::Property_Reporter = protobuf::parse_from_bytes(bytes)
+        let proto: track_and_trace_state::Property_Reporter = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError("Unable to get Reporter from bytes".into())
             })?;
@@ -282,7 +282,7 @@ impl FromNative<Property> for track_and_trace_state::Property {
 impl FromBytes<Property> for Property {
     fn from_bytes(bytes: &[u8]) -> Result<Property, ProtoConversionError> {
         let proto: track_and_trace_state::Property =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError("Unable to get Property from bytes".into())
             })?;
         proto.into_native()
@@ -369,8 +369,8 @@ impl FromNative<PropertyList> for track_and_trace_state::PropertyList {
 
 impl FromBytes<PropertyList> for PropertyList {
     fn from_bytes(bytes: &[u8]) -> Result<PropertyList, ProtoConversionError> {
-        let proto: track_and_trace_state::PropertyList = protobuf::parse_from_bytes(bytes)
-            .map_err(|_| {
+        let proto: track_and_trace_state::PropertyList =
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get PropertyList from Bytes".into(),
                 )
@@ -482,7 +482,7 @@ impl FromNative<ReportedValue> for track_and_trace_state::PropertyPage_ReportedV
 impl FromBytes<ReportedValue> for ReportedValue {
     fn from_bytes(bytes: &[u8]) -> Result<ReportedValue, ProtoConversionError> {
         let proto: track_and_trace_state::PropertyPage_ReportedValue =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get ReportedValue from bytes".into(),
                 )
@@ -611,8 +611,8 @@ impl FromNative<PropertyPage> for track_and_trace_state::PropertyPage {
 
 impl FromBytes<PropertyPage> for PropertyPage {
     fn from_bytes(bytes: &[u8]) -> Result<PropertyPage, ProtoConversionError> {
-        let proto: track_and_trace_state::PropertyPage = protobuf::parse_from_bytes(bytes)
-            .map_err(|_| {
+        let proto: track_and_trace_state::PropertyPage =
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Undable to get PropertyPage from bytes".into(),
                 )
@@ -704,7 +704,7 @@ impl FromNative<PropertyPageList> for track_and_trace_state::PropertyPageList {
 
 impl FromBytes<PropertyPageList> for PropertyPageList {
     fn from_bytes(bytes: &[u8]) -> Result<PropertyPageList, ProtoConversionError> {
-        let proto: track_and_trace_state::PropertyPageList = protobuf::parse_from_bytes(bytes)
+        let proto: track_and_trace_state::PropertyPageList = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get PropertyPageList from Bytes".into(),
@@ -982,7 +982,7 @@ impl FromNative<Proposal> for track_and_trace_state::Proposal {
 impl FromBytes<Proposal> for Proposal {
     fn from_bytes(bytes: &[u8]) -> Result<Proposal, ProtoConversionError> {
         let proto: track_and_trace_state::Proposal =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError("Unable to get Proposal from bytes".into())
             })?;
         proto.into_native()
@@ -1070,8 +1070,8 @@ impl FromNative<ProposalList> for track_and_trace_state::ProposalList {
 
 impl FromBytes<ProposalList> for ProposalList {
     fn from_bytes(bytes: &[u8]) -> Result<ProposalList, ProtoConversionError> {
-        let proto: track_and_trace_state::ProposalList = protobuf::parse_from_bytes(bytes)
-            .map_err(|_| {
+        let proto: track_and_trace_state::ProposalList =
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get ProposalList from bytes".into(),
                 )
@@ -1170,8 +1170,8 @@ impl FromNative<AssociatedAgent> for track_and_trace_state::Record_AssociatedAge
 
 impl FromBytes<AssociatedAgent> for AssociatedAgent {
     fn from_bytes(bytes: &[u8]) -> Result<AssociatedAgent, ProtoConversionError> {
-        let proto: track_and_trace_state::Record_AssociatedAgent =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: track_and_trace_state::Record_AssociatedAgent = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get AssociatedAgent from bytes".into(),
                 )
@@ -1349,7 +1349,7 @@ impl FromNative<Record> for track_and_trace_state::Record {
 impl FromBytes<Record> for Record {
     fn from_bytes(bytes: &[u8]) -> Result<Record, ProtoConversionError> {
         let proto: track_and_trace_state::Record =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError("Unable to get Record from bytes".into())
             })?;
         proto.into_native()
@@ -1435,7 +1435,7 @@ impl FromNative<RecordList> for track_and_trace_state::RecordList {
 impl FromBytes<RecordList> for RecordList {
     fn from_bytes(bytes: &[u8]) -> Result<RecordList, ProtoConversionError> {
         let proto: track_and_trace_state::RecordList =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError("Unable to get Record from bytes".into())
             })?;
         proto.into_native()


### PR DESCRIPTION
protobuf::parse_from_bytes has been deprecated.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>