### PR TITLE
Add Roles to Pike TP and Grid SDK

### DIFF
--- a/contracts/pike/Cargo.toml
+++ b/contracts/pike/Cargo.toml
@@ -25,10 +25,10 @@ grid-sdk = {path = "../../sdk"}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rust-crypto-wasm = "0.3"
-sabre-sdk = "0.4"
+sabre-sdk = "0.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-sawtooth-sdk = "0.3"
+sawtooth-sdk = "0.4"
 log = "0.4"
 flexi_logger = "0.14"
 clap = "2"

--- a/contracts/pike/src/addresser.rs
+++ b/contracts/pike/src/addresser.rs
@@ -15,23 +15,29 @@
 /// Represents part of address that designates resource type
 #[derive(Debug)]
 pub enum Resource {
-    AGENT,
-    ORG,
+    Agent,
+    Org,
+    Role,
+    AlternateIDIndexEntry,
 }
 
 /// Convert resource part to byte value in hex
 pub fn resource_to_byte(part: Resource) -> String {
     match part {
-        Resource::AGENT => String::from("00"),
-        Resource::ORG => String::from("01"),
+        Resource::Agent => String::from("00"),
+        Resource::Org => String::from("01"),
+        Resource::Role => String::from("02"),
+        Resource::AlternateIDIndexEntry => String::from("03"),
     }
 }
 
 /// Convert byte string to Resource
 pub fn byte_to_resource(bytes: &str) -> Result<Resource, ResourceError> {
     match bytes {
-        "00" => Ok(Resource::AGENT),
-        "01" => Ok(Resource::ORG),
+        "00" => Ok(Resource::Agent),
+        "01" => Ok(Resource::Org),
+        "02" => Ok(Resource::Role),
+        "03" => Ok(Resource::AlternateIDIndexEntry),
         _ => Err(ResourceError::UnknownResource(format!(
             "No resource found matching byte pattern {}",
             bytes

--- a/contracts/pike/src/handler.rs
+++ b/contracts/pike/src/handler.rs
@@ -44,7 +44,7 @@ pub struct PikeTransactionHandler {
     namespaces: Vec<String>,
 }
 
-const NAMESPACE: &str = "cad11d";
+const NAMESPACE: &str = "621dee05";
 
 fn compute_address(name: &str, resource: Resource) -> String {
     let mut sha = Sha512::new();
@@ -63,7 +63,7 @@ impl<'a> PikeState<'a> {
     }
 
     pub fn get_agent(&mut self, public_key: &str) -> Result<Option<Agent>, ApplyError> {
-        let address = compute_address(public_key, Resource::AGENT);
+        let address = compute_address(public_key, Resource::Agent);
         let d = self.context.get_state_entry(&address)?;
         match d {
             Some(packed) => {
@@ -90,7 +90,7 @@ impl<'a> PikeState<'a> {
     }
 
     pub fn set_agent(&mut self, public_key: &str, new_agent: Agent) -> Result<(), ApplyError> {
-        let address = compute_address(public_key, Resource::AGENT);
+        let address = compute_address(public_key, Resource::Agent);
         let d = self.context.get_state_entry(&address)?;
         let mut agent_list = match d {
             Some(packed) => match protobuf::Message::parse_from_bytes(packed.as_slice()) {
@@ -134,7 +134,7 @@ impl<'a> PikeState<'a> {
     }
 
     pub fn get_organization(&mut self, id: &str) -> Result<Option<Organization>, ApplyError> {
-        let address = compute_address(id, Resource::ORG);
+        let address = compute_address(id, Resource::Org);
         let d = self.context.get_state_entry(&address)?;
         match d {
             Some(packed) => {
@@ -165,7 +165,7 @@ impl<'a> PikeState<'a> {
         id: &str,
         new_organization: Organization,
     ) -> Result<(), ApplyError> {
-        let address = compute_address(id, Resource::ORG);
+        let address = compute_address(id, Resource::Org);
         let d = self.context.get_state_entry(&address)?;
         let mut organization_list = match d {
             Some(packed) => match protobuf::Message::parse_from_bytes(packed.as_slice()) {

--- a/contracts/pike/src/main.rs
+++ b/contracts/pike/src/main.rs
@@ -41,6 +41,7 @@ cfg_if! {
 
 pub mod addresser;
 pub mod handler;
+pub mod permissions;
 
 //use sawtooth_sdk::processor::TransactionProcessor;
 //use handler::PikeTransactionHandler;

--- a/contracts/pike/src/permissions.rs
+++ b/contracts/pike/src/permissions.rs
@@ -1,0 +1,35 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub enum Permission {
+    CanCreateAgents,
+    CanUpdateAgents,
+    CanDeleteAgents,
+    CanUpdateOrganization,
+    CanCreateRoles,
+    CanUpdateRoles,
+    CanDeleteRoles,
+}
+
+pub fn permission_to_perm_string(permission: Permission) -> String {
+    match permission {
+        Permission::CanCreateAgents => String::from("pike::can-create-agents"),
+        Permission::CanUpdateAgents => String::from("pike::can-update-agents"),
+        Permission::CanDeleteAgents => String::from("pike::can-delete-agents"),
+        Permission::CanUpdateOrganization => String::from("pike::can-update-organization"),
+        Permission::CanCreateRoles => String::from("pike::can-create-roles"),
+        Permission::CanUpdateRoles => String::from("pike::can-update-roles"),
+        Permission::CanDeleteRoles => String::from("pike::can-delete-roles"),
+    }
+}

--- a/sdk/protos/pike_payload.proto
+++ b/sdk/protos/pike_payload.proto
@@ -22,18 +22,30 @@ message PikePayload {
 
     CREATE_AGENT = 1;
     UPDATE_AGENT = 2;
+    DELETE_AGENT = 8;
 
     CREATE_ORGANIZATION = 3;
     UPDATE_ORGANIZATION = 4;
+    DELETE_ORGANIZATION = 9;
+
+    CREATE_ROLE = 5;
+    UPDATE_ROLE = 6;
+    DELETE_ROLE = 7;
   }
 
   Action action = 1;
 
   CreateAgentAction create_agent = 2;
   UpdateAgentAction update_agent = 3;
+  DeleteAgentAction delete_agent = 4;
 
-  CreateOrganizationAction create_organization = 4;
-  UpdateOrganizationAction update_organization = 5;
+  CreateOrganizationAction create_organization = 5;
+  UpdateOrganizationAction update_organization = 6;
+  DeleteOrganizationAction delete_organization = 7;
+
+  CreateRoleAction create_role = 8;
+  UpdateRoleAction update_role = 9;
+  DeleteRoleAction delete_role = 10;
 }
 
 message CreateAgentAction {
@@ -52,16 +64,52 @@ message UpdateAgentAction {
   repeated KeyValueEntry metadata = 5;
 }
 
+message DeleteAgentAction {
+  string org_id = 1;
+  string public_key = 2;
+}
+
 message CreateOrganizationAction {
   string id = 1;
   string name = 2;
-  string address = 3;
-  repeated KeyValueEntry metadata = 4;
+  repeated string locations = 3;
+  repeated AlternateID alternate_ids = 4;
+  repeated KeyValueEntry metadata = 5;
 }
 
 message UpdateOrganizationAction {
   string id = 1;
   string name = 2;
-  string address = 3;
-  repeated KeyValueEntry metadata = 4;
+  repeated string locations = 3;
+  repeated AlternateID alternate_ids = 4;
+  repeated KeyValueEntry metadata = 5;
+}
+
+message DeleteOrganizationAction {
+  string id = 1;
+}
+
+message CreateRoleAction {
+  string org_id = 1;
+  string name = 2;
+  string description = 3;
+  repeated string permissions = 4;
+  repeated string allowed_organizations = 5;
+  repeated string inherit_from = 6;
+  bool active = 7;
+}
+
+message UpdateRoleAction {
+  string org_id = 1;
+  string name = 2;
+  string description = 3;
+  repeated string permissions = 4;
+  repeated string allowed_organizations = 5;
+  repeated string inherit_from = 6;
+  bool active = 7;
+}
+
+message DeleteRoleAction {
+  string org_id = 1;
+  string name = 2;
 }

--- a/sdk/protos/pike_state.proto
+++ b/sdk/protos/pike_state.proto
@@ -27,18 +27,43 @@ message AgentList {
   repeated Agent agents = 1;
 }
 
+message Organization {
+  string org_id = 1;
+  string name = 2;
+  repeated string locations = 3;
+  repeated AlternateID alternate_id = 4;
+  repeated KeyValueEntry metadata = 5;
+}
+
+message OrganizationList {
+  repeated Organization organizations = 1;
+}
+
+message Role {
+  string org_id = 1;
+  string name = 2;
+  string description = 3;
+  repeated string permissions = 4;
+  repeated string allowed_organizations = 5;
+  repeated string inherit_from= 6;
+}
+
+message RoleList {
+  repeated Role roles = 1;
+}
+
+message AlternateIDIndexEntry {
+  string id_type = 1;
+  string id = 2;
+  string grid_identity_id = 3;
+}
+
 message KeyValueEntry {
   string key = 1;
   string value = 2;
 }
 
-message Organization {
-  string org_id = 1;
-  string name = 2;
-  string address = 3;
-  repeated KeyValueEntry metadata = 4;
-}
-
-message OrganizationList {
-  repeated Organization organizations = 1;
+message AlternateID {
+  string type = 1;
+  string id = 2;
 }

--- a/sdk/src/permissions.rs
+++ b/sdk/src/permissions.rs
@@ -27,16 +27,23 @@ cfg_if! {
     }
 }
 
-use crate::protocol::pike::state::{Agent, AgentList};
+use crate::protocol::pike::state::{Agent, AgentList, Role, RoleList};
 use crate::protos::{FromBytes, ProtoConversionError};
 
-const PIKE_NAMESPACE: &str = "cad11d";
+const PIKE_NAMESPACE: &str = "621dee05";
 const PIKE_AGENT_RESOURCE: &str = "00";
+const PIKE_ROLE_RESOURCE: &str = "02";
 
 fn compute_agent_address(public_key: &str) -> String {
     let mut sha = Sha512::new();
     sha.input(public_key.as_bytes());
-    String::from(PIKE_NAMESPACE) + PIKE_AGENT_RESOURCE + &sha.result_str()[..62].to_string()
+    String::from(PIKE_NAMESPACE) + PIKE_AGENT_RESOURCE + &sha.result_str()[..60].to_string()
+}
+
+fn compute_role_address(public_key: &str) -> String {
+    let mut sha = Sha512::new();
+    sha.input(public_key.as_bytes());
+    String::from(PIKE_NAMESPACE) + PIKE_ROLE_RESOURCE + &sha.result_str()[..60].to_string()
 }
 
 #[derive(Debug)]
@@ -45,6 +52,8 @@ pub enum PermissionCheckerError {
     Context(ContextError),
     /// Returned for an invalid agent public key.
     InvalidPublicKey(String),
+    /// Returned for an invalid role.
+    InvalidRole(String),
     /// Returned for an error in the protobuf data.
     ProtoConversion(ProtoConversionError),
 }
@@ -56,6 +65,9 @@ impl fmt::Display for PermissionCheckerError {
             PermissionCheckerError::InvalidPublicKey(ref msg) => {
                 write!(f, "InvalidPublicKey: {}", msg)
             }
+            PermissionCheckerError::InvalidRole(ref msg) => {
+                write!(f, "InvalidRole: {}", msg)
+            }
             PermissionCheckerError::ProtoConversion(ref e) => e.fmt(f),
         }
     }
@@ -66,6 +78,7 @@ impl Error for PermissionCheckerError {
         match *self {
             PermissionCheckerError::Context(_) => None,
             PermissionCheckerError::InvalidPublicKey(_) => None,
+            PermissionCheckerError::InvalidRole(_) => None,
             PermissionCheckerError::ProtoConversion(ref e) => Some(e),
         }
     }
@@ -101,26 +114,87 @@ impl<'a> PermissionChecker<'a> {
         PermissionChecker { context }
     }
 
-    /// Checks whether an agent with a given public key has a certain role.
+    /// Checks whether an agent with a given public key has a certain permission.
     ///
     /// # Arguments
     ///
     /// * `public_key` - Public key of a Pike agent.
     /// * `permission` - Permission string to be checked.
+    /// * `resource_owner` - The Pike org ID of the resource to check permissions for.
     ///
     pub fn has_permission(
         &self,
         public_key: &str,
         permission: &str,
+        resource_owner: &str,
     ) -> Result<bool, PermissionCheckerError> {
         let agent = self.get_agent(public_key)?;
         match agent {
-            Some(agent) => Ok(agent.roles().iter().any(|r| r == permission)),
+            Some(agent) => {
+                let agent_org_id = agent.org_id();
+                let agent_roles: Vec<Role> = agent
+                    .roles()
+                    .iter()
+                    .filter_map(|r| self.get_role(r).ok())
+                    .filter_map(|r| r)
+                    .collect();
+                Ok(self.check_roles_for_permission(
+                    &permission,
+                    &agent_roles,
+                    &resource_owner,
+                    &agent_org_id,
+                ))
+            }
             None => Err(PermissionCheckerError::InvalidPublicKey(format!(
                 "The signer is not an Agent: {}",
                 public_key
             ))),
         }
+    }
+
+    fn check_roles_for_permission(
+        &self,
+        permission: &str,
+        roles: &Vec<Role>,
+        resource_owner: &str,
+        agent_org_id: &str,
+    ) -> bool {
+        roles.iter().any(|r| {
+            if r.permissions().iter().any(|p| p == permission) {
+                if resource_owner == r.org_id() {
+                    if agent_org_id == r.org_id() {
+                        return true;
+                    } else if r
+                        .allowed_organizations()
+                        .iter()
+                        .any(|org| org == agent_org_id)
+                    {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                // return true;
+                } else {
+                    if r.inherit_from().is_empty() {
+                        return false;
+                    }
+                    let inheriting_roles = r
+                        .inherit_from()
+                        .iter()
+                        .filter_map(|r| self.get_role(r).ok())
+                        .filter_map(|r| r)
+                        .collect();
+                    self.check_roles_for_permission(
+                        &permission,
+                        &inheriting_roles,
+                        &resource_owner,
+                        &agent_org_id,
+                    )
+                }
+            } else {
+                false
+            }
+        })
     }
 
     fn get_agent(&self, public_key: &str) -> Result<Option<Agent>, PermissionCheckerError> {
@@ -139,6 +213,23 @@ impl<'a> PermissionChecker<'a> {
             None => Ok(None),
         }
     }
+
+    fn get_role(&self, name: &str) -> Result<Option<Role>, PermissionCheckerError> {
+        let address = compute_role_address(name);
+        let d = self.context.get_state_entry(&address)?;
+        match d {
+            Some(packed) => {
+                let role_list = RoleList::from_bytes(packed.as_slice())?;
+                for role in role_list.roles() {
+                    if role.name() == name {
+                        return Ok(Some(role.clone()));
+                    }
+                }
+                Ok(None)
+            }
+            None => Ok(None),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -148,14 +239,32 @@ mod tests {
     use std::cell::RefCell;
     use std::collections::HashMap;
 
-    use crate::protocol::pike::state::{AgentBuilder, AgentListBuilder};
+    use crate::protocol::pike::state::{
+        AgentBuilder, AgentListBuilder, RoleBuilder, RoleListBuilder,
+    };
     use crate::protos::IntoBytes;
 
-    const ROLE_A: &str = "Role A";
-    const ROLE_B: &str = "Role B";
+    const PUBLIC_KEY_ALPHA: &str = "alpha_agent_public_key";
+    const PUBLIC_KEY_BETA: &str = "beta_agent_public_key";
+    const PUBLIC_KEY_GAMMA_1: &str = "gamma_agent_public_key_1";
+    const PUBLIC_KEY_GAMMA_2: &str = "gamma_agent_public_key_2";
 
-    const PUBLIC_KEY: &str = "test_public_key";
-    const ORG_ID: &str = "test_org";
+    const ORG_ID_ALPHA: &str = "alpha";
+    const ORG_ID_BETA: &str = "beta";
+    const ORG_ID_GAMMA: &str = "gamma";
+    const ORG_ID_DELTA: &str = "delta";
+
+    const PERM_CAN_DRIVE: &str = "tankops::can-drive";
+    const PERM_CAN_TURN_TURRET: &str = "tankops::can-turn-turret";
+    const PERM_CAN_FIRE: &str = "tankops::can-fire";
+    const PERM_CAN_DECOMMISSION: &str = "tankops::can-decommission";
+
+    const ROLE_ALPHA_INSPECTOR: &str = "alpha.Inspector";
+    const ROLE_ALPHA_DRIVER: &str = "alpha.Driver";
+    const ROLE_BETA_DRIVER: &str = "beta.Driver";
+    const ROLE_GAMMA_NAVIGATOR: &str = "gamma.Navigator";
+    const ROLE_GAMMA_BLASTER: &str = "gamma.Blaster";
+    const ROLE_DELTA_TANK_OPERATOR: &str = "delta.TankOperator";
 
     #[derive(Default)]
     /// A MockTransactionContext that can be used to test PermissionChecker
@@ -207,122 +316,564 @@ mod tests {
         }
     }
 
+    fn agent_to_bytes(agent: Agent) -> Vec<u8> {
+        let builder = AgentListBuilder::new();
+        let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
+        return agent_list.into_bytes().unwrap();
+    }
+
+    fn role_to_bytes(role: Role) -> Vec<u8> {
+        let builder = RoleListBuilder::new();
+        let role_list = builder.with_roles(vec![role.clone()]).build().unwrap();
+        return role_list.into_bytes().unwrap();
+    }
+
+    /// These tests are based on the example in the Grid Identity RFC.
+
+    /// has_permission() returns false if the agent doesn't have any roles.
     #[test]
-    // Test that if an agent has no roles and Role A is checked, false is returned
-    fn test_has_permission_a_has_none() {
+    fn test_alpha_can_decommission_no_roles() {
         let context = MockTransactionContext::default();
         let pc = PermissionChecker::new(&context);
 
-        let builder = AgentBuilder::new();
-        let agent = builder
-            .with_org_id(ORG_ID.to_string())
-            .with_public_key(PUBLIC_KEY.to_string())
+        let agent_builder = AgentBuilder::new();
+        let agent = agent_builder
+            .with_org_id(ORG_ID_ALPHA.to_string())
+            .with_public_key(PUBLIC_KEY_ALPHA.to_string())
             .with_active(true)
             .build()
             .unwrap();
-        let builder = AgentListBuilder::new();
-        let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
-        let agent_bytes = agent_list.into_bytes().unwrap();
-        let agent_address = compute_agent_address(PUBLIC_KEY);
-        context.set_state_entry(agent_address, agent_bytes).unwrap();
 
-        let result = pc.has_permission(PUBLIC_KEY, ROLE_A).unwrap();
+        let agent_address = compute_agent_address(PUBLIC_KEY_ALPHA);
+        context
+            .set_state_entry(agent_address, agent_to_bytes(agent))
+            .unwrap();
+
+        let result = pc
+            .has_permission(PUBLIC_KEY_ALPHA, PERM_CAN_DECOMMISSION, ORG_ID_ALPHA)
+            .unwrap();
         assert!(!result);
     }
 
+    /// has_permission() returns false if the agent doesn't have any roles with
+    /// the given permission.
     #[test]
-    // Test that if an agent has Role A and Role A is checked, true is returned
-    fn test_has_permission_a_has_a() {
+    fn test_alpha_can_decommission_wrong_role() {
         let context = MockTransactionContext::default();
         let pc = PermissionChecker::new(&context);
 
-        let builder = AgentBuilder::new();
-        let agent = builder
-            .with_org_id(ORG_ID.to_string())
-            .with_public_key(PUBLIC_KEY.to_string())
-            .with_active(true)
-            .with_roles(vec![ROLE_A.to_string()])
+        let role_builder = RoleBuilder::new();
+        let role = role_builder
+            .with_org_id(ORG_ID_ALPHA.to_string())
+            .with_name(ROLE_ALPHA_INSPECTOR.to_string())
             .build()
             .unwrap();
-        let builder = AgentListBuilder::new();
-        let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
-        let agent_bytes = agent_list.into_bytes().unwrap();
-        let agent_address = compute_agent_address(PUBLIC_KEY);
-        context.set_state_entry(agent_address, agent_bytes).unwrap();
 
-        let result = pc.has_permission(PUBLIC_KEY, ROLE_A).unwrap();
-        assert!(result);
-    }
+        let role_address = compute_role_address(ROLE_ALPHA_INSPECTOR);
+        context
+            .set_state_entry(role_address, role_to_bytes(role))
+            .unwrap();
 
-    #[test]
-    // Test that if an agent has Role A and Role B is checked, false is returned
-    fn test_has_permission_b_has_a() {
-        let context = MockTransactionContext::default();
-        let pc = PermissionChecker::new(&context);
-
-        let builder = AgentBuilder::new();
-        let agent = builder
-            .with_org_id(ORG_ID.to_string())
-            .with_public_key(PUBLIC_KEY.to_string())
+        let agent_builder = AgentBuilder::new();
+        let agent = agent_builder
+            .with_org_id(ORG_ID_ALPHA.to_string())
+            .with_public_key(PUBLIC_KEY_ALPHA.to_string())
             .with_active(true)
-            .with_roles(vec![ROLE_A.to_string()])
+            .with_roles(vec![ROLE_ALPHA_INSPECTOR.to_string()])
             .build()
             .unwrap();
-        let builder = AgentListBuilder::new();
-        let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
-        let agent_bytes = agent_list.into_bytes().unwrap();
-        let agent_address = compute_agent_address(PUBLIC_KEY);
-        context.set_state_entry(agent_address, agent_bytes).unwrap();
 
-        let result = pc.has_permission(PUBLIC_KEY, ROLE_B).unwrap();
+        let agent_address = compute_agent_address(PUBLIC_KEY_ALPHA);
+        context
+            .set_state_entry(agent_address, agent_to_bytes(agent))
+            .unwrap();
+
+        let result = pc
+            .has_permission(PUBLIC_KEY_ALPHA, PERM_CAN_DECOMMISSION, ORG_ID_ALPHA)
+            .unwrap();
         assert!(!result);
     }
 
+    /// has_permission() returns true if the agent has a role with the given
+    /// permission.
     #[test]
-    // Test that if an agent has Roles A and B and Role A is checked, true is returned
-    fn test_has_permission_a_has_ab() {
+    fn test_alpha_can_decommission() {
         let context = MockTransactionContext::default();
         let pc = PermissionChecker::new(&context);
 
-        let builder = AgentBuilder::new();
-        let agent = builder
-            .with_org_id(ORG_ID.to_string())
-            .with_public_key(PUBLIC_KEY.to_string())
-            .with_active(true)
-            .with_roles(vec![ROLE_A.to_string(), ROLE_B.to_string()])
+        let role_builder = RoleBuilder::new();
+        let role = role_builder
+            .with_org_id(ORG_ID_ALPHA.to_string())
+            .with_name(ROLE_ALPHA_INSPECTOR.to_string())
+            .with_permissions(vec![PERM_CAN_DECOMMISSION.to_string()])
             .build()
             .unwrap();
-        let builder = AgentListBuilder::new();
-        let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
-        let agent_bytes = agent_list.into_bytes().unwrap();
-        let agent_address = compute_agent_address(PUBLIC_KEY);
-        context.set_state_entry(agent_address, agent_bytes).unwrap();
 
-        let result = pc.has_permission(PUBLIC_KEY, ROLE_A).unwrap();
+        let role_address = compute_role_address(ROLE_ALPHA_INSPECTOR);
+        context
+            .set_state_entry(role_address, role_to_bytes(role))
+            .unwrap();
+
+        let agent_builder = AgentBuilder::new();
+        let agent = agent_builder
+            .with_org_id(ORG_ID_ALPHA.to_string())
+            .with_public_key(PUBLIC_KEY_ALPHA.to_string())
+            .with_active(true)
+            .with_roles(vec![ROLE_ALPHA_INSPECTOR.to_string()])
+            .build()
+            .unwrap();
+
+        let agent_address = compute_agent_address(PUBLIC_KEY_ALPHA);
+        context
+            .set_state_entry(agent_address, agent_to_bytes(agent))
+            .unwrap();
+
+        let result = pc
+            .has_permission(PUBLIC_KEY_ALPHA, PERM_CAN_DECOMMISSION, ORG_ID_ALPHA)
+            .unwrap();
         assert!(result);
     }
 
+    /// has_permission() returns true if the agent has a role with multiple
+    /// given permissions.
     #[test]
-    // Test that if an agent has Roles A and B and Role B is checked, true is returned
-    fn test_has_permission_b_has_ab() {
+    fn test_alpha_multiple_perms() {
         let context = MockTransactionContext::default();
         let pc = PermissionChecker::new(&context);
 
-        let builder = AgentBuilder::new();
-        let agent = builder
-            .with_org_id(ORG_ID.to_string())
-            .with_public_key(PUBLIC_KEY.to_string())
-            .with_active(true)
-            .with_roles(vec![ROLE_A.to_string(), ROLE_B.to_string()])
+        let role_builder = RoleBuilder::new();
+        let role = role_builder
+            .with_org_id(ORG_ID_ALPHA.to_string())
+            .with_name(ROLE_ALPHA_DRIVER.to_string())
+            .with_permissions(vec![
+                PERM_CAN_DRIVE.to_string(),
+                PERM_CAN_FIRE.to_string(),
+                PERM_CAN_TURN_TURRET.to_string(),
+            ])
             .build()
             .unwrap();
-        let builder = AgentListBuilder::new();
-        let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
-        let agent_bytes = agent_list.into_bytes().unwrap();
-        let agent_address = compute_agent_address(PUBLIC_KEY);
-        context.set_state_entry(agent_address, agent_bytes).unwrap();
 
-        let result = pc.has_permission(PUBLIC_KEY, ROLE_B).unwrap();
-        assert!(result);
+        let role_address = compute_role_address(ROLE_ALPHA_DRIVER);
+        context
+            .set_state_entry(role_address, role_to_bytes(role))
+            .unwrap();
+
+        let agent_builder = AgentBuilder::new();
+        let agent = agent_builder
+            .with_org_id(ORG_ID_ALPHA.to_string())
+            .with_public_key(PUBLIC_KEY_ALPHA.to_string())
+            .with_active(true)
+            .with_roles(vec![ROLE_ALPHA_DRIVER.to_string()])
+            .build()
+            .unwrap();
+
+        let agent_address = compute_agent_address(PUBLIC_KEY_ALPHA);
+        context
+            .set_state_entry(agent_address, agent_to_bytes(agent))
+            .unwrap();
+
+        let result_drive = pc
+            .has_permission(PUBLIC_KEY_ALPHA, PERM_CAN_DRIVE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(result_drive);
+
+        let result_fire = pc
+            .has_permission(PUBLIC_KEY_ALPHA, PERM_CAN_FIRE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(result_fire);
+
+        let result_turn = pc
+            .has_permission(PUBLIC_KEY_ALPHA, PERM_CAN_TURN_TURRET, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(result_turn);
+    }
+
+    /// has_permission() returns true if the agent has a role with multiple
+    /// given permissions from an inherited role.
+    #[test]
+    fn test_beta_multiple_perms() {
+        let context = MockTransactionContext::default();
+        let pc = PermissionChecker::new(&context);
+
+        let alpha_role_builder = RoleBuilder::new();
+        let alpha_role = alpha_role_builder
+            .with_org_id(ORG_ID_ALPHA.to_string())
+            .with_name(ROLE_ALPHA_DRIVER.to_string())
+            .with_permissions(vec![
+                PERM_CAN_DRIVE.to_string(),
+                PERM_CAN_FIRE.to_string(),
+                PERM_CAN_TURN_TURRET.to_string(),
+            ])
+            .with_allowed_organizations(vec![ORG_ID_BETA.to_string()])
+            .build()
+            .unwrap();
+
+        let alpha_role_address = compute_role_address(ROLE_ALPHA_DRIVER);
+        context
+            .set_state_entry(alpha_role_address, role_to_bytes(alpha_role))
+            .unwrap();
+
+        let beta_role_builder = RoleBuilder::new();
+        let beta_role = beta_role_builder
+            .with_org_id(ORG_ID_BETA.to_string())
+            .with_name(ROLE_BETA_DRIVER.to_string())
+            .with_permissions(vec![
+                PERM_CAN_DRIVE.to_string(),
+                PERM_CAN_FIRE.to_string(),
+                PERM_CAN_TURN_TURRET.to_string(),
+            ])
+            .with_inherit_from(vec![ROLE_ALPHA_DRIVER.to_string()])
+            .build()
+            .unwrap();
+
+        let beta_role_address = compute_role_address(ROLE_BETA_DRIVER);
+        context
+            .set_state_entry(beta_role_address, role_to_bytes(beta_role))
+            .unwrap();
+
+        let agent_builder = AgentBuilder::new();
+        let agent = agent_builder
+            .with_org_id(ORG_ID_BETA.to_string())
+            .with_public_key(PUBLIC_KEY_BETA.to_string())
+            .with_active(true)
+            .with_roles(vec![ROLE_BETA_DRIVER.to_string()])
+            .build()
+            .unwrap();
+
+        let agent_address = compute_agent_address(PUBLIC_KEY_BETA);
+        context
+            .set_state_entry(agent_address, agent_to_bytes(agent))
+            .unwrap();
+
+        let result_drive = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_DRIVE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(result_drive);
+
+        let result_fire = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_FIRE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(result_fire);
+
+        let result_turn = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_TURN_TURRET, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(result_turn);
+    }
+
+    /// has_permission() returns false if the agent has a role with multiple
+    /// given permissions but the agent's org has not been delegated those
+    /// permissions by the record owner.
+    #[test]
+    fn test_beta_multiple_perms_not_allowed() {
+        let context = MockTransactionContext::default();
+        let pc = PermissionChecker::new(&context);
+
+        let alpha_role_builder = RoleBuilder::new();
+        let alpha_role = alpha_role_builder
+            .with_org_id(ORG_ID_ALPHA.to_string())
+            .with_name(ROLE_ALPHA_DRIVER.to_string())
+            .with_permissions(vec![
+                PERM_CAN_DRIVE.to_string(),
+                PERM_CAN_FIRE.to_string(),
+                PERM_CAN_TURN_TURRET.to_string(),
+            ])
+            .build()
+            .unwrap();
+
+        let alpha_role_address = compute_role_address(ROLE_ALPHA_DRIVER);
+        context
+            .set_state_entry(alpha_role_address, role_to_bytes(alpha_role))
+            .unwrap();
+
+        let beta_role_builder = RoleBuilder::new();
+        let beta_role = beta_role_builder
+            .with_org_id(ORG_ID_BETA.to_string())
+            .with_name(ROLE_BETA_DRIVER.to_string())
+            .with_permissions(vec![
+                PERM_CAN_DRIVE.to_string(),
+                PERM_CAN_FIRE.to_string(),
+                PERM_CAN_TURN_TURRET.to_string(),
+            ])
+            .with_inherit_from(vec![ROLE_ALPHA_DRIVER.to_string()])
+            .build()
+            .unwrap();
+
+        let role_address = compute_role_address(ROLE_BETA_DRIVER);
+        context
+            .set_state_entry(role_address, role_to_bytes(beta_role))
+            .unwrap();
+
+        let agent_builder = AgentBuilder::new();
+        let agent = agent_builder
+            .with_org_id(ORG_ID_BETA.to_string())
+            .with_public_key(PUBLIC_KEY_BETA.to_string())
+            .with_active(true)
+            .with_roles(vec![ROLE_BETA_DRIVER.to_string()])
+            .build()
+            .unwrap();
+
+        let agent_address = compute_agent_address(PUBLIC_KEY_BETA);
+        context
+            .set_state_entry(agent_address, agent_to_bytes(agent))
+            .unwrap();
+
+        let result_drive = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_DRIVE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(!result_drive);
+
+        let result_fire = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_FIRE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(!result_fire);
+
+        let result_turn = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_TURN_TURRET, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(!result_turn);
+    }
+
+    /// has_permission() returns true for agents that have a role with a given
+    /// permission and false for agents that have a role without a given
+    /// permission. This is to test that inherited roles can be properly
+    /// decomposed by the inheriting org.
+    #[test]
+    fn test_gamma_multiple_perms_multiple_agents() {
+        let context = MockTransactionContext::default();
+        let pc = PermissionChecker::new(&context);
+
+        let alpha_role_builder = RoleBuilder::new();
+        let alpha_role = alpha_role_builder
+            .with_org_id(ORG_ID_ALPHA.to_string())
+            .with_name(ROLE_ALPHA_DRIVER.to_string())
+            .with_permissions(vec![
+                PERM_CAN_DRIVE.to_string(),
+                PERM_CAN_FIRE.to_string(),
+                PERM_CAN_TURN_TURRET.to_string(),
+            ])
+            .with_allowed_organizations(vec![ORG_ID_GAMMA.to_string()])
+            .build()
+            .unwrap();
+
+        let alpha_role_address = compute_role_address(ROLE_ALPHA_DRIVER);
+        context
+            .set_state_entry(alpha_role_address, role_to_bytes(alpha_role))
+            .unwrap();
+
+        let gamma_role_navigator_builder = RoleBuilder::new();
+        let gamma_role_navigator = gamma_role_navigator_builder
+            .with_org_id(ORG_ID_GAMMA.to_string())
+            .with_name(ROLE_GAMMA_NAVIGATOR.to_string())
+            .with_permissions(vec![PERM_CAN_DRIVE.to_string()])
+            .with_inherit_from(vec![ROLE_ALPHA_DRIVER.to_string()])
+            .build()
+            .unwrap();
+
+        let gamma_role_navigator_address = compute_role_address(ROLE_GAMMA_NAVIGATOR);
+        context
+            .set_state_entry(
+                gamma_role_navigator_address,
+                role_to_bytes(gamma_role_navigator),
+            )
+            .unwrap();
+
+        let agent_builder = AgentBuilder::new();
+        let agent = agent_builder
+            .with_org_id(ORG_ID_GAMMA.to_string())
+            .with_public_key(PUBLIC_KEY_GAMMA_1.to_string())
+            .with_active(true)
+            .with_roles(vec![ROLE_GAMMA_NAVIGATOR.to_string()])
+            .build()
+            .unwrap();
+
+        let agent_address = compute_agent_address(PUBLIC_KEY_GAMMA_1);
+        context
+            .set_state_entry(agent_address, agent_to_bytes(agent))
+            .unwrap();
+
+        let result_drive = pc
+            .has_permission(PUBLIC_KEY_GAMMA_1, PERM_CAN_DRIVE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(result_drive);
+
+        let result_fire = pc
+            .has_permission(PUBLIC_KEY_GAMMA_1, PERM_CAN_FIRE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(!result_fire);
+
+        let result_turn = pc
+            .has_permission(PUBLIC_KEY_GAMMA_1, PERM_CAN_TURN_TURRET, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(!result_turn);
+
+        let gamma_role_blaster_builder = RoleBuilder::new();
+        let gamma_role_blaster = gamma_role_blaster_builder
+            .with_org_id(ORG_ID_GAMMA.to_string())
+            .with_name(ROLE_GAMMA_BLASTER.to_string())
+            .with_permissions(vec![PERM_CAN_FIRE.to_string()])
+            .with_inherit_from(vec![ROLE_ALPHA_DRIVER.to_string()])
+            .build()
+            .unwrap();
+
+        let gamma_role_blaster_address = compute_role_address(ROLE_GAMMA_BLASTER);
+        context
+            .set_state_entry(
+                gamma_role_blaster_address,
+                role_to_bytes(gamma_role_blaster),
+            )
+            .unwrap();
+
+        let agent_builder = AgentBuilder::new();
+        let agent = agent_builder
+            .with_org_id(ORG_ID_GAMMA.to_string())
+            .with_public_key(PUBLIC_KEY_GAMMA_2.to_string())
+            .with_active(true)
+            .with_roles(vec![ROLE_GAMMA_BLASTER.to_string()])
+            .build()
+            .unwrap();
+
+        let agent_address = compute_agent_address(PUBLIC_KEY_GAMMA_2);
+        context
+            .set_state_entry(agent_address, agent_to_bytes(agent))
+            .unwrap();
+
+        let result_drive = pc
+            .has_permission(PUBLIC_KEY_GAMMA_2, PERM_CAN_DRIVE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(!result_drive);
+
+        let result_fire = pc
+            .has_permission(PUBLIC_KEY_GAMMA_2, PERM_CAN_FIRE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(result_fire);
+
+        let result_turn = pc
+            .has_permission(PUBLIC_KEY_GAMMA_2, PERM_CAN_TURN_TURRET, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(!result_turn);
+    }
+
+    /// has_permission() can properly check permissions for a role that inherits
+    /// from multiple roles with different permissions. The check will return
+    /// true if the inherited role from the record owner contains the permission
+    /// in question, and false if it does not.
+    #[test]
+    fn test_beta_multiple_inherits() {
+        let context = MockTransactionContext::default();
+        let pc = PermissionChecker::new(&context);
+
+        let alpha_role_builder = RoleBuilder::new();
+        let alpha_role = alpha_role_builder
+            .with_org_id(ORG_ID_ALPHA.to_string())
+            .with_name(ROLE_ALPHA_DRIVER.to_string())
+            .with_permissions(vec![
+                PERM_CAN_DRIVE.to_string(),
+                PERM_CAN_FIRE.to_string(),
+                PERM_CAN_TURN_TURRET.to_string(),
+            ])
+            .with_allowed_organizations(vec![ORG_ID_BETA.to_string()])
+            .build()
+            .unwrap();
+
+        let alpha_role_address = compute_role_address(ROLE_ALPHA_DRIVER);
+        context
+            .set_state_entry(alpha_role_address, role_to_bytes(alpha_role))
+            .unwrap();
+
+        let delta_role_builder = RoleBuilder::new();
+        let delta_role = delta_role_builder
+            .with_org_id(ORG_ID_DELTA.to_string())
+            .with_name(ROLE_DELTA_TANK_OPERATOR.to_string())
+            .with_permissions(vec![
+                PERM_CAN_DECOMMISSION.to_string(),
+                PERM_CAN_DRIVE.to_string(),
+                PERM_CAN_FIRE.to_string(),
+                PERM_CAN_TURN_TURRET.to_string(),
+            ])
+            .with_allowed_organizations(vec![ORG_ID_BETA.to_string()])
+            .build()
+            .unwrap();
+
+        let delta_role_address = compute_role_address(ROLE_DELTA_TANK_OPERATOR);
+        context
+            .set_state_entry(delta_role_address, role_to_bytes(delta_role))
+            .unwrap();
+
+        let beta_role_builder = RoleBuilder::new();
+        let beta_role = beta_role_builder
+            .with_org_id(ORG_ID_BETA.to_string())
+            .with_name(ROLE_BETA_DRIVER.to_string())
+            .with_permissions(vec![
+                PERM_CAN_DECOMMISSION.to_string(),
+                PERM_CAN_DRIVE.to_string(),
+                PERM_CAN_FIRE.to_string(),
+                PERM_CAN_TURN_TURRET.to_string(),
+            ])
+            .with_inherit_from(vec![
+                ROLE_ALPHA_DRIVER.to_string(),
+                ROLE_DELTA_TANK_OPERATOR.to_string(),
+            ])
+            .build()
+            .unwrap();
+
+        let beta_role_address = compute_role_address(ROLE_BETA_DRIVER);
+        context
+            .set_state_entry(beta_role_address, role_to_bytes(beta_role))
+            .unwrap();
+
+        let agent_builder = AgentBuilder::new();
+        let agent = agent_builder
+            .with_org_id(ORG_ID_BETA.to_string())
+            .with_public_key(PUBLIC_KEY_BETA.to_string())
+            .with_active(true)
+            .with_roles(vec![ROLE_BETA_DRIVER.to_string()])
+            .build()
+            .unwrap();
+
+        let agent_address = compute_agent_address(PUBLIC_KEY_BETA);
+        context
+            .set_state_entry(agent_address, agent_to_bytes(agent))
+            .unwrap();
+
+        let alpha_result_decommission = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_DECOMMISSION, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(!alpha_result_decommission);
+
+        let alpha_result_drive = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_DRIVE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(alpha_result_drive);
+
+        let alpha_result_fire = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_FIRE, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(alpha_result_fire);
+
+        let alpha_result_turn = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_TURN_TURRET, ORG_ID_ALPHA)
+            .unwrap();
+        assert!(alpha_result_turn);
+
+        let delta_result_decommission = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_DECOMMISSION, ORG_ID_DELTA)
+            .unwrap();
+        assert!(delta_result_decommission);
+
+        let delta_result_drive = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_DRIVE, ORG_ID_DELTA)
+            .unwrap();
+        assert!(delta_result_drive);
+
+        let delta_result_fire = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_FIRE, ORG_ID_DELTA)
+            .unwrap();
+        assert!(delta_result_fire);
+
+        let delta_result_turn = pc
+            .has_permission(PUBLIC_KEY_BETA, PERM_CAN_TURN_TURRET, ORG_ID_DELTA)
+            .unwrap();
+        assert!(delta_result_turn);
     }
 }

--- a/sdk/src/protocol/pike/payload.rs
+++ b/sdk/src/protocol/pike/payload.rs
@@ -17,7 +17,7 @@ use protobuf::RepeatedField;
 
 use std::error::Error as StdError;
 
-use crate::protocol::pike::state::KeyValueEntry;
+use crate::protocol::pike::state::{AlternateID, KeyValueEntry};
 use crate::protos;
 use crate::protos::{
     FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
@@ -28,8 +28,13 @@ use crate::protos::{
 pub enum Action {
     CreateAgent,
     UpdateAgent,
+    DeleteAgent,
     CreateOrganization,
     UpdateOrganization,
+    DeleteOrganization,
+    CreateRole,
+    UpdateRole,
+    DeleteRole,
 }
 
 impl FromProto<protos::pike_payload::PikePayload_Action> for Action {
@@ -39,12 +44,19 @@ impl FromProto<protos::pike_payload::PikePayload_Action> for Action {
         match actions {
             protos::pike_payload::PikePayload_Action::CREATE_AGENT => Ok(Action::CreateAgent),
             protos::pike_payload::PikePayload_Action::UPDATE_AGENT => Ok(Action::UpdateAgent),
+            protos::pike_payload::PikePayload_Action::DELETE_AGENT => Ok(Action::DeleteAgent),
             protos::pike_payload::PikePayload_Action::CREATE_ORGANIZATION => {
                 Ok(Action::CreateOrganization)
             }
             protos::pike_payload::PikePayload_Action::UPDATE_ORGANIZATION => {
                 Ok(Action::UpdateOrganization)
             }
+            protos::pike_payload::PikePayload_Action::DELETE_ORGANIZATION => {
+                Ok(Action::DeleteOrganization)
+            }
+            protos::pike_payload::PikePayload_Action::CREATE_ROLE => Ok(Action::CreateRole),
+            protos::pike_payload::PikePayload_Action::UPDATE_ROLE => Ok(Action::UpdateRole),
+            protos::pike_payload::PikePayload_Action::DELETE_ROLE => Ok(Action::DeleteRole),
             protos::pike_payload::PikePayload_Action::ACTION_UNSET => {
                 Err(ProtoConversionError::InvalidTypeError(
                     "Cannot convert PikePayload_Action with type unset.".to_string(),
@@ -59,12 +71,19 @@ impl FromNative<Action> for protos::pike_payload::PikePayload_Action {
         match action {
             Action::CreateAgent => Ok(protos::pike_payload::PikePayload_Action::CREATE_AGENT),
             Action::UpdateAgent => Ok(protos::pike_payload::PikePayload_Action::UPDATE_AGENT),
+            Action::DeleteAgent => Ok(protos::pike_payload::PikePayload_Action::DELETE_AGENT),
             Action::CreateOrganization => {
                 Ok(protos::pike_payload::PikePayload_Action::CREATE_ORGANIZATION)
             }
             Action::UpdateOrganization => {
                 Ok(protos::pike_payload::PikePayload_Action::UPDATE_ORGANIZATION)
             }
+            Action::DeleteOrganization => {
+                Ok(protos::pike_payload::PikePayload_Action::DELETE_ORGANIZATION)
+            }
+            Action::CreateRole => Ok(protos::pike_payload::PikePayload_Action::CREATE_ROLE),
+            Action::UpdateRole => Ok(protos::pike_payload::PikePayload_Action::UPDATE_ROLE),
+            Action::DeleteRole => Ok(protos::pike_payload::PikePayload_Action::DELETE_ROLE),
         }
     }
 }
@@ -454,12 +473,79 @@ impl UpdateAgentActionBuilder {
     }
 }
 
-/// Native implementation for CreageOrganizationAction
+/// Native implementation for DeleteAgentAction
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct DeleteAgentAction {
+    org_id: String,
+    public_key: String,
+}
+
+impl DeleteAgentAction {
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    pub fn public_key(&self) -> &str {
+        &self.public_key
+    }
+}
+
+impl FromProto<protos::pike_payload::DeleteAgentAction> for DeleteAgentAction {
+    fn from_proto(
+        delete_agent: protos::pike_payload::DeleteAgentAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(DeleteAgentAction {
+            org_id: delete_agent.get_org_id().to_string(),
+            public_key: delete_agent.get_public_key().to_string(),
+        })
+    }
+}
+
+impl FromNative<DeleteAgentAction> for protos::pike_payload::DeleteAgentAction {
+    fn from_native(delete_agent: DeleteAgentAction) -> Result<Self, ProtoConversionError> {
+        let mut proto_delete_agent = protos::pike_payload::DeleteAgentAction::new();
+
+        proto_delete_agent.set_org_id(delete_agent.org_id().to_string());
+        proto_delete_agent.set_public_key(delete_agent.public_key().to_string());
+
+        Ok(proto_delete_agent)
+    }
+}
+
+impl FromBytes<DeleteAgentAction> for DeleteAgentAction {
+    fn from_bytes(bytes: &[u8]) -> Result<DeleteAgentAction, ProtoConversionError> {
+        let proto: protos::pike_payload::DeleteAgentAction = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get DeleteAgentAction from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for DeleteAgentAction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from DeleteAgentAction".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::pike_payload::DeleteAgentAction> for DeleteAgentAction {}
+impl IntoNative<DeleteAgentAction> for protos::pike_payload::DeleteAgentAction {}
+
+/// Native implementation for CreateOrganizationAction
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct CreateOrganizationAction {
     org_id: String,
     name: String,
-    address: String,
+    locations: Vec<String>,
+    alternate_ids: Vec<AlternateID>,
     metadata: Vec<KeyValueEntry>,
 }
 
@@ -472,8 +558,12 @@ impl CreateOrganizationAction {
         &self.name
     }
 
-    pub fn address(&self) -> &str {
-        &self.address
+    pub fn locations(&self) -> &[String] {
+        &self.locations
+    }
+
+    pub fn alternate_ids(&self) -> &[AlternateID] {
+        &self.alternate_ids
     }
 
     pub fn metadata(&self) -> &[KeyValueEntry] {
@@ -488,7 +578,13 @@ impl FromProto<protos::pike_payload::CreateOrganizationAction> for CreateOrganiz
         Ok(CreateOrganizationAction {
             org_id: create_org.get_id().to_string(),
             name: create_org.get_name().to_string(),
-            address: create_org.get_address().to_string(),
+            locations: create_org.get_locations().to_vec(),
+            alternate_ids: create_org
+                .get_alternate_ids()
+                .to_vec()
+                .into_iter()
+                .map(AlternateID::from_proto)
+                .collect::<Result<Vec<AlternateID>, ProtoConversionError>>()?,
             metadata: create_org
                 .get_metadata()
                 .to_vec()
@@ -505,7 +601,15 @@ impl FromNative<CreateOrganizationAction> for protos::pike_payload::CreateOrgani
 
         proto_create_org.set_id(create_org.org_id().to_string());
         proto_create_org.set_name(create_org.name().to_string());
-        proto_create_org.set_address(create_org.address().to_string());
+        proto_create_org.set_locations(RepeatedField::from_vec(create_org.locations().to_vec()));
+        proto_create_org.set_alternate_ids(RepeatedField::from_vec(
+            create_org
+                .alternate_ids()
+                .to_vec()
+                .into_iter()
+                .map(AlternateID::into_proto)
+                .collect::<Result<Vec<protos::pike_state::AlternateID>, ProtoConversionError>>()?,
+        ));
         proto_create_org.set_metadata(RepeatedField::from_vec(
             create_org
                 .metadata()
@@ -581,7 +685,8 @@ impl std::fmt::Display for CreateOrganizationActionBuildError {
 pub struct CreateOrganizationActionBuilder {
     pub org_id: Option<String>,
     pub name: Option<String>,
-    pub address: Option<String>,
+    pub locations: Vec<String>,
+    pub alternate_ids: Vec<AlternateID>,
     pub metadata: Vec<KeyValueEntry>,
 }
 
@@ -600,8 +705,16 @@ impl CreateOrganizationActionBuilder {
         self
     }
 
-    pub fn with_address(mut self, address: String) -> CreateOrganizationActionBuilder {
-        self.address = Some(address);
+    pub fn with_locations(mut self, locations: Vec<String>) -> CreateOrganizationActionBuilder {
+        self.locations = locations;
+        self
+    }
+
+    pub fn with_alternate_ids(
+        mut self,
+        alternate_ids: Vec<AlternateID>,
+    ) -> CreateOrganizationActionBuilder {
+        self.alternate_ids = alternate_ids;
         self
     }
 
@@ -624,18 +737,17 @@ impl CreateOrganizationActionBuilder {
             CreateOrganizationActionBuildError::MissingField("'name' field is required".to_string())
         })?;
 
-        let address = self.address.ok_or_else(|| {
-            CreateOrganizationActionBuildError::MissingField(
-                "'address' field is required".to_string(),
-            )
-        })?;
+        let locations = self.locations;
+
+        let alternate_ids = self.alternate_ids;
 
         let metadata = self.metadata;
 
         Ok(CreateOrganizationAction {
             org_id,
             name,
-            address,
+            locations,
+            alternate_ids,
             metadata,
         })
     }
@@ -646,7 +758,8 @@ impl CreateOrganizationActionBuilder {
 pub struct UpdateOrganizationAction {
     org_id: String,
     name: String,
-    address: String,
+    locations: Vec<String>,
+    alternate_ids: Vec<AlternateID>,
     metadata: Vec<KeyValueEntry>,
 }
 
@@ -659,8 +772,12 @@ impl UpdateOrganizationAction {
         &self.name
     }
 
-    pub fn address(&self) -> &str {
-        &self.address
+    pub fn locations(&self) -> &[String] {
+        &self.locations
+    }
+
+    pub fn alternate_ids(&self) -> &[AlternateID] {
+        &self.alternate_ids
     }
 
     pub fn metadata(&self) -> &[KeyValueEntry] {
@@ -675,7 +792,13 @@ impl FromProto<protos::pike_payload::UpdateOrganizationAction> for UpdateOrganiz
         Ok(UpdateOrganizationAction {
             org_id: create_org.get_id().to_string(),
             name: create_org.get_name().to_string(),
-            address: create_org.get_address().to_string(),
+            locations: create_org.get_locations().to_vec(),
+            alternate_ids: create_org
+                .get_alternate_ids()
+                .to_vec()
+                .into_iter()
+                .map(AlternateID::from_proto)
+                .collect::<Result<Vec<AlternateID>, ProtoConversionError>>()?,
             metadata: create_org
                 .get_metadata()
                 .to_vec()
@@ -692,7 +815,15 @@ impl FromNative<UpdateOrganizationAction> for protos::pike_payload::UpdateOrgani
 
         proto_update_org.set_id(update_org.org_id().to_string());
         proto_update_org.set_name(update_org.name().to_string());
-        proto_update_org.set_address(update_org.address().to_string());
+        proto_update_org.set_locations(RepeatedField::from_vec(update_org.locations().to_vec()));
+        proto_update_org.set_alternate_ids(RepeatedField::from_vec(
+            update_org
+                .alternate_ids()
+                .to_vec()
+                .into_iter()
+                .map(AlternateID::into_proto)
+                .collect::<Result<Vec<protos::pike_state::AlternateID>, ProtoConversionError>>()?,
+        ));
         proto_update_org.set_metadata(RepeatedField::from_vec(
             update_org
                 .metadata()
@@ -768,7 +899,8 @@ impl std::fmt::Display for UpdateOrganizationActionBuildError {
 pub struct UpdateOrganizationActionBuilder {
     pub org_id: Option<String>,
     pub name: Option<String>,
-    pub address: Option<String>,
+    pub locations: Vec<String>,
+    pub alternate_ids: Vec<AlternateID>,
     pub metadata: Vec<KeyValueEntry>,
 }
 
@@ -787,8 +919,16 @@ impl UpdateOrganizationActionBuilder {
         self
     }
 
-    pub fn with_address(mut self, address: String) -> UpdateOrganizationActionBuilder {
-        self.address = Some(address);
+    pub fn with_locations(mut self, locations: Vec<String>) -> UpdateOrganizationActionBuilder {
+        self.locations = locations;
+        self
+    }
+
+    pub fn with_alternate_ids(
+        mut self,
+        alternate_ids: Vec<AlternateID>,
+    ) -> UpdateOrganizationActionBuilder {
+        self.alternate_ids = alternate_ids;
         self
     }
 
@@ -809,16 +949,712 @@ impl UpdateOrganizationActionBuilder {
 
         let name = self.name.unwrap_or_default();
 
-        let address = self.address.unwrap_or_default();
+        let locations = self.locations;
+
+        let alternate_ids = self.alternate_ids;
 
         let metadata = self.metadata;
 
         Ok(UpdateOrganizationAction {
             org_id,
             name,
-            address,
+            locations,
+            alternate_ids,
             metadata,
         })
+    }
+}
+
+/// Native implementation for DeleteOrganizationAction
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct DeleteOrganizationAction {
+    id: String,
+}
+
+impl DeleteOrganizationAction {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+impl FromProto<protos::pike_payload::DeleteOrganizationAction> for DeleteOrganizationAction {
+    fn from_proto(
+        delete_organization: protos::pike_payload::DeleteOrganizationAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(DeleteOrganizationAction {
+            id: delete_organization.get_id().to_string(),
+        })
+    }
+}
+
+impl FromNative<DeleteOrganizationAction> for protos::pike_payload::DeleteOrganizationAction {
+    fn from_native(
+        delete_organization: DeleteOrganizationAction,
+    ) -> Result<Self, ProtoConversionError> {
+        let mut proto_delete_organization = protos::pike_payload::DeleteOrganizationAction::new();
+
+        proto_delete_organization.set_id(delete_organization.id().to_string());
+
+        Ok(proto_delete_organization)
+    }
+}
+
+impl FromBytes<DeleteOrganizationAction> for DeleteOrganizationAction {
+    fn from_bytes(bytes: &[u8]) -> Result<DeleteOrganizationAction, ProtoConversionError> {
+        let proto: protos::pike_payload::DeleteOrganizationAction =
+            Message::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get DeleteOrganizationAction from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for DeleteOrganizationAction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from DeleteOrganizationAction".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::pike_payload::DeleteOrganizationAction> for DeleteOrganizationAction {}
+impl IntoNative<DeleteOrganizationAction> for protos::pike_payload::DeleteOrganizationAction {}
+
+#[derive(Debug)]
+pub enum DeleteOrganizationActionBuildError {
+    MissingField(String),
+}
+
+impl StdError for DeleteOrganizationActionBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            DeleteOrganizationActionBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            DeleteOrganizationActionBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for DeleteOrganizationActionBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            DeleteOrganizationActionBuildError::MissingField(ref s) => {
+                write!(f, "MissingField: {}", s)
+            }
+        }
+    }
+}
+
+/// Builder used to create a DeleteOrganizationAction
+#[derive(Default, Clone)]
+pub struct DeleteOrganizationActionBuilder {
+    pub id: Option<String>,
+}
+
+impl DeleteOrganizationActionBuilder {
+    pub fn new() -> Self {
+        DeleteOrganizationActionBuilder::default()
+    }
+
+    pub fn with_id(mut self, id: String) -> DeleteOrganizationActionBuilder {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn build(self) -> Result<DeleteOrganizationAction, DeleteOrganizationActionBuildError> {
+        let id = self.id.ok_or_else(|| {
+            DeleteOrganizationActionBuildError::MissingField("'id' field is required".to_string())
+        })?;
+
+        Ok(DeleteOrganizationAction { id })
+    }
+}
+
+/// Native implementation for CreateRoleAction
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct CreateRoleAction {
+    org_id: String,
+    name: String,
+    description: String,
+    permissions: Vec<String>,
+    allowed_organizations: Vec<String>,
+    inherit_from: Vec<String>,
+    active: bool,
+}
+
+impl CreateRoleAction {
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn permissions(&self) -> &[String] {
+        &self.permissions
+    }
+
+    pub fn allowed_organizations(&self) -> &[String] {
+        &self.allowed_organizations
+    }
+
+    pub fn inherit_from(&self) -> &[String] {
+        &self.inherit_from
+    }
+
+    pub fn active(&self) -> &bool {
+        &self.active
+    }
+}
+
+impl FromProto<protos::pike_payload::CreateRoleAction> for CreateRoleAction {
+    fn from_proto(
+        create_role: protos::pike_payload::CreateRoleAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(CreateRoleAction {
+            org_id: create_role.get_org_id().to_string(),
+            name: create_role.get_name().to_string(),
+            description: create_role.get_description().to_string(),
+            permissions: create_role.get_permissions().to_vec(),
+            allowed_organizations: create_role.get_allowed_organizations().to_vec(),
+            inherit_from: create_role.get_inherit_from().to_vec(),
+            active: create_role.get_active(),
+        })
+    }
+}
+
+impl FromNative<CreateRoleAction> for protos::pike_payload::CreateRoleAction {
+    fn from_native(create_role: CreateRoleAction) -> Result<Self, ProtoConversionError> {
+        let mut proto_create_role = protos::pike_payload::CreateRoleAction::new();
+
+        proto_create_role.set_org_id(create_role.org_id().to_string());
+        proto_create_role.set_name(create_role.name().to_string());
+        proto_create_role.set_description(create_role.description().to_string());
+        proto_create_role
+            .set_permissions(RepeatedField::from_vec(create_role.permissions().to_vec()));
+        proto_create_role.set_allowed_organizations(RepeatedField::from_vec(
+            create_role.allowed_organizations().to_vec(),
+        ));
+        proto_create_role
+            .set_inherit_from(RepeatedField::from_vec(create_role.inherit_from().to_vec()));
+        proto_create_role.set_active(*create_role.active());
+
+        Ok(proto_create_role)
+    }
+}
+
+impl FromBytes<CreateRoleAction> for CreateRoleAction {
+    fn from_bytes(bytes: &[u8]) -> Result<CreateRoleAction, ProtoConversionError> {
+        let proto: protos::pike_payload::CreateRoleAction = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get CreateRoleAction from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for CreateRoleAction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from CreateRoleAction".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::pike_payload::CreateRoleAction> for CreateRoleAction {}
+impl IntoNative<CreateRoleAction> for protos::pike_payload::CreateRoleAction {}
+
+#[derive(Debug)]
+pub enum CreateRoleActionBuildError {
+    MissingField(String),
+}
+
+impl StdError for CreateRoleActionBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            CreateRoleActionBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            CreateRoleActionBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for CreateRoleActionBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            CreateRoleActionBuildError::MissingField(ref s) => {
+                write!(f, "MissingField: {}", s)
+            }
+        }
+    }
+}
+
+/// Builder used to create a CreateRoleAction
+#[derive(Default, Clone)]
+pub struct CreateRoleActionBuilder {
+    pub org_id: Option<String>,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub permissions: Vec<String>,
+    pub allowed_organizations: Vec<String>,
+    pub inherit_from: Vec<String>,
+    pub active: Option<bool>,
+}
+
+impl CreateRoleActionBuilder {
+    pub fn new() -> Self {
+        CreateRoleActionBuilder::default()
+    }
+
+    pub fn with_org_id(mut self, org_id: String) -> CreateRoleActionBuilder {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    pub fn with_name(mut self, name: String) -> CreateRoleActionBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> CreateRoleActionBuilder {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_permissions(mut self, permissions: Vec<String>) -> CreateRoleActionBuilder {
+        self.permissions = permissions;
+        self
+    }
+
+    pub fn with_allowed_organizations(
+        mut self,
+        allowed_organizations: Vec<String>,
+    ) -> CreateRoleActionBuilder {
+        self.allowed_organizations = allowed_organizations;
+        self
+    }
+
+    pub fn with_inherit_from(mut self, inherit_from: Vec<String>) -> CreateRoleActionBuilder {
+        self.inherit_from = inherit_from;
+        self
+    }
+
+    pub fn with_active(mut self, active: bool) -> CreateRoleActionBuilder {
+        self.active = Some(active);
+        self
+    }
+
+    pub fn build(self) -> Result<CreateRoleAction, CreateRoleActionBuildError> {
+        let org_id = self.org_id.ok_or_else(|| {
+            CreateRoleActionBuildError::MissingField("'org_id' field is required".to_string())
+        })?;
+
+        let name = self.name.ok_or_else(|| {
+            CreateRoleActionBuildError::MissingField("'name' field is required".to_string())
+        })?;
+
+        let description = self.description.ok_or_else(|| {
+            CreateRoleActionBuildError::MissingField("'description' field is required".to_string())
+        })?;
+
+        let permissions = self.permissions;
+
+        let allowed_organizations = self.allowed_organizations;
+
+        let inherit_from = self.inherit_from;
+
+        let active = self.active.ok_or_else(|| {
+            CreateRoleActionBuildError::MissingField("'active' field is required".to_string())
+        })?;
+
+        Ok(CreateRoleAction {
+            org_id,
+            name,
+            description,
+            permissions,
+            allowed_organizations,
+            inherit_from,
+            active,
+        })
+    }
+}
+
+/// Native implementation for UpdateRoleAction
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct UpdateRoleAction {
+    org_id: String,
+    name: String,
+    description: String,
+    permissions: Vec<String>,
+    allowed_organizations: Vec<String>,
+    inherit_from: Vec<String>,
+    active: bool,
+}
+
+impl UpdateRoleAction {
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn permissions(&self) -> &[String] {
+        &self.permissions
+    }
+
+    pub fn allowed_organizations(&self) -> &[String] {
+        &self.allowed_organizations
+    }
+
+    pub fn inherit_from(&self) -> &[String] {
+        &self.inherit_from
+    }
+
+    pub fn active(&self) -> &bool {
+        &self.active
+    }
+}
+
+impl FromProto<protos::pike_payload::UpdateRoleAction> for UpdateRoleAction {
+    fn from_proto(
+        update_role: protos::pike_payload::UpdateRoleAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(UpdateRoleAction {
+            org_id: update_role.get_org_id().to_string(),
+            name: update_role.get_name().to_string(),
+            description: update_role.get_description().to_string(),
+            permissions: update_role.get_permissions().to_vec(),
+            allowed_organizations: update_role.get_allowed_organizations().to_vec(),
+            inherit_from: update_role.get_inherit_from().to_vec(),
+            active: update_role.get_active(),
+        })
+    }
+}
+
+impl FromNative<UpdateRoleAction> for protos::pike_payload::UpdateRoleAction {
+    fn from_native(update_role: UpdateRoleAction) -> Result<Self, ProtoConversionError> {
+        let mut proto_update_role = protos::pike_payload::UpdateRoleAction::new();
+
+        proto_update_role.set_org_id(update_role.org_id().to_string());
+        proto_update_role.set_name(update_role.name().to_string());
+        proto_update_role.set_description(update_role.description().to_string());
+        proto_update_role
+            .set_permissions(RepeatedField::from_vec(update_role.permissions().to_vec()));
+        proto_update_role.set_allowed_organizations(RepeatedField::from_vec(
+            update_role.allowed_organizations().to_vec(),
+        ));
+        proto_update_role
+            .set_inherit_from(RepeatedField::from_vec(update_role.inherit_from().to_vec()));
+        proto_update_role.set_active(*update_role.active());
+
+        Ok(proto_update_role)
+    }
+}
+
+impl FromBytes<UpdateRoleAction> for UpdateRoleAction {
+    fn from_bytes(bytes: &[u8]) -> Result<UpdateRoleAction, ProtoConversionError> {
+        let proto: protos::pike_payload::UpdateRoleAction = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get UpdateRoleAction from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for UpdateRoleAction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from UpdateRoleAction".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::pike_payload::UpdateRoleAction> for UpdateRoleAction {}
+impl IntoNative<UpdateRoleAction> for protos::pike_payload::UpdateRoleAction {}
+
+#[derive(Debug)]
+pub enum UpdateRoleActionBuildError {
+    MissingField(String),
+}
+
+impl StdError for UpdateRoleActionBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            UpdateRoleActionBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            UpdateRoleActionBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for UpdateRoleActionBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            UpdateRoleActionBuildError::MissingField(ref s) => {
+                write!(f, "MissingField: {}", s)
+            }
+        }
+    }
+}
+
+/// Builder used to create a UpdateRoleAction
+#[derive(Default, Clone)]
+pub struct UpdateRoleActionBuilder {
+    pub org_id: Option<String>,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub permissions: Vec<String>,
+    pub allowed_organizations: Vec<String>,
+    pub inherit_from: Vec<String>,
+    pub active: Option<bool>,
+}
+
+impl UpdateRoleActionBuilder {
+    pub fn new() -> Self {
+        UpdateRoleActionBuilder::default()
+    }
+
+    pub fn with_org_id(mut self, org_id: String) -> UpdateRoleActionBuilder {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    pub fn with_name(mut self, name: String) -> UpdateRoleActionBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> UpdateRoleActionBuilder {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_permissions(mut self, permissions: Vec<String>) -> UpdateRoleActionBuilder {
+        self.permissions = permissions;
+        self
+    }
+
+    pub fn with_allowed_organizations(
+        mut self,
+        allowed_organizations: Vec<String>,
+    ) -> UpdateRoleActionBuilder {
+        self.allowed_organizations = allowed_organizations;
+        self
+    }
+
+    pub fn with_inherit_from(mut self, inherit_from: Vec<String>) -> UpdateRoleActionBuilder {
+        self.inherit_from = inherit_from;
+        self
+    }
+
+    pub fn with_active(mut self, active: bool) -> UpdateRoleActionBuilder {
+        self.active = Some(active);
+        self
+    }
+
+    pub fn build(self) -> Result<UpdateRoleAction, UpdateRoleActionBuildError> {
+        let org_id = self.org_id.ok_or_else(|| {
+            UpdateRoleActionBuildError::MissingField("'org_id' field is required".to_string())
+        })?;
+
+        let name = self.name.ok_or_else(|| {
+            UpdateRoleActionBuildError::MissingField("'name' field is required".to_string())
+        })?;
+
+        let description = self.description.ok_or_else(|| {
+            UpdateRoleActionBuildError::MissingField("'description' field is required".to_string())
+        })?;
+
+        let permissions = self.permissions;
+
+        let allowed_organizations = self.allowed_organizations;
+
+        let inherit_from = self.inherit_from;
+
+        let active = self.active.ok_or_else(|| {
+            UpdateRoleActionBuildError::MissingField("'active' field is required".to_string())
+        })?;
+
+        Ok(UpdateRoleAction {
+            org_id,
+            name,
+            description,
+            permissions,
+            allowed_organizations,
+            inherit_from,
+            active,
+        })
+    }
+}
+
+/// Native implementation for DeleteRoleAction
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct DeleteRoleAction {
+    org_id: String,
+    name: String,
+}
+
+impl DeleteRoleAction {
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl FromProto<protos::pike_payload::DeleteRoleAction> for DeleteRoleAction {
+    fn from_proto(
+        delete_role: protos::pike_payload::DeleteRoleAction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(DeleteRoleAction {
+            org_id: delete_role.get_org_id().to_string(),
+            name: delete_role.get_name().to_string(),
+        })
+    }
+}
+
+impl FromNative<DeleteRoleAction> for protos::pike_payload::DeleteRoleAction {
+    fn from_native(delete_role: DeleteRoleAction) -> Result<Self, ProtoConversionError> {
+        let mut proto_delete_role = protos::pike_payload::DeleteRoleAction::new();
+
+        proto_delete_role.set_org_id(delete_role.org_id().to_string());
+        proto_delete_role.set_name(delete_role.name().to_string());
+
+        Ok(proto_delete_role)
+    }
+}
+
+impl FromBytes<DeleteRoleAction> for DeleteRoleAction {
+    fn from_bytes(bytes: &[u8]) -> Result<DeleteRoleAction, ProtoConversionError> {
+        let proto: protos::pike_payload::DeleteRoleAction = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get DeleteRoleAction from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for DeleteRoleAction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from DeleteRoleAction".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::pike_payload::DeleteRoleAction> for DeleteRoleAction {}
+impl IntoNative<DeleteRoleAction> for protos::pike_payload::DeleteRoleAction {}
+
+#[derive(Debug)]
+pub enum DeleteRoleActionBuildError {
+    MissingField(String),
+}
+
+impl StdError for DeleteRoleActionBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            DeleteRoleActionBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            DeleteRoleActionBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for DeleteRoleActionBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            DeleteRoleActionBuildError::MissingField(ref s) => {
+                write!(f, "MissingField: {}", s)
+            }
+        }
+    }
+}
+
+/// Builder used to create a DeleteRoleAction
+#[derive(Default, Clone)]
+pub struct DeleteRoleActionBuilder {
+    pub org_id: Option<String>,
+    pub name: Option<String>,
+}
+
+impl DeleteRoleActionBuilder {
+    pub fn new() -> Self {
+        DeleteRoleActionBuilder::default()
+    }
+
+    pub fn with_org_id(mut self, org_id: String) -> DeleteRoleActionBuilder {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    pub fn with_name(mut self, name: String) -> DeleteRoleActionBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn build(self) -> Result<DeleteRoleAction, DeleteRoleActionBuildError> {
+        let org_id = self.org_id.ok_or_else(|| {
+            DeleteRoleActionBuildError::MissingField("'org_id' field is required".to_string())
+        })?;
+
+        let name = self.name.ok_or_else(|| {
+            DeleteRoleActionBuildError::MissingField("'name' field is required".to_string())
+        })?;
+
+        Ok(DeleteRoleAction { org_id, name })
     }
 }
 
@@ -828,8 +1664,13 @@ pub struct PikePayload {
     action: Action,
     create_agent: CreateAgentAction,
     update_agent: UpdateAgentAction,
+    delete_agent: DeleteAgentAction,
     create_organization: CreateOrganizationAction,
     update_organization: UpdateOrganizationAction,
+    delete_organization: DeleteOrganizationAction,
+    create_role: CreateRoleAction,
+    update_role: UpdateRoleAction,
+    delete_role: DeleteRoleAction,
 }
 
 impl PikePayload {
@@ -845,12 +1686,32 @@ impl PikePayload {
         &self.update_agent
     }
 
+    pub fn delete_agent(&self) -> &DeleteAgentAction {
+        &self.delete_agent
+    }
+
     pub fn create_organization(&self) -> &CreateOrganizationAction {
         &self.create_organization
     }
 
     pub fn update_organization(&self) -> &UpdateOrganizationAction {
         &self.update_organization
+    }
+
+    pub fn delete_organization(&self) -> &DeleteOrganizationAction {
+        &self.delete_organization
+    }
+
+    pub fn create_role(&self) -> &CreateRoleAction {
+        &self.create_role
+    }
+
+    pub fn update_role(&self) -> &UpdateRoleAction {
+        &self.update_role
+    }
+
+    pub fn delete_role(&self) -> &DeleteRoleAction {
+        &self.delete_role
     }
 }
 
@@ -862,12 +1723,19 @@ impl FromProto<protos::pike_payload::PikePayload> for PikePayload {
             action: Action::from_proto(payload.get_action())?,
             create_agent: CreateAgentAction::from_proto(payload.get_create_agent().clone())?,
             update_agent: UpdateAgentAction::from_proto(payload.get_update_agent().clone())?,
+            delete_agent: DeleteAgentAction::from_proto(payload.get_delete_agent().clone())?,
             create_organization: CreateOrganizationAction::from_proto(
                 payload.get_create_organization().clone(),
             )?,
             update_organization: UpdateOrganizationAction::from_proto(
                 payload.get_update_organization().clone(),
             )?,
+            delete_organization: DeleteOrganizationAction::from_proto(
+                payload.get_delete_organization().clone(),
+            )?,
+            create_role: CreateRoleAction::from_proto(payload.get_create_role().clone())?,
+            update_role: UpdateRoleAction::from_proto(payload.get_update_role().clone())?,
+            delete_role: DeleteRoleAction::from_proto(payload.get_delete_role().clone())?,
         })
     }
 }
@@ -879,8 +1747,13 @@ impl FromNative<PikePayload> for protos::pike_payload::PikePayload {
         proto_payload.set_action(payload.action().clone().into_proto()?);
         proto_payload.set_create_agent(payload.create_agent().clone().into_proto()?);
         proto_payload.set_update_agent(payload.update_agent().clone().into_proto()?);
+        proto_payload.set_delete_agent(payload.delete_agent().clone().into_proto()?);
         proto_payload.set_create_organization(payload.create_organization().clone().into_proto()?);
         proto_payload.set_update_organization(payload.update_organization().clone().into_proto()?);
+        proto_payload.set_delete_organization(payload.delete_organization().clone().into_proto()?);
+        proto_payload.set_create_role(payload.create_role().clone().into_proto()?);
+        proto_payload.set_update_role(payload.update_role().clone().into_proto()?);
+        proto_payload.set_delete_role(payload.delete_role().clone().into_proto()?);
 
         Ok(proto_payload)
     }
@@ -946,8 +1819,13 @@ pub struct PikePayloadBuilder {
     pub action: Option<Action>,
     pub create_agent: Option<CreateAgentAction>,
     pub update_agent: Option<UpdateAgentAction>,
+    pub delete_agent: Option<DeleteAgentAction>,
     pub create_organization: Option<CreateOrganizationAction>,
     pub update_organization: Option<UpdateOrganizationAction>,
+    pub delete_organization: Option<DeleteOrganizationAction>,
+    pub create_role: Option<CreateRoleAction>,
+    pub update_role: Option<UpdateRoleAction>,
+    pub delete_role: Option<DeleteRoleAction>,
 }
 
 impl PikePayloadBuilder {
@@ -970,6 +1848,11 @@ impl PikePayloadBuilder {
         self
     }
 
+    pub fn with_delete_agent(mut self, delete_agent: DeleteAgentAction) -> PikePayloadBuilder {
+        self.delete_agent = Some(delete_agent);
+        self
+    }
+
     pub fn with_create_organization(
         mut self,
         create_organization: CreateOrganizationAction,
@@ -983,6 +1866,29 @@ impl PikePayloadBuilder {
         update_organization: UpdateOrganizationAction,
     ) -> PikePayloadBuilder {
         self.update_organization = Some(update_organization);
+        self
+    }
+
+    pub fn with_delete_organization(
+        mut self,
+        delete_organization: DeleteOrganizationAction,
+    ) -> PikePayloadBuilder {
+        self.delete_organization = Some(delete_organization);
+        self
+    }
+
+    pub fn with_create_role(mut self, create_role: CreateRoleAction) -> PikePayloadBuilder {
+        self.create_role = Some(create_role);
+        self
+    }
+
+    pub fn with_update_role(mut self, update_role: UpdateRoleAction) -> PikePayloadBuilder {
+        self.update_role = Some(update_role);
+        self
+    }
+
+    pub fn with_delete_role(mut self, delete_role: DeleteRoleAction) -> PikePayloadBuilder {
+        self.delete_role = Some(delete_role);
         self
     }
 
@@ -1015,6 +1921,18 @@ impl PikePayloadBuilder {
             }
         };
 
+        let delete_agent = {
+            if action == Action::DeleteAgent {
+                self.delete_agent.ok_or_else(|| {
+                    PikePayloadBuildError::MissingField(
+                        "'delete_agent' field is required".to_string(),
+                    )
+                })?
+            } else {
+                DeleteAgentAction::default()
+            }
+        };
+
         let create_organization = {
             if action == Action::CreateOrganization {
                 self.create_organization.ok_or_else(|| {
@@ -1039,12 +1957,65 @@ impl PikePayloadBuilder {
             }
         };
 
+        let delete_organization = {
+            if action == Action::DeleteOrganization {
+                self.delete_organization.ok_or_else(|| {
+                    PikePayloadBuildError::MissingField(
+                        "'delete_organization' field is required".to_string(),
+                    )
+                })?
+            } else {
+                DeleteOrganizationAction::default()
+            }
+        };
+
+        let create_role = {
+            if action == Action::CreateRole {
+                self.create_role.ok_or_else(|| {
+                    PikePayloadBuildError::MissingField(
+                        "'create_role' field is required".to_string(),
+                    )
+                })?
+            } else {
+                CreateRoleAction::default()
+            }
+        };
+
+        let update_role = {
+            if action == Action::UpdateRole {
+                self.update_role.ok_or_else(|| {
+                    PikePayloadBuildError::MissingField(
+                        "'update_role' field is required".to_string(),
+                    )
+                })?
+            } else {
+                UpdateRoleAction::default()
+            }
+        };
+
+        let delete_role = {
+            if action == Action::DeleteRole {
+                self.delete_role.ok_or_else(|| {
+                    PikePayloadBuildError::MissingField(
+                        "'delete_role' field is required".to_string(),
+                    )
+                })?
+            } else {
+                DeleteRoleAction::default()
+            }
+        };
+
         Ok(PikePayload {
             action,
             create_agent,
             update_agent,
+            delete_agent,
             create_organization,
             update_organization,
+            delete_organization,
+            create_role,
+            update_role,
+            delete_role,
         })
     }
 }
@@ -1173,14 +2144,14 @@ mod tests {
         let create_organization = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_address("address".to_string())
+            .with_locations(vec!["location".to_string()])
             .with_metadata(vec![key_value.clone()])
             .build()
             .unwrap();
 
         assert_eq!(create_organization.org_id(), "organization");
         assert_eq!(create_organization.name(), "name");
-        assert_eq!(create_organization.address(), "address");
+        assert_eq!(create_organization.locations(), ["location"]);
         assert_eq!(create_organization.metadata(), [key_value]);
     }
 
@@ -1198,7 +2169,7 @@ mod tests {
         let original = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_address("address".to_string())
+            .with_locations(vec!["location".to_string()])
             .with_metadata(vec![key_value.clone()])
             .build()
             .unwrap();
@@ -1215,13 +2186,13 @@ mod tests {
         let update_organization = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_address("address".to_string())
+            .with_locations(vec!["location".to_string()])
             .build()
             .unwrap();
 
         assert_eq!(update_organization.org_id(), "organization");
         assert_eq!(update_organization.name(), "name");
-        assert_eq!(update_organization.address(), "address");
+        assert_eq!(update_organization.locations(), ["location"]);
     }
 
     #[test]
@@ -1231,7 +2202,7 @@ mod tests {
         let original = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_address("address".to_string())
+            .with_locations(vec!["location".to_string()])
             .build()
             .unwrap();
 
@@ -1327,7 +2298,7 @@ mod tests {
         let action = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_address("address".to_string())
+            .with_locations(vec!["location".to_string()])
             .build()
             .unwrap();
 
@@ -1355,7 +2326,7 @@ mod tests {
         let action = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_address("address".to_string())
+            .with_locations(vec!["location".to_string()])
             .build()
             .unwrap();
 
@@ -1383,7 +2354,7 @@ mod tests {
         let action = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_address("address".to_string())
+            .with_locations(vec!["location".to_string()])
             .build()
             .unwrap();
 

--- a/sdk/src/protocol/pike/state.rs
+++ b/sdk/src/protocol/pike/state.rs
@@ -239,6 +239,105 @@ impl IntoBytes for Role {
 impl IntoProto<protos::pike_state::Role> for Role {}
 impl IntoNative<Role> for protos::pike_state::Role {}
 
+#[derive(Debug)]
+pub enum RoleBuildError {
+    MissingField(String),
+}
+
+impl StdError for RoleBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            RoleBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            RoleBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for RoleBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            RoleBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+/// Builder used to create a Role
+#[derive(Default, Clone)]
+pub struct RoleBuilder {
+    org_id: Option<String>,
+    name: Option<String>,
+    description: Option<String>,
+    permissions: Vec<String>,
+    allowed_organizations: Vec<String>,
+    inherit_from: Vec<String>,
+}
+
+impl RoleBuilder {
+    pub fn new() -> Self {
+        RoleBuilder::default()
+    }
+
+    pub fn with_org_id(mut self, org_id: String) -> RoleBuilder {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    pub fn with_name(mut self, name: String) -> RoleBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> RoleBuilder {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_permissions(mut self, permissions: Vec<String>) -> RoleBuilder {
+        self.permissions = permissions;
+        self
+    }
+
+    pub fn with_allowed_organizations(mut self, allowed_organizations: Vec<String>) -> RoleBuilder {
+        self.allowed_organizations = allowed_organizations;
+        self
+    }
+
+    pub fn with_inherit_from(mut self, inherit_from: Vec<String>) -> RoleBuilder {
+        self.inherit_from = inherit_from;
+        self
+    }
+
+    pub fn build(self) -> Result<Role, RoleBuildError> {
+        let org_id = self.org_id.ok_or_else(|| {
+            RoleBuildError::MissingField("'org_id' field is required".to_string())
+        })?;
+
+        let name = self
+            .name
+            .ok_or_else(|| RoleBuildError::MissingField("'name' field is required".to_string()))?;
+
+        let description = self.description.unwrap_or("".to_string());
+
+        let permissions = self.permissions;
+        let allowed_organizations = self.allowed_organizations;
+        let inherit_from = self.inherit_from;
+
+        Ok(Role {
+            org_id,
+            name,
+            description,
+            permissions,
+            allowed_organizations,
+            inherit_from,
+        })
+    }
+}
+
 /// Native implementation of RoleList
 #[derive(Debug, Clone, PartialEq)]
 pub struct RoleList {
@@ -308,6 +407,64 @@ impl IntoBytes for RoleList {
 
 impl IntoProto<protos::pike_state::RoleList> for RoleList {}
 impl IntoNative<RoleList> for protos::pike_state::RoleList {}
+
+#[derive(Debug)]
+pub enum RoleListBuildError {
+    MissingField(String),
+}
+
+impl StdError for RoleListBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            RoleListBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            RoleListBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for RoleListBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            RoleListBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+/// Builder used to create a RoleList
+#[derive(Default, Clone)]
+pub struct RoleListBuilder {
+    pub roles: Vec<Role>,
+}
+
+impl RoleListBuilder {
+    pub fn new() -> Self {
+        RoleListBuilder::default()
+    }
+
+    pub fn with_roles(mut self, roles: Vec<Role>) -> RoleListBuilder {
+        self.roles = roles;
+        self
+    }
+
+    pub fn build(self) -> Result<RoleList, RoleListBuildError> {
+        let roles = {
+            if self.roles.is_empty() {
+                return Err(RoleListBuildError::MissingField(
+                    "'roles' cannot be empty".to_string(),
+                ));
+            } else {
+                self.roles
+            }
+        };
+
+        Ok(RoleList { roles })
+    }
+}
 
 /// Native implementation of AlternateIDIndexEntry
 #[derive(Debug, Clone, PartialEq)]

--- a/sdk/src/protocol/pike/state.rs
+++ b/sdk/src/protocol/pike/state.rs
@@ -150,6 +150,302 @@ impl KeyValueEntryBuilder {
     }
 }
 
+/// Native implementation of Role
+#[derive(Debug, Clone, PartialEq)]
+pub struct Role {
+    org_id: String,
+    name: String,
+    description: String,
+    permissions: Vec<String>,
+    allowed_organizations: Vec<String>,
+    inherit_from: Vec<String>,
+}
+
+impl Role {
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn permissions(&self) -> &[String] {
+        &self.permissions
+    }
+
+    pub fn allowed_organizations(&self) -> &[String] {
+        &self.allowed_organizations
+    }
+
+    pub fn inherit_from(&self) -> &[String] {
+        &self.inherit_from
+    }
+}
+
+impl FromProto<protos::pike_state::Role> for Role {
+    fn from_proto(role: protos::pike_state::Role) -> Result<Self, ProtoConversionError> {
+        Ok(Role {
+            org_id: role.get_org_id().to_string(),
+            name: role.get_name().to_string(),
+            description: role.get_description().to_string(),
+            permissions: role.get_permissions().to_vec(),
+            allowed_organizations: role.get_allowed_organizations().to_vec(),
+            inherit_from: role.get_inherit_from().to_vec(),
+        })
+    }
+}
+
+impl FromNative<Role> for protos::pike_state::Role {
+    fn from_native(role: Role) -> Result<Self, ProtoConversionError> {
+        let mut role_proto = protos::pike_state::Role::new();
+
+        role_proto.set_org_id(role.org_id().to_string());
+        role_proto.set_name(role.name().to_string());
+        role_proto.set_description(role.description().to_string());
+        role_proto.set_permissions(RepeatedField::from_vec(role.permissions().to_vec()));
+        role_proto.set_allowed_organizations(RepeatedField::from_vec(
+            role.allowed_organizations().to_vec(),
+        ));
+        role_proto.set_inherit_from(RepeatedField::from_vec(role.inherit_from().to_vec()));
+
+        Ok(role_proto)
+    }
+}
+
+impl FromBytes<Role> for Role {
+    fn from_bytes(bytes: &[u8]) -> Result<Role, ProtoConversionError> {
+        let proto: protos::pike_state::Role = Message::parse_from_bytes(bytes).map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get Role from bytes".to_string())
+        })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for Role {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get bytes from Role".to_string())
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::pike_state::Role> for Role {}
+impl IntoNative<Role> for protos::pike_state::Role {}
+
+/// Native implementation of RoleList
+#[derive(Debug, Clone, PartialEq)]
+pub struct RoleList {
+    roles: Vec<Role>,
+}
+
+impl RoleList {
+    pub fn roles(&self) -> &[Role] {
+        &self.roles
+    }
+}
+
+impl FromProto<protos::pike_state::RoleList> for RoleList {
+    fn from_proto(role_list: protos::pike_state::RoleList) -> Result<Self, ProtoConversionError> {
+        Ok(RoleList {
+            roles: role_list
+                .get_roles()
+                .to_vec()
+                .into_iter()
+                .map(Role::from_proto)
+                .collect::<Result<Vec<Role>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<RoleList> for protos::pike_state::RoleList {
+    fn from_native(role_list: RoleList) -> Result<Self, ProtoConversionError> {
+        let mut role_list_proto = protos::pike_state::RoleList::new();
+
+        role_list_proto.set_roles(RepeatedField::from_vec(
+            role_list
+                .roles()
+                .to_vec()
+                .into_iter()
+                .map(Role::into_proto)
+                .collect::<Result<Vec<protos::pike_state::Role>, ProtoConversionError>>()?,
+        ));
+
+        Ok(role_list_proto)
+    }
+}
+
+impl FromBytes<RoleList> for RoleList {
+    fn from_bytes(bytes: &[u8]) -> Result<RoleList, ProtoConversionError> {
+        let proto: protos::pike_state::RoleList =
+            Message::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get RoleList from bytes".to_string(),
+                )
+            })?;
+
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for RoleList {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from RoleList".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::pike_state::RoleList> for RoleList {}
+impl IntoNative<RoleList> for protos::pike_state::RoleList {}
+
+/// Native implementation of AlternateIDIndexEntry
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlternateIDIndexEntry {
+    id_type: String,
+    id: String,
+    grid_identity_id: String,
+}
+
+impl AlternateIDIndexEntry {
+    pub fn id_type(&self) -> &str {
+        &self.id_type
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn grid_identity_id(&self) -> &str {
+        &self.grid_identity_id
+    }
+}
+
+impl FromProto<protos::pike_state::AlternateIDIndexEntry> for AlternateIDIndexEntry {
+    fn from_proto(
+        id: protos::pike_state::AlternateIDIndexEntry,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(AlternateIDIndexEntry {
+            id_type: id.get_id_type().to_string(),
+            id: id.get_id().to_string(),
+            grid_identity_id: id.get_grid_identity_id().to_string(),
+        })
+    }
+}
+
+impl FromNative<AlternateIDIndexEntry> for protos::pike_state::AlternateIDIndexEntry {
+    fn from_native(id: AlternateIDIndexEntry) -> Result<Self, ProtoConversionError> {
+        let mut alt_id_proto = protos::pike_state::AlternateIDIndexEntry::new();
+
+        alt_id_proto.set_id_type(id.id_type().to_string());
+        alt_id_proto.set_id(id.id().to_string());
+        alt_id_proto.set_grid_identity_id(id.grid_identity_id().to_string());
+
+        Ok(alt_id_proto)
+    }
+}
+
+impl FromBytes<AlternateIDIndexEntry> for AlternateIDIndexEntry {
+    fn from_bytes(bytes: &[u8]) -> Result<AlternateIDIndexEntry, ProtoConversionError> {
+        let proto: protos::pike_state::AlternateIDIndexEntry = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get AlternateIDIndexEntry from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for AlternateIDIndexEntry {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from AlternateIDIndexEntry".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::pike_state::AlternateIDIndexEntry> for AlternateIDIndexEntry {}
+impl IntoNative<AlternateIDIndexEntry> for protos::pike_state::AlternateIDIndexEntry {}
+
+/// Native implementation of AlternateID
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlternateID {
+    id_type: String,
+    id: String,
+}
+
+impl AlternateID {
+    pub fn id_type(&self) -> &str {
+        &self.id_type
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+impl FromProto<protos::pike_state::AlternateID> for AlternateID {
+    fn from_proto(id: protos::pike_state::AlternateID) -> Result<Self, ProtoConversionError> {
+        Ok(AlternateID {
+            id_type: id.get_field_type().to_string(),
+            id: id.get_id().to_string(),
+        })
+    }
+}
+
+impl FromNative<AlternateID> for protos::pike_state::AlternateID {
+    fn from_native(id: AlternateID) -> Result<Self, ProtoConversionError> {
+        let mut alt_id_proto = protos::pike_state::AlternateID::new();
+
+        alt_id_proto.set_field_type(id.id_type().to_string());
+        alt_id_proto.set_id(id.id().to_string());
+
+        Ok(alt_id_proto)
+    }
+}
+
+impl FromBytes<AlternateID> for AlternateID {
+    fn from_bytes(bytes: &[u8]) -> Result<AlternateID, ProtoConversionError> {
+        let proto: protos::pike_state::AlternateID =
+            Message::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get AlternateID from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for AlternateID {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from AlternateID".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::pike_state::AlternateID> for AlternateID {}
+impl IntoNative<AlternateID> for protos::pike_state::AlternateID {}
+
 /// Native implementation of Agent
 #[derive(Debug, Clone, PartialEq)]
 pub struct Agent {
@@ -466,7 +762,8 @@ impl AgentListBuilder {
 pub struct Organization {
     org_id: String,
     name: String,
-    address: String,
+    locations: Vec<String>,
+    alternate_ids: Vec<AlternateID>,
     metadata: Vec<KeyValueEntry>,
 }
 
@@ -479,8 +776,12 @@ impl Organization {
         &self.name
     }
 
-    pub fn address(&self) -> &str {
-        &self.address
+    pub fn locations(&self) -> &[String] {
+        &self.locations
+    }
+
+    pub fn alternate_ids(&self) -> &[AlternateID] {
+        &self.alternate_ids
     }
 
     pub fn metadata(&self) -> &[KeyValueEntry] {
@@ -493,7 +794,13 @@ impl FromProto<protos::pike_state::Organization> for Organization {
         Ok(Organization {
             org_id: org.get_org_id().to_string(),
             name: org.get_name().to_string(),
-            address: org.get_address().to_string(),
+            locations: org.get_locations().to_vec(),
+            alternate_ids: org
+                .get_alternate_id()
+                .to_vec()
+                .into_iter()
+                .map(AlternateID::from_proto)
+                .collect::<Result<Vec<AlternateID>, ProtoConversionError>>()?,
             metadata: org
                 .get_metadata()
                 .to_vec()
@@ -510,7 +817,14 @@ impl FromNative<Organization> for protos::pike_state::Organization {
 
         org_proto.set_org_id(org.org_id().to_string());
         org_proto.set_name(org.name().to_string());
-        org_proto.set_address(org.address().to_string());
+        org_proto.set_locations(RepeatedField::from_vec(org.locations().to_vec()));
+        org_proto.set_alternate_id(RepeatedField::from_vec(
+            org.alternate_ids()
+                .to_vec()
+                .into_iter()
+                .map(AlternateID::into_proto)
+                .collect::<Result<Vec<protos::pike_state::AlternateID>, ProtoConversionError>>()?,
+        ));
         org_proto.set_metadata(RepeatedField::from_vec(
             org.metadata()
                 .to_vec()
@@ -583,7 +897,8 @@ impl std::fmt::Display for OrganizationBuildError {
 pub struct OrganizationBuilder {
     pub org_id: Option<String>,
     pub name: Option<String>,
-    pub address: Option<String>,
+    pub locations: Vec<String>,
+    pub alternate_ids: Vec<AlternateID>,
     pub metadata: Vec<KeyValueEntry>,
 }
 
@@ -602,8 +917,13 @@ impl OrganizationBuilder {
         self
     }
 
-    pub fn with_address(mut self, name: String) -> OrganizationBuilder {
-        self.address = Some(name);
+    pub fn with_locations(mut self, locations: Vec<String>) -> OrganizationBuilder {
+        self.locations = locations;
+        self
+    }
+
+    pub fn with_alternate_ids(mut self, alternate_ids: Vec<AlternateID>) -> OrganizationBuilder {
+        self.alternate_ids = alternate_ids;
         self
     }
 
@@ -621,16 +941,17 @@ impl OrganizationBuilder {
             OrganizationBuildError::MissingField("'name' field is required".to_string())
         })?;
 
-        let address = self.address.ok_or_else(|| {
-            OrganizationBuildError::MissingField("'address' field is required".to_string())
-        })?;
+        let locations = self.locations;
+
+        let alternate_ids = self.alternate_ids;
 
         let metadata = self.metadata;
 
         Ok(Organization {
             org_id,
             name,
-            address,
+            locations,
+            alternate_ids,
             metadata,
         })
     }
@@ -921,14 +1242,14 @@ mod tests {
         let organization = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_address("address".to_string())
+            .with_locations(vec!["location".to_string()])
             .with_metadata(vec![key_value.clone()])
             .build()
             .unwrap();
 
         assert_eq!(organization.org_id(), "organization");
         assert_eq!(organization.name(), "name");
-        assert_eq!(organization.address(), "address");
+        assert_eq!(organization.locations(), ["location"]);
         assert_eq!(organization.metadata(), [key_value]);
     }
 
@@ -946,7 +1267,7 @@ mod tests {
         let original = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_address("address".to_string())
+            .with_locations(vec!["locations".to_string()])
             .with_metadata(vec![key_value.clone()])
             .build()
             .unwrap();
@@ -970,7 +1291,7 @@ mod tests {
         let organization = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_address("address".to_string())
+            .with_locations(vec!["location".to_string()])
             .with_metadata(vec![key_value.clone()])
             .build()
             .unwrap();
@@ -998,7 +1319,7 @@ mod tests {
         let organization = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_address("address".to_string())
+            .with_locations(vec!["locations".to_string()])
             .with_metadata(vec![key_value.clone()])
             .build()
             .unwrap();


### PR DESCRIPTION
Implements Roles based on the Grid Identity RFC. This included some updates to the transaction processor and an overhaul of the has_permissions() call to implement roles and role inheritance checks.