### PR TITLE
Stabilize database and splinter-support in 0.1

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -66,12 +66,12 @@ stable = [
     "pike",
     "schema",
     "product",
-    "location"
+    "location",
+    "splinter-support"
 ]
 
 experimental = [
     "stable",
-    "splinter-support",
     "track-and-trace"
 ]
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -58,14 +58,14 @@ stable = [
     "pike",
     "schema",
     "product",
-    "location"
+    "location",
+    "database"
 ]
 
 experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
-    "database",
     "track-and-trace"
 ]
 


### PR DESCRIPTION
These need to be stable in 0.1, but they will still go through the stabilization process for 0.2