### PR TITLE
Include record owner in has_permission check

### DIFF
--- a/contracts/location/src/state.rs
+++ b/contracts/location/src/state.rs
@@ -23,12 +23,11 @@ cfg_if! {
 }
 
 use grid_sdk::{
-    agents::addressing::compute_agent_address,
     locations::addressing::compute_gs1_location_address,
     organizations::addressing::compute_organization_address,
     protocol::{
         location::state::{Location, LocationList, LocationListBuilder},
-        pike::state::{Agent, AgentList, Organization, OrganizationList},
+        pike::state::{Organization, OrganizationList},
         schema::state::{Schema, SchemaList},
     },
     protos::{FromBytes, IntoBytes},
@@ -168,31 +167,6 @@ impl<'a> LocationState<'a> {
         }
 
         Ok(())
-    }
-
-    pub fn get_agent(&self, public_key: &str) -> Result<Option<Agent>, ApplyError> {
-        let address = compute_agent_address(public_key);
-        match self.context.get_state_entry(&address)? {
-            Some(packed) => {
-                let agents: AgentList = match AgentList::from_bytes(packed.as_slice()) {
-                    Ok(agents) => agents,
-                    Err(err) => {
-                        return Err(ApplyError::InvalidTransaction(format!(
-                            "Cannot deserialize agent list: {:?}",
-                            err,
-                        )));
-                    }
-                };
-
-                for agent in agents.agents() {
-                    if agent.public_key() == public_key {
-                        return Ok(Some(agent.clone()));
-                    }
-                }
-                Ok(None)
-            }
-            None => Ok(None),
-        }
     }
 
     pub fn get_organization(&self, org_id: &str) -> Result<Option<Organization>, ApplyError> {

--- a/contracts/pike/Cargo.toml
+++ b/contracts/pike/Cargo.toml
@@ -25,10 +25,10 @@ grid-sdk = {path = "../../sdk", features = ["pike"]}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rust-crypto-wasm = "0.3"
-sabre-sdk = "0.4"
+sabre-sdk = "0.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-sawtooth-sdk = "0.3"
+sawtooth-sdk = "0.4"
 log = "0.4"
 flexi_logger = "0.14"
 clap = "2"

--- a/contracts/product/src/addressing.rs
+++ b/contracts/product/src/addressing.rs
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 Target Brands, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crypto::digest::Digest;
+use crypto::sha2::Sha512;
+
+const GRID_NAMESPACE: &str = "621dee"; // Grid prefix
+pub const PIKE_NAMESPACE: &str = "cad11d";
+#[cfg(test)]
+pub const PIKE_AGENT_NAMESPACE: &str = "00";
+pub const PIKE_ORG_NAMESPACE: &str = "01";
+
+pub fn get_product_prefix() -> String {
+    GRID_NAMESPACE.to_string()
+}
+
+pub fn compute_gs1_product_address(gtin: &str) -> String {
+    // 621ddee (grid namespace) + 02 (product namespace) + 01 (gs1 namespace)
+    String::from(GRID_NAMESPACE)
+        + "02"
+        + "01"
+        + "00000000000000000000000000000000000000000000"
+        + &format!("{:0>14}", gtin)
+        + "00"
+}
+
+/// Computes the address a Pike Agent is stored at based on its public_key
+#[cfg(test)]
+pub fn compute_agent_address(public_key: &str) -> String {
+    let mut sha = Sha512::new();
+    sha.input(public_key.as_bytes());
+
+    String::from(PIKE_NAMESPACE) + PIKE_AGENT_NAMESPACE + &sha.result_str()[..62]
+}
+
+/// Computes the address a Pike Organization is stored at based on its identifier
+pub fn compute_org_address(identifier: &str) -> String {
+    let mut sha = Sha512::new();
+    sha.input(identifier.as_bytes());
+
+    String::from(PIKE_NAMESPACE) + PIKE_ORG_NAMESPACE + &sha.result_str()[..62]
+}
+
+pub fn compute_schema_address(name: &str) -> String {
+    let mut sha = Sha512::new();
+    sha.input(name.as_bytes());
+
+    String::from(GRID_NAMESPACE) + "01" + &sha.result_str()[..62].to_string()
+}

--- a/contracts/product/src/state.rs
+++ b/contracts/product/src/state.rs
@@ -23,11 +23,10 @@ cfg_if! {
 }
 
 use grid_sdk::{
-    agents::addressing::compute_agent_address,
     organizations::addressing::compute_organization_address,
     products::addressing::compute_gs1_product_address,
     protocol::{
-        pike::state::{Agent, AgentList, Organization, OrganizationList},
+        pike::state::{Organization, OrganizationList},
         product::state::{Product, ProductList, ProductListBuilder},
         schema::state::{Schema, SchemaList},
     },
@@ -173,34 +172,6 @@ impl<'a> ProductState<'a> {
         Ok(())
     }
 
-    /// Gets a Pike Agent. Handles retrieving the correct agent from an AgentList.
-    pub fn get_agent(&self, public_key: &str) -> Result<Option<Agent>, ApplyError> {
-        let address = compute_agent_address(public_key);
-        let d = self.context.get_state_entry(&address)?;
-        match d {
-            Some(packed) => {
-                let agents: AgentList = match AgentList::from_bytes(packed.as_slice()) {
-                    Ok(agents) => agents,
-                    Err(err) => {
-                        return Err(ApplyError::InvalidTransaction(format!(
-                            "Cannot deserialize agent list: {:?}",
-                            err,
-                        )));
-                    }
-                };
-
-                // find the agent with the correct public_key
-                for agent in agents.agents() {
-                    if agent.public_key() == public_key {
-                        return Ok(Some(agent.clone()));
-                    }
-                }
-                Ok(None)
-            }
-            None => Ok(None),
-        }
-    }
-
     pub fn get_organization(&self, id: &str) -> Result<Option<Organization>, ApplyError> {
         let address = compute_organization_address(id);
         let d = self.context.get_state_entry(&address)?;
@@ -262,7 +233,6 @@ mod tests {
     use std::cell::RefCell;
     use std::collections::HashMap;
 
-    use grid_sdk::protocol::pike::state::{AgentBuilder, AgentListBuilder};
     use grid_sdk::protocol::product::state::{ProductBuilder, ProductNamespace};
     use grid_sdk::protocol::schema::state::{DataType, PropertyValue, PropertyValueBuilder};
 
@@ -320,38 +290,6 @@ mod tests {
         }
     }
 
-    impl MockTransactionContext {
-        fn add_agent(&self, public_key: &str) {
-            let agent_list = AgentListBuilder::new()
-                .with_agents(vec![make_agent(public_key)])
-                .build()
-                .unwrap();
-            let agent_bytes = agent_list.into_bytes().unwrap();
-            let agent_address = compute_agent_address(public_key);
-            self.set_state_entry(agent_address, agent_bytes).unwrap();
-        }
-    }
-
-    #[test]
-    // Test that if an agent does not exist in state, None is returned
-    fn test_get_agent_none() {
-        let mut transaction_context = MockTransactionContext::default();
-        let state = ProductState::new(&mut transaction_context);
-
-        let result = state.get_agent("agent_public_key").unwrap();
-        assert!(result.is_none())
-    }
-
-    #[test]
-    // Test that if an agent exist in state, Some(agent) is returned
-    fn test_get_agent_some() {
-        let mut transaction_context = MockTransactionContext::default();
-        transaction_context.add_agent("agent_public_key");
-        let state = ProductState::new(&mut transaction_context);
-        let result = state.get_agent("agent_public_key").unwrap();
-        assert_eq!(result, Some(make_agent("agent_public_key")))
-    }
-
     #[test]
     // Test that if a product does not exist in state, None is returned
     fn test_get_product_none() {
@@ -371,16 +309,6 @@ mod tests {
         assert!(state.set_product(PRODUCT_ID, make_product()).is_ok());
         let result = state.get_product(PRODUCT_ID).unwrap();
         assert_eq!(result, Some(make_product()));
-    }
-
-    fn make_agent(public_key: &str) -> Agent {
-        AgentBuilder::new()
-            .with_org_id("test_org".to_string())
-            .with_public_key(public_key.to_string())
-            .with_active(true)
-            .with_roles(vec![])
-            .build()
-            .expect("Failed to build agent")
     }
 
     fn make_product() -> Product {


### PR DESCRIPTION
Updates the has_permission check to include `record_owner`, which is the Pike ID of the org that owns the record that we are checking permissions for.  This also adds a check to make sure the agent actually belongs to that org and removes it from the smart contract. This is part of an effort to move common code from the contracts to the SDK.