### PR TITLE
Remove unnecessary SDK features

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,7 +38,7 @@ log = "0.4"
 flexi_logger = "0.14"
 sawtooth-sdk = "0.4"
 sabre-sdk = "0.5"
-grid-sdk = { path = "../sdk", features = ["database", "pike", "schema", "product", "location"] }
+grid-sdk = { path = "../sdk", features = ["postgres", "sqlite", "pike", "schema", "product", "location"] }
 rust-crypto = "0.2"
 protobuf = "2.19"
 users = "0.9"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -41,7 +41,7 @@ diesel = { version = "1.0.0", features = ["r2d2", "serde_json"] }
 diesel_migrations = "1.4"
 flexi_logger = "0.14"
 futures = "0.3"
-grid-sdk = { path = "../sdk", features = ["database", "experimental"] }
+grid-sdk = { path = "../sdk", features = ["postgres", "sqlite", "experimental"] }
 log = "0.4"
 protobuf = "2.19"
 reqwest = { version = "0.10.1", optional = true, features = ["json", "blocking"] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -72,14 +72,15 @@ experimental = [
     "stable",
     # The following features are experimental:
     "batch-store",
-    "database",
+    "postgres",
     "rest-api-resources",
     "rest-api-actix-web-3",
+    "sawtooth-compat",
+    "sqlite",
     "track-and-trace",
     "workflow"
 ]
 
-database = ["grid_db", "postgres", "sqlite" ]
 location = ["pike", "schema"]
 pike = []
 product = ["pike", "schema"]
@@ -87,7 +88,6 @@ schema = ["pike"]
 track-and-trace = []
 batch-store = []
 
-grid_db = ["sawtooth-compat"]
 postgres = ["diesel/postgres", "diesel_migrations", "log"]
 rest-api-actix-web-3 = ["actix-web", "futures-util", "rest-api-resources", "sqlite", "postgres"]
 rest-api-resources = ["cylinder", "sabre-sdk", "log"]


### PR DESCRIPTION
This removes the unnecessary `grid_db` and `database` features from the
SDK. These features just wrapped other features but weren't actually
used to guard any code. The wrapped features that actually guard code
are now just moved up one level.

Signed-off-by: Davey Newhall <newhall@bitwise.io>