### PR TITLE
Update splinter-canopyjs dependency

### DIFF
--- a/ui/grid-ui/package.json
+++ b/ui/grid-ui/package.json
@@ -12,7 +12,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-scripts": "^3.4.0",
-    "splinter-canopyjs": "github:cargill/splinter-canopyjs#master"
+    "splinter-canopyjs": "github:cargill/splinter-canopyjs#main"
   },
   "scripts": {
     "start:saplings": "http-server .. -p 3030 --cors",


### PR DESCRIPTION
This updates the splinter-canopyjs dependency in the grid-ui to pull
from the correct Github branch.

Signed-off-by: Davey Newhall <newhall@bitwise.io>