### PR TITLE
Fix builds

### DIFF
--- a/daemon/src/sawtooth/event.rs
+++ b/daemon/src/sawtooth/event.rs
@@ -393,6 +393,15 @@ mod tests {
 
     use sawtooth_sdk::messages::events::Event_Attribute;
 
+    #[cfg(feature = "schema")]
+    use grid_sdk::schemas::addressing::GRID_SCHEMA_NAMESPACE;
+
+    #[cfg(feature = "product")]
+    use grid_sdk::products::addressing::GRID_PRODUCT_NAMESPACE;
+
+    #[cfg(feature = "location")]
+    use grid_sdk::locations::addressing::GRID_LOCATION_NAMESPACE;
+
     /// Verify that a valid set of Sawtooth events can be converted to a `CommitEvent`.
     #[test]
     fn sawtooth_events_to_commit_event() {
@@ -401,11 +410,11 @@ mod tests {
 
         let grid_state_changes = vec![
             #[cfg(feature = "schema")]
-            create_state_change(format!("{}01", GRID_NAMESPACE), Some(vec![0x01])),
+            create_state_change(GRID_SCHEMA_NAMESPACE.to_string(), Some(vec![0x01])),
             #[cfg(feature = "product")]
-            create_state_change(format!("{}02", GRID_NAMESPACE), Some(vec![0x02])),
+            create_state_change(GRID_PRODUCT_NAMESPACE.to_string(), Some(vec![0x02])),
             #[cfg(feature = "location")]
-            create_state_change(format!("{}04", GRID_NAMESPACE), None),
+            create_state_change(GRID_LOCATION_NAMESPACE.to_string(), None),
         ];
         let non_grid_state_changes = vec![create_state_change("ef".into(), None)];
 

--- a/ui/grid-ui/package.json
+++ b/ui/grid-ui/package.json
@@ -12,7 +12,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-scripts": "^3.4.0",
-    "splinter-canopyjs": "github:cargill/splinter-canopyjs#master"
+    "splinter-canopyjs": "github:cargill/splinter-canopyjs#main"
   },
   "scripts": {
     "start:saplings": "http-server .. -p 3030 --cors",


### PR DESCRIPTION
1. The canopyjs branch changed from master to main so I updated it in the grid UI package.json
2. Strange issue with features. The `GRID_NAMESPACE` const was removed from the event.rs module in a previous commit and the build passed, but builds after this broke due to it not being defined. I changed it to pull in the proper consts from the relevant addressing modules and guarding it by feature. Not entirely sure why it passed to begin with.