### PR TITLE
Grid daemon Pagination

### DIFF
--- a/cli/src/actions/mod.rs
+++ b/cli/src/actions/mod.rs
@@ -20,6 +20,8 @@ use std::path::Path;
 
 use super::error::CliError;
 
+use serde::Deserialize;
+
 fn chown(path: &Path, uid: u32, gid: u32) -> Result<(), CliError> {
     let pathstr = path
         .to_str()
@@ -33,6 +35,17 @@ fn chown(path: &Path, uid: u32, gid: u32) -> Result<(), CliError> {
             pathstr, code
         ))),
     }
+}
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct Paging {
+    current: String,
+    offset: i64,
+    limit: i64,
+    total: i64,
+    first: String,
+    prev: String,
+    next: Option<String>,
+    last: String,
 }
 
 #[cfg(feature = "admin-keygen")]

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -186,6 +186,8 @@ paths:
       operationId: list_locations
       parameters:
         - $ref: "#/components/parameters/service_id"
+        - $ref: "#/components/parameters/page_offset"
+        - $ref: "#/components/parameters/page_limit"
       responses:
         "200":
           description: |
@@ -194,9 +196,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Location"
+                $ref: "#/components/schemas/LocationList"
         "400":
           $ref: "#/components/responses/400BadRequest"
         "500":
@@ -244,6 +244,8 @@ paths:
       operationId: list_agents
       parameters:
         - $ref: "#/components/parameters/service_id"
+        - $ref: "#/components/parameters/page_offset"
+        - $ref: "#/components/parameters/page_limit"
       responses:
         "200":
           description: |
@@ -252,9 +254,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Agent"
+                $ref: "#/components/schemas/AgentList"
         "400":
           $ref: "#/components/responses/400BadRequest"
         "500":
@@ -300,6 +300,8 @@ paths:
       operationId: list_organizations
       parameters:
         - $ref: "#/components/parameters/service_id"
+        - $ref: "#/components/parameters/page_offset"
+        - $ref: "#/components/parameters/page_limit"
       responses:
         "200":
           description: |
@@ -308,9 +310,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Organization"
+                $ref: "#/components/schemas/OrganizationList"
         "400":
           $ref: "#/components/responses/400BadRequest"
         "500":
@@ -358,6 +358,8 @@ paths:
       operationId: list_products
       parameters:
         - $ref: "#/components/parameters/service_id"
+        - $ref: "#/components/parameters/page_offset"
+        - $ref: "#/components/parameters/page_limit"
       responses:
         "200":
           description: |
@@ -366,9 +368,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Product"
+                $ref: "#/components/schemas/ProductList"
         "400":
           $ref: "#/components/responses/400BadRequest"
         "500":
@@ -416,6 +416,8 @@ paths:
       operationId: list_grid_schemas
       parameters:
         - $ref: "#/components/parameters/service_id"
+        - $ref: "#/components/parameters/page_offset"
+        - $ref: "#/components/parameters/page_limit"
       responses:
         "200":
           description: |
@@ -424,9 +426,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Schema"
+                $ref: "#/components/schemas/SchemaList"
         "400":
           $ref: "#/components/responses/400BadRequest"
         "500":
@@ -476,6 +476,8 @@ paths:
       operationId: list_records
       parameters:
         - $ref: "#/components/parameters/service_id"
+        - $ref: "#/components/parameters/page_offset"
+        - $ref: "#/components/parameters/page_limit"
       responses:
         "200":
           description: |
@@ -484,9 +486,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Record"
+                $ref: "#/components/schemas/RecordList"
         "400":
           $ref: "#/components/responses/400BadRequest"
         "500":
@@ -566,6 +566,14 @@ paths:
 components:
   schemas:
     # Location models
+    LocationList:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Location"
+        paging:
+          $ref: "#/components/schemas/Paging"
     Location:
       type: object
       properties:
@@ -585,6 +593,14 @@ components:
           $ref: "#/components/schemas/ServiceID"
 
     # Pike models
+    AgentList:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Agent"
+        paging:
+          $ref: "#/components/schemas/Paging"
     Agent:
       properties:
         public_key:
@@ -607,6 +623,14 @@ components:
             $ref: "#/components/schemas/Metadata"
         service_id:
           $ref: "#/components/schemas/ServiceID"
+    OrganizationList:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Organization"
+        paging:
+          $ref: "#/components/schemas/Paging"
     Organization:
       type: object
       properties:
@@ -627,6 +651,14 @@ components:
           $ref: "#/components/schemas/ServiceID"
 
     # Product models
+    ProductList:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Product"
+        paging:
+          $ref: "#/components/schemas/Paging"
     Product:
       type: object
       properties:
@@ -649,6 +681,14 @@ components:
           $ref: "#/components/schemas/ServiceID"
 
     # Schema models
+    SchemaList:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Schema"
+        paging:
+          $ref: "#/components/schemas/Paging"
     Schema:
       properties:
         name:
@@ -776,7 +816,47 @@ components:
       items:
         $ref: "#/components/schemas/StructPropertyValue"
 
+    Paging:
+      type: object
+      properties:
+        current:
+          type: string
+          description: Link to the current page
+          example: /agent?offset0&limit=10
+        offset:
+          type: integer
+          description: Index of first element in page
+          example: 0
+        limit:
+          type: integer
+          description: The maximum number of elements per page
+          example: 10
+        total:
+          type: integer
+          description: The total number of elements that exist
+          example: 1000
+        prev:
+          type: string
+          description: Link to previous page
+          example: /agent?offset=0&limit=10
+        next:
+          type: string
+          description: Link to next page
+          example: /agent?offset=10&limit=10
+        last:
+          type: string
+          description: Link to last page
+          example: /agent?offset100&limit=10
+
     # Track and Trace models
+    RecordList:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Record"
+        paging:
+          $ref: "#/components/schemas/Paging"
     Record:
       type: object
       properties:
@@ -1040,6 +1120,20 @@ components:
       description: |
         The number of seconds to wait for batches to be committed before
         returning.
+      schema:
+        type: integer
+    page_offset:
+      name: offset
+      in: query
+      description: |
+        The index of the first element to be in the page
+      schema:
+        type: integer
+    page_limit:
+      name: limit
+      in: query
+      description: |
+        The maximum number of elements in a page
       schema:
         type: integer
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -33,7 +33,12 @@ extern crate log;
 ))]
 #[macro_use]
 extern crate serde_json;
-#[cfg(feature = "splinter-support")]
+#[cfg(any(
+    feature = "pike",
+    feature = "schema",
+    feature = "product",
+    feature = "location"
+))]
 #[macro_use]
 extern crate serde;
 

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -86,6 +86,12 @@ pub struct QueryServiceId {
     pub wait: Option<u64>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QueryPaging {
+    pub offset: Option<i64>,
+    pub limit: Option<i64>,
+}
+
 pub struct AcceptServiceIdParam;
 
 impl FromRequest for AcceptServiceIdParam {

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -120,7 +120,7 @@ mod test {
     use crate::database;
     use crate::rest_api::{
         error::RestApiResponseError,
-        routes::{AgentSlice, OrganizationSlice},
+        routes::{AgentListSlice, AgentSlice, OrganizationListSlice, OrganizationSlice},
         AppState,
     };
     use crate::sawtooth::batch_submitter::{
@@ -716,9 +716,9 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<AgentSlice> =
+        let body: AgentListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert!(body.is_empty());
+        assert!(body.data.is_empty());
 
         // Adds a single Agent to the test database
         populate_agent_table(get_agent(None));
@@ -731,10 +731,10 @@ mod test {
             .unwrap();
 
         assert!(response.status().is_success());
-        let body: Vec<AgentSlice> =
+        let body: AgentListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
-        let agent = body.first().unwrap();
+        assert_eq!(body.data.len(), 1);
+        let agent = body.data.first().unwrap();
         assert_eq!(agent.public_key, KEY1.to_string());
         assert_eq!(agent.org_id, KEY2.to_string());
     }
@@ -762,9 +762,9 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<AgentSlice> =
+        let body: AgentListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert!(body.is_empty());
+        assert!(body.data.is_empty());
 
         // Adds a single Agent to the test database
         populate_agent_table(get_agent(Some(TEST_SERVICE_ID.to_string())));
@@ -780,10 +780,10 @@ mod test {
             .unwrap();
 
         assert!(response.status().is_success());
-        let body: Vec<AgentSlice> =
+        let body: AgentListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
-        let agent = body.first().unwrap();
+        assert_eq!(body.data.len(), 1);
+        let agent = body.data.first().unwrap();
         assert_eq!(agent.public_key, KEY1.to_string());
         assert_eq!(agent.org_id, KEY2.to_string());
         assert_eq!(agent.service_id, Some(TEST_SERVICE_ID.to_string()));
@@ -805,9 +805,9 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<OrganizationSlice> =
+        let body: OrganizationListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert!(body.is_empty());
+        assert!(body.data.is_empty());
     }
 
     ///
@@ -830,10 +830,10 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<OrganizationSlice> =
+        let body: OrganizationListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
-        let org = body.first().unwrap();
+        assert_eq!(body.data.len(), 1);
+        let org = body.data.first().unwrap();
         assert_eq!(org.name, ORG_NAME_1.to_string());
         assert_eq!(org.org_id, KEY2.to_string());
         assert_eq!(org.address, ADDRESS_1.to_string());
@@ -862,10 +862,10 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<OrganizationSlice> =
+        let body: OrganizationListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
-        let org = body.first().unwrap();
+        assert_eq!(body.data.len(), 1);
+        let org = body.data.first().unwrap();
         assert_eq!(org.name, ORG_NAME_1.to_string());
         assert_eq!(org.org_id, KEY2.to_string());
         assert_eq!(org.address, ADDRESS_1.to_string());
@@ -895,10 +895,10 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<OrganizationSlice> =
+        let body: OrganizationListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
-        let org = body.first().unwrap();
+        assert_eq!(body.data.len(), 1);
+        let org = body.data.first().unwrap();
         assert_eq!(org.name, ORG_NAME_2.to_string());
         assert_eq!(org.org_id, KEY3.to_string());
         // Checks is returned the organization with the most recent information
@@ -1161,9 +1161,9 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let empty_body: Vec<GridSchemaSlice> =
+        let empty_body: GridSchemaListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert!(empty_body.is_empty());
+        assert!(empty_body.data.is_empty());
 
         populate_grid_schema_table(get_grid_schema(None));
         let mut response = srv
@@ -1172,11 +1172,11 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<GridSchemaSlice> =
+        let body: GridSchemaListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
+        assert_eq!(body.data.len(), 1);
 
-        let test_schema = body.first().unwrap();
+        let test_schema = body.data.first().unwrap();
         assert_eq!(test_schema.name, "TestGridSchema".to_string());
         assert_eq!(test_schema.owner, "phillips001".to_string());
         assert_eq!(test_schema.properties.len(), 2);
@@ -1202,9 +1202,9 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let empty_body: Vec<GridSchemaSlice> =
+        let empty_body: GridSchemaListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert!(empty_body.is_empty());
+        assert!(empty_body.data.is_empty());
 
         populate_grid_schema_table(get_grid_schema(Some(TEST_SERVICE_ID.to_string())));
         let mut response = srv
@@ -1216,11 +1216,11 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<GridSchemaSlice> =
+        let body: GridSchemaListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
+        assert_eq!(body.data.len(), 1);
 
-        let test_schema = body.first().unwrap();
+        let test_schema = body.data.first().unwrap();
         assert_eq!(test_schema.name, "TestGridSchema".to_string());
         assert_eq!(test_schema.owner, "phillips001".to_string());
         assert_eq!(test_schema.properties.len(), 2);
@@ -1341,9 +1341,9 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let empty_body: Vec<ProductSlice> =
+        let empty_body: ProductListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert!(empty_body.is_empty());
+        assert!(empty_body.data.is_empty());
 
         populate_product_table(get_product(None));
         let mut response = srv
@@ -1352,11 +1352,11 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<ProductSlice> =
+        let body: ProductListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
+        assert_eq!(body.data.len(), 1);
 
-        let test_product = body.first().unwrap();
+        let test_product = body.data.first().unwrap();
         assert_eq!(test_product.product_id, "041205707820".to_string());
         assert_eq!(test_product.product_address, "test_address".to_string());
         assert_eq!(test_product.product_namespace, "Grid Product".to_string());
@@ -1382,9 +1382,9 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let empty_body: Vec<LocationSlice> =
+        let empty_body: LocationListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert!(empty_body.is_empty());
+        assert!(empty_body.data.is_empty());
 
         populate_location_table(get_location(None));
 
@@ -1394,11 +1394,11 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<LocationSlice> =
+        let body: LocationListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
+        assert_eq!(body.data.len(), 1);
 
-        let test_location = body.first().unwrap();
+        let test_location = body.data.first().unwrap();
         assert_eq!(
             test_location.location_namespace,
             "Grid Location".to_string()
@@ -1427,9 +1427,9 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let empty_body: Vec<ProductSlice> =
+        let empty_body: ProductListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert!(empty_body.is_empty());
+        assert!(empty_body.data.is_empty());
 
         populate_product_table(get_product(Some(TEST_SERVICE_ID.to_string())));
         let mut response = srv
@@ -1441,11 +1441,11 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<ProductSlice> =
+        let body: ProductListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
+        assert_eq!(body.data.len(), 1);
 
-        let test_product = body.first().unwrap();
+        let test_product = body.data.first().unwrap();
         assert_eq!(test_product.product_id, "041205707820".to_string());
         assert_eq!(test_product.product_address, "test_address".to_string());
         assert_eq!(test_product.product_namespace, "Grid Product".to_string());
@@ -1474,9 +1474,9 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let empty_body: Vec<LocationSlice> =
+        let empty_body: LocationListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert!(empty_body.is_empty());
+        assert!(empty_body.data.is_empty());
 
         populate_location_table(get_location(Some(TEST_SERVICE_ID.to_string())));
         let mut response = srv
@@ -1488,11 +1488,11 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<LocationSlice> =
+        let body: LocationListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
+        assert_eq!(body.data.len(), 1);
 
-        let test_location = body.first().unwrap();
+        let test_location = body.data.first().unwrap();
         assert_eq!(test_location.location_id, "0653114000000".to_string());
         assert_eq!(
             test_location.location_namespace,
@@ -1742,10 +1742,10 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<RecordSlice> =
+        let body: RecordListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
-        let test_record = body.first().unwrap();
+        assert_eq!(body.data.len(), 1);
+        let test_record = body.data.first().unwrap();
         assert_eq!(test_record.record_id, "TestRecord".to_string());
         assert_eq!(test_record.schema, "TestGridSchema".to_string());
         assert_eq!(test_record.owner, KEY1.to_string());
@@ -1874,10 +1874,10 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<RecordSlice> =
+        let body: RecordListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
-        let test_record = body.first().unwrap();
+        assert_eq!(body.data.len(), 1);
+        let test_record = body.data.first().unwrap();
         assert_eq!(test_record.record_id, "TestRecord".to_string());
         assert_eq!(test_record.schema, "TestGridSchema".to_string());
         assert_eq!(test_record.owner, KEY1.to_string());
@@ -2036,10 +2036,10 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<RecordSlice> =
+        let body: RecordListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
-        assert_eq!(body.len(), 1);
-        let test_record = body.first().unwrap();
+        assert_eq!(body.data.len(), 1);
+        let test_record = body.data.first().unwrap();
         assert_eq!(test_record.record_id, "TestRecord".to_string());
         assert_eq!(test_record.schema, "TestGridSchema".to_string());
         assert_eq!(test_record.r#final, true);
@@ -2072,14 +2072,14 @@ mod test {
             .await
             .unwrap();
         assert!(response.status().is_success());
-        let body: Vec<RecordSlice> =
+        let body: RecordListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
 
-        assert_eq!(body.len(), 2);
-        let record_1 = &body[0];
+        assert_eq!(body.data.len(), 2);
+        let record_1 = &body.data[0];
         assert_eq!(record_1.properties.len(), 2);
 
-        let record_2 = &body[1];
+        let record_2 = &body.data[1];
         assert!(record_2.properties.is_empty());
     }
 

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -30,6 +30,8 @@ mod batches;
 mod locations;
 #[cfg(feature = "pike")]
 mod organizations;
+#[cfg(feature = "pike")]
+mod paging;
 #[cfg(feature = "product")]
 mod products;
 #[cfg(feature = "track-and-trace")]

--- a/daemon/src/rest_api/routes/paging.rs
+++ b/daemon/src/rest_api/routes/paging.rs
@@ -1,0 +1,113 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use grid_sdk::paging;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Paging {
+    current: String,
+    offset: i64,
+    limit: i64,
+    total: i64,
+    first: String,
+    prev: String,
+    next: Option<String>,
+    last: String,
+}
+
+impl Paging {
+    pub fn new(base_link: &str, paging: paging::Paging, service_id: Option<&str>) -> Self {
+        let current = if let Some(service_id) = service_id {
+            format!(
+                "{}?offset={}&limit={}&service_id={}",
+                base_link, paging.offset, paging.limit, service_id
+            )
+        } else {
+            format!(
+                "{}?offset={}&limit={}",
+                base_link, paging.offset, paging.limit
+            )
+        };
+        let first = if let Some(service_id) = service_id {
+            format!(
+                "{}?offset=0&limit={}&service_id={}",
+                base_link, paging.limit, service_id
+            )
+        } else {
+            format!("{}?offset=0&limit={}", base_link, paging.limit)
+        };
+        let previous_offset = if paging.offset > paging.limit {
+            paging.offset - paging.limit
+        } else {
+            0
+        };
+        let prev = if let Some(service_id) = service_id {
+            format!(
+                "{}?offset={}&limit={}&service_id={}",
+                base_link, previous_offset, paging.limit, service_id
+            )
+        } else {
+            format!(
+                "{}?offset={}&limit={}",
+                base_link, previous_offset, paging.limit
+            )
+        };
+
+        let last_offset = if paging.total > 0 {
+            ((paging.total - 1) / paging.limit) * paging.limit
+        } else {
+            0
+        };
+        let last = if let Some(service_id) = service_id {
+            format!(
+                "{}?offset={}&limit={}&service_id={}",
+                base_link, last_offset, paging.limit, service_id
+            )
+        } else {
+            format!(
+                "{}?offset={}&limit={}",
+                base_link, last_offset, paging.limit
+            )
+        };
+
+        let next_offset = if paging.offset + paging.limit > last_offset {
+            last_offset
+        } else {
+            paging.offset + paging.limit
+        };
+
+        let next = if let Some(service_id) = service_id {
+            format!(
+                "{}?offset={}&limit={}&service_id={}",
+                base_link, next_offset, paging.limit, service_id
+            )
+        } else {
+            format!(
+                "{}?offset={}&limit={}",
+                base_link, next_offset, paging.limit
+            )
+        };
+
+        Paging {
+            current,
+            offset: paging.offset,
+            limit: paging.limit,
+            total: paging.total,
+            first,
+            prev,
+            next: if next == last { None } else { Some(next) },
+            last,
+        }
+    }
+}

--- a/sdk/src/agents/store/diesel/mod.rs
+++ b/sdk/src/agents/store/diesel/mod.rs
@@ -19,7 +19,7 @@ pub(in crate) mod schema;
 use diesel::r2d2::{ConnectionManager, Pool};
 
 use super::diesel::models::{AgentModel, NewAgentModel, NewRoleModel, RoleModel};
-use super::{Agent, AgentStore, AgentStoreError, Role};
+use super::{Agent, AgentList, AgentStore, AgentStoreError, Role};
 use crate::commits::MAX_COMMIT_NUM;
 use crate::error::{
     ConstraintViolationError, ConstraintViolationType, InternalError,
@@ -59,13 +59,18 @@ impl AgentStore for DieselAgentStore<diesel::pg::PgConnection> {
         .add_agent(agent.clone().into(), make_role_models(&agent))
     }
 
-    fn list_agents(&self, service_id: Option<&str>) -> Result<Vec<Agent>, AgentStoreError> {
+    fn list_agents(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<AgentList, AgentStoreError> {
         AgentStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             AgentStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_agents(service_id)
+        .list_agents(service_id, offset, limit)
     }
 
     fn fetch_agent(
@@ -102,13 +107,18 @@ impl AgentStore for DieselAgentStore<diesel::sqlite::SqliteConnection> {
         .add_agent(agent.clone().into(), make_role_models(&agent))
     }
 
-    fn list_agents(&self, service_id: Option<&str>) -> Result<Vec<Agent>, AgentStoreError> {
+    fn list_agents(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<AgentList, AgentStoreError> {
         AgentStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             AgentStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_agents(service_id)
+        .list_agents(service_id, offset, limit)
     }
 
     fn fetch_agent(

--- a/sdk/src/agents/store/mod.rs
+++ b/sdk/src/agents/store/mod.rs
@@ -16,6 +16,8 @@
 pub mod diesel;
 mod error;
 
+use crate::paging::Paging;
+
 pub use error::AgentStoreError;
 
 /// Represents a Grid Agent
@@ -44,6 +46,18 @@ pub struct Role {
     pub service_id: Option<String>,
 }
 
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct AgentList {
+    pub data: Vec<Agent>,
+    pub paging: Paging,
+}
+
+impl AgentList {
+    pub fn new(data: Vec<Agent>, paging: Paging) -> Self {
+        Self { data, paging }
+    }
+}
+
 pub trait AgentStore: Send + Sync {
     /// Adds an agent to the underlying storage
     ///
@@ -57,7 +71,14 @@ pub trait AgentStore: Send + Sync {
     /// # Arguments
     ///
     ///  * `service_id` - The service id to list agents for
-    fn list_agents(&self, service_id: Option<&str>) -> Result<Vec<Agent>, AgentStoreError>;
+    ///  * `offset` - The index of the first in storage to retrieve
+    ///  * `limit` - The number of items to retrieve from the offset
+    fn list_agents(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<AgentList, AgentStoreError>;
 
     /// Fetches an agent from the underlying storage
     ///
@@ -87,8 +108,13 @@ where
         (**self).add_agent(agent)
     }
 
-    fn list_agents(&self, service_id: Option<&str>) -> Result<Vec<Agent>, AgentStoreError> {
-        (**self).list_agents(service_id)
+    fn list_agents(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<AgentList, AgentStoreError> {
+        (**self).list_agents(service_id, offset, limit)
     }
 
     fn fetch_agent(

--- a/sdk/src/batches/store/diesel/mod.rs
+++ b/sdk/src/batches/store/diesel/mod.rs
@@ -19,7 +19,7 @@ pub(in crate) mod schema;
 use diesel::r2d2::{ConnectionManager, Pool};
 
 use super::diesel::models::BatchModel;
-use super::{Batch, BatchStatus, BatchStore, BatchStoreError};
+use super::{Batch, BatchList, BatchStatus, BatchStore, BatchStoreError};
 use crate::error::ResourceTemporarilyUnavailableError;
 
 use operations::add_batch::AddBatchOperation as _;
@@ -62,24 +62,27 @@ impl BatchStore for DieselBatchStore<diesel::pg::PgConnection> {
         .map(|op| op.map(|model| model.into()))
     }
 
-    fn list_batches(&self) -> Result<Vec<Batch>, BatchStoreError> {
+    fn list_batches(&self, offset: i64, limit: i64) -> Result<BatchList, BatchStoreError> {
         BatchStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             BatchStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_batches()
-        .map(|models| models.into_iter().map(|model| model.into()).collect())
+        .list_batches(offset, limit)
     }
 
-    fn list_batches_with_status(&self, status: BatchStatus) -> Result<Vec<Batch>, BatchStoreError> {
+    fn list_batches_with_status(
+        &self,
+        status: BatchStatus,
+        offset: i64,
+        limit: i64,
+    ) -> Result<BatchList, BatchStoreError> {
         BatchStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             BatchStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_batches_with_status(&status.to_string())
-        .map(|models| models.into_iter().map(|model| model.into()).collect())
+        .list_batches_with_status(&status.to_string(), offset, limit)
     }
 
     fn update_status(&self, id: &str, status: BatchStatus) -> Result<(), BatchStoreError> {
@@ -113,24 +116,27 @@ impl BatchStore for DieselBatchStore<diesel::sqlite::SqliteConnection> {
         .map(|op| op.map(|model| model.into()))
     }
 
-    fn list_batches(&self) -> Result<Vec<Batch>, BatchStoreError> {
+    fn list_batches(&self, offset: i64, limit: i64) -> Result<BatchList, BatchStoreError> {
         BatchStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             BatchStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_batches()
-        .map(|models| models.into_iter().map(|model| model.into()).collect())
+        .list_batches(offset, limit)
     }
 
-    fn list_batches_with_status(&self, status: BatchStatus) -> Result<Vec<Batch>, BatchStoreError> {
+    fn list_batches_with_status(
+        &self,
+        status: BatchStatus,
+        offset: i64,
+        limit: i64,
+    ) -> Result<BatchList, BatchStoreError> {
         BatchStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             BatchStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_batches_with_status(&status.to_string())
-        .map(|models| models.into_iter().map(|model| model.into()).collect())
+        .list_batches_with_status(&status.to_string(), offset, limit)
     }
 
     fn update_status(&self, id: &str, status: BatchStatus) -> Result<(), BatchStoreError> {

--- a/sdk/src/batches/store/diesel/operations/list_batches.rs
+++ b/sdk/src/batches/store/diesel/operations/list_batches.rs
@@ -15,34 +15,63 @@
 use super::BatchStoreOperations;
 use crate::batches::store::{diesel::schema::batches, BatchStoreError};
 
-use crate::batches::store::diesel::BatchModel;
 use crate::error::InternalError;
+use crate::{
+    batches::store::{diesel::BatchModel, BatchList},
+    paging::Paging,
+};
 use diesel::prelude::*;
 
 pub(in crate::batches::store::diesel) trait ListBatchesOperation {
-    fn list_batches(&self) -> Result<Vec<BatchModel>, BatchStoreError>;
+    fn list_batches(&self, offset: i64, limit: i64) -> Result<BatchList, BatchStoreError>;
 }
 
 #[cfg(feature = "postgres")]
 impl<'a> ListBatchesOperation for BatchStoreOperations<'a, diesel::pg::PgConnection> {
-    fn list_batches(&self) -> Result<Vec<BatchModel>, BatchStoreError> {
-        batches::table
+    fn list_batches(&self, offset: i64, limit: i64) -> Result<BatchList, BatchStoreError> {
+        let batches = batches::table
             .select(batches::all_columns)
+            .offset(offset)
+            .limit(limit)
             .load::<BatchModel>(self.conn)
+            .map(|models| models.into_iter().map(|model| model.into()).collect())
             .map_err(|err| {
                 BatchStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })
+            })?;
+
+        let total = batches::table
+            .select(batches::all_columns)
+            .count()
+            .get_result(self.conn)
+            .map_err(|err| {
+                BatchStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
+
+        Ok(BatchList::new(batches, Paging::new(offset, limit, total)))
     }
 }
 
 #[cfg(feature = "sqlite")]
 impl<'a> ListBatchesOperation for BatchStoreOperations<'a, diesel::sqlite::SqliteConnection> {
-    fn list_batches(&self) -> Result<Vec<BatchModel>, BatchStoreError> {
-        batches::table
+    fn list_batches(&self, offset: i64, limit: i64) -> Result<BatchList, BatchStoreError> {
+        let batches = batches::table
             .select(batches::all_columns)
+            .offset(offset)
+            .limit(limit)
             .load::<BatchModel>(self.conn)
+            .map(|models| models.into_iter().map(|model| model.into()).collect())
             .map_err(|err| {
                 BatchStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })
+            })?;
+
+        let total = batches::table
+            .select(batches::all_columns)
+            .count()
+            .get_result(self.conn)
+            .map_err(|err| {
+                BatchStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
+
+        Ok(BatchList::new(batches, Paging::new(offset, limit, total)))
     }
 }

--- a/sdk/src/batches/store/mod.rs
+++ b/sdk/src/batches/store/mod.rs
@@ -19,6 +19,7 @@ mod error;
 use std::fmt;
 
 use crate::hex;
+use crate::paging::Paging;
 
 pub use error::BatchStoreError;
 
@@ -58,14 +59,31 @@ impl Batch {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct BatchList {
+    data: Vec<Batch>,
+    paging: Paging,
+}
+
+impl BatchList {
+    fn new(data: Vec<Batch>, paging: Paging) -> Self {
+        Self { data, paging }
+    }
+}
+
 pub trait BatchStore: Send + Sync {
     fn add_batch(&self, batch: Batch) -> Result<(), BatchStoreError>;
 
     fn fetch_batch(&self, id: &str) -> Result<Option<Batch>, BatchStoreError>;
 
-    fn list_batches(&self) -> Result<Vec<Batch>, BatchStoreError>;
+    fn list_batches(&self, offset: i64, limit: i64) -> Result<BatchList, BatchStoreError>;
 
-    fn list_batches_with_status(&self, status: BatchStatus) -> Result<Vec<Batch>, BatchStoreError>;
+    fn list_batches_with_status(
+        &self,
+        status: BatchStatus,
+        offset: i64,
+        limit: i64,
+    ) -> Result<BatchList, BatchStoreError>;
 
     fn update_status(&self, id: &str, status: BatchStatus) -> Result<(), BatchStoreError>;
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -43,6 +43,7 @@ pub mod locations;
 pub mod migrations;
 #[cfg(feature = "pike")]
 pub mod organizations;
+pub mod paging;
 #[cfg(feature = "pike")]
 pub mod permissions;
 #[cfg(feature = "product")]

--- a/sdk/src/locations/store/diesel/mod.rs
+++ b/sdk/src/locations/store/diesel/mod.rs
@@ -21,7 +21,9 @@ use diesel::r2d2::{ConnectionManager, Pool};
 use super::diesel::models::{
     LocationAttributeModel, LocationModel, NewLocationAttributeModel, NewLocationModel,
 };
-use super::{LatLongValue, Location, LocationAttribute, LocationStore, LocationStoreError};
+use super::{
+    LatLongValue, Location, LocationAttribute, LocationList, LocationStore, LocationStoreError,
+};
 use crate::commits::MAX_COMMIT_NUM;
 use crate::error::ResourceTemporarilyUnavailableError;
 
@@ -78,13 +80,15 @@ impl LocationStore for DieselLocationStore<diesel::pg::PgConnection> {
     fn list_locations(
         &self,
         service_id: Option<&str>,
-    ) -> Result<Vec<Location>, LocationStoreError> {
+        offset: i64,
+        limit: i64,
+    ) -> Result<LocationList, LocationStoreError> {
         LocationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             LocationStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_locations(service_id)
+        .list_locations(service_id, offset, limit)
     }
 
     fn update_location(&self, location: Location) -> Result<(), LocationStoreError> {
@@ -141,13 +145,15 @@ impl LocationStore for DieselLocationStore<diesel::sqlite::SqliteConnection> {
     fn list_locations(
         &self,
         service_id: Option<&str>,
-    ) -> Result<Vec<Location>, LocationStoreError> {
+        offset: i64,
+        limit: i64,
+    ) -> Result<LocationList, LocationStoreError> {
         LocationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             LocationStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_locations(service_id)
+        .list_locations(service_id, offset, limit)
     }
 
     fn update_location(&self, location: Location) -> Result<(), LocationStoreError> {

--- a/sdk/src/locations/store/mod.rs
+++ b/sdk/src/locations/store/mod.rs
@@ -16,6 +16,8 @@
 pub mod diesel;
 mod error;
 
+use crate::paging::Paging;
+
 pub use error::LocationStoreError;
 
 /// Represents a Grid Location
@@ -30,6 +32,18 @@ pub struct Location {
     pub start_commit_num: i64,
     pub end_commit_num: i64,
     pub service_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct LocationList {
+    pub data: Vec<Location>,
+    pub paging: Paging,
+}
+
+impl LocationList {
+    pub fn new(data: Vec<Location>, paging: Paging) -> Self {
+        Self { data, paging }
+    }
 }
 
 /// Represents a Grid Location Attribute
@@ -83,8 +97,14 @@ pub trait LocationStore: Send + Sync {
     /// # Arguments
     ///
     ///  * `service_id` - optional - The service ID to get the locations for
-    fn list_locations(&self, service_id: Option<&str>)
-        -> Result<Vec<Location>, LocationStoreError>;
+    ///  * `offset` - The index of the first in storage to retrieve
+    ///  * `limit` - The number of items to retrieve from the offset
+    fn list_locations(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<LocationList, LocationStoreError>;
 
     /// Updates a location in the underlying storage
     ///
@@ -125,8 +145,10 @@ where
     fn list_locations(
         &self,
         service_id: Option<&str>,
-    ) -> Result<Vec<Location>, LocationStoreError> {
-        (**self).list_locations(service_id)
+        offset: i64,
+        limit: i64,
+    ) -> Result<LocationList, LocationStoreError> {
+        (**self).list_locations(service_id, offset, limit)
     }
 
     fn update_location(&self, location: Location) -> Result<(), LocationStoreError> {

--- a/sdk/src/organizations/store/diesel/mod.rs
+++ b/sdk/src/organizations/store/diesel/mod.rs
@@ -19,7 +19,7 @@ pub(in crate) mod schema;
 use diesel::r2d2::{ConnectionManager, Pool};
 
 use super::diesel::models::{NewOrganizationModel, OrganizationModel};
-use super::{Organization, OrganizationStore, OrganizationStoreError};
+use super::{Organization, OrganizationList, OrganizationStore, OrganizationStoreError};
 use crate::error::{
     ConstraintViolationError, ConstraintViolationType, InternalError,
     ResourceTemporarilyUnavailableError,
@@ -60,13 +60,15 @@ impl OrganizationStore for DieselOrganizationStore<diesel::pg::PgConnection> {
     fn list_organizations(
         &self,
         service_id: Option<&str>,
-    ) -> Result<Vec<Organization>, OrganizationStoreError> {
+        offset: i64,
+        limit: i64,
+    ) -> Result<OrganizationList, OrganizationStoreError> {
         OrganizationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             OrganizationStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_organizations(service_id)
+        .list_organizations(service_id, offset, limit)
     }
 
     fn fetch_organization(
@@ -97,13 +99,15 @@ impl OrganizationStore for DieselOrganizationStore<diesel::sqlite::SqliteConnect
     fn list_organizations(
         &self,
         service_id: Option<&str>,
-    ) -> Result<Vec<Organization>, OrganizationStoreError> {
+        offset: i64,
+        limit: i64,
+    ) -> Result<OrganizationList, OrganizationStoreError> {
         OrganizationStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             OrganizationStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_organizations(service_id)
+        .list_organizations(service_id, offset, limit)
     }
 
     fn fetch_organization(

--- a/sdk/src/organizations/store/mod.rs
+++ b/sdk/src/organizations/store/mod.rs
@@ -19,7 +19,7 @@ pub mod memory;
 
 pub use error::OrganizationStoreError;
 
-use crate::hex::as_hex;
+use crate::{hex::as_hex, paging::Paging};
 
 /// Represents a Grid commit
 #[derive(Clone, Debug, Serialize, PartialEq)]
@@ -37,6 +37,17 @@ pub struct Organization {
     pub service_id: Option<String>,
 }
 
+pub struct OrganizationList {
+    pub data: Vec<Organization>,
+    pub paging: Paging,
+}
+
+impl OrganizationList {
+    pub fn new(data: Vec<Organization>, paging: Paging) -> Self {
+        Self { data, paging }
+    }
+}
+
 pub trait OrganizationStore: Send + Sync {
     /// Adds an organization to the underlying storage
     ///
@@ -50,10 +61,14 @@ pub trait OrganizationStore: Send + Sync {
     /// # Arguments
     ///
     ///  * `service_id` - The service ID to list organizations for
+    ///  * `offset` - The index of the first in storage to retrieve
+    ///  * `limit` - The number of items to retrieve from the offset
     fn list_organizations(
         &self,
         service_id: Option<&str>,
-    ) -> Result<Vec<Organization>, OrganizationStoreError>;
+        offset: i64,
+        limit: i64,
+    ) -> Result<OrganizationList, OrganizationStoreError>;
 
     /// Fetches an organization from the underlying storage
     ///
@@ -79,8 +94,10 @@ where
     fn list_organizations(
         &self,
         service_id: Option<&str>,
-    ) -> Result<Vec<Organization>, OrganizationStoreError> {
-        (**self).list_organizations(service_id)
+        offset: i64,
+        limit: i64,
+    ) -> Result<OrganizationList, OrganizationStoreError> {
+        (**self).list_organizations(service_id, offset, limit)
     }
 
     fn fetch_organization(

--- a/sdk/src/paging.rs
+++ b/sdk/src/paging.rs
@@ -1,0 +1,30 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct Paging {
+    pub offset: i64,
+    pub limit: i64,
+    pub total: i64,
+}
+
+impl Paging {
+    pub fn new(offset: i64, limit: i64, total: i64) -> Self {
+        Paging {
+            offset,
+            limit,
+            total,
+        }
+    }
+}

--- a/sdk/src/products/store/diesel/mod.rs
+++ b/sdk/src/products/store/diesel/mod.rs
@@ -28,7 +28,7 @@ use operations::{
 
 use diesel::r2d2::{ConnectionManager, Pool};
 
-use super::{LatLongValue, Product, ProductStore, ProductStoreError, PropertyValue};
+use super::{LatLongValue, Product, ProductList, ProductStore, ProductStoreError, PropertyValue};
 
 #[derive(Clone)]
 pub struct DieselProductStore<C: diesel::Connection + 'static> {
@@ -65,13 +65,18 @@ impl ProductStore for DieselProductStore<diesel::pg::PgConnection> {
         .fetch_product(product_id, service_id)
     }
 
-    fn list_products(&self, service_id: Option<&str>) -> Result<Vec<Product>, ProductStoreError> {
+    fn list_products(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<ProductList, ProductStoreError> {
         ProductStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             ProductStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_products(service_id)
+        .list_products(service_id, offset, limit)
     }
 
     fn update_product(
@@ -126,13 +131,18 @@ impl ProductStore for DieselProductStore<diesel::sqlite::SqliteConnection> {
         .fetch_product(product_id, service_id)
     }
 
-    fn list_products(&self, service_id: Option<&str>) -> Result<Vec<Product>, ProductStoreError> {
+    fn list_products(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<ProductList, ProductStoreError> {
         ProductStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             ProductStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_products(service_id)
+        .list_products(service_id, offset, limit)
     }
 
     fn update_product(

--- a/sdk/src/products/store/mod.rs
+++ b/sdk/src/products/store/mod.rs
@@ -16,6 +16,8 @@
 pub mod diesel;
 pub mod error;
 
+use crate::paging::Paging;
+
 pub use error::ProductStoreError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -48,6 +50,18 @@ pub struct PropertyValue {
     pub service_id: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ProductList {
+    pub data: Vec<Product>,
+    pub paging: Paging,
+}
+
+impl ProductList {
+    pub fn new(data: Vec<Product>, paging: Paging) -> Self {
+        Self { data, paging }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LatLongValue {
     pub latitude: i64,
@@ -63,7 +77,12 @@ pub trait ProductStore: Send + Sync {
         service_id: Option<&str>,
     ) -> Result<Option<Product>, ProductStoreError>;
 
-    fn list_products(&self, service_id: Option<&str>) -> Result<Vec<Product>, ProductStoreError>;
+    fn list_products(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<ProductList, ProductStoreError>;
 
     fn update_product(
         &self,

--- a/sdk/src/schemas/store/diesel/mod.rs
+++ b/sdk/src/schemas/store/diesel/mod.rs
@@ -32,7 +32,7 @@ use operations::{
 
 use diesel::r2d2::{ConnectionManager, Pool};
 
-use super::{PropertyDefinition, Schema, SchemaStore, SchemaStoreError};
+use super::{PropertyDefinition, Schema, SchemaList, SchemaStore, SchemaStoreError};
 
 /// Manages creating commits in the database
 #[derive(Clone)]
@@ -70,13 +70,18 @@ impl SchemaStore for DieselSchemaStore<diesel::pg::PgConnection> {
         .fetch_schema(name, service_id)
     }
 
-    fn list_schemas(&self, service_id: Option<&str>) -> Result<Vec<Schema>, SchemaStoreError> {
+    fn list_schemas(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<SchemaList, SchemaStoreError> {
         SchemaStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             SchemaStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_schemas(service_id)
+        .list_schemas(service_id, offset, limit)
     }
 
     fn list_property_definitions(
@@ -143,13 +148,18 @@ impl SchemaStore for DieselSchemaStore<diesel::sqlite::SqliteConnection> {
         .fetch_schema(name, service_id)
     }
 
-    fn list_schemas(&self, service_id: Option<&str>) -> Result<Vec<Schema>, SchemaStoreError> {
+    fn list_schemas(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<SchemaList, SchemaStoreError> {
         SchemaStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             SchemaStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_schemas(service_id)
+        .list_schemas(service_id, offset, limit)
     }
 
     fn list_property_definitions(

--- a/sdk/src/schemas/store/mod.rs
+++ b/sdk/src/schemas/store/mod.rs
@@ -16,6 +16,8 @@
 pub mod diesel;
 mod error;
 
+use crate::paging::Paging;
+
 pub use error::SchemaStoreError;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -48,6 +50,18 @@ pub struct PropertyDefinition {
     pub service_id: Option<String>,
 }
 
+#[derive(Clone, Debug)]
+pub struct SchemaList {
+    pub data: Vec<Schema>,
+    pub paging: Paging,
+}
+
+impl SchemaList {
+    pub fn new(data: Vec<Schema>, paging: Paging) -> Self {
+        Self { data, paging }
+    }
+}
+
 pub trait SchemaStore: Send + Sync {
     /// Adds a new schema to underlying storage
     ///
@@ -72,8 +86,16 @@ pub trait SchemaStore: Send + Sync {
     ///
     /// # Arguments
     ///
-    ///  * `service_id` - Service ID needed for when the source of the schema is a splinter circuit
-    fn list_schemas(&self, service_id: Option<&str>) -> Result<Vec<Schema>, SchemaStoreError>;
+    ///  * `service_id` - Service ID needed for when the source of the schema
+    ///  is a splinter circuit
+    ///  * `offset` - The index of the first in storage to retrieve
+    ///  * `limit` - The number of items to retrieve from the offset
+    fn list_schemas(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<SchemaList, SchemaStoreError>;
 
     /// List all property definitions in underlying storage
     ///

--- a/sdk/src/track_and_trace/store/diesel/mod.rs
+++ b/sdk/src/track_and_trace/store/diesel/mod.rs
@@ -24,7 +24,7 @@ use super::diesel::models::{
     RecordModel, ReportedValueReporterToAgentMetadataModel, ReporterModel,
 };
 use super::{
-    AssociatedAgent, LatLongValue, Property, Proposal, Record, ReportedValue,
+    AssociatedAgent, LatLongValue, Property, Proposal, Record, RecordList, ReportedValue,
     ReportedValueReporterToAgentMetadata, Reporter, TrackAndTraceStore, TrackAndTraceStoreError,
 };
 use crate::error::{
@@ -217,13 +217,15 @@ impl TrackAndTraceStore for DieselTrackAndTraceStore<diesel::pg::PgConnection> {
     fn list_records(
         &self,
         service_id: Option<&str>,
-    ) -> Result<Vec<Record>, TrackAndTraceStoreError> {
+        offset: i64,
+        limit: i64,
+    ) -> Result<RecordList, TrackAndTraceStoreError> {
         TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             TrackAndTraceStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_records(service_id)
+        .list_records(service_id, offset, limit)
     }
 
     fn list_reported_value_reporter_to_agent_metadata(
@@ -410,13 +412,15 @@ impl TrackAndTraceStore for DieselTrackAndTraceStore<diesel::sqlite::SqliteConne
     fn list_records(
         &self,
         service_id: Option<&str>,
-    ) -> Result<Vec<Record>, TrackAndTraceStoreError> {
+        offset: i64,
+        limit: i64,
+    ) -> Result<RecordList, TrackAndTraceStoreError> {
         TrackAndTraceStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
             TrackAndTraceStoreError::ResourceTemporarilyUnavailableError(
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_records(service_id)
+        .list_records(service_id, offset, limit)
     }
 
     fn list_reported_value_reporter_to_agent_metadata(


### PR DESCRIPTION
Adds pagination to all routes that list multiple elements. Now, instead of returning a list, these endpoints return objects that contain a fixed number of elements and pagination data
```
{
   "data" : [ ... ]
   "paging": {
      "current": "/agent?offset0&limit=10",
      "offset": 0,
      "limit": 10,
      "total": 1000,
      "prev": "/agent?offset=0&limit=10",
      "next": "/agent?offset=10&limit=10",
      "last": "/agent?offset100&limit=10"
    }
}
  ```