### PR TITLE
Add batch-store to to_hex feature guard

### DIFF
--- a/sdk/src/hex.rs
+++ b/sdk/src/hex.rs
@@ -14,7 +14,7 @@
 
 use std::error::Error;
 use std::fmt;
-#[cfg(feature = "pike")]
+#[cfg(any(feature = "pike", feature = "batch-store"))]
 use std::fmt::Write;
 
 use serde::de;
@@ -27,7 +27,7 @@ use serde::Serializer;
 /// # Arguments
 ///
 ///  * `bytes`: the byte array to convert
-#[cfg(feature = "pike")]
+#[cfg(any(feature = "pike", feature = "batch-store"))]
 pub fn to_hex(bytes: &[u8]) -> String {
     let mut buf = String::new();
     for b in bytes {


### PR DESCRIPTION
Batch store uses to_hex to serialize batches, so it needs to be added to
its feature guard.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>