### PR TITLE
Added libzmq3-dev dependency needed for building on Debian and Debian-based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ discussion](https://grid.hyperledger.org/community/join_the_discussion.html).
 
 ## Building Grid
 
+Before building, make sure you `libzmq3-dev package` installed in Debian(Ubuntu). 
+
+This can be installed with:
+
+```
+	sudo apt install libzmq3-dev -y
+```
+
 To build Grid, run `cargo build` from the root directory. This command
 builds all of the Grid components, including `gridd` (the grid daemon),
 the CLI, and all of the smart contracts in the `contracts` directory.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ discussion](https://grid.hyperledger.org/community/join_the_discussion.html).
 
 ## Building Grid
 
-Before building, make sure you `libzmq3-dev package` installed in Debian(Ubuntu). 
+Before building, make sure you `libzmq3-dev` package installed in Debian(Ubuntu). 
 
 This can be installed with:
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Before building, make sure you `libzmq3-dev package` installed in Debian(Ubuntu)
 This can be installed with:
 
 ```
-	sudo apt install libzmq3-dev -y
+sudo apt install libzmq3-dev -y
 ```
 
 To build Grid, run `cargo build` from the root directory. This command


### PR DESCRIPTION
The build process misses the `libzmq3-dev` dependency in the build steps. This PR addresses this.