### PR TITLE
Add roles delete functionality

### DIFF
--- a/contracts/pike/src/handler.rs
+++ b/contracts/pike/src/handler.rs
@@ -156,7 +156,7 @@ impl<'a> PikeState<'a> {
 
         let filtered_roles = roles
             .into_iter()
-            .filter(|role| role.name() == name && role.org_id() == org_id)
+            .filter(|role| role.name() != name && role.org_id() != org_id)
             .collect::<Vec<_>>();
 
         if filtered_roles.is_empty() {

--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -723,7 +723,7 @@ mod test {
             .await
             .unwrap();
 
-        assert!(response.status().is_success());
+        assert_eq!(response.status(), actix_web::http::StatusCode::OK);
         let body: AgentListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
         assert_eq!(body.data.len(), 1);
@@ -772,7 +772,7 @@ mod test {
             .await
             .unwrap();
 
-        assert!(response.status().is_success());
+        assert_eq!(response.status(), actix_web::http::StatusCode::OK);
         let body: AgentListSlice =
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
         assert_eq!(body.data.len(), 1);

--- a/sdk/src/migrations/diesel/postgres/migrations/2021-02-05-160000_pike_2_tables/down.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-02-05-160000_pike_2_tables/down.sql
@@ -147,3 +147,4 @@ DROP TABLE pike_organization_location_assoc;
 DROP TABLE pike_inherit_from;
 DROP TABLE pike_permissions;
 DROP TABLE pike_allowed_orgs;
+DROP TABLE pike_role_state_address_assoc;

--- a/sdk/src/migrations/diesel/postgres/migrations/2021-02-05-160000_pike_2_tables/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-02-05-160000_pike_2_tables/up.sql
@@ -18,6 +18,7 @@ DROP VIEW reporter_to_agent_metadata;
 
 CREATE TABLE pike_agent (
     id BIGSERIAL PRIMARY KEY,
+    state_address VARCHAR(70) NOT NULL,
     public_key VARCHAR(70) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
     active BOOLEAN NOT NULL,
@@ -27,6 +28,7 @@ CREATE TABLE pike_agent (
 
 CREATE TABLE pike_organization (
     id BIGSERIAL PRIMARY KEY,
+    state_address VARCHAR(70) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
     name VARCHAR(256) NOT NULL,
     service_id TEXT
@@ -42,6 +44,7 @@ CREATE TABLE pike_agent_role_assoc (
 
 CREATE TABLE pike_role (
     id BIGSERIAL PRIMARY KEY,
+    state_address VARCHAR(70) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
     name VARCHAR NOT NULL,
     description TEXT NOT NULL,
@@ -94,6 +97,14 @@ CREATE TABLE pike_allowed_orgs (
     role_name VARCHAR(256) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
     allowed_org_id VARCHAR(256) NOT NULL,
+    service_id TEXT
+) INHERITS (chain_record);
+
+CREATE TABLE pike_role_state_address_assoc (
+    id BIGSERIAL PRIMARY KEY,
+    state_address VARCHAR(70) NOT NULL,
+    name VARCHAR(256) NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
     service_id TEXT
 ) INHERITS (chain_record);
 

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-02-05-160000_pike_2_tables/down.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-02-05-160000_pike_2_tables/down.sql
@@ -152,3 +152,4 @@ DROP TABLE pike_organization_location_assoc;
 DROP TABLE pike_inherit_from;
 DROP TABLE pike_permissions;
 DROP TABLE pike_allowed_orgs;
+DROP TABLE pike_role_state_address_assoc;

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-02-05-160000_pike_2_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-02-05-160000_pike_2_tables/up.sql
@@ -119,6 +119,16 @@ CREATE TABLE pike_allowed_orgs (
     service_id TEXT
 );
 
+CREATE TABLE pike_role_state_address_assoc (
+    id BIGSERIAL PRIMARY KEY,
+    state_address VARCHAR(70) NOT NULL,
+    name VARCHAR(256) NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
 CREATE VIEW reporter_to_agent_metadata
 AS
   SELECT id,

--- a/sdk/src/pike/store/diesel/mod.rs
+++ b/sdk/src/pike/store/diesel/mod.rs
@@ -30,6 +30,7 @@ use models::{
 use operations::add_agent::PikeStoreAddAgentOperation as _;
 use operations::add_organization::PikeStoreAddOrganizationOperation as _;
 use operations::add_role::PikeStoreAddRoleOperation as _;
+use operations::delete_role::PikeStoreDeleteRoleOperation as _;
 use operations::fetch_agent::PikeStoreFetchAgentOperation as _;
 use operations::fetch_organization::PikeStoreFetchOrganizationOperation as _;
 use operations::fetch_role::PikeStoreFetchRoleOperation as _;
@@ -196,6 +197,15 @@ impl PikeStore for DieselPikeStore<diesel::pg::PgConnection> {
             make_allowed_orgs_models(&role),
         )
     }
+
+    fn delete_role(&self, address: &str, current_commit_num: i64) -> Result<(), PikeStoreError> {
+        PikeStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PikeStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .delete_role(address, current_commit_num)
+    }
 }
 
 #[cfg(feature = "sqlite")]
@@ -336,5 +346,14 @@ impl PikeStore for DieselPikeStore<diesel::sqlite::SqliteConnection> {
             make_permissions_models(&role),
             make_allowed_orgs_models(&role),
         )
+    }
+
+    fn delete_role(&self, address: &str, current_commit_num: i64) -> Result<(), PikeStoreError> {
+        PikeStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PikeStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .delete_role(address, current_commit_num)
     }
 }

--- a/sdk/src/pike/store/diesel/operations/delete_role.rs
+++ b/sdk/src/pike/store/diesel/operations/delete_role.rs
@@ -1,0 +1,237 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::PikeStoreOperations;
+use crate::error::InternalError;
+use crate::pike::store::diesel::{
+    models::RoleStateAddressAssociationModel,
+    schema::{
+        pike_agent_role_assoc, pike_allowed_orgs, pike_inherit_from, pike_permissions, pike_role,
+        pike_role_state_address_assoc,
+    },
+    PikeStoreError,
+};
+
+use crate::commits::MAX_COMMIT_NUM;
+use diesel::{dsl::update, prelude::*, result::Error as dsl_error};
+
+pub(in crate::pike) trait PikeStoreDeleteRoleOperation {
+    fn delete_role(&self, address: &str, current_commit_num: i64) -> Result<(), PikeStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> PikeStoreDeleteRoleOperation for PikeStoreOperations<'a, diesel::pg::PgConnection> {
+    fn delete_role(&self, address: &str, current_commit_num: i64) -> Result<(), PikeStoreError> {
+        self.conn.transaction::<_, PikeStoreError, _>(|| {
+            let query = pike_role_state_address_assoc::table.into_boxed().filter(
+                pike_role_state_address_assoc::state_address
+                    .eq(address)
+                    .and(pike_role_state_address_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+            let duplicate_role = query
+                .first::<RoleStateAddressAssociationModel>(self.conn)
+                .map(Some)
+                .or_else(|err| {
+                    if err == dsl_error::NotFound {
+                        Ok(None)
+                    } else {
+                        Err(err)
+                    }
+                })
+                .map_err(|err| {
+                    PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })?;
+
+            if let Some(existing_role) = duplicate_role {
+                update(pike_role::table)
+                    .filter(
+                        pike_role::state_address
+                            .eq(&existing_role.state_address)
+                            .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_role::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+
+                update(pike_agent_role_assoc::table)
+                    .filter(
+                        pike_agent_role_assoc::role_name
+                            .eq(&existing_role.name)
+                            .and(pike_agent_role_assoc::org_id.eq(&existing_role.org_id))
+                            .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_agent_role_assoc::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+
+                update(pike_permissions::table)
+                    .filter(
+                        pike_permissions::role_name
+                            .eq(&existing_role.name)
+                            .and(pike_permissions::org_id.eq(&existing_role.org_id))
+                            .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_permissions::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+
+                update(pike_inherit_from::table)
+                    .filter(
+                        pike_inherit_from::role_name
+                            .eq(&existing_role.name)
+                            .and(pike_inherit_from::org_id.eq(&existing_role.org_id))
+                            .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_inherit_from::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+
+                update(pike_inherit_from::table)
+                    .filter(
+                        pike_inherit_from::role_name
+                            .eq(&existing_role.name)
+                            .and(pike_inherit_from::inherit_from_org_id.eq(&existing_role.org_id))
+                            .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_inherit_from::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+
+                update(pike_allowed_orgs::table)
+                    .filter(
+                        pike_allowed_orgs::role_name
+                            .eq(&existing_role.name)
+                            .and(pike_allowed_orgs::org_id.eq(&existing_role.org_id))
+                            .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_allowed_orgs::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+            }
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> PikeStoreDeleteRoleOperation
+    for PikeStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn delete_role(&self, address: &str, current_commit_num: i64) -> Result<(), PikeStoreError> {
+        self.conn.transaction::<_, PikeStoreError, _>(|| {
+            let query = pike_role_state_address_assoc::table.into_boxed().filter(
+                pike_role_state_address_assoc::state_address
+                    .eq(address)
+                    .and(pike_role_state_address_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+            let duplicate_role = query
+                .first::<RoleStateAddressAssociationModel>(self.conn)
+                .map(Some)
+                .or_else(|err| {
+                    if err == dsl_error::NotFound {
+                        Ok(None)
+                    } else {
+                        Err(err)
+                    }
+                })
+                .map_err(|err| {
+                    PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })?;
+
+            if let Some(existing_role) = duplicate_role {
+                update(pike_role::table)
+                    .filter(
+                        pike_role::state_address
+                            .eq(&existing_role.state_address)
+                            .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_role::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+
+                update(pike_agent_role_assoc::table)
+                    .filter(
+                        pike_agent_role_assoc::role_name
+                            .eq(&existing_role.name)
+                            .and(pike_agent_role_assoc::org_id.eq(&existing_role.org_id))
+                            .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_agent_role_assoc::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+
+                update(pike_permissions::table)
+                    .filter(
+                        pike_permissions::role_name
+                            .eq(&existing_role.name)
+                            .and(pike_permissions::org_id.eq(&existing_role.org_id))
+                            .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_permissions::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+
+                update(pike_inherit_from::table)
+                    .filter(
+                        pike_inherit_from::role_name
+                            .eq(&existing_role.name)
+                            .and(pike_inherit_from::org_id.eq(&existing_role.org_id))
+                            .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_inherit_from::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+
+                update(pike_inherit_from::table)
+                    .filter(
+                        pike_inherit_from::role_name
+                            .eq(&existing_role.name)
+                            .and(pike_inherit_from::inherit_from_org_id.eq(&existing_role.org_id))
+                            .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_inherit_from::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+
+                update(pike_allowed_orgs::table)
+                    .filter(
+                        pike_allowed_orgs::role_name
+                            .eq(&existing_role.name)
+                            .and(pike_allowed_orgs::org_id.eq(&existing_role.org_id))
+                            .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(pike_allowed_orgs::end_commit_num.eq(current_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PikeStoreError::from)?;
+            }
+
+            Ok(())
+        })
+    }
+}

--- a/sdk/src/pike/store/diesel/operations/mod.rs
+++ b/sdk/src/pike/store/diesel/operations/mod.rs
@@ -15,6 +15,7 @@
 pub(super) mod add_agent;
 pub(super) mod add_organization;
 pub(super) mod add_role;
+pub(super) mod delete_role;
 pub(super) mod fetch_agent;
 pub(super) mod fetch_organization;
 pub(super) mod fetch_role;

--- a/sdk/src/pike/store/diesel/schema.rs
+++ b/sdk/src/pike/store/diesel/schema.rs
@@ -15,6 +15,7 @@
 table! {
     pike_agent (id) {
         id -> Int8,
+        state_address -> Varchar,
         public_key -> Varchar,
         org_id -> Varchar,
         active -> Bool,
@@ -28,6 +29,7 @@ table! {
 table! {
     pike_role (id) {
         id -> Int8,
+        state_address -> Varchar,
         org_id -> Varchar,
         name -> Varchar,
         description -> Text,
@@ -90,6 +92,7 @@ table! {
 table! {
     pike_organization (id) {
         id -> Int8,
+        state_address -> Varchar,
         org_id -> Varchar,
         name -> Varchar,
         start_commit_num -> Int8,
@@ -127,6 +130,18 @@ table! {
         id -> Int8,
         org_id -> Varchar,
         location_id -> Varchar,
+        start_commit_num -> Int8,
+        end_commit_num -> Int8,
+        service_id -> Nullable<Text>,
+    }
+}
+
+table! {
+    pike_role_state_address_assoc (id) {
+        id -> Int8,
+        state_address -> Varchar,
+        org_id -> Varchar,
+        name -> Varchar,
         start_commit_num -> Int8,
         end_commit_num -> Int8,
         service_id -> Nullable<Text>,

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -203,6 +203,14 @@ pub trait PikeStore: Send + Sync {
     ///  * `role` - The role to update
     fn update_role(&self, role: Role) -> Result<(), PikeStoreError>;
 
+    /// Deletes a role from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `address` - The state address of the role to delete
+    ///  * `current_commit_num` - The current commit number to update the chain record
+    fn delete_role(&self, address: &str, current_commit_num: i64) -> Result<(), PikeStoreError>;
+
     /// Adds an organization to the underlying storage
     ///
     /// # Arguments
@@ -291,6 +299,10 @@ where
 
     fn update_role(&self, role: Role) -> Result<(), PikeStoreError> {
         (**self).update_role(role)
+    }
+
+    fn delete_role(&self, address: &str, current_commit_num: i64) -> Result<(), PikeStoreError> {
+        (**self).delete_role(address, current_commit_num)
     }
 
     fn add_organization(&self, org: Organization) -> Result<(), PikeStoreError> {


### PR DESCRIPTION
This adds the functionality to delete roles. This includes updating the DB record to set the `end_commit_num` SCD column to the current commit number, essentially making that record no longer current.