### PR TITLE
Add GridTradeItems.xsd for XML schema validation

### DIFF
--- a/cli/schemas/GridTradeItems.xsd
+++ b/cli/schemas/GridTradeItems.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:gdsn_common="urn:gs1:gdsn:gdsn_common:xsd:3"
+    xmlns:shared_common="urn:gs1:shared:shared_common:xsd:3"
+    xmlns:ti="urn:gs1:gdsn:trade_item:xsd:3">
+    <xsd:annotation>
+        <xsd:documentation>
+            <![CDATA[
+                Copyright 2021 Cargill Incorporated
+
+                Licensed under the Apache License, Version 2.0 (the "License");
+                you may not use this file except in compliance with the License.
+                You may obtain a copy of the License at
+
+                    http://www.apache.org/licenses/LICENSE-2.0
+
+                Unless required by applicable law or agreed to in writing, software
+                distributed under the License is distributed on an "AS IS" BASIS,
+                WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                See the License for the specific language governing permissions and
+                limitations under the License.
+            ]]>
+        </xsd:documentation>
+    </xsd:annotation>
+    <!-- GDSN Modules -->
+    <!-- General imports -->
+    <xsd:import namespace="urn:gs1:shared:shared_common:xsd:3" schemaLocation="http://www.gs1globalregistry.net/3.1/schemas/gs1/shared/SharedCommon.xsd"/>
+    <xsd:import namespace="urn:gs1:gdsn:gdsn_common:xsd:3" schemaLocation="http://www.gs1globalregistry.net/3.1/schemas/gs1/gdsn/GdsnCommon.xsd"/>
+    <!-- Trade Item Module-->
+    <xsd:import namespace="urn:gs1:gdsn:trade_item:xsd:3" schemaLocation="http://www.gs1globalregistry.net/3.1/schemas/gs1/gdsn/TradeItem.xsd"/>
+
+
+    <!-- Product attributes -->
+    <xsd:element name="gridTradeItems" type="gridTradeItems"/>
+
+    <xsd:complexType name="gridTradeItems">
+        <xsd:sequence>
+            <xsd:element name="tradeItem" type="ti:TradeItemType" minOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
This file can be used to validate product definitions in XML format. It
references the GDSN TradeItem schema.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>