### PR TITLE
Add sqlite tests to integration test and add chain commands

### DIFF
--- a/daemon/test/docker-compose.yaml
+++ b/daemon/test/docker-compose.yaml
@@ -43,9 +43,10 @@ services:
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1
         done
-        cd daemon
-        cargo test --features test-postgres,experimental -- --test-threads=1
-        cd ../cli
-        cargo test --features stable actions -- --test-threads=1
+        cd daemon &&
+        cargo test --features stable -- --test-threads=1 &&
+        cargo test --features test-postgres,experimental -- --test-threads=1 &&
+        cd ../cli &&
+        cargo test --features stable actions -- --test-threads=1 &&
         cargo test --features stable yaml_parser -- --test-threads=1
         "


### PR DESCRIPTION
Adds sqlite tests to integration docker compose and chains together
commands using "&". Chaining commands together is necessary because
without chaining, the Jenkins build will pass as long as the last set of
tests pass, regardless as to whether or not the other test suits
failed leading to Jenkins falsely reporting that all the tests passeed.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>