### PR TITLE
Fix rest api tests

### DIFF
--- a/daemon/src/rest_api/routes/mod.rs
+++ b/daemon/src/rest_api/routes/mod.rs
@@ -829,8 +829,7 @@ mod test {
         let org = body.data.first().unwrap();
         assert_eq!(org.name, ORG_NAME_1.to_string());
         assert_eq!(org.org_id, KEY2.to_string());
-        let locs: Vec<String> = vec![];
-        assert_eq!(org.locations, locs);
+        assert_eq!(org.locations, vec![ADDRESS_1.to_string()]);
     }
 
     ///
@@ -862,8 +861,7 @@ mod test {
         let org = body.data.first().unwrap();
         assert_eq!(org.name, ORG_NAME_1.to_string());
         assert_eq!(org.org_id, KEY2.to_string());
-        let locs: Vec<String> = vec![];
-        assert_eq!(org.locations, locs);
+        assert_eq!(org.locations, vec![ADDRESS_1.to_string()]);
         assert_eq!(org.service_id, Some(TEST_SERVICE_ID.to_string()));
     }
 
@@ -971,8 +969,7 @@ mod test {
             serde_json::from_slice(&*response.body().await.unwrap()).unwrap();
         assert_eq!(org.name, ORG_NAME_1.to_string());
         assert_eq!(org.org_id, KEY2.to_string());
-        let locs: Vec<String> = vec![];
-        assert_eq!(org.locations, locs);
+        assert_eq!(org.locations, vec![ADDRESS_1.to_string()]);
     }
 
     ///
@@ -3006,7 +3003,7 @@ mod test {
         vec![Organization {
             org_id: KEY2.to_string(),
             name: ORG_NAME_1.to_string(),
-            locations: vec![],
+            locations: vec![ADDRESS_1.to_string()],
             alternate_ids: vec![],
             metadata: vec![],
             start_commit_num: 1,

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-02-05-160000_pike_2_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-02-05-160000_pike_2_tables/up.sql
@@ -20,7 +20,8 @@ DROP TABLE role;
 DROP TABLE organization;
 
 CREATE TABLE pike_agent (
-    id BIGSERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
+    state_address VARCHAR(70) NOT NULL,
     public_key VARCHAR(70) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
     active BOOLEAN NOT NULL,
@@ -31,7 +32,8 @@ CREATE TABLE pike_agent (
 );
 
 CREATE TABLE pike_organization (
-    id BIGSERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
+    state_address VARCHAR(70) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
     name VARCHAR(256) NOT NULL,
     start_commit_num BIGINT NOT NULL,
@@ -40,7 +42,7 @@ CREATE TABLE pike_organization (
 );
 
 CREATE TABLE pike_agent_role_assoc (
-    id BIGSERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
     agent_public_key VARCHAR(70) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
     role_name VARCHAR(256) NOT NULL,
@@ -50,17 +52,19 @@ CREATE TABLE pike_agent_role_assoc (
 );
 
 CREATE TABLE pike_role (
-    id BIGSERIAL PRIMARY KEY,
-    name VARCHAR NOT NULL,
+    id INTEGER PRIMARY KEY,
+    state_address VARCHAR(70) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
+    name VARCHAR NOT NULL,
     description TEXT NOT NULL,
+    active BOOLEAN NOT NULL,
     start_commit_num BIGINT NOT NULL,
     end_commit_num BIGINT NOT NULL,
     service_id TEXT
 );
 
 CREATE TABLE pike_organization_metadata (
-    id BIGSERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
     org_id VARCHAR(256) NOT NULL,
     key VARCHAR NOT NULL,
     value BYTEA NOT NULL,
@@ -70,7 +74,7 @@ CREATE TABLE pike_organization_metadata (
 );
 
 CREATE TABLE pike_organization_alternate_id (
-    id BIGSERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
     org_id VARCHAR(256) NOT NULL,
     alternate_id_type VARCHAR NOT NULL,
     alternate_id VARCHAR NOT NULL,
@@ -80,7 +84,7 @@ CREATE TABLE pike_organization_alternate_id (
 );
 
 CREATE TABLE pike_organization_location_assoc (
-    id BIGSERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
     org_id VARCHAR(256) NOT NULL,
     location_id VARCHAR(256) NOT NULL,
     start_commit_num BIGINT NOT NULL,
@@ -89,7 +93,7 @@ CREATE TABLE pike_organization_location_assoc (
 );
 
 CREATE TABLE pike_inherit_from (
-    id BIGSERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
     role_name VARCHAR(256) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
     inherit_from_role_name VARCHAR(256) NOT NULL,
@@ -100,7 +104,7 @@ CREATE TABLE pike_inherit_from (
 );
 
 CREATE TABLE pike_permissions (
-    id BIGSERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
     role_name VARCHAR(256) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
     name VARCHAR(256) NOT NULL,
@@ -110,7 +114,7 @@ CREATE TABLE pike_permissions (
 );
 
 CREATE TABLE pike_allowed_orgs (
-    id BIGSERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
     role_name VARCHAR(256) NOT NULL,
     org_id VARCHAR(256) NOT NULL,
     allowed_org_id VARCHAR(256) NOT NULL,
@@ -120,7 +124,7 @@ CREATE TABLE pike_allowed_orgs (
 );
 
 CREATE TABLE pike_role_state_address_assoc (
-    id BIGSERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
     state_address VARCHAR(70) NOT NULL,
     name VARCHAR(256) NOT NULL,
     org_id VARCHAR(256) NOT NULL,

--- a/sdk/src/pike/store/diesel/mod.rs
+++ b/sdk/src/pike/store/diesel/mod.rs
@@ -24,8 +24,8 @@ use super::{
 };
 use crate::error::ResourceTemporarilyUnavailableError;
 use models::{
-    make_allowed_orgs_models, make_inherit_from_models, make_org_metadata_models,
-    make_permissions_models, make_role_association_models,
+    make_allowed_orgs_models, make_inherit_from_models, make_location_association_models,
+    make_org_metadata_models, make_permissions_models, make_role_association_models,
 };
 use operations::add_agent::PikeStoreAddAgentOperation as _;
 use operations::add_organization::PikeStoreAddOrganizationOperation as _;
@@ -154,7 +154,11 @@ impl PikeStore for DieselPikeStore<diesel::pg::PgConnection> {
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .add_organization(org.clone().into(), make_org_metadata_models(&org))
+        .add_organization(
+            org.clone().into(),
+            make_location_association_models(&org),
+            make_org_metadata_models(&org),
+        )
     }
 
     fn list_organizations(
@@ -304,7 +308,11 @@ impl PikeStore for DieselPikeStore<diesel::sqlite::SqliteConnection> {
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .add_organization(org.clone().into(), make_org_metadata_models(&org))
+        .add_organization(
+            org.clone().into(),
+            make_location_association_models(&org),
+            make_org_metadata_models(&org),
+        )
     }
 
     fn list_organizations(

--- a/sdk/src/pike/store/diesel/models.rs
+++ b/sdk/src/pike/store/diesel/models.rs
@@ -379,6 +379,24 @@ pub fn make_inherit_from_models(role: &Role) -> Vec<NewInheritFromModel> {
     models
 }
 
+pub fn make_location_association_models(org: &Organization) -> Vec<NewLocationAssociationModel> {
+    let mut models = Vec::new();
+
+    for l in &org.locations {
+        let model = NewLocationAssociationModel {
+            org_id: org.org_id.to_string(),
+            location_id: l.to_string(),
+            start_commit_num: org.start_commit_num,
+            end_commit_num: org.end_commit_num,
+            service_id: org.service_id.clone(),
+        };
+
+        models.push(model);
+    }
+
+    models
+}
+
 pub fn make_permissions_models(role: &Role) -> Vec<NewPermissionModel> {
     let mut models = Vec::new();
 


### PR DESCRIPTION
This fixes some of the Rest API tests that were breaking due to the updates to locations storage in Pike 2. This also updates the add_organization database operation to properly store location association records.