### PR TITLE
Add alternate ID support

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -329,7 +329,7 @@ fn run() -> Result<(), CliError> {
                                 .long("alternate-ids")
                                 .multiple(true)
                                 .use_delimiter(true)
-                                .help("Alternate IDs for organization"),
+                                .help("Alternate IDs for organization (format: <id_type>:<id>) in a comma-separated list"),
                         )
                         .arg(
                             Arg::with_name("metadata")
@@ -369,9 +369,19 @@ fn run() -> Result<(), CliError> {
                                 .help("Name of organization"),
                         )
                         .arg(
-                            Arg::with_name("address")
+                            Arg::with_name("locations")
+                                .long("locations")
                                 .takes_value(true)
-                                .help("Physical address for organization"),
+                                .multiple(true)
+                                .use_delimiter(true)
+                                .help("Locations for an organization"),
+                        )
+                        .arg(
+                            Arg::with_name("alternate_ids")
+                                .long("alternate-ids")
+                                .multiple(true)
+                                .use_delimiter(true)
+                                .help("Alternate IDs for organization (format: <id_type>:<id>) in a comma-separated list"),
                         )
                         .arg(
                             Arg::with_name("metadata")

--- a/cli/tests/product.rs
+++ b/cli/tests/product.rs
@@ -152,7 +152,10 @@ mod integration {
             .arg("create")
             .arg(&ORG_ID)
             .arg(&ORG_NAME)
-            .args(&["--metadata", &format!("gs1_company_prefixes={}", &ORG_ID)])
+            .args(&[
+                "--alternate-ids",
+                &format!("gs1_company_prefix:{}", &ORG_ID),
+            ])
             .args(&["--wait", "300000"]);
         cmd_org_create.assert().success();
 

--- a/contracts/location/src/handler.rs
+++ b/contracts/location/src/handler.rs
@@ -171,16 +171,16 @@ fn create_location(
     )?;
 
     // check if organization has gln in gs1_company_prefix metadata
-    let mut has_gs1_prefix = false;
-    for metadata in organization.metadata() {
-        if metadata.key() == "gs1_company_prefixes"
-            && payload.location_id().contains(metadata.value())
+    let mut has_gs1_alt_id = false;
+    for alternate_id in organization.alternate_ids() {
+        if alternate_id.id_type() == "gs1_company_prefix"
+            && payload.location_id().contains(alternate_id.id())
         {
-            has_gs1_prefix = true;
+            has_gs1_alt_id = true;
         }
     }
 
-    if !has_gs1_prefix {
+    if !has_gs1_alt_id {
         return Err(ApplyError::InvalidTransaction(format!(
             "Organization {} does not have the correct gs1 prefix",
             organization.org_id()
@@ -429,7 +429,7 @@ mod tests {
                 LocationUpdateActionBuilder,
             },
             pike::state::{
-                AgentBuilder, AgentListBuilder, KeyValueEntryBuilder, OrganizationBuilder,
+                AgentBuilder, AgentListBuilder, AlternateIDBuilder, OrganizationBuilder,
                 OrganizationListBuilder, RoleBuilder, RoleListBuilder,
             },
             schema::state::{
@@ -453,16 +453,16 @@ mod tests {
             let mut entries = Vec::new();
 
             // create organization with prefix
-            let key_value = KeyValueEntryBuilder::new()
-                .with_key("gs1_company_prefixes".to_string())
-                .with_value("9012".to_string())
+            let alternate_id = AlternateIDBuilder::new()
+                .with_id_type("gs1_company_prefix".to_string())
+                .with_id("9012".to_string())
                 .build()
                 .unwrap();
             let prefix_org = OrganizationBuilder::new()
                 .with_org_id("prefix_org".to_string())
                 .with_name("test_org_name".to_string())
                 .with_locations(vec![])
-                .with_metadata(vec![key_value.clone()])
+                .with_alternate_ids(vec![alternate_id.clone()])
                 .build()
                 .unwrap();
             let prefix_org_list = OrganizationListBuilder::new()

--- a/daemon/src/event/db_handler.rs
+++ b/daemon/src/event/db_handler.rs
@@ -545,9 +545,9 @@ fn state_change_to_db_operation(
                                 .alternate_ids()
                                 .iter()
                                 .map(|a| AlternateID {
-                                    alternate_id: a.id().to_string(),
-                                    alternate_id_type: a.id_type().to_string(),
                                     org_id: org.org_id().to_string(),
+                                    alternate_id_type: a.id_type().to_string(),
+                                    alternate_id: a.id().to_string(),
                                     start_commit_num: commit_num,
                                     end_commit_num: MAX_COMMIT_NUM,
                                     service_id: service_id.cloned(),

--- a/sdk/protos/pike_state.proto
+++ b/sdk/protos/pike_state.proto
@@ -31,7 +31,7 @@ message Organization {
   string org_id = 1;
   string name = 2;
   repeated string locations = 3;
-  repeated AlternateID alternate_id = 4;
+  repeated AlternateID alternate_ids = 4;
   repeated KeyValueEntry metadata = 5;
 }
 
@@ -57,6 +57,10 @@ message AlternateIDIndexEntry {
   string id_type = 1;
   string id = 2;
   string grid_identity_id = 3;
+}
+
+message AlternateIDIndexEntryList {
+  repeated AlternateIDIndexEntry entries = 1;
 }
 
 message KeyValueEntry {

--- a/sdk/src/pike/addressing.rs
+++ b/sdk/src/pike/addressing.rs
@@ -58,9 +58,10 @@ pub fn compute_role_address(name: &str, org_id: &str) -> String {
 }
 
 /// Computes the address a Pike Alternate ID Index is stored at based on its name
-pub fn compute_alternate_id_index_entry_address(id: &str) -> String {
+pub fn compute_alternate_id_index_entry_address(id_type: &str, id: &str) -> String {
+    let uname = format!("{}:{}", id_type, id);
     let mut sha = Sha512::new();
-    sha.input(id.as_bytes());
+    sha.input(uname.as_bytes());
     // (pike namespace) + (alternate ID namespace) + hash
     let hash_str =
         String::from(PIKE_NAMESPACE) + ALTERNATE_ID_INDEX_ENTRY_PREFIX + &sha.result_str();

--- a/sdk/src/pike/store/diesel/mod.rs
+++ b/sdk/src/pike/store/diesel/mod.rs
@@ -24,8 +24,9 @@ use super::{
 };
 use crate::error::ResourceTemporarilyUnavailableError;
 use models::{
-    make_allowed_orgs_models, make_inherit_from_models, make_location_association_models,
-    make_org_metadata_models, make_permissions_models, make_role_association_models,
+    make_allowed_orgs_models, make_alternate_id_models, make_inherit_from_models,
+    make_location_association_models, make_org_metadata_models, make_permissions_models,
+    make_role_association_models,
 };
 use operations::add_agent::PikeStoreAddAgentOperation as _;
 use operations::add_organization::PikeStoreAddOrganizationOperation as _;
@@ -157,6 +158,7 @@ impl PikeStore for DieselPikeStore<diesel::pg::PgConnection> {
         .add_organization(
             org.clone().into(),
             make_location_association_models(&org),
+            make_alternate_id_models(&org),
             make_org_metadata_models(&org),
         )
     }
@@ -311,6 +313,7 @@ impl PikeStore for DieselPikeStore<diesel::sqlite::SqliteConnection> {
         .add_organization(
             org.clone().into(),
             make_location_association_models(&org),
+            make_alternate_id_models(&org),
             make_org_metadata_models(&org),
         )
     }

--- a/sdk/src/pike/store/diesel/models.rs
+++ b/sdk/src/pike/store/diesel/models.rs
@@ -260,6 +260,24 @@ pub struct AlternateIDModel {
     pub service_id: Option<String>,
 }
 
+pub fn make_alternate_id_models(org: &Organization) -> Vec<NewAlternateIDModel> {
+    let mut models = Vec::new();
+    for entry in &org.alternate_ids {
+        let model = NewAlternateIDModel {
+            org_id: org.org_id.to_string(),
+            alternate_id_type: entry.alternate_id_type.to_string(),
+            alternate_id: entry.alternate_id.to_string(),
+            start_commit_num: org.start_commit_num,
+            end_commit_num: org.end_commit_num,
+            service_id: org.service_id.clone(),
+        };
+
+        models.push(model);
+    }
+
+    models
+}
+
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "pike_organization_location_assoc"]
 pub struct NewLocationAssociationModel {
@@ -604,15 +622,15 @@ impl From<&AlternateIDModel> for AlternateID {
     }
 }
 
-impl Into<NewAlternateIDModel> for AlternateID {
+impl Into<NewAlternateIDModel> for &AlternateID {
     fn into(self) -> NewAlternateIDModel {
         NewAlternateIDModel {
-            org_id: self.org_id,
-            alternate_id_type: self.alternate_id_type,
-            alternate_id: self.alternate_id,
+            org_id: self.org_id.to_string(),
+            alternate_id_type: self.alternate_id_type.to_string(),
+            alternate_id: self.alternate_id.to_string(),
             start_commit_num: self.start_commit_num,
             end_commit_num: self.end_commit_num,
-            service_id: self.service_id,
+            service_id: self.service_id.clone(),
         }
     }
 }

--- a/sdk/src/protocol/pike/state.rs
+++ b/sdk/src/protocol/pike/state.rs
@@ -555,6 +555,224 @@ impl IntoBytes for AlternateIDIndexEntry {
 impl IntoProto<protos::pike_state::AlternateIDIndexEntry> for AlternateIDIndexEntry {}
 impl IntoNative<AlternateIDIndexEntry> for protos::pike_state::AlternateIDIndexEntry {}
 
+#[derive(Debug)]
+pub enum AlternateIDIndexEntryBuildError {
+    MissingField(String),
+}
+
+impl StdError for AlternateIDIndexEntryBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            AlternateIDIndexEntryBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            AlternateIDIndexEntryBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for AlternateIDIndexEntryBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            AlternateIDIndexEntryBuildError::MissingField(ref s) => {
+                write!(f, "MissingField: {}", s)
+            }
+        }
+    }
+}
+
+/// Builder used to create a AlternateIDIndexEntry
+#[derive(Default, Clone)]
+pub struct AlternateIDIndexEntryBuilder {
+    pub id_type: Option<String>,
+    pub id: Option<String>,
+    pub grid_identity_id: Option<String>,
+}
+
+impl AlternateIDIndexEntryBuilder {
+    pub fn new() -> Self {
+        AlternateIDIndexEntryBuilder::default()
+    }
+
+    pub fn with_id_type(mut self, id_type: String) -> AlternateIDIndexEntryBuilder {
+        self.id_type = Some(id_type);
+        self
+    }
+
+    pub fn with_id(mut self, id: String) -> AlternateIDIndexEntryBuilder {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn with_grid_identity_id(
+        mut self,
+        grid_identity_id: String,
+    ) -> AlternateIDIndexEntryBuilder {
+        self.grid_identity_id = Some(grid_identity_id);
+        self
+    }
+
+    pub fn build(self) -> Result<AlternateIDIndexEntry, AlternateIDIndexEntryBuildError> {
+        let id_type = self.id_type.ok_or_else(|| {
+            AlternateIDIndexEntryBuildError::MissingField("'id_type' field is required".to_string())
+        })?;
+
+        let id = self.id.ok_or_else(|| {
+            AlternateIDIndexEntryBuildError::MissingField("'id' field is required".to_string())
+        })?;
+
+        let grid_identity_id = self.grid_identity_id.ok_or_else(|| {
+            AlternateIDIndexEntryBuildError::MissingField(
+                "'grid_identity_id' field is required".to_string(),
+            )
+        })?;
+
+        Ok(AlternateIDIndexEntry {
+            id_type,
+            id,
+            grid_identity_id,
+        })
+    }
+}
+
+/// Native implementation of AlternateIDIndexEntryList
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlternateIDIndexEntryList {
+    entries: Vec<AlternateIDIndexEntry>,
+}
+
+impl AlternateIDIndexEntryList {
+    pub fn entries(&self) -> &[AlternateIDIndexEntry] {
+        &self.entries
+    }
+}
+
+impl FromProto<protos::pike_state::AlternateIDIndexEntryList> for AlternateIDIndexEntryList {
+    fn from_proto(
+        entry_list: protos::pike_state::AlternateIDIndexEntryList,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(AlternateIDIndexEntryList {
+            entries: entry_list
+                .get_entries()
+                .to_vec()
+                .into_iter()
+                .map(AlternateIDIndexEntry::from_proto)
+                .collect::<Result<Vec<AlternateIDIndexEntry>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<AlternateIDIndexEntryList> for protos::pike_state::AlternateIDIndexEntryList {
+    fn from_native(entry_list: AlternateIDIndexEntryList) -> Result<Self, ProtoConversionError> {
+        let mut entry_list_proto = protos::pike_state::AlternateIDIndexEntryList::new();
+
+        entry_list_proto.set_entries(RepeatedField::from_vec(
+            entry_list
+                .entries()
+                .to_vec()
+                .into_iter()
+                .map(AlternateIDIndexEntry::into_proto)
+                .collect::<Result<Vec<protos::pike_state::AlternateIDIndexEntry>, ProtoConversionError>>()?,
+        ));
+
+        Ok(entry_list_proto)
+    }
+}
+
+impl FromBytes<AlternateIDIndexEntryList> for AlternateIDIndexEntryList {
+    fn from_bytes(bytes: &[u8]) -> Result<AlternateIDIndexEntryList, ProtoConversionError> {
+        let proto: protos::pike_state::AlternateIDIndexEntryList = Message::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get AlternateIDIndexEntryList from bytes".to_string(),
+                )
+            })?;
+
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for AlternateIDIndexEntryList {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from AlternateIDIndexEntryList".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::pike_state::AlternateIDIndexEntryList> for AlternateIDIndexEntryList {}
+impl IntoNative<AlternateIDIndexEntryList> for protos::pike_state::AlternateIDIndexEntryList {}
+
+#[derive(Debug)]
+pub enum AlternateIDIndexEntryListBuildError {
+    MissingField(String),
+}
+
+impl StdError for AlternateIDIndexEntryListBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            AlternateIDIndexEntryListBuildError::MissingField(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            AlternateIDIndexEntryListBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for AlternateIDIndexEntryListBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            AlternateIDIndexEntryListBuildError::MissingField(ref s) => {
+                write!(f, "MissingField: {}", s)
+            }
+        }
+    }
+}
+
+/// Builder used to create a AlternateIDIndexEntryList
+#[derive(Default, Clone)]
+pub struct AlternateIDIndexEntryListBuilder {
+    pub entries: Vec<AlternateIDIndexEntry>,
+}
+
+impl AlternateIDIndexEntryListBuilder {
+    pub fn new() -> Self {
+        AlternateIDIndexEntryListBuilder::default()
+    }
+
+    pub fn with_entries(
+        mut self,
+        entries: Vec<AlternateIDIndexEntry>,
+    ) -> AlternateIDIndexEntryListBuilder {
+        self.entries = entries;
+        self
+    }
+
+    pub fn build(self) -> Result<AlternateIDIndexEntryList, AlternateIDIndexEntryListBuildError> {
+        let entries = {
+            if self.entries.is_empty() {
+                return Err(AlternateIDIndexEntryListBuildError::MissingField(
+                    "'entries' cannot be empty".to_string(),
+                ));
+            } else {
+                self.entries
+            }
+        };
+
+        Ok(AlternateIDIndexEntryList { entries })
+    }
+}
+
 /// Native implementation of AlternateID
 #[derive(Debug, Clone, PartialEq)]
 pub struct AlternateID {
@@ -1031,7 +1249,7 @@ impl FromProto<protos::pike_state::Organization> for Organization {
             name: org.get_name().to_string(),
             locations: org.get_locations().to_vec(),
             alternate_ids: org
-                .get_alternate_id()
+                .get_alternate_ids()
                 .to_vec()
                 .into_iter()
                 .map(AlternateID::from_proto)
@@ -1053,7 +1271,7 @@ impl FromNative<Organization> for protos::pike_state::Organization {
         org_proto.set_org_id(org.org_id().to_string());
         org_proto.set_name(org.name().to_string());
         org_proto.set_locations(RepeatedField::from_vec(org.locations().to_vec()));
-        org_proto.set_alternate_id(RepeatedField::from_vec(
+        org_proto.set_alternate_ids(RepeatedField::from_vec(
             org.alternate_ids()
                 .to_vec()
                 .into_iter()


### PR DESCRIPTION
This adds alternate ID support to the Pike, Product, and Location smart contracts. This replaces the functionality of the special case of organization metadata that was being checked for GS1 company prefixes with a more flexible field on the Organization object. This field can be used for any number of alternate identifiers for an organization.

## Testing

- Follow grid walkthrough directions to set up a circuit
- create an organization and add the `gs1_company_prefixes` ID with the `--alternate-ids` flag
- create a role to create schemas, products, and locations
- Add the role to the agent
- create schemas for products and locations
- create a product and create a location