### PR TITLE
Add Roles list CLI command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -606,6 +606,16 @@ fn run() -> Result<(), CliError> {
                                 .required(true)
                                 .help("Name of role"),
                         ),
+                )
+                .subcommand(
+                    SubCommand::with_name("list")
+                        .about("List all roles for a given org ID")
+                        .arg(
+                            Arg::with_name("org_id")
+                                .takes_value(true)
+                                .required(true)
+                                .help("Org ID of role"),
+                        )
                 ),
         );
     }
@@ -1332,6 +1342,9 @@ fn run() -> Result<(), CliError> {
                     m.value_of("name").unwrap(),
                     service_id,
                 )?,
+                ("list", Some(m)) => {
+                    roles::do_list_roles(&url, m.value_of("org_id").unwrap(), service_id)?
+                }
                 _ => return Err(CliError::UserError("Subcommand not recognized".into())),
             }
         }


### PR DESCRIPTION
This adds a command to the Grid CLI to list roles for a given org ID.
This command lists basic information about the roles. More detailed info
can be fetched with the `grid role show` command.

Signed-off-by: Davey Newhall <newhall@bitwise.io>