### PR TITLE
Create repolinter.yml

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2021 Hyperledger Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Hyperledger Repolinter Action
+
+name: Repolinter
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: hyperledger-tools.jfrog.io/repolinter:0.10.0
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Lint Repo
+        continue-on-error: true
+        run: bundle exec /app/bin/repolinter.js --rulesetUrl https://raw.githubusercontent.com/hyperledger-labs/hyperledger-community-management-tools/master/repo_structure/repolint.json --format markdown > /repolinter-report.md
+      - name: Save repolinter-report file
+        uses: actions/upload-artifact@v2
+        with:
+          name: repolinter-report
+          path: /repolinter-report.md


### PR DESCRIPTION
In February 2020, the TSC [adopted the requirement](https://wiki.hyperledger.org/display/TSC/Common+Repo+structure) that repos under Hyperledger have a common structure. The repolinter tool, along with a specified configuration, was also adopted; this is stored in a [labs repo](https://github.com/hyperledger-labs/hyperledger-community-management-tools/tree/main/repo_structure).

This creates a manually triggered action which saves the output for
later inspection. It was originally adopted in [Besu](https://github.com/hyperledger/besu/pull/2016).

Signed-off-by: Ry Jones <ry@linux.com>