### PR TITLE
Add purchase_order SDK module

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -81,6 +81,7 @@ experimental = [
     "batch-store",
     "postgres",
     "pike-rest-api",
+    "purchase-order",
     "rest-api-resources",
     "rest-api-actix-web-3",
     "sawtooth-compat",
@@ -92,6 +93,7 @@ experimental = [
 location = ["pike", "schema"]
 pike = []
 pike-rest-api = ["pike", "serde_json", "rest-api-resources"]
+purchase-order = []
 product = ["pike", "schema"]
 schema = ["pike"]
 track-and-trace = ["base64"]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -51,6 +51,8 @@ pub mod pike;
 pub mod products;
 pub mod protocol;
 pub mod protos;
+#[cfg(feature = "purchase-order")]
+pub mod purchase_order;
 pub mod rest_api;
 #[cfg(feature = "schema")]
 pub mod schemas;

--- a/sdk/src/purchase_order/mod.rs
+++ b/sdk/src/purchase_order/mod.rs
@@ -1,0 +1,13 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.


### PR DESCRIPTION
This change adds the purchase_order module to the SDK.  It is initialized with an empty mod.rs.

This module is guarded by the feature "purchase-order".
