### PR TITLE
Add skeleton for Grid Purchase Order smart contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "contracts/location",
     "contracts/pike",
     "contracts/product",
+    "contracts/purchase_order",
     "contracts/schema",
     "contracts/track_and_trace",
     "daemon",

--- a/ci/grid-dev
+++ b/ci/grid-dev
@@ -64,6 +64,7 @@ RUN USER=root cargo new --bin sdk
 RUN USER=root cargo new --bin contracts/location
 RUN USER=root cargo new --bin contracts/pike
 RUN USER=root cargo new --bin contracts/product
+RUN USER=root cargo new --bin contracts/purchase_order
 RUN USER=root cargo new --bin contracts/schema
 RUN USER=root cargo new --bin contracts/track_and_trace
 
@@ -77,6 +78,7 @@ COPY sdk/Cargo.toml /build/sdk/Cargo.toml
 COPY contracts/location/Cargo.toml /build/contracts/location/Cargo.toml
 COPY contracts/pike/Cargo.toml /build/contracts/pike/Cargo.toml
 COPY contracts/product/Cargo.toml /build/contracts/product/Cargo.toml
+COPY contracts/purchase_order/Cargo.toml /build/contracts/purchase_order/Cargo.toml
 COPY contracts/schema/Cargo.toml /build/contracts/schema/Cargo.toml
 COPY contracts/track_and_trace/Cargo.toml /build/contracts/track_and_trace/Cargo.toml
 

--- a/ci/grid-dev.yaml
+++ b/ci/grid-dev.yaml
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   grid-dev:
-    image: hyperledger/grid-dev:v7
+    image: hyperledger/grid-dev:v8
     build:
       context: ..
       dockerfile: ci/grid-dev

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -16,6 +16,7 @@ FROM hyperledger/grid-dev:v5 as grid-cli-builder
 
 # Temporary workaround until sabre is updated to focal
 RUN USER=root cargo new --bin griddle
+RUN USER=root cargo new --bin contracts/purchase_order
 
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
@@ -27,6 +28,7 @@ COPY sdk/Cargo.toml /build/sdk/Cargo.toml
 COPY contracts/location/Cargo.toml /build/contracts/location/Cargo.toml
 COPY contracts/pike/Cargo.toml /build/contracts/pike/Cargo.toml
 COPY contracts/product/Cargo.toml /build/contracts/product/Cargo.toml
+COPY contracts/purchase_order/Cargo.toml /build/contracts/purchase_order/Cargo.toml
 COPY contracts/schema/Cargo.toml /build/contracts/schema/Cargo.toml
 COPY contracts/track_and_trace/Cargo.toml /build/contracts/track_and_trace/Cargo.toml
 

--- a/contracts/location/Dockerfile
+++ b/contracts/location/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hyperledger/grid-dev:v7 as grid-location-builder
+FROM hyperledger/grid-dev:v8 as grid-location-builder
 
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
@@ -24,6 +24,7 @@ COPY sdk/Cargo.toml /build/sdk/Cargo.toml
 COPY contracts/location/Cargo.toml /build/contracts/location/Cargo.toml
 COPY contracts/pike/Cargo.toml /build/contracts/pike/Cargo.toml
 COPY contracts/product/Cargo.toml /build/contracts/product/Cargo.toml
+COPY contracts/purchase_order/Cargo.toml /build/contracts/purchase_order/Cargo.toml
 COPY contracts/schema/Cargo.toml /build/contracts/schema/Cargo.toml
 COPY contracts/track_and_trace/Cargo.toml /build/contracts/track_and_trace/Cargo.toml
 

--- a/contracts/pike/Dockerfile
+++ b/contracts/pike/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hyperledger/grid-dev:v7 as grid-pike-builder
+FROM hyperledger/grid-dev:v8 as grid-pike-builder
 
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
@@ -24,6 +24,7 @@ COPY sdk/Cargo.toml /build/sdk/Cargo.toml
 COPY contracts/location/Cargo.toml /build/contracts/location/Cargo.toml
 COPY contracts/pike/Cargo.toml /build/contracts/pike/Cargo.toml
 COPY contracts/product/Cargo.toml /build/contracts/product/Cargo.toml
+COPY contracts/purchase_order/Cargo.toml /build/contracts/purchase_order/Cargo.toml
 COPY contracts/schema/Cargo.toml /build/contracts/schema/Cargo.toml
 COPY contracts/track_and_trace/Cargo.toml /build/contracts/track_and_trace/Cargo.toml
 

--- a/contracts/product/Dockerfile
+++ b/contracts/product/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hyperledger/grid-dev:v7 as grid-product-builder
+FROM hyperledger/grid-dev:v8 as grid-product-builder
 
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
@@ -25,6 +25,7 @@ COPY sdk/Cargo.toml /build/sdk/Cargo.toml
 COPY contracts/location/Cargo.toml /build/contracts/location/Cargo.toml
 COPY contracts/pike/Cargo.toml /build/contracts/pike/Cargo.toml
 COPY contracts/product/Cargo.toml /build/contracts/product/Cargo.toml
+COPY contracts/purchase_order/Cargo.toml /build/contracts/purchase_order/Cargo.toml
 COPY contracts/schema/Cargo.toml /build/contracts/schema/Cargo.toml
 COPY contracts/track_and_trace/Cargo.toml /build/contracts/track_and_trace/Cargo.toml
 

--- a/contracts/purchase_order/Cargo.toml
+++ b/contracts/purchase_order/Cargo.toml
@@ -1,0 +1,55 @@
+# Copyright 2021 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "grid-purchase-order-tp"
+version = "0.2.1"
+authors = ["Cargill Incorporated"]
+description = "Grid Purchase Order Smart Contract"
+homepage = "https://grid.hyperledger.org"
+edition = "2018"
+
+[dependencies]
+clap = "2"
+grid-sdk = { path = "../../sdk", features = ["purchase-order"] }
+cfg-if = "0.1"
+hex = "0.3.1"
+protobuf = "2.19"
+
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+rust-crypto-wasm = "0.3"
+sabre-sdk = "0.5"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rust-crypto = "0.2.36"
+sawtooth-sdk = "0.4"
+rustc-serialize = "0.3.22"
+log = "0.3.0"
+log4rs = "0.7.0"
+
+[features]
+default = []
+
+stable = [
+    # The stable feature extends default:
+    "default",
+    # The following features are stable:
+]
+
+experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
+]

--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -1,0 +1,95 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        use sabre_sdk::ApplyError;
+        use sabre_sdk::TransactionContext;
+        use sabre_sdk::TransactionHandler;
+        use sabre_sdk::TpProcessRequest;
+        use sabre_sdk::{WasmPtr, execute_entrypoint};
+    } else {
+        use sawtooth_sdk::processor::handler::ApplyError;
+        use sawtooth_sdk::processor::handler::TransactionContext;
+        use sawtooth_sdk::processor::handler::TransactionHandler;
+        use sawtooth_sdk::messages::processor::TpProcessRequest;
+    }
+}
+
+use grid_sdk::purchase_order::addressing::GRID_PURCHASE_ORDER_NAMESPACE;
+
+use crate::state::PurchaseOrderState;
+
+#[cfg(target_arch = "wasm32")]
+fn apply(
+    request: &TpProcessRequest,
+    context: &mut dyn TransactionContext,
+) -> Result<bool, ApplyError> {
+    let handler = PurchaseOrderTransactionHandler::new();
+    match handler.apply(request, context) {
+        Ok(_) => Ok(true),
+        Err(err) => {
+            info!("{} received {}", handler.family_name(), err);
+            Err(err)
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub unsafe fn entrypoint(payload: WasmPtr, signer: WasmPtr, signature: WasmPtr) -> i32 {
+    execute_entrypoint(payload, signer, signature, apply)
+}
+
+#[derive(Default)]
+pub struct PurchaseOrderTransactionHandler {
+    family_name: String,
+    family_versions: Vec<String>,
+    namespaces: Vec<String>,
+}
+
+impl PurchaseOrderTransactionHandler {
+    pub fn new() -> Self {
+        Self {
+            family_name: "grid_purchase_order".to_string(),
+            family_versions: vec!["1".to_string()],
+            namespaces: vec![GRID_PURCHASE_ORDER_NAMESPACE.to_string()],
+        }
+    }
+}
+
+impl TransactionHandler for PurchaseOrderTransactionHandler {
+    fn family_name(&self) -> String {
+        self.family_name.clone()
+    }
+
+    fn family_versions(&self) -> Vec<String> {
+        self.family_versions.clone()
+    }
+
+    fn namespaces(&self) -> Vec<String> {
+        self.namespaces.clone()
+    }
+
+    fn apply(
+        &self,
+        request: &TpProcessRequest,
+        context: &mut dyn TransactionContext,
+    ) -> Result<(), ApplyError> {
+        let _signer = request.get_header().get_signer_public_key();
+        let mut _state = PurchaseOrderState::new(context);
+
+        unimplemented!()
+    }
+}

--- a/contracts/purchase_order/src/main.rs
+++ b/contracts/purchase_order/src/main.rs
@@ -1,0 +1,92 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate cfg_if;
+extern crate grid_sdk;
+cfg_if! {
+    if #[cfg(not(target_arch = "wasm32"))] {
+        #[macro_use]
+        extern crate clap;
+        #[macro_use]
+        extern crate log;
+        use std::process;
+        use log::LogLevelFilter;
+        use log4rs::append::console::ConsoleAppender;
+        use log4rs::config::{Appender, Config, Root};
+        use log4rs::encode::pattern::PatternEncoder;
+        use sawtooth_sdk::processor::TransactionProcessor;
+        use crate::handler::PurchaseOrderTransactionHandler;
+    } else {
+        #[macro_use]
+        extern crate sabre_sdk;
+    }
+}
+
+pub mod handler;
+mod state;
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+    let matches = clap_app!(intkey =>
+        (version: crate_version!())
+        (about: "Grid Purchase Order Processor (Rust)")
+        (@arg connect: -C --connect +takes_value
+         "connection endpoint for validator")
+        (@arg verbose: -v --verbose +multiple
+         "increase output verbosity"))
+    .get_matches();
+
+    let endpoint = matches
+        .value_of("connect")
+        .unwrap_or("tcp://localhost:4004");
+
+    let console_log_level;
+    match matches.occurrences_of("verbose") {
+        0 => console_log_level = LogLevelFilter::Warn,
+        1 => console_log_level = LogLevelFilter::Info,
+        2 => console_log_level = LogLevelFilter::Debug,
+        _ => console_log_level = LogLevelFilter::Trace,
+    }
+
+    let stdout = ConsoleAppender::builder()
+        .encoder(Box::new(PatternEncoder::new(
+            "{h({l:5.5})} | {({M}:{L}):20.20} | {m}{n}",
+        )))
+        .build();
+
+    let config = match Config::builder()
+        .appender(Appender::builder().build("stdout", Box::new(stdout)))
+        .build(Root::builder().appender("stdout").build(console_log_level))
+    {
+        Ok(x) => x,
+        Err(_) => process::exit(1),
+    };
+
+    match log4rs::init_config(config) {
+        Ok(_) => (),
+        Err(_) => process::exit(1),
+    }
+
+    let handler = PurchaseOrderTransactionHandler::new();
+    let mut processor = TransactionProcessor::new(endpoint);
+
+    info!("Console logging level: {}", console_log_level);
+
+    processor.add_handler(&handler);
+    processor.start();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/contracts/purchase_order/src/state.rs
+++ b/contracts/purchase_order/src/state.rs
@@ -1,0 +1,31 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        use sabre_sdk::TransactionContext;
+    } else {
+        use sawtooth_sdk::processor::handler::TransactionContext;
+    }
+}
+
+pub struct PurchaseOrderState<'a> {
+    _context: &'a dyn TransactionContext,
+}
+
+impl<'a> PurchaseOrderState<'a> {
+    pub fn new(context: &'a dyn TransactionContext) -> Self {
+        Self { _context: context }
+    }
+}

--- a/contracts/schema/Dockerfile
+++ b/contracts/schema/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hyperledger/grid-dev:v7 as grid-schema-builder
+FROM hyperledger/grid-dev:v8 as grid-schema-builder
 
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
@@ -24,6 +24,7 @@ COPY sdk/Cargo.toml /build/sdk/Cargo.toml
 COPY contracts/location/Cargo.toml /build/contracts/location/Cargo.toml
 COPY contracts/pike/Cargo.toml /build/contracts/pike/Cargo.toml
 COPY contracts/product/Cargo.toml /build/contracts/product/Cargo.toml
+COPY contracts/purchase_order/Cargo.toml /build/contracts/purchase_order/Cargo.toml
 COPY contracts/schema/Cargo.toml /build/contracts/schema/Cargo.toml
 COPY contracts/track_and_trace/Cargo.toml /build/contracts/track_and_trace/Cargo.toml
 

--- a/contracts/track_and_trace/Dockerfile
+++ b/contracts/track_and_trace/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hyperledger/grid-dev:v7 as grid-track_and_trace-builder
+FROM hyperledger/grid-dev:v8 as grid-track_and_trace-builder
 
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
@@ -24,6 +24,7 @@ COPY sdk/Cargo.toml /build/sdk/Cargo.toml
 COPY contracts/location/Cargo.toml /build/contracts/location/Cargo.toml
 COPY contracts/pike/Cargo.toml /build/contracts/pike/Cargo.toml
 COPY contracts/product/Cargo.toml /build/contracts/product/Cargo.toml
+COPY contracts/purchase_order/Cargo.toml /build/contracts/purchase_order/Cargo.toml
 COPY contracts/schema/Cargo.toml /build/contracts/schema/Cargo.toml
 COPY contracts/track_and_trace/Cargo.toml /build/contracts/track_and_trace/Cargo.toml
 

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hyperledger/grid-dev:v7 as gridd-builder
+FROM hyperledger/grid-dev:v8 as gridd-builder
 
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
@@ -24,6 +24,7 @@ COPY sdk/Cargo.toml /build/sdk/Cargo.toml
 COPY contracts/location/Cargo.toml /build/contracts/location/Cargo.toml
 COPY contracts/pike/Cargo.toml /build/contracts/pike/Cargo.toml
 COPY contracts/product/Cargo.toml /build/contracts/product/Cargo.toml
+COPY contracts/purchase_order/Cargo.toml /build/contracts/purchase_order/Cargo.toml
 COPY contracts/schema/Cargo.toml /build/contracts/schema/Cargo.toml
 COPY contracts/track_and_trace/Cargo.toml /build/contracts/track_and_trace/Cargo.toml
 

--- a/griddle/Dockerfile
+++ b/griddle/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hyperledger/grid-dev:v7 as builder
+FROM hyperledger/grid-dev:v8 as builder
 
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
@@ -24,6 +24,7 @@ COPY sdk/Cargo.toml /build/sdk/Cargo.toml
 COPY contracts/location/Cargo.toml /build/contracts/location/Cargo.toml
 COPY contracts/pike/Cargo.toml /build/contracts/pike/Cargo.toml
 COPY contracts/product/Cargo.toml /build/contracts/product/Cargo.toml
+COPY contracts/purchase_order/Cargo.toml /build/contracts/purchase_order/Cargo.toml
 COPY contracts/schema/Cargo.toml /build/contracts/schema/Cargo.toml
 COPY contracts/track_and_trace/Cargo.toml /build/contracts/track_and_trace/Cargo.toml
 


### PR DESCRIPTION
Includes the ability to build as a wasm smart contract
but the handling of the transaction is left unimplemented.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>