### PR TITLE
Add initial PO migrations

### DIFF
--- a/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/down.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/down.sql
@@ -1,0 +1,19 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE purchase_order;
+DROP TABLE purchase_order_version;
+DROP TABLE purchase_order_version_revision;
+DROP TABLE purchase_order_alternate_id;

--- a/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -1,0 +1,54 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE purchase_order (
+    id BIGSERIAL PRIMARY KEY,
+    uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    workflow_status TEXT NOT NULL,
+    is_closed BOOLEAN NOT NULL,
+    accepted_version_id TEXT NOT NULL,
+    service_id TEXT
+) INHERITS (chain_record);
+
+CREATE TABLE purchase_order_version (
+    id BIGSERIAL PRIMARY KEY,
+    purchase_order_uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    version_id TEXT NOT NULL,
+    is_draft BOOLEAN NOT NULL,
+    current_revision_number BIGINT NOT NULL,
+    service_id TEXT,
+) INHERITS (chain_record);
+
+CREATE TABLE purchase_order_version_revision (
+    id BIGSERIAL PRIMARY KEY,
+    version_id TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    revision_number BIGINT NOT NULL,
+    order_xml_v3_4 TEXT NOT NULL,
+    submitter TEXT NOT NULL,
+    created_at BIGINT NOT NULL,
+    service_id TEXT
+) INHERITS (chain_record);
+
+CREATE TABLE purchase_order_alternate_id (
+    id BIGSERIAL PRIMARY KEY,
+    purchase_order_uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    alternate_id_type TEXT NOT NULL,
+    alternate_id TEXT NOT NULL,
+    service_id TEXT
+) INHERITS (chain_record);

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/down.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/down.sql
@@ -1,0 +1,19 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE purchase_order;
+DROP TABLE purchase_order_version;
+DROP TABLE purchase_order_version_revision;
+DROP TABLE purchase_order_alternate_id;

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -1,0 +1,62 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE purchase_order (
+    id INTEGER PRIMARY KEY,
+    uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    workflow_status TEXT NOT NULL,
+    is_closed BOOLEAN NOT NULL,
+    accepted_version_id TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+CREATE TABLE purchase_order_version (
+    id INTEGER PRIMARY KEY,
+    purchase_order_uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    version_id TEXT NOT NULL,
+    is_draft BOOLEAN NOT NULL,
+    current_revision_number BIGINT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT,
+);
+
+CREATE TABLE purchase_order_version_revision (
+    id INTEGER PRIMARY KEY,
+    version_id TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    revision_number BIGINT NOT NULL,
+    order_xml_v3_4 TEXT NOT NULL,
+    submitter TEXT NOT NULL,
+    created_at BIGINT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+CREATE TABLE purchase_order_alternate_id (
+    id INTEGER PRIMARY KEY,
+    purchase_order_uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    alternate_id_type TEXT NOT NULL,
+    alternate_id TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);


### PR DESCRIPTION
This adds the initial postgres and sqlite migrations for the purchase
order module.

Signed-off-by: Davey Newhall <newhall@bitwise.io>