### PR TITLE
Rename uid to uuid in address computation

### DIFF
--- a/sdk/src/purchase_order/addressing.rs
+++ b/sdk/src/purchase_order/addressing.rs
@@ -25,10 +25,10 @@ pub const ALTERNATE_ID_PREFIX: &str = "01";
 pub const GRID_PURCHASE_ORDER_PO_NAMESPACE: &str = "621dee0600";
 pub const GRID_PURCHASE_ORDER_ALT_ID_NAMESPACE: &str = "621dee0601";
 
-/// Computes the Merkle address of a Purchase Order based on its UID.
-pub fn compute_purchase_order_address(uid: &str) -> String {
+/// Computes the Merkle address of a Purchase Order based on its UUID.
+pub fn compute_purchase_order_address(uuid: &str) -> String {
     let mut sha = Sha512::new();
-    sha.input(uid.as_bytes());
+    sha.input(uuid.as_bytes());
     let hash_str = String::from(GRID_PURCHASE_ORDER_NAMESPACE) + PO_PREFIX + &sha.result_str();
     hash_str[..70].to_string()
 }


### PR DESCRIPTION
This change renames the uid to uuid to be more explicit about the meaning of an ID of a PO.