### PR TITLE
Add CLI subcommands

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -70,6 +70,7 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "purchase-order",
     "splinter",
     "sqlite",
 ]
@@ -86,6 +87,7 @@ admin-keygen = []
 location = ["pike", "schema"]
 pike = []
 product = ["pike", "schema"]
+purchase-order = []
 sawtooth = []
 schema = ["pike"]
 splinter = ["admin-keygen"]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1745,6 +1745,39 @@ fn run() -> Result<(), CliError> {
                 _ => return Err(CliError::UserError("Subcommand not recognized".into())),
             }
         }
+        #[cfg(feature = "purchase-order")]
+        ("po", Some(m)) => {
+            let _url = m
+                .value_of("url")
+                .map(String::from)
+                .or_else(|| env::var(GRID_DAEMON_ENDPOINT).ok())
+                .unwrap_or_else(|| String::from("http://localhost:8000"));
+
+            let _service_id = m
+                .value_of("service_id")
+                .map(String::from)
+                .or_else(|| env::var(GRID_SERVICE_ID).ok());
+
+            match m.subcommand() {
+                ("create", Some(_)) => unimplemented!(),
+                ("update", Some(_)) => unimplemented!(),
+                ("list", Some(_)) => unimplemented!(),
+                ("show", Some(_)) => unimplemented!(),
+                ("version", Some(m)) => match m.subcommand() {
+                    ("create", Some(_)) => unimplemented!(),
+                    ("update", Some(_)) => unimplemented!(),
+                    ("list", Some(_)) => unimplemented!(),
+                    ("show", Some(_)) => unimplemented!(),
+                    _ => return Err(CliError::UserError("Subcommand not recognized".into())),
+                },
+                ("revision", Some(m)) => match m.subcommand() {
+                    ("list", Some(_)) => unimplemented!(),
+                    ("show", Some(_)) => unimplemented!(),
+                    _ => return Err(CliError::UserError("Subcommand not recognized".into())),
+                },
+                _ => return Err(CliError::UserError("Subcommand not recognized".into())),
+            }
+        }
         _ => return Err(CliError::UserError("Subcommand not recognized".into())),
     }
 


### PR DESCRIPTION
This PR: 

- Adds the experimental `purchase-order` feature to the grid CLI
- Adds an outline for the purchase order CLI subcommands, unimplemented currently