### PR TITLE
Compile crates with cargo build instead of cargo deb

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ build only the grid-cli, run `docker-compose build grid-cli`.
 
 To use Docker to build Grid with experimental features enabled, set an
 environment variable in your shell before running the build commands. For
-example: `export 'CARGO_ARGS=-- --features experimental'`. To go back to
+example: `export 'CARGO_ARGS= --features experimental'`. To go back to
 building with default features, unset the environment variable:
 `unset CARGO_ARGS`
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -38,11 +38,11 @@ COPY daemon /build/daemon
 COPY sdk /build/sdk
 
 # Build the grid-cli package
-WORKDIR /build/cli
 ARG CARGO_ARGS
 ARG REPO_VERSION
-RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
-RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" cli/Cargo.toml
+RUN cargo build --manifest-path=cli/Cargo.toml --release $CARGO_ARGS
+RUN (cd cli && cargo deb --no-build --deb-version $REPO_VERSION --manifest-path ./Cargo.toml)
 
 # Log the commit hash
 COPY .git/ /tmp/.git/

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -34,18 +34,18 @@ COPY daemon /build/daemon
 COPY sdk /build/sdk
 
 # Build the gridd package
-WORKDIR /build/daemon
 ARG CARGO_ARGS
 ARG REPO_VERSION
-RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
-RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" daemon/Cargo.toml
+RUN cargo build --manifest-path=daemon/Cargo.toml --release $CARGO_ARGS
+RUN (cd daemon && cargo deb --no-build --deb-version $REPO_VERSION --manifest-path ./Cargo.toml)
 
 # Build the grid-cli package
-WORKDIR /build/cli
 ARG CARGO_ARGS
 ARG REPO_VERSION
-RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
-RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" cli/Cargo.toml
+RUN cargo build --manifest-path=cli/Cargo.toml --release $CARGO_ARGS
+RUN (cd cli && cargo deb --no-build --deb-version $REPO_VERSION --manifest-path ./Cargo.toml)
 
 # Log the commit hash
 COPY .git/ /tmp/.git/

--- a/griddle/Dockerfile
+++ b/griddle/Dockerfile
@@ -34,18 +34,18 @@ COPY griddle /build/griddle
 COPY sdk /build/sdk
 
 # Build the griddle package
-WORKDIR /build/griddle
 ARG CARGO_ARGS
 ARG REPO_VERSION
-RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
-RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" griddle/Cargo.toml
+RUN cargo build --manifest-path=griddle/Cargo.toml --release $CARGO_ARGS
+RUN (cd griddle && cargo deb --no-build --deb-version $REPO_VERSION --manifest-path ./Cargo.toml)
 
 # Build the grid-cli package
-WORKDIR /build/cli
 ARG CARGO_ARGS
 ARG REPO_VERSION
-RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
-RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" cli/Cargo.toml
+RUN cargo build --manifest-path=cli/Cargo.toml --release $CARGO_ARGS
+RUN (cd cli && cargo deb --no-build --deb-version $REPO_VERSION --manifest-path ./Cargo.toml)
 
 # Log the commit hash
 COPY .git/ /tmp/.git/


### PR DESCRIPTION
The cargo deb subcommand is not fully compatible with workspaces, so
using it for deb package creation only provides us with more consistent
results.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>