### PR TITLE
Add reqwest stub

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -80,6 +80,7 @@ experimental = [
     # The following features are experimental:
     "batch-store",
     "client",
+    "client-reqwest",
     "postgres",
     "pike-rest-api",
     "purchase-order",
@@ -92,6 +93,7 @@ experimental = [
 ]
 
 client = []
+client-reqwest = ["client", "reqwest"]
 location = ["pike", "schema"]
 pike = []
 pike-rest-api = ["pike", "serde_json", "rest-api-resources"]

--- a/sdk/src/client/mod.rs
+++ b/sdk/src/client/mod.rs
@@ -37,6 +37,19 @@ pub trait Client {
     #[cfg(feature = "purchase-order")]
     fn get_purchase_order(&self, id: String) -> Result<Option<PurchaseOrder>, InternalError>;
 
+    /// Adds the given `PurchaseOrderVersion`.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The uuid of the `PurchaseOrder` the purchase order version will be added to
+    /// * `purchase_order_version` - The `PurchaseOrderVersion` to be added
+    #[cfg(feature = "purchase-order")]
+    fn add_purchase_order_version(
+        &self,
+        id: String,
+        purchase_order_version: &PurchaseOrderVersion,
+    ) -> Result<(), InternalError>;
+
     /// Retrieves the purchase order version with the given `version_id` of the purchase
     /// order with the given `id`
     ///
@@ -50,6 +63,21 @@ pub trait Client {
         id: String,
         version_id: String,
     ) -> Result<Option<PurchaseOrderVersion>, InternalError>;
+
+    /// Adds the given `PurchaseOrderRevision`.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The uuid of the `PurchaseOrder` the purchase order revision will be added to
+    /// * `version_id` - The version id of the `PurchaseOrderVersion` the puchase order revision will be added to
+    /// * `purchase_order_version` - The `PurchaseOrderVersion` to be added
+    #[cfg(feature = "purchase-order")]
+    fn add_purchase_order_revision(
+        &self,
+        id: String,
+        version_id: String,
+        purchase_order_revision: &PurchaseOrderRevision,
+    ) -> Result<(), InternalError>;
 
     /// Retrieves the purchase order revision with the given `revision_number` of
     /// the purchase order version with the given `version_id` of the purchase order with the given `id`
@@ -115,6 +143,20 @@ pub trait Client {
     ///   same uuid
     #[cfg(feature = "purchase-order")]
     fn update_purchase_order(&self, purchase_order: &PurchaseOrder) -> Result<(), InternalError>;
+
+    /// Updates the purchase order version with the same version_id as the given `purchase_order_version`.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The uuid of the `PurchaseOrder` containing the `PurchaseOrderVersion` to be updated
+    /// * `purchase_order_version` - The updated `PurchaseOrderVersion` replacing the existing `PurchaseOrderVersion` with the
+    ///   same version_id
+    #[cfg(feature = "purchase-order")]
+    fn update_purchase_order_version(
+        &self,
+        id: String,
+        purchase_order_version: &PurchaseOrderVersion,
+    ) -> Result<(), InternalError>;
 }
 
 #[cfg(feature = "purchase-order")]

--- a/sdk/src/client/mod.rs
+++ b/sdk/src/client/mod.rs
@@ -82,7 +82,7 @@ pub trait Client {
         purchase_order_revision: &PurchaseOrderRevision,
     ) -> Result<(), InternalError>;
 
-    /// Retrieves the purchase order revision with the given `revision_number` of
+    /// Retrieves the purchase order revision with the given `revision_id` of
     /// the purchase order version with the given `version_id` of the purchase order with the given `id`
     ///
     /// # Arguments
@@ -90,13 +90,13 @@ pub trait Client {
     /// * `id` - The uuid of the `PurchaseOrder` containing the `PurchaseOrderRevision` to be retrieved
     /// * `version_id` - The version id of the `PurchaseOrderVersion` containing the
     ///   `PurchaseOrderRevision` to be retrieved
-    /// * `revision_number` - The revision number of the `PurchaseOrderRevision` to be retrieved
+    /// * `revision_id` - The revision number of the `PurchaseOrderRevision` to be retrieved
     #[cfg(feature = "purchase-order")]
     fn get_purchase_order_revision(
         &self,
         id: String,
         version_id: String,
-        revision_number: String,
+        revision_id: String,
     ) -> Result<Option<PurchaseOrderRevision>, InternalError>;
 
     /// lists purchase orders.
@@ -180,14 +180,14 @@ pub struct PurchaseOrderVersion {
     version_id: String,
     workflow_status: String,
     is_draft: bool,
-    current_version_number: u64,
+    current_revision_id: u64,
     revisions: Vec<PurchaseOrderRevision>,
 }
 
 #[cfg(feature = "purchase-order")]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PurchaseOrderRevision {
-    revision_number: u64,
+    revision_id: u64,
     order_xml_v3_4: String,
     submitter: String,
     created_at: u64,

--- a/sdk/src/client/mod.rs
+++ b/sdk/src/client/mod.rs
@@ -14,6 +14,9 @@
 
 //! Traits and implementations useful for interacting with the REST API.
 
+#[cfg(feature = "client-reqwest")]
+mod reqwest;
+
 use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};

--- a/sdk/src/client/reqwest.rs
+++ b/sdk/src/client/reqwest.rs
@@ -1,0 +1,140 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A Reqwest-based implementation of Client
+
+use crate::error::InternalError;
+
+use super::Client;
+#[cfg(feature = "purchase-order")]
+use super::{PurchaseOrder, PurchaseOrderRevision, PurchaseOrderVersion};
+
+#[derive(Deserialize)]
+struct ServerError {
+    pub message: String,
+}
+
+pub struct ReqwestClient {
+    pub url: String,
+}
+
+impl ReqwestClient {
+    pub fn _new(url: String) -> Self {
+        ReqwestClient { url }
+    }
+}
+
+impl Client for ReqwestClient {
+    /// Adds the given `PurchaseOrder`.
+    #[cfg(feature = "purchase-order")]
+    fn add_purchase_order(&self, _purchase_order: &PurchaseOrder) -> Result<(), InternalError> {
+        unimplemented!()
+    }
+
+    /// Retrieves the purchase order with the specified `id`.
+    #[cfg(feature = "purchase-order")]
+    fn get_purchase_order(&self, _id: String) -> Result<Option<PurchaseOrder>, InternalError> {
+        unimplemented!()
+    }
+
+    /// Adds the given `PurchaseOrderVersion`.
+    #[cfg(feature = "purchase-order")]
+    fn add_purchase_order_version(
+        &self,
+        _id: String,
+        _purchase_order_version: &PurchaseOrderVersion,
+    ) -> Result<(), InternalError> {
+        unimplemented!()
+    }
+
+    /// Retrieves the purchase order version with the given `version_id` of the purchase order
+    /// with the given `id`
+    #[cfg(feature = "purchase-order")]
+    fn get_purchase_order_version(
+        &self,
+        _id: String,
+        _version_id: String,
+    ) -> Result<Option<PurchaseOrderVersion>, InternalError> {
+        unimplemented!()
+    }
+
+    /// Adds the given `PurchaseOrderRevision`.
+    #[cfg(feature = "purchase-order")]
+    fn add_purchase_order_revision(
+        &self,
+        _id: String,
+        _version_id: String,
+        _purchase_order_revision: &PurchaseOrderRevision,
+    ) -> Result<(), InternalError> {
+        unimplemented!()
+    }
+
+    /// Retrieves the purchase order revision with the given `revision_id` of the purchase
+    /// order version with the given `version_id` of the purchase order with the given `id`
+    #[cfg(feature = "purchase-order")]
+    fn get_purchase_order_revision(
+        &self,
+        _id: String,
+        _version_id: String,
+        _revision_id: String,
+    ) -> Result<Option<PurchaseOrderRevision>, InternalError> {
+        unimplemented!()
+    }
+
+    /// lists purchase orders.
+    #[cfg(feature = "purchase-order")]
+    fn list_purchase_orders(
+        &self,
+        _filter: Option<&str>,
+    ) -> Result<Vec<PurchaseOrder>, InternalError> {
+        unimplemented!()
+    }
+
+    /// lists the purchase order versions of a specific purchase order.
+    #[cfg(feature = "purchase-order")]
+    fn list_purchase_order_versions(
+        &self,
+        _id: String,
+        _filter: Option<&str>,
+    ) -> Result<Vec<PurchaseOrderVersion>, InternalError> {
+        unimplemented!()
+    }
+
+    /// lists the purchase order revisions of a specific purchase order version.
+    #[cfg(feature = "purchase-order")]
+    fn list_purchase_order_revisions(
+        &self,
+        _id: String,
+        _version_id: String,
+        _filter: Option<&str>,
+    ) -> Result<Vec<PurchaseOrderRevision>, InternalError> {
+        unimplemented!()
+    }
+
+    /// Updates the purchase order with the same id as the given `purchase_order`.
+    #[cfg(feature = "purchase-order")]
+    fn update_purchase_order(&self, _purchase_order: &PurchaseOrder) -> Result<(), InternalError> {
+        unimplemented!()
+    }
+
+    /// Updates the purchase order version with the same version_id as the given `purchase_order_version`.
+    #[cfg(feature = "purchase-order")]
+    fn update_purchase_order_version(
+        &self,
+        _id: String,
+        _purchase_order_version: &PurchaseOrderVersion,
+    ) -> Result<(), InternalError> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
Update the Client trait to have `add_purchase_order_version` `update_purchase_order_version` and `add_purchase_order_revision` method definitions.

Add an outline for the reqwest based implementation of the `Client` trait. All methods are unimplemented. The `reqwest` module is guarded by the experimental feature `client-reqwest`

Fix the `PurchaseOrderRevision` and `PurchaseOrderVersion` structs to match protos. Update the `PurchaseOrderRevision` struct to have `revision_id` instead of `revision_number` and update the `PurchaseOrderVersion` to have `current_revision_id` instead of `current_revision_number`