### PR TITLE
Add operations and stubs

### DIFF
--- a/sdk/src/purchase_order/mod.rs
+++ b/sdk/src/purchase_order/mod.rs
@@ -15,4 +15,6 @@
 pub mod addressing;
 pub mod store;
 
+#[cfg(feature = "postgres")]
+pub use store::diesel::DieselPurchaseOrderStore;
 pub use store::PurchaseOrderStore;

--- a/sdk/src/purchase_order/store/diesel/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/mod.rs
@@ -32,7 +32,7 @@ use operations::add_alternate_id::PurchaseOrderStoreAddAlternateIdOperation as _
 use operations::add_purchase_order::PurchaseOrderStoreAddPurchaseOrderOperation as _;
 use operations::fetch_purchase_order::PurchaseOrderStoreFetchPurchaseOrderOperation as _;
 use operations::list_alternate_ids_for_purchase_order::PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation as _;
-use operations::list_purchase_orders_for_organization::PurchaseOrderStoreListPurchaseOrdersForOrganizationOperation as _;
+use operations::list_purchase_orders::PurchaseOrderStoreListPurchaseOrdersOperation as _;
 use operations::PurchaseOrderStoreOperations;
 
 /// Manages creating agents in the database
@@ -67,9 +67,9 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
         )
     }
 
-    fn list_purchase_orders_for_organization(
+    fn list_purchase_orders(
         &self,
-        org_id: &str,
+        org_id: Option<&str>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
@@ -79,7 +79,7 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_purchase_orders_for_organization(org_id, service_id, offset, limit)
+        .list_purchase_orders(org_id, service_id, offset, limit)
     }
 
     fn fetch_purchase_order(
@@ -146,9 +146,9 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
         )
     }
 
-    fn list_purchase_orders_for_organization(
+    fn list_purchase_orders(
         &self,
-        org_id: &str,
+        org_id: Option<&str>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
@@ -158,7 +158,7 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_purchase_orders_for_organization(org_id, service_id, offset, limit)
+        .list_purchase_orders(org_id, service_id, offset, limit)
     }
 
     fn fetch_purchase_order(

--- a/sdk/src/purchase_order/store/diesel/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/mod.rs
@@ -11,3 +11,201 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+pub mod models;
+mod operations;
+pub(in crate) mod schema;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use super::{
+    PurchaseOrder, PurchaseOrderAlternateId, PurchaseOrderAlternateIdList, PurchaseOrderList,
+    PurchaseOrderStore, PurchaseOrderStoreError, PurchaseOrderVersion,
+    PurchaseOrderVersionRevision,
+};
+
+use models::{make_purchase_order_version_revisions, make_purchase_order_versions};
+
+use crate::error::ResourceTemporarilyUnavailableError;
+
+use operations::add_alternate_id::PurchaseOrderStoreAddAlternateIdOperation as _;
+use operations::add_purchase_order::PurchaseOrderStoreAddPurchaseOrderOperation as _;
+use operations::fetch_purchase_order::PurchaseOrderStoreFetchPurchaseOrderOperation as _;
+use operations::list_alternate_ids_for_purchase_order::PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation as _;
+use operations::list_purchase_orders_for_organization::PurchaseOrderStoreListPurchaseOrdersForOrganizationOperation as _;
+use operations::PurchaseOrderStoreOperations;
+
+/// Manages creating agents in the database
+#[derive(Clone)]
+pub struct DieselPurchaseOrderStore<C: diesel::Connection + 'static> {
+    connection_pool: Pool<ConnectionManager<C>>,
+}
+
+impl<C: diesel::Connection> DieselPurchaseOrderStore<C> {
+    /// Creates a new DieselPurchaseOrderStore
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool to the database
+    pub fn new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        DieselPurchaseOrderStore { connection_pool }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
+    fn add_purchase_order(&self, order: PurchaseOrder) -> Result<(), PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .add_purchase_order(
+            order.clone().into(),
+            make_purchase_order_versions(&order),
+            make_purchase_order_version_revisions(&order),
+        )
+    }
+
+    fn list_purchase_orders_for_organization(
+        &self,
+        org_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .list_purchase_orders_for_organization(org_id, service_id, offset, limit)
+    }
+
+    fn fetch_purchase_order(
+        &self,
+        org_id: &str,
+        uuid: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .fetch_purchase_order(org_id, uuid, service_id)
+    }
+
+    fn add_alternate_id(
+        &self,
+        alternate_id: PurchaseOrderAlternateId,
+    ) -> Result<(), PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .add_alternate_id(alternate_id.into())
+    }
+
+    fn list_alternate_ids_for_purchase_order(
+        &self,
+        purchase_order_uuid: &str,
+        org_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderAlternateIdList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .list_alternate_ids_for_purchase_order(
+            purchase_order_uuid,
+            org_id,
+            service_id,
+            offset,
+            limit,
+        )
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConnection> {
+    fn add_purchase_order(&self, order: PurchaseOrder) -> Result<(), PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .add_purchase_order(
+            order.clone().into(),
+            make_purchase_order_versions(&order),
+            make_purchase_order_version_revisions(&order),
+        )
+    }
+
+    fn list_purchase_orders_for_organization(
+        &self,
+        org_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .list_purchase_orders_for_organization(org_id, service_id, offset, limit)
+    }
+
+    fn fetch_purchase_order(
+        &self,
+        org_id: &str,
+        uuid: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .fetch_purchase_order(org_id, uuid, service_id)
+    }
+
+    fn add_alternate_id(
+        &self,
+        alternate_id: PurchaseOrderAlternateId,
+    ) -> Result<(), PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .add_alternate_id(alternate_id.into())
+    }
+
+    fn list_alternate_ids_for_purchase_order(
+        &self,
+        purchase_order_uuid: &str,
+        org_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderAlternateIdList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .list_alternate_ids_for_purchase_order(
+            purchase_order_uuid,
+            org_id,
+            service_id,
+            offset,
+            limit,
+        )
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/add_alternate_id.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/add_alternate_id.rs
@@ -1,0 +1,49 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::PurchaseOrderStoreOperations;
+use crate::purchase_order::store::diesel::{
+    models::NewPurchaseOrderAlternateIdModel, PurchaseOrderStoreError,
+};
+
+pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreAddAlternateIdOperation {
+    fn add_alternate_id(
+        &self,
+        alternate_id: NewPurchaseOrderAlternateIdModel,
+    ) -> Result<(), PurchaseOrderStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> PurchaseOrderStoreAddAlternateIdOperation
+    for PurchaseOrderStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_alternate_id(
+        &self,
+        _alternate_id: NewPurchaseOrderAlternateIdModel,
+    ) -> Result<(), PurchaseOrderStoreError> {
+        unimplemented!()
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> PurchaseOrderStoreAddAlternateIdOperation
+    for PurchaseOrderStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_alternate_id(
+        &self,
+        _alternate_id: NewPurchaseOrderAlternateIdModel,
+    ) -> Result<(), PurchaseOrderStoreError> {
+        unimplemented!()
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/add_purchase_order.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/add_purchase_order.rs
@@ -1,0 +1,331 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::PurchaseOrderStoreOperations;
+use crate::purchase_order::store::diesel::{
+    models::{
+        NewPurchaseOrderModel, NewPurchaseOrderVersionModel, NewPurchaseOrderVersionRevisionModel,
+        PurchaseOrderModel, PurchaseOrderVersionModel, PurchaseOrderVersionRevisionModel,
+    },
+    schema::{purchase_order, purchase_order_version, purchase_order_version_revision},
+    PurchaseOrderStoreError,
+};
+
+use crate::commits::MAX_COMMIT_NUM;
+use crate::error::InternalError;
+
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error as dsl_error,
+};
+
+pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreAddPurchaseOrderOperation {
+    fn add_purchase_order(
+        &self,
+        order: NewPurchaseOrderModel,
+        versions: Vec<NewPurchaseOrderVersionModel>,
+        revisions: Vec<NewPurchaseOrderVersionRevisionModel>,
+    ) -> Result<(), PurchaseOrderStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> PurchaseOrderStoreAddPurchaseOrderOperation
+    for PurchaseOrderStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_purchase_order(
+        &self,
+        order: NewPurchaseOrderModel,
+        versions: Vec<NewPurchaseOrderVersionModel>,
+        revisions: Vec<NewPurchaseOrderVersionRevisionModel>,
+    ) -> Result<(), PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let duplicate = purchase_order::table
+                .filter(
+                    purchase_order::uuid
+                        .eq(&order.uuid)
+                        .and(purchase_order::org_id.eq(&order.org_id))
+                        .and(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM)),
+                )
+                .first::<PurchaseOrderModel>(self.conn)
+                .map(Some)
+                .or_else(|err| {
+                    if err == dsl_error::NotFound {
+                        Ok(None)
+                    } else {
+                        Err(err)
+                    }
+                })
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            if duplicate.is_some() {
+                update(purchase_order::table)
+                    .filter(
+                        purchase_order::uuid
+                            .eq(&order.uuid)
+                            .and(purchase_order::org_id.eq(&order.org_id))
+                            .and(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(purchase_order::end_commit_num.eq(&order.start_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PurchaseOrderStoreError::from)?;
+            }
+
+            insert_into(purchase_order::table)
+                .values(&order)
+                .execute(self.conn)
+                .map(|_| ())
+                .map_err(PurchaseOrderStoreError::from)?;
+
+            for version in versions {
+                let duplicate = purchase_order_version::table
+                    .filter(
+                        purchase_order_version::purchase_order_uuid
+                            .eq(&order.uuid)
+                            .and(purchase_order_version::org_id.eq(&order.org_id))
+                            .and(purchase_order_version::version_id.eq(&version.version_id))
+                            .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .first::<PurchaseOrderVersionModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| {
+                        if err == dsl_error::NotFound {
+                            Ok(None)
+                        } else {
+                            Err(err)
+                        }
+                    })
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+                if duplicate.is_some() {
+                    update(purchase_order_version::table)
+                        .filter(
+                            purchase_order_version::purchase_order_uuid
+                                .eq(&order.uuid)
+                                .and(purchase_order_version::org_id.eq(&order.org_id))
+                                .and(purchase_order_version::version_id.eq(&version.version_id))
+                                .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(purchase_order_version::end_commit_num.eq(&version.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PurchaseOrderStoreError::from)?;
+                }
+
+                insert_into(purchase_order_version::table)
+                    .values(&version)
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PurchaseOrderStoreError::from)?;
+            }
+
+            for revision in revisions {
+                let duplicate = purchase_order_version_revision::table
+                    .filter(
+                        purchase_order_version_revision::org_id
+                            .eq(&revision.org_id)
+                            .and(
+                                purchase_order_version_revision::version_id
+                                    .eq(&revision.version_id),
+                            )
+                            .and(
+                                purchase_order_version_revision::revision_id
+                                    .eq(&revision.revision_id),
+                            )
+                            .and(
+                                purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
+                            ),
+                    )
+                    .first::<PurchaseOrderVersionRevisionModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| {
+                        if err == dsl_error::NotFound {
+                            Ok(None)
+                        } else {
+                            Err(err)
+                        }
+                    })
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+                if duplicate.is_none() {
+                    insert_into(purchase_order_version_revision::table)
+                        .values(&revision)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PurchaseOrderStoreError::from)?;
+                }
+            }
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> PurchaseOrderStoreAddPurchaseOrderOperation
+    for PurchaseOrderStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_purchase_order(
+        &self,
+        order: NewPurchaseOrderModel,
+        versions: Vec<NewPurchaseOrderVersionModel>,
+        revisions: Vec<NewPurchaseOrderVersionRevisionModel>,
+    ) -> Result<(), PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let duplicate = purchase_order::table
+                .filter(
+                    purchase_order::uuid
+                        .eq(&order.uuid)
+                        .and(purchase_order::org_id.eq(&order.org_id))
+                        .and(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM)),
+                )
+                .first::<PurchaseOrderModel>(self.conn)
+                .map(Some)
+                .or_else(|err| {
+                    if err == dsl_error::NotFound {
+                        Ok(None)
+                    } else {
+                        Err(err)
+                    }
+                })
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            if duplicate.is_some() {
+                update(purchase_order::table)
+                    .filter(
+                        purchase_order::uuid
+                            .eq(&order.uuid)
+                            .and(purchase_order::org_id.eq(&order.org_id))
+                            .and(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .set(purchase_order::end_commit_num.eq(&order.start_commit_num))
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PurchaseOrderStoreError::from)?;
+            }
+
+            insert_into(purchase_order::table)
+                .values(&order)
+                .execute(self.conn)
+                .map(|_| ())
+                .map_err(PurchaseOrderStoreError::from)?;
+
+            for version in versions {
+                let duplicate = purchase_order_version::table
+                    .filter(
+                        purchase_order_version::purchase_order_uuid
+                            .eq(&order.uuid)
+                            .and(purchase_order_version::org_id.eq(&order.org_id))
+                            .and(purchase_order_version::version_id.eq(&version.version_id))
+                            .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    )
+                    .first::<PurchaseOrderVersionModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| {
+                        if err == dsl_error::NotFound {
+                            Ok(None)
+                        } else {
+                            Err(err)
+                        }
+                    })
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+                if duplicate.is_some() {
+                    update(purchase_order_version::table)
+                        .filter(
+                            purchase_order_version::purchase_order_uuid
+                                .eq(&order.uuid)
+                                .and(purchase_order_version::org_id.eq(&order.org_id))
+                                .and(purchase_order_version::version_id.eq(&version.version_id))
+                                .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(purchase_order_version::end_commit_num.eq(&version.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PurchaseOrderStoreError::from)?;
+                }
+
+                insert_into(purchase_order_version::table)
+                    .values(&version)
+                    .execute(self.conn)
+                    .map(|_| ())
+                    .map_err(PurchaseOrderStoreError::from)?;
+            }
+
+            for revision in revisions {
+                let duplicate = purchase_order_version_revision::table
+                    .filter(
+                        purchase_order_version_revision::org_id
+                            .eq(&revision.org_id)
+                            .and(
+                                purchase_order_version_revision::version_id
+                                    .eq(&revision.version_id),
+                            )
+                            .and(
+                                purchase_order_version_revision::revision_id
+                                    .eq(&revision.revision_id),
+                            )
+                            .and(
+                                purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
+                            ),
+                    )
+                    .first::<PurchaseOrderVersionRevisionModel>(self.conn)
+                    .map(Some)
+                    .or_else(|err| {
+                        if err == dsl_error::NotFound {
+                            Ok(None)
+                        } else {
+                            Err(err)
+                        }
+                    })
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+                if duplicate.is_none() {
+                    insert_into(purchase_order_version_revision::table)
+                        .values(&revision)
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PurchaseOrderStoreError::from)?;
+                }
+            }
+
+            Ok(())
+        })
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/fetch_purchase_order.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/fetch_purchase_order.rs
@@ -1,0 +1,234 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::PurchaseOrderStoreOperations;
+use crate::commits::MAX_COMMIT_NUM;
+use crate::error::InternalError;
+use crate::purchase_order::store::diesel::{
+    models::{PurchaseOrderModel, PurchaseOrderVersionModel, PurchaseOrderVersionRevisionModel},
+    schema::{purchase_order, purchase_order_version, purchase_order_version_revision},
+    PurchaseOrder, PurchaseOrderVersion,
+};
+
+use crate::purchase_order::store::PurchaseOrderStoreError;
+use diesel::{prelude::*, result::Error::NotFound};
+
+pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreFetchPurchaseOrderOperation {
+    fn fetch_purchase_order(
+        &self,
+        org_id: &str,
+        uuid: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> PurchaseOrderStoreFetchPurchaseOrderOperation
+    for PurchaseOrderStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn fetch_purchase_order(
+        &self,
+        org_id: &str,
+        uuid: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order::table
+                .into_boxed()
+                .select(purchase_order::all_columns)
+                .filter(
+                    purchase_order::org_id
+                        .eq(&org_id)
+                        .and(purchase_order::uuid.eq(&uuid))
+                        .and(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order::service_id.is_null());
+            }
+
+            let order = query
+                .first::<PurchaseOrderModel>(self.conn)
+                .map(Some)
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            let mut query = purchase_order_version::table
+                .into_boxed()
+                .select(purchase_order_version::all_columns)
+                .filter(
+                    purchase_order_version::purchase_order_uuid
+                        .eq(&uuid)
+                        .and(purchase_order_version::org_id.eq(&org_id))
+                        .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version::service_id.is_null());
+            }
+
+            let version_models =
+                query
+                    .load::<PurchaseOrderVersionModel>(self.conn)
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+            let mut versions = Vec::new();
+
+            for v in version_models {
+                let mut query = purchase_order_version_revision::table
+                    .into_boxed()
+                    .select(purchase_order_version_revision::all_columns)
+                    .filter(
+                        purchase_order_version_revision::version_id
+                            .eq(&v.version_id)
+                            .and(purchase_order_version_revision::org_id.eq(&v.org_id))
+                            .and(
+                                purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
+                            ),
+                    );
+
+                if let Some(service_id) = service_id {
+                    query =
+                        query.filter(purchase_order_version_revision::service_id.eq(service_id));
+                } else {
+                    query = query.filter(purchase_order_version_revision::service_id.is_null());
+                }
+
+                let revision_models = query
+                    .load::<PurchaseOrderVersionRevisionModel>(self.conn)
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+                versions.push(PurchaseOrderVersion::from((&v, &revision_models)))
+            }
+
+            Ok(order.map(|order| PurchaseOrder::from((order, versions))))
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> PurchaseOrderStoreFetchPurchaseOrderOperation
+    for PurchaseOrderStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn fetch_purchase_order(
+        &self,
+        org_id: &str,
+        uuid: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order::table
+                .into_boxed()
+                .select(purchase_order::all_columns)
+                .filter(
+                    purchase_order::org_id
+                        .eq(&org_id)
+                        .and(purchase_order::uuid.eq(&uuid))
+                        .and(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order::service_id.is_null());
+            }
+
+            let order = query
+                .first::<PurchaseOrderModel>(self.conn)
+                .map(Some)
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            let mut query = purchase_order_version::table
+                .into_boxed()
+                .select(purchase_order_version::all_columns)
+                .filter(
+                    purchase_order_version::purchase_order_uuid
+                        .eq(&uuid)
+                        .and(purchase_order_version::org_id.eq(&org_id))
+                        .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version::service_id.is_null());
+            }
+
+            let version_models =
+                query
+                    .load::<PurchaseOrderVersionModel>(self.conn)
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+            let mut versions = Vec::new();
+
+            for v in version_models {
+                let mut query = purchase_order_version_revision::table
+                    .into_boxed()
+                    .select(purchase_order_version_revision::all_columns)
+                    .filter(
+                        purchase_order_version_revision::version_id
+                            .eq(&v.version_id)
+                            .and(purchase_order_version_revision::org_id.eq(&v.org_id))
+                            .and(
+                                purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
+                            ),
+                    );
+
+                if let Some(service_id) = service_id {
+                    query =
+                        query.filter(purchase_order_version_revision::service_id.eq(service_id));
+                } else {
+                    query = query.filter(purchase_order_version_revision::service_id.is_null());
+                }
+
+                let revision_models = query
+                    .load::<PurchaseOrderVersionRevisionModel>(self.conn)
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+                versions.push(PurchaseOrderVersion::from((&v, &revision_models)))
+            }
+
+            Ok(order.map(|order| PurchaseOrder::from((order, versions))))
+        })
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/list_alternate_ids_for_purchase_order.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_alternate_ids_for_purchase_order.rs
@@ -1,0 +1,60 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::PurchaseOrderStoreOperations;
+use crate::purchase_order::store::diesel::{PurchaseOrderAlternateIdList, PurchaseOrderStoreError};
+
+pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation
+{
+    fn list_alternate_ids_for_purchase_order(
+        &self,
+        purchase_order_uuid: &str,
+        org_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderAlternateIdList, PurchaseOrderStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation
+    for PurchaseOrderStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_alternate_ids_for_purchase_order(
+        &self,
+        _purchase_order_uuid: &str,
+        _org_id: &str,
+        _service_id: Option<&str>,
+        _offset: i64,
+        _limit: i64,
+    ) -> Result<PurchaseOrderAlternateIdList, PurchaseOrderStoreError> {
+        unimplemented!()
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation
+    for PurchaseOrderStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn list_alternate_ids_for_purchase_order(
+        &self,
+        _purchase_order_uuid: &str,
+        _org_id: &str,
+        _service_id: Option<&str>,
+        _offset: i64,
+        _limit: i64,
+    ) -> Result<PurchaseOrderAlternateIdList, PurchaseOrderStoreError> {
+        unimplemented!()
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/list_purchase_orders.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_purchase_orders.rs
@@ -1,0 +1,278 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::PurchaseOrderStoreOperations;
+use crate::commits::MAX_COMMIT_NUM;
+use crate::error::InternalError;
+use crate::paging::Paging;
+use crate::purchase_order::store::diesel::{
+    models::{PurchaseOrderModel, PurchaseOrderVersionModel, PurchaseOrderVersionRevisionModel},
+    schema::{purchase_order, purchase_order_version, purchase_order_version_revision},
+    PurchaseOrder, PurchaseOrderList, PurchaseOrderVersion,
+};
+
+use crate::purchase_order::store::PurchaseOrderStoreError;
+use diesel::prelude::*;
+
+pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreListPurchaseOrdersOperation {
+    fn list_purchase_orders(
+        &self,
+        org_id: Option<&str>,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderList, PurchaseOrderStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
+    for PurchaseOrderStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_purchase_orders(
+        &self,
+        org_id: Option<&str>,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderList, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order::table
+                .into_boxed()
+                .select(purchase_order::all_columns)
+                .offset(offset)
+                .limit(limit)
+                .filter(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM));
+
+            if let Some(org_id) = org_id {
+                query = query.filter(purchase_order::org_id.eq(org_id))
+            }
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order::service_id.is_null());
+            }
+
+            let purchase_order_models =
+                query.load::<PurchaseOrderModel>(self.conn).map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            let mut count_query = purchase_order::table
+                .into_boxed()
+                .select(purchase_order::all_columns);
+
+            if let Some(service_id) = service_id {
+                count_query = count_query.filter(purchase_order::service_id.eq(service_id));
+            } else {
+                count_query = count_query.filter(purchase_order::service_id.is_null());
+            }
+
+            let total = count_query.count().get_result(self.conn)?;
+
+            let mut orders = Vec::new();
+
+            for o in purchase_order_models {
+                let mut query = purchase_order_version::table
+                    .into_boxed()
+                    .select(purchase_order_version::all_columns)
+                    .filter(
+                        purchase_order_version::purchase_order_uuid
+                            .eq(&o.uuid)
+                            .and(purchase_order_version::org_id.eq(&o.org_id))
+                            .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    );
+
+                if let Some(service_id) = service_id {
+                    query = query.filter(purchase_order_version::service_id.eq(service_id));
+                } else {
+                    query = query.filter(purchase_order_version::service_id.is_null());
+                }
+
+                let version_models =
+                    query
+                        .load::<PurchaseOrderVersionModel>(self.conn)
+                        .map_err(|err| {
+                            PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                                Box::new(err),
+                            ))
+                        })?;
+
+                let mut versions = Vec::new();
+
+                for v in version_models {
+                    let mut query = purchase_order_version_revision::table
+                        .into_boxed()
+                        .select(purchase_order_version_revision::all_columns)
+                        .filter(
+                            purchase_order_version_revision::version_id
+                                .eq(&v.version_id)
+                                .and(purchase_order_version_revision::org_id.eq(&v.org_id))
+                                .and(
+                                    purchase_order_version_revision::end_commit_num
+                                        .eq(MAX_COMMIT_NUM),
+                                ),
+                        );
+
+                    if let Some(service_id) = service_id {
+                        query = query
+                            .filter(purchase_order_version_revision::service_id.eq(service_id));
+                    } else {
+                        query = query.filter(purchase_order_version_revision::service_id.is_null());
+                    }
+
+                    let revision_models = query
+                        .load::<PurchaseOrderVersionRevisionModel>(self.conn)
+                        .map_err(|err| {
+                            PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                                Box::new(err),
+                            ))
+                        })?;
+
+                    versions.push(PurchaseOrderVersion::from((&v, &revision_models)))
+                }
+
+                orders.push(PurchaseOrder::from((o, versions)));
+            }
+
+            Ok(PurchaseOrderList::new(
+                orders,
+                Paging::new(offset, limit, total),
+            ))
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
+    for PurchaseOrderStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn list_purchase_orders(
+        &self,
+        org_id: Option<&str>,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderList, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order::table
+                .into_boxed()
+                .select(purchase_order::all_columns)
+                .offset(offset)
+                .limit(limit)
+                .filter(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM));
+
+            if let Some(org_id) = org_id {
+                query = query.filter(purchase_order::org_id.eq(org_id))
+            }
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order::service_id.is_null());
+            }
+
+            let purchase_order_models =
+                query.load::<PurchaseOrderModel>(self.conn).map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            let mut count_query = purchase_order::table
+                .into_boxed()
+                .select(purchase_order::all_columns);
+
+            if let Some(service_id) = service_id {
+                count_query = count_query.filter(purchase_order::service_id.eq(service_id));
+            } else {
+                count_query = count_query.filter(purchase_order::service_id.is_null());
+            }
+
+            let total = count_query.count().get_result(self.conn)?;
+
+            let mut orders = Vec::new();
+
+            for o in purchase_order_models {
+                let mut query = purchase_order_version::table
+                    .into_boxed()
+                    .select(purchase_order_version::all_columns)
+                    .filter(
+                        purchase_order_version::purchase_order_uuid
+                            .eq(&o.uuid)
+                            .and(purchase_order_version::org_id.eq(&o.org_id))
+                            .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                    );
+
+                if let Some(service_id) = service_id {
+                    query = query.filter(purchase_order_version::service_id.eq(service_id));
+                } else {
+                    query = query.filter(purchase_order_version::service_id.is_null());
+                }
+
+                let version_models =
+                    query
+                        .load::<PurchaseOrderVersionModel>(self.conn)
+                        .map_err(|err| {
+                            PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                                Box::new(err),
+                            ))
+                        })?;
+
+                let mut versions = Vec::new();
+
+                for v in version_models {
+                    let mut query = purchase_order_version_revision::table
+                        .into_boxed()
+                        .select(purchase_order_version_revision::all_columns)
+                        .filter(
+                            purchase_order_version_revision::version_id
+                                .eq(&v.version_id)
+                                .and(purchase_order_version_revision::org_id.eq(&v.org_id))
+                                .and(
+                                    purchase_order_version_revision::end_commit_num
+                                        .eq(MAX_COMMIT_NUM),
+                                ),
+                        );
+
+                    if let Some(service_id) = service_id {
+                        query = query
+                            .filter(purchase_order_version_revision::service_id.eq(service_id));
+                    } else {
+                        query = query.filter(purchase_order_version_revision::service_id.is_null());
+                    }
+
+                    let revision_models = query
+                        .load::<PurchaseOrderVersionRevisionModel>(self.conn)
+                        .map_err(|err| {
+                            PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                                Box::new(err),
+                            ))
+                        })?;
+
+                    versions.push(PurchaseOrderVersion::from((&v, &revision_models)))
+                }
+
+                orders.push(PurchaseOrder::from((o, versions)));
+            }
+
+            Ok(PurchaseOrderList::new(
+                orders,
+                Paging::new(offset, limit, total),
+            ))
+        })
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/mod.rs
@@ -16,7 +16,7 @@ pub(super) mod add_alternate_id;
 pub(super) mod add_purchase_order;
 pub(super) mod fetch_purchase_order;
 pub(super) mod list_alternate_ids_for_purchase_order;
-pub(super) mod list_purchase_orders_for_organization;
+pub(super) mod list_purchase_orders;
 
 pub(super) struct PurchaseOrderStoreOperations<'a, C> {
     conn: &'a C,

--- a/sdk/src/purchase_order/store/diesel/operations/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/mod.rs
@@ -1,0 +1,32 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) mod add_alternate_id;
+pub(super) mod add_purchase_order;
+pub(super) mod fetch_purchase_order;
+pub(super) mod list_alternate_ids_for_purchase_order;
+pub(super) mod list_purchase_orders_for_organization;
+
+pub(super) struct PurchaseOrderStoreOperations<'a, C> {
+    conn: &'a C,
+}
+
+impl<'a, C> PurchaseOrderStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    pub fn new(conn: &'a C) -> Self {
+        PurchaseOrderStoreOperations { conn }
+    }
+}

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -98,7 +98,7 @@ pub trait PurchaseOrderStore: Send + Sync {
     ///  * `order` - The purchase order to be added
     fn add_purchase_order(&self, order: PurchaseOrder) -> Result<(), PurchaseOrderStoreError>;
 
-    /// Lists purchase orders for a given org from the underlying storage
+    /// Lists purchase orders from the underlying storage
     ///
     /// # Arguments
     ///
@@ -106,9 +106,9 @@ pub trait PurchaseOrderStore: Send + Sync {
     ///  * `service_id` - The service id
     ///  * `offset` - The index of the first in storage to retrieve
     ///  * `limit` - The number of items to retrieve from the offset
-    fn list_purchase_orders_for_organization(
+    fn list_purchase_orders(
         &self,
-        org_id: &str,
+        org_id: Option<&str>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
@@ -165,14 +165,14 @@ where
         (**self).add_purchase_order(order)
     }
 
-    fn list_purchase_orders_for_organization(
+    fn list_purchase_orders(
         &self,
-        org_id: &str,
+        org_id: Option<&str>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
     ) -> Result<PurchaseOrderList, PurchaseOrderStoreError> {
-        (**self).list_purchase_orders_for_organization(org_id, service_id, offset, limit)
+        (**self).list_purchase_orders(org_id, service_id, offset, limit)
     }
 
     fn fetch_purchase_order(

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -16,12 +16,21 @@
 pub mod diesel;
 mod error;
 
+use crate::paging::Paging;
+
 pub use error::PurchaseOrderStoreError;
 
 /// Represents a list of Grid Purchase Orders
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct PurchaseOrderList {
-    pub purchase_orders: Vec<PurchaseOrder>,
+    pub data: Vec<PurchaseOrder>,
+    pub paging: Paging,
+}
+
+impl PurchaseOrderList {
+    pub fn new(data: Vec<PurchaseOrder>, paging: Paging) -> Self {
+        Self { data, paging }
+    }
 }
 
 /// Represents a Grid Purchase Order
@@ -72,6 +81,8 @@ pub struct PurchaseOrderAlternateIdList {
 /// Represents a Grid Purchase Order Alternate ID
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct PurchaseOrderAlternateId {
+    pub purchase_order_uuid: String,
+    pub org_id: String,
     pub id_type: String,
     pub id: String,
     pub start_commit_num: i64,


### PR DESCRIPTION
This adds the add_purchase_order, fetch_purchase_order, and list_purchase_orders_for_organization db operations. This also implements the conversion methods to and from the database models. Additionally, stubs are added for the unimplemented operations.