### PR TITLE
revert run removal

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,6 +15,7 @@
 crates := '\
     sdk \
     daemon \
+    griddle \
     cli \
     contracts/pike \
     contracts/location \


### PR DESCRIPTION
Missed the use of this function -- since griddle wasn't in justfile, so also add griddle to justfile.