### PR TITLE
Update `po update` subcommand `rm_id` arg

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1212,10 +1212,13 @@ fn run() -> Result<(), CliError> {
                         )
                         .arg(
                             Arg::with_name("rm_id")
-                                .value_name("alternate_id_type")
+                                .value_name("alternate_id")
                                 .long("rm-id")
                                 .takes_value(true)
-                                .help("Remove an Alternate ID from Purchase Order"),
+                                .help(
+                                    "Remove an Alternate ID from Purchase Order \
+                                    (format: <alternate_id_type>:<alternate_id>)",
+                                ),
                         )
                         .arg(
                             Arg::with_name("workflow_status")


### PR DESCRIPTION
This change updates the Grid CLI's `po update` subcommand's `rm_id`
argument's help section to clarify this argument takes the full
alternate id, meaning `<alternate_id_type>:<alternate_id>` rather than
just the alternate id's type.

This change also updates the `value_name` of the `rm_id` argument from
`alternate_id_type` to `alternate_id`, to clarify what value is expected
for this argument.

Signed-off-by: Shannyn Telander <telander@bitwise.io>