### PR TITLE
Add grid po version man pages

### DIFF
--- a/cli/man/grid-po-version-create.1.md
+++ b/cli/man/grid-po-version-create.1.md
@@ -1,0 +1,129 @@
+% GRID-PO-VERSION-CREATE(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-po-version-create** - Create a new Grid Purchase Order Version.
+
+SYNOPSIS
+========
+
+**grid po create** \[**FLAGS**\] \[**OPTIONS**\] VERSION_ID
+
+DESCRIPTION
+===========
+
+This command allows for the creation of Grid Purchase Orders versions. It
+submits a Sabre transaction to create the purchase order version.
+
+ARGS
+====
+
+`VERSION_ID`
+: The user-specified version identifier.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Do not display output.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output.
+
+`--draft`
+: Sets the resulting version as a draft.
+
+OPTIONS
+=======
+
+`-k`, `--key`
+: Base name for private key file.
+
+`--order-xml`
+: Specify the path to an order xml FILE to load.  The file must conform to the
+  GS1 Order spec v3.4
+
+`--org`
+: Specify the organization that owns the purchase order.
+
+`--po`
+: Either a UUID or an alternate ID of a purchase order.
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>.
+
+`--url`
+: URL for the REST API.
+
+`--wait`
+: Specify how long to wait, in seconds, for the transaction to be committed.
+
+`--workflow-status`
+: Specifies the initial workflow state of the purchase order.
+
+EXAMPLES
+========
+
+The command
+
+```
+$ grid po version create \
+    --org=crgl \
+    --po=82urioz098aui3871uc \
+    --order-xml ./my_test_order.xml \
+    --draft \
+    --workflow-status=Editable \
+    --wait \
+    v3
+```
+
+will generate version `v3` of purchase order `82urioz098aui3871uc` owned by the
+organization `crgl`. It will be created as a draft and have the workflow status
+of `Editable`.  It will generate output like the following:
+
+```
+Creating version "v3" for Purchase Order 82urioz098aui3871uc.
+Submitted Purchase Order Version create transaction:
+    Batch: 142312uoisufoin38908fyhsdfhs098yv98y98v
+    Transaction: af32348uofo238098fyu80h028yf082ehf8h
+Waiting for transaction to be committed...
+Transaction was committed successfully.
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+**`GRID_ORG_ID`**
+: Specifies the organization id that owns the purchase order.
+
+SEE ALSO
+========
+| `grid-po(1)`
+| `grid-po-version-create(1)`
+| `grid-po-version-list(1)`
+| `grid-po-version-update(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| GS1 Order 3.4:
+| https://www.gs1.org/sites/default/files/docs/EDI/ecom-xml/functional-user-guide/3_4/HTML/O/a1.htm

--- a/cli/man/grid-po-version-list.1.md
+++ b/cli/man/grid-po-version-list.1.md
@@ -1,0 +1,114 @@
+% GRID-PO-VERSION-LIST(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-po-version-list** - List all purchase orders versions.
+
+SYNOPSIS
+========
+
+**grid po version list** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+
+List all purchase orders in grid.
+
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Do not display output.
+
+`-V`, `--version`
+: Prints version information.
+
+`--accepted`
+: Filter on whether the purchase order version is an accepted version.
+  Conflicts with `--not-accepted`.
+
+`--not-accepted`
+: Filter on whether the purchase order version is not an accepted version.
+  Conflicts with `--accepted`.
+
+`--draft`
+: Filter on whether the purchase order version is a draft. Conflicts with
+  `--not-draft`.
+
+`--not-draft`
+: Filter on whether the purchase order version is not a draft. Conflicts with
+  `--draft`.
+
+`--closed`
+: Selects closed purchase orders only. Conflicts with `--open`.
+
+`--open`
+: Selects open purchase orders only. Conflicts with `--closed`.
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+
+`--url`
+: URL for the REST API.
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>.
+
+`--org`
+: Optionally, filter the purchase orders for the organization specified by
+  `ORG_ID`.  This does *not* use the `GRID_ORG_ID` environment variable.
+
+`-F`, `--format=FORMAT`
+: Specifies the output format of the list. Possible values for formatting are
+  `human`, `csv`, `yaml`, and `json`. Defaults to `human`.
+
+EXAMPLES
+========
+
+The command
+
+```
+$ grid po version list --org=crgl
+```
+
+will list all purchase orders version for the org `crgl` in human-readable
+format:
+
+```
+ORG  PO                  ID STATUS   REVISON
+crgl 82urioz098aui3871uc v3 Editable       2
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-po(1)`
+| `grid-po-version-create(1)`
+| `grid-po-version-list(1)`
+| `grid-po-version-update(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-po-version-update.1.md
+++ b/cli/man/grid-po-version-update.1.md
@@ -1,0 +1,122 @@
+% GRID-PO-VERSION-UPDATE(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-po-version-update** - Update an existing Grid Purchase Order Version.
+
+SYNOPSIS
+========
+
+**grid po create** \[**FLAGS**\] \[**OPTIONS**\] VERSION_ID
+
+DESCRIPTION
+===========
+
+This command allows for the update of Grid Purchase Orders versions. It
+submits a Sabre transaction to create the purchase order version. Each update
+creates a new revision of that version.
+
+ARGS
+====
+
+`VERSION_ID`
+: The user-specified version identifier.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Do not display output.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output.
+
+`--draft`
+: Sets the resulting version as a draft.
+
+`--not-draft`
+: Sets the resulting version as a non-draft.
+
+OPTIONS
+=======
+
+`-k`, `--key`
+: Base name for private key file.
+
+`--org`
+: Specify the organization that owns the purchase order.
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>.
+
+`--url`
+: URL for the REST API.
+
+`--wait`
+: Specify how long to wait, in seconds, for the transaction to be committed.
+
+`--workflow-status`
+: Specifies the initial workflow state of the purchase order.
+
+EXAMPLES
+========
+
+The command
+
+```
+$ grid po version update \
+    --org=crgl \
+    --po=po_number:809832081 \
+    --workflow-status=Review \
+    --wait \
+    v3
+```
+
+will update the version `v3` of purchase order `82urioz098aui3871uc`, owned by
+the organization `crgl`, to have the workflow status of `Review`. It will
+generate output like the following:
+
+```
+Updating version "v3" for Purchase Order 82urioz098aui3871uc.
+Submitted Purchase Order Version create transaction:
+    Batch: 52342uoisufoin38908fyhsdfhs098yv98y98v
+    Transaction: 123456uofo238098fyu80h028yf082ehf8h
+Waiting for transaction to be committed...
+Transaction was committed successfully.
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+**`GRID_ORG_ID`**
+: Specifies the organization id that owns the purchase order.
+
+SEE ALSO
+========
+| `grid-po(1)`
+| `grid-po-version-create(1)`
+| `grid-po-version-list(1)`
+| `grid-po-version-update(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-po-version.1.md
+++ b/cli/man/grid-po-version.1.md
@@ -1,0 +1,89 @@
+% GRID-PO-VERSION(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-po-version** — Create or update Grid Purchase Order versions.
+
+SYNOPSIS
+========
+
+**grid po version** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+
+This command allows for the creation and management of Grid Purchase Orders
+version.  Commands to list Purchase Order version data are also available.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Do not display output.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+
+`-k`, `--key`
+: Base name for private key file.
+
+`--url`
+: URL for the REST API.
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>.
+
+`--wait`
+: How long to wait for transaction to be committed.
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SUBCOMMANDS
+===========
+
+`create`
+: Create a new purchase order version.
+
+`list`
+: List details of all existing purchase orders versions.
+
+`update`
+: Update an existing purchase order version.
+
+SEE ALSO
+========
+| `grid-po(1)`
+| `grid-po-version-create(1)`
+| `grid-po-version-list(1)`
+| `grid-po-version-update(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/


### PR DESCRIPTION
This PR adds the man pages for the following grid subcommands:

* grid po version
* grid po version create
* grid po version update
* grid po version list