### PR TITLE
Update key dir cli arg

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -104,7 +104,7 @@ fn run() -> Result<(), CliError> {
             (about: "Generates keys with which the user can sign transactions and batches.")
             (@arg key_name: +takes_value "Name of the key to create")
             (@arg force: --force "Overwrite files if they exist")
-            (@arg key_dir: -d --key_dir +takes_value conflicts_with[system] "Specify the directory for the key files")
+            (@arg key_dir: -d --("key-dir") +takes_value conflicts_with[system] "Specify the directory for the key files")
             (@arg system: --system "Generate system keys in /etc/grid/keys")
         )
 


### PR DESCRIPTION
This updates the `--key_dir` keygen argument to replace the underscore
with a dash. This brings the arg more in line with others.

Signed-off-by: Davey Newhall <newhall@bitwise.io>