### PR TITLE
Add Pike 2 man pages

### DIFF
--- a/cli/man/grid-agent-create.1.md
+++ b/cli/man/grid-agent-create.1.md
@@ -1,0 +1,85 @@
+% GRID-AGENT-CREATE(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-agent-create** - Create a new Grid Pike agent.
+
+SYNOPSIS
+========
+
+**grid agent create** \[**FLAGS**\] \[**OPTIONS**\] ORG_ID PUBLIC_KEY --active --inactive
+
+ARGS
+====
+
+`ORG_ID`
+: The Pike organization identifier to create the agent for
+
+`PUBLIC_KEY`
+: The user-specified public key of the agent to create
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+OPTIONS
+=======
+
+`-k`, `--key`
+: Base name for private signing key file
+
+`--metadata`
+: Key-value pairs (format: <key>=<value>) in a comma-separated list
+
+`--role`
+: Roles assigned to the agent
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+Splinter. Format <circuit-id>::<service-id>
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid organization(1)`
+| `grid agent(1)`
+| `grid agent update(1)`
+| `grid role(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-agent-update.1.md
+++ b/cli/man/grid-agent-update.1.md
@@ -1,0 +1,85 @@
+% GRID-AGENT-UPDATE(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-agent-update** - Update an existing Grid Pike agent.
+
+SYNOPSIS
+========
+
+**grid agent update** \[**FLAGS**\] \[**OPTIONS**\] ORG_ID PUBLIC_KEY --active --inactive
+
+ARGS
+====
+
+`ORG_ID`
+: The Pike organization identifier to create the agent for
+
+`PUBLIC_KEY`
+: The user-specified public key of the agent to create
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+OPTIONS
+=======
+
+`-k`, `--key`
+: Base name for private signing key file
+
+`--metadata`
+: Key-value pairs (format: <key>=<value>) in a comma-separated list
+
+`--role`
+: Roles assigned to the agent
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+Splinter. Format <circuit-id>::<service-id>
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid organization(1)`
+| `grid agent(1)`
+| `grid agent create(1)`
+| `grid role(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-agent.1.md
+++ b/cli/man/grid-agent.1.md
@@ -1,0 +1,71 @@
+% GRID-AGENT(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-agent** - Create or update Grid Pike agents.
+
+SYNOPSIS
+========
+
+**grid agent** \[**FLAGS**\] \[**OPTIONS**\] <**SUBCOMMAND**>
+
+DESCRIPTION
+===========
+
+This command allows for the creation and management of Grid Pike agents.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SUBCOMMANDS
+===========
+
+`create`
+: Create an agent
+
+`help`
+: Prints this message or the help of the given subcommand(s)
+
+`update`
+: Update an agent
+
+SEE ALSO
+========
+| `grid agent create(1)`
+| `grid agent update(1)`
+| `grid organization(1)`
+| `grid role(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-organization-create.1.md
+++ b/cli/man/grid-organization-create.1.md
@@ -1,0 +1,85 @@
+% GRID-ORGANIZATION-CREATE(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-organization-create** - Create a new Grid Pike organization.
+
+SYNOPSIS
+========
+
+**grid organization create** \[**FLAGS**\] \[**OPTIONS**\] ORG_ID NAME
+
+ARGS
+====
+
+`ORG_ID`
+: The user-specified organization identifier
+
+`NAME`
+: The user-specified name of the organization
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+OPTIONS
+=======
+
+`--alternate-ids`
+: Alternate IDs for organization
+
+`-k`, `--key`
+: Base name for private signing key file
+
+`--metadata`
+: Key-value pairs (format: <key>=<value>) in a comma-separated list
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+Splinter. Format <circuit-id>::<service-id>
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid organization(1)`
+| `grid organization update(1)`
+| `grid agent(1)`
+| `grid role(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-organization-update.1.md
+++ b/cli/man/grid-organization-update.1.md
@@ -1,0 +1,88 @@
+% GRID-ORGANIZATION-UPDATE(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-organization-update** - Update an existing Grid Pike organization.
+
+SYNOPSIS
+========
+
+**grid organization update** \[**FLAGS**\] \[**OPTIONS**\] ORG_ID NAME
+
+ARGS
+====
+
+`ORG_ID`
+: The user-specified organization identifier
+
+`NAME`
+: The user-specified name of the organization
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+OPTIONS
+=======
+
+`--alternate-ids`
+: Alternate IDs for organization
+
+`-k`, `--key`
+: Base name for private signing key file
+
+`--locations`
+: List of locations associated with this organization
+
+`--metadata`
+: Key-value pairs (format: <key>=<value>) in a comma-separated list
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+Splinter. Format <circuit-id>::<service-id>
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid organization(1)`
+| `grid organization create(1)`
+| `grid agent(1)`
+| `grid role(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-organization.1.md
+++ b/cli/man/grid-organization.1.md
@@ -1,0 +1,71 @@
+% GRID-ORGANIZATION(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-organization** - Create or update Grid Pike organizations.
+
+SYNOPSIS
+========
+
+**grid organization** \[**FLAGS**\] \[**OPTIONS**\] <**SUBCOMMAND**>
+
+DESCRIPTION
+===========
+
+This command allows for the creation and management of Grid Pike organizations.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SUBCOMMANDS
+===========
+
+`create`
+: Create an organization
+
+`help`
+: Prints this message or the help of the given subcommand(s)
+
+`update`
+: Update an organization
+
+SEE ALSO
+========
+| `grid organization create(1)`
+| `grid organization update(1)`
+| `grid agent(1)`
+| `grid role(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-role-create.1.md
+++ b/cli/man/grid-role-create.1.md
@@ -1,0 +1,98 @@
+% GRID-ROLE-CREATE(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-role-create** - Create a new Grid Pike role.
+
+SYNOPSIS
+========
+
+**grid role create** \[**FLAGS**\] \[**OPTIONS**\] ORG_ID NAME
+
+ARGS
+====
+
+`ORG_ID`
+: The organization identifier to create the role for
+
+`NAME`
+: The user-specified name of the role
+
+FLAGS
+=====
+
+`--active`
+: Set role as active
+
+`-h`, `--help`
+: Prints help information
+
+`--inactive`
+: Set role as inactive
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+OPTIONS
+=======
+
+`--allowed-orgs`
+: List of organizations allowed use of the role
+
+`-d`, `--description`
+: Description of the role
+
+`--inherit-from`
+: List of roles to inherit permissions from
+
+`-k`, `--key`
+: Base name for private signing key file
+
+`--permissions`
+: List of permissions belonging to the role
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+Splinter. Format <circuit-id>::<service-id>
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid agent(1)`
+| `grid organization(1)`
+| `grid role(1)`
+| `grid role delete(1)`
+| `grid role update(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-role-delete.1.md
+++ b/cli/man/grid-role-delete.1.md
@@ -1,0 +1,73 @@
+% GRID-ROLE-DELETE(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-role-delete** - Removes a Grid Pike role.
+
+SYNOPSIS
+========
+
+**grid role delete** \[**FLAGS**\] \[**OPTIONS**\] ORG_ID NAME
+
+ARGS
+====
+
+`ORG_ID`
+: The organization identifier to delete the role from
+
+`NAME`
+: The user-specified name of the role
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+OPTIONS
+=======
+
+`-k`, `--key`
+: Base name for private signing key file
+
+`--wait`
+: How long to wait for transaction to be committed
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid agent(1)`
+| `grid organization(1)`
+| `grid role(1)`
+| `grid role create(1)`
+| `grid role update(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-role-list.1.md
+++ b/cli/man/grid-role-list.1.md
@@ -1,0 +1,60 @@
+% GRID-ROLE-LIST(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-role-list** - List Grid Pike roles for a given organization.
+
+SYNOPSIS
+========
+
+**grid role list** \[**FLAGS**\] ORG_ID
+
+ARGS
+====
+
+`ORG_ID`
+: The organization identifier to create the role for
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid agent(1)`
+| `grid organization(1)`
+| `grid role(1)`
+| `grid role show(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-role-show.1.md
+++ b/cli/man/grid-role-show.1.md
@@ -1,0 +1,63 @@
+% GRID-ROLE-SHOW(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-role-show** - Show information about a Grid Pike role.
+
+SYNOPSIS
+========
+
+**grid role show** \[**FLAGS**\] \[**OPTIONS**\] ORG_ID NAME
+
+ARGS
+====
+
+`ORG_ID`
+: The organization identifier to show the role for
+
+`NAME`
+: The user-specified name of the role to show
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid agent(1)`
+| `grid organization(1)`
+| `grid role(1)`
+| `grid role list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-role-update.1.md
+++ b/cli/man/grid-role-update.1.md
@@ -1,0 +1,98 @@
+% GRID-ROLE-UPDATE(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-role-update** - Update an existing Grid Pike role.
+
+SYNOPSIS
+========
+
+**grid role update** \[**FLAGS**\] \[**OPTIONS**\] ORG_ID NAME
+
+ARGS
+====
+
+`ORG_ID`
+: The organization identifier the role belongs to
+
+`NAME`
+: The user-specified name of the role
+
+FLAGS
+=====
+
+`--active`
+: Set role as active
+
+`-h`, `--help`
+: Prints help information
+
+`--inactive`
+: Set role as inactive
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+OPTIONS
+=======
+
+`--allowed-orgs`
+: List of organizations allowed use of the role
+
+`-d`, `--description`
+: Description of the role
+
+`--inherit-from`
+: List of roles to inherit permissions from
+
+`-k`, `--key`
+: Base name for private signing key file
+
+`--permissions`
+: List of permissions belonging to the role
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+Splinter. Format <circuit-id>::<service-id>
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid agent(1)`
+| `grid organization(1)`
+| `grid role(1)`
+| `grid role create(1)`
+| `grid role delete(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/man/grid-role.1.md
+++ b/cli/man/grid-role.1.md
@@ -1,0 +1,81 @@
+% GRID-ROLE(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-role** - Create, update, or delete Grid Pike roles.
+
+SYNOPSIS
+========
+
+**grid role** \[**FLAGS**\] \[**OPTIONS**\] <**SUBCOMMAND**>
+
+DESCRIPTION
+===========
+
+This command allows for the creation and management of Grid Pike roles.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Log verbosely
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SUBCOMMANDS
+===========
+
+`create`
+: Create a role
+
+`delete`
+: Delete a role
+
+`help`
+: Prints this message or the help of the given subcommand(s)
+
+`list`
+: List all roles for a given org ID
+
+`show`
+: Show role specified by org ID and name
+
+`update`
+: Update a role
+
+SEE ALSO
+========
+| `grid agent(1)`
+| `grid organization(1)`
+| `grid role create(1)`
+| `grid role delete(1)`
+| `grid role update(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/


### PR DESCRIPTION
This adds man pages for all the Pike 2 CLI commands. This includes
man pages pertaining to the `grid role`, `grid agent`, and `grid
organization` commands and their respective subcommands.

Signed-off-by: Davey Newhall <newhall@bitwise.io>