### PR TITLE
Implement create product using XML data

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -70,6 +70,7 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "product-gdsn",
     "purchase-order",
     "splinter",
     "sqlite",
@@ -87,6 +88,9 @@ admin-keygen = []
 location = ["pike", "schema"]
 pike = []
 product = ["pike", "schema"]
+product-gdsn = [
+    "grid-sdk/product-gdsn"
+]
 purchase-order = []
 sawtooth = []
 schema = ["pike"]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -14,6 +14,13 @@
 
 FROM hyperledger/grid-dev:v5 as grid-cli-builder
 
+# Install dependencies
+RUN apt-get update \
+ && apt-get install -y -q \
+    libxml2-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 # Temporary workaround until sabre is updated to focal
 RUN USER=root cargo new --bin griddle
 RUN USER=root cargo new --bin contracts/purchase_order

--- a/cli/schemas/xsd_schema.yaml
+++ b/cli/schemas/xsd_schema.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+- name: gs1_product
+  description: GS1 product schema
+  owner: crgl
+  properties:
+    - name: xml_data
+      data_type: STRING
+      description: A string containing a GDSN Trade Item product definition in XML format.
+      required: true

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -123,3 +123,10 @@ impl From<sabre_sdk::protos::ProtoConversionError> for CliError {
         CliError::SabreProtoError(err)
     }
 }
+
+#[cfg(feature = "product-gdsn")]
+impl From<grid_sdk::products::gdsn::error::ProductGdsnError> for CliError {
+    fn from(err: grid_sdk::products::gdsn::error::ProductGdsnError) -> Self {
+        CliError::PayloadError(err.to_string())
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -718,6 +718,74 @@ fn run() -> Result<(), CliError> {
     {
         use clap::{Arg, SubCommand};
 
+        #[allow(unused_mut)]
+        let mut create_product_subcmd = SubCommand::with_name("create")
+            .about("Create a product")
+            .arg(
+                Arg::with_name("product_id")
+                    .conflicts_with("file")
+                    .takes_value(true)
+                    .required_unless_one(&["file", "xml"])
+                    .help("Unique ID for product"),
+            )
+            .arg(
+                Arg::with_name("product_namespace")
+                    .long("namespace")
+                    .takes_value(true)
+                    .conflicts_with("file")
+                    .conflicts_with("xml")
+                    .help("Product namespace (example: GS1)"),
+            )
+            .arg(
+                Arg::with_name("owner")
+                    .long("owner")
+                    .takes_value(true)
+                    .conflicts_with("file")
+                    .help("Pike organization ID"),
+            )
+            .arg(
+                Arg::with_name("property")
+                    .long("property")
+                    .use_delimiter(true)
+                    .takes_value(true)
+                    .multiple(true)
+                    .conflicts_with("file")
+                    .help("Key value pair specifying a product property formatted as key=value"),
+            )
+            .arg(
+                Arg::with_name("file")
+                    .long("file")
+                    .short("f")
+                    .takes_value(true)
+                    .conflicts_with("xml")
+                    .help("Path to yaml file containing a list of products"),
+            )
+            .arg(
+                Arg::with_name("key")
+                    .long("key")
+                    .short("k")
+                    .takes_value(true)
+                    .help("Base name for private signing key file"),
+            )
+            .arg(
+                Arg::with_name("wait")
+                    .long("wait")
+                    .takes_value(true)
+                    .help("How long to wait for transaction to be committed"),
+            );
+
+        #[cfg(feature = "product-gdsn")]
+        {
+            create_product_subcmd = create_product_subcmd.arg(
+                Arg::with_name("xml")
+                    .long("xml")
+                    .short("x")
+                    .takes_value(true)
+                    .conflicts_with("file")
+                    .help("Path to xml file containing a product definition"),
+            )
+        }
+
         app = app.subcommand(
             SubCommand::with_name("product")
                 .about("Create, update, delete, list, or show products")
@@ -738,60 +806,7 @@ fn run() -> Result<(), CliError> {
                         .takes_value(true)
                         .help("URL for the REST API"),
                 )
-                .subcommand(
-                    SubCommand::with_name("create")
-                        .about("Create a product")
-                        .arg(
-                            Arg::with_name("product_id")
-                                .conflicts_with("file")
-                                .takes_value(true)
-                                .required_unless("file")
-                                .help("Unique ID for product"),
-                        )
-                        .arg(
-                            Arg::with_name("product_namespace")
-                                .long("namespace")
-                                .takes_value(true)
-                                .conflicts_with("file")
-                                .help("Product namespace (example: GS1)"),
-                        )
-                        .arg(
-                            Arg::with_name("owner")
-                                .long("owner")
-                                .takes_value(true)
-                                .conflicts_with("file")
-                                .help("Pike organization ID"),
-                        )
-                        .arg(
-                            Arg::with_name("property")
-                                .long("property")
-                                .use_delimiter(true)
-                                .takes_value(true)
-                                .multiple(true)
-                                .conflicts_with("file")
-                                .help("Key value pair specifying a product property formatted as key=value"),
-                        )
-                        .arg(
-                            Arg::with_name("file")
-                                .long("file")
-                                .short("f")
-                                .takes_value(true)
-                                .help("Path to yaml file containing a list of products"),
-                        )
-                        .arg(
-                            Arg::with_name("key")
-                                .long("key")
-                                .short("k")
-                                .takes_value(true)
-                                .help("Base name for private signing key file"),
-                        )
-                        .arg(
-                            Arg::with_name("wait")
-                                .long("wait")
-                                .takes_value(true)
-                                .help("How long to wait for transaction to be committed"),
-                        ),
-                )
+                .subcommand(create_product_subcmd)
                 .subcommand(
                     SubCommand::with_name("update")
                         .about("Update products from a yaml file")
@@ -928,6 +943,7 @@ fn run() -> Result<(), CliError> {
                                 .long("owner")
                                 .takes_value(true)
                                 .conflicts_with("file")
+                                .required_unless("file")
                                 .help("Pike organization ID"),
                         )
                         .arg(
@@ -1959,6 +1975,23 @@ fn run() -> Result<(), CliError> {
                 .or_else(|| env::var(GRID_SERVICE_ID).ok());
 
             match m.subcommand() {
+                #[cfg(feature = "product-gdsn")]
+                ("create", Some(m)) if m.is_present("xml") => {
+                    let key = m
+                        .value_of("key")
+                        .map(String::from)
+                        .or_else(|| env::var(GRID_DAEMON_KEY).ok());
+
+                    let wait = value_t!(m, "wait", u64).unwrap_or(0);
+
+                    let actions = products::create_product_payloads_from_xml(
+                        m.value_of("xml").unwrap(),
+                        m.value_of("owner").unwrap(),
+                    )?;
+
+                    info!("Submitting request to create product from XML...");
+                    products::do_create_products(&url, key, wait, actions, service_id)?;
+                }
                 ("create", Some(m)) if m.is_present("file") => {
                     let key = m
                         .value_of("key")

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -14,6 +14,13 @@
 
 FROM hyperledger/grid-dev:v8 as gridd-builder
 
+# Install dependencies
+RUN apt-get update \
+ && apt-get install -y -q \
+    libxml2-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
 COPY cli/Cargo.toml /build/cli/Cargo.toml

--- a/docker/lint
+++ b/docker/lint
@@ -27,6 +27,7 @@ RUN apt-get update \
         libpq-dev \
         libssl-dev \
         libsqlite3-dev \
+        libxml2-dev \
         libzmq3-dev \
         pkg-config \
         unzip \

--- a/docker/tests
+++ b/docker/tests
@@ -27,6 +27,7 @@ RUN apt-get update \
         libssl-dev \
         libsasl2-dev \
         libsqlite3-dev \
+        libxml2-dev \
         libzmq3-dev \
         openssl \
         pkg-config \

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -83,6 +83,7 @@ experimental = [
     "client-reqwest",
     "postgres",
     "pike-rest-api",
+    "product-gdsn",
     "purchase-order",
     "rest-api-resources",
     "rest-api-actix-web-3",
@@ -97,6 +98,9 @@ client-reqwest = ["client", "reqwest"]
 location = ["pike", "schema"]
 pike = []
 pike-rest-api = ["pike", "serde_json", "rest-api-resources"]
+product-gdsn = [
+    "reqwest"
+]
 purchase-order = []
 product = ["pike", "schema"]
 schema = ["pike"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -55,6 +55,9 @@ sabre-sdk = "0.5"
 cylinder = { version = "0.2.2", features = ["key-load"], optional = true}
 rust-crypto = "0.2"
 sawtooth-sdk = "0.4"
+quick-xml = { version = "0.22", features = [ "serialize" ] }
+libxml = "0.2.16"
+tempfile = "3"
 
 [build-dependencies]
 protoc-rust = "2.14"

--- a/sdk/src/error/invalid_argument.rs
+++ b/sdk/src/error/invalid_argument.rs
@@ -1,0 +1,84 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module containing InvalidArgumentError implementation.
+
+use std::error;
+use std::fmt;
+
+/// An error returned when an argument passed to a function does not conform to the expected format.
+///
+/// This always indicates a programming error on behalf of the caller, since the caller should have
+/// verified the argument prior to passing it into the function.
+#[derive(Debug)]
+pub struct InvalidArgumentError {
+    argument: String,
+    message: String,
+}
+
+impl InvalidArgumentError {
+    /// Constructs a new `InvalidArgumentError` with a specified argument and message string.
+    ///
+    /// The argument passed in should be the name of the argument in the function's signature. The
+    /// message should be the reason it is invalid, and should not contain the name of the argument
+    /// (since Display will combine both argument and message).
+    ///
+    /// The implementation of `std::fmt::Display` for this error will be a combination of the
+    /// argument and the message string provided.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grid_sdk::error::InvalidArgumentError;
+    ///
+    /// let invalid_arg_error = InvalidArgumentError::new("arg1".to_string(), "argument too long".to_string());
+    /// assert_eq!(format!("{}", invalid_arg_error), "argument too long (arg1)");
+    /// ```
+    pub fn new(argument: String, message: String) -> Self {
+        Self { argument, message }
+    }
+
+    /// Returns the name of the invalid argument.
+    pub fn argument(&self) -> String {
+        self.argument.clone()
+    }
+
+    /// Returns the message, which is an explanation of why the argument is invalid.
+    pub fn message(&self) -> String {
+        self.message.clone()
+    }
+}
+
+impl error::Error for InvalidArgumentError {}
+
+impl fmt::Display for InvalidArgumentError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} ({})", &self.message, &self.argument)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    /// Tests that error constructed with `InvalidArgumentError::new` return message as the
+    /// display string.
+    #[test]
+    fn test_display() {
+        let arg = "arg1";
+        let msg = "test message";
+        let err = InvalidArgumentError::new(arg.to_string(), msg.to_string());
+        assert_eq!(format!("{}", err), format!("{} ({})", msg, arg));
+    }
+}

--- a/sdk/src/error/mod.rs
+++ b/sdk/src/error/mod.rs
@@ -76,8 +76,10 @@
 
 mod constraint_violation;
 mod internal;
+mod invalid_argument;
 mod unavailable;
 
 pub use constraint_violation::{ConstraintViolationError, ConstraintViolationType};
 pub use internal::InternalError;
+pub use invalid_argument::InvalidArgumentError;
 pub use unavailable::ResourceTemporarilyUnavailableError;

--- a/sdk/src/products/gdsn/error.rs
+++ b/sdk/src/products/gdsn/error.rs
@@ -1,0 +1,66 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::error::{InternalError, InvalidArgumentError};
+
+#[derive(Debug)]
+pub enum ProductGdsnError {
+    Internal(InternalError),
+    InvalidArgument(InvalidArgumentError),
+}
+
+impl Error for ProductGdsnError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ProductGdsnError::Internal(err) => Some(err),
+            ProductGdsnError::InvalidArgument(err) => Some(err),
+        }
+    }
+}
+
+impl fmt::Display for ProductGdsnError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ProductGdsnError::Internal(err) => err.fmt(f),
+            ProductGdsnError::InvalidArgument(err) => err.fmt(f),
+        }
+    }
+}
+
+impl From<quick_xml::Error> for ProductGdsnError {
+    fn from(err: quick_xml::Error) -> Self {
+        ProductGdsnError::Internal(InternalError::from_source(Box::new(err)))
+    }
+}
+
+impl From<std::str::Utf8Error> for ProductGdsnError {
+    fn from(err: std::str::Utf8Error) -> Self {
+        ProductGdsnError::Internal(InternalError::from_source(Box::new(err)))
+    }
+}
+
+impl From<crate::protocol::schema::state::PropertyValueBuildError> for ProductGdsnError {
+    fn from(err: crate::protocol::schema::state::PropertyValueBuildError) -> Self {
+        ProductGdsnError::Internal(InternalError::from_source(Box::new(err)))
+    }
+}
+
+impl From<crate::protocol::errors::BuilderError> for ProductGdsnError {
+    fn from(err: crate::protocol::errors::BuilderError) -> Self {
+        ProductGdsnError::Internal(InternalError::from_source(Box::new(err)))
+    }
+}

--- a/sdk/src/products/gdsn/mod.rs
+++ b/sdk/src/products/gdsn/mod.rs
@@ -1,0 +1,170 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod error;
+
+use quick_xml::{
+    de::from_str,
+    events::{BytesEnd, BytesStart, BytesText, Event},
+    Reader, Writer,
+};
+use serde::Deserialize;
+use std::io::Cursor;
+use std::io::Read;
+
+use crate::error::InvalidArgumentError;
+use error::ProductGdsnError;
+
+use crate::protocol::{
+    product::{
+        payload::{ProductCreateAction, ProductCreateActionBuilder},
+        state::ProductNamespace,
+    },
+    schema::state::{DataType, PropertyValueBuilder},
+};
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct GridTradeItems {
+    #[serde(rename = "tradeItem")]
+    pub trade_items: Vec<TradeItem>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct TradeItem {
+    pub gtin: String,
+    #[serde(default)]
+    pub payload: String,
+}
+
+impl TradeItem {
+    pub fn into_create_payload(self, owner: &str) -> Result<ProductCreateAction, ProductGdsnError> {
+        let xml_property = PropertyValueBuilder::new()
+            .with_name("xml_data".to_string())
+            .with_data_type(DataType::String)
+            .with_string_value(self.payload)
+            .build()?;
+        Ok(ProductCreateActionBuilder::new()
+            .with_product_id(self.gtin)
+            .with_product_namespace(ProductNamespace::Gs1)
+            .with_owner(owner.to_string())
+            .with_properties(vec![xml_property])
+            .build()?)
+    }
+}
+
+pub fn get_trade_items_from_xml(path: &str) -> Result<Vec<TradeItem>, ProductGdsnError> {
+    let mut xml_file = std::fs::File::open(path).map_err(|error| {
+        ProductGdsnError::InvalidArgument(InvalidArgumentError::new(
+            path.to_string(),
+            error.to_string(),
+        ))
+    })?;
+    let mut xml_str = String::new();
+
+    xml_file.read_to_string(&mut xml_str).map_err(|error| {
+        ProductGdsnError::InvalidArgument(InvalidArgumentError::new(
+            path.to_string(),
+            error.to_string(),
+        ))
+    })?;
+
+    let mut grid_trade_items: GridTradeItems = from_str(&xml_str).map_err(|error| {
+        ProductGdsnError::InvalidArgument(InvalidArgumentError::new(
+            path.to_string(),
+            error.to_string(),
+        ))
+    })?;
+
+    let mut reader = Reader::from_str(&xml_str);
+    reader.trim_text(true);
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event(&mut buf) {
+            Ok(Event::Start(ref e)) if e.name() == b"tradeItem" => {
+                let mut writer = Writer::new(Cursor::new(Vec::new()));
+                let mut elem = BytesStart::owned(b"tradeItem".to_vec(), "tradeItem".len());
+                elem.extend_attributes(e.attributes().map(|attr| attr.unwrap()));
+                writer.write_event(Event::Start(elem))?;
+
+                let mut gtin_buf = Vec::new();
+                let mut current_gtin = String::new();
+
+                loop {
+                    match reader.read_event(&mut buf) {
+                        Ok(Event::End(ref e)) if e.name() == b"tradeItem" => {
+                            writer.write_event(Event::End(BytesEnd::borrowed(b"tradeItem")))?;
+                            let result_bytes = writer.into_inner().into_inner();
+                            let result = std::str::from_utf8(&result_bytes)?;
+
+                            for trade_item in grid_trade_items.trade_items.iter_mut() {
+                                if trade_item.gtin == current_gtin {
+                                    trade_item.payload = result.to_string();
+                                }
+                            }
+                            break;
+                        }
+                        Ok(Event::Start(ref e)) if e.name() == b"gtin" => {
+                            reader.read_text(&e.name(), &mut gtin_buf)?;
+                            current_gtin = std::str::from_utf8(&gtin_buf)?
+                                .split('/')
+                                .next()
+                                .ok_or_else(|| {
+                                    ProductGdsnError::InvalidArgument(InvalidArgumentError::new(
+                                        path.to_string(),
+                                        "Unable to parse GTIN from XML".to_string(),
+                                    ))
+                                })?
+                                .to_string();
+                            writer.write_event(Event::Start(BytesStart::owned(
+                                b"gtin".to_vec(),
+                                "gtin".len(),
+                            )))?;
+                            writer.write_event(Event::Text(BytesText::from_plain(
+                                &current_gtin.as_bytes(),
+                            )))?;
+                            writer.write_event(Event::End(BytesEnd::owned(b"gtin".to_vec())))?;
+                        }
+                        Ok(Event::Eof) => break,
+                        Ok(e) => writer.write_event(&e)?,
+                        Err(e) => {
+                            return Err(ProductGdsnError::InvalidArgument(
+                                InvalidArgumentError::new(
+                                    path.to_string(),
+                                    format!(
+                                        "Error at position {}: {:?}",
+                                        reader.buffer_position(),
+                                        e
+                                    ),
+                                ),
+                            ));
+                        }
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(ProductGdsnError::InvalidArgument(
+                    InvalidArgumentError::new(
+                        path.to_string(),
+                        format!("Error at position {}: {:?}", reader.buffer_position(), e),
+                    ),
+                ));
+            }
+            _ => (),
+        }
+        buf.clear();
+    }
+    Ok(grid_trade_items.trade_items)
+}

--- a/sdk/src/products/mod.rs
+++ b/sdk/src/products/mod.rs
@@ -20,3 +20,6 @@ pub const MAX_COMMIT_NUM: i64 = i64::MAX;
 #[cfg(feature = "diesel")]
 pub use store::diesel::DieselProductStore;
 pub use store::ProductStore;
+
+#[cfg(feature = "product-gdsn")]
+pub mod gdsn;

--- a/sdk/src/protocol/errors.rs
+++ b/sdk/src/protocol/errors.rs
@@ -24,3 +24,11 @@ impl std::fmt::Display for BuilderError {
         }
     }
 }
+
+impl std::error::Error for BuilderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            BuilderError::MissingField(_) => None,
+        }
+    }
+}


### PR DESCRIPTION
This is the first PR to implement XML support for product. The code was getting a bit complex so I am submitting this one first to keep it incremental. Remaining tasks include:

- Implementing update
- Validation
- Fetching alternate ID to fill in the owner

To test: 

1. start up the `examples/splinter/docker-compose.yaml` network and create a Grid circuit between alpha and beta
2. Set up agents and organizations as follows:

```
grid keygen alpha-agent

export GRID_SERVICE_ID=<circuit ID>::gsAA

grid organization create crgl Cargill --metadata gs1_company_prefixes=0
grid role create crgl productowner --permissions schema::can-create-schema,product::can-create-product --active
grid agent update crgl $(cat ~/.grid/keys/alpha-agent.pub) --active --role productowner --role admin
```
3. submit a transaction to create a schema with the new `xsd_schema.yaml` file. If you are executing this from the gridd-alpha container you might need to copy it in. 
`$ grid schema create xsd-schema.yaml`
4. Create a product using some example XML data that conforms to the GridTradeItems XSD.
`$ grid product create -f yourproduct.yaml`