### PR TITLE
Fix UI sidebar

### DIFF
--- a/ui/grid-ui/public/index.html
+++ b/ui/grid-ui/public/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="UI for Grid" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <title>Grid</title>
 </head>

--- a/ui/sapling-dev-server/userSaplings
+++ b/ui/sapling-dev-server/userSaplings
@@ -9,7 +9,7 @@
       "localhost:3030/sapling-dev-server/product/css/product.css"
     ],
     "workerFiles": [],
-    "icon": "http://localhost:3030/sapling-dev-server/product/product_logo.svg"
+    "logo": "http://localhost:3030/sapling-dev-server/product/product_logo.svg"
   },
   {
     "displayName": "Circuits",
@@ -21,6 +21,6 @@
       "localhost:3030/sapling-dev-server/circuits/static/css/circuits.css"
     ],
     "workerFiles": [],
-    "icon": "http://localhost:3030/sapling-dev-server/circuits/images/circuits_logo.svg"
+    "logo": "http://localhost:3030/sapling-dev-server/circuits/images/circuits_logo.svg"
   }
 ]


### PR DESCRIPTION
This fixes the sidebar for the grid UI to correctly show icons for the
different saplings. This change depends on the PR to splinter-canopyjs:
https://github.com/Cargill/splinter-canopyjs/pull/21.

Signed-off-by: Davey Newhall <newhall@bitwise.io>