### PR TITLE
Implement multiple file handler for product CLI

### DIFF
--- a/cli/schemas/gdsn_3_1_schema.yaml
+++ b/cli/schemas/gdsn_3_1_schema.yaml
@@ -17,7 +17,7 @@
   description: GS1 product schema
   owner: crgl
   properties:
-    - name: xml_data
+    - name: GDSN_3_1
       data_type: STRING
-      description: A string containing a GDSN Trade Item product definition in XML format.
+      description: A string containing a GDSN 3.1 Trade Item product definition in XML format.
       required: true

--- a/cli/src/actions/products.rs
+++ b/cli/src/actions/products.rs
@@ -298,7 +298,7 @@ pub fn create_product_payloads_from_xml(
     Ok(payloads)
 }
 
-pub fn create_product_payloads_from_file(
+pub fn create_product_payloads_from_yaml(
     path: &str,
     url: &str,
     service_id: Option<&str>,

--- a/cli/src/actions/products.rs
+++ b/cli/src/actions/products.rs
@@ -19,7 +19,7 @@ use crate::transaction::product_batch_builder;
 use grid_sdk::pike::addressing::PIKE_NAMESPACE;
 use grid_sdk::products::addressing::GRID_PRODUCT_NAMESPACE;
 #[cfg(feature = "product-gdsn")]
-use grid_sdk::products::gdsn::get_trade_items_from_xml;
+use grid_sdk::products::gdsn::{get_trade_items_from_xml, GDSN_3_1_PROPERTY_NAME};
 use grid_sdk::protocol::product::payload::{
     Action, ProductCreateAction, ProductCreateActionBuilder, ProductDeleteAction,
     ProductPayloadBuilder, ProductUpdateAction, ProductUpdateActionBuilder,
@@ -510,10 +510,11 @@ fn yaml_to_property_values(
         } else if !def.required {
             continue;
         } else {
-            return Err(CliError::PayloadError(format!(
-                "Field {} not found",
-                def.name
-            )));
+            #[cfg(feature = "product-gdsn")]
+            if def.name == GDSN_3_1_PROPERTY_NAME {
+                continue;
+            }
+            return Err(CliError::UserError(format!("Field {} not found", def.name)));
         };
 
         match def.data_type {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2000,7 +2000,7 @@ fn run() -> Result<(), CliError> {
 
                     let wait = value_t!(m, "wait", u64).unwrap_or(0);
 
-                    let actions = products::create_product_payloads_from_file(
+                    let actions = products::create_product_payloads_from_yaml(
                         m.value_of("file").unwrap(),
                         &url,
                         service_id.as_deref(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -740,7 +740,6 @@ fn run() -> Result<(), CliError> {
                 Arg::with_name("owner")
                     .long("owner")
                     .takes_value(true)
-                    .conflicts_with("file")
                     .help("Pike organization ID"),
             )
             .arg(
@@ -753,11 +752,20 @@ fn run() -> Result<(), CliError> {
                     .help("Key value pair specifying a product property formatted as key=value"),
             )
             .arg(
+                #[cfg(not(feature = "product-gdsn"))]
                 Arg::with_name("file")
                     .long("file")
                     .short("f")
                     .takes_value(true)
                     .conflicts_with("xml")
+                    .help("Path to yaml file containing a list of products"),
+                #[cfg(feature = "product-gdsn")]
+                Arg::with_name("file")
+                    .long("file")
+                    .short("f")
+                    .takes_value(true)
+                    .multiple(true)
+                    .number_of_values(1)
                     .help("Path to yaml file containing a list of products"),
             )
             .arg(
@@ -1976,7 +1984,7 @@ fn run() -> Result<(), CliError> {
 
             match m.subcommand() {
                 #[cfg(feature = "product-gdsn")]
-                ("create", Some(m)) if m.is_present("xml") => {
+                ("create", Some(m)) if m.is_present("file") => {
                     let key = m
                         .value_of("key")
                         .map(String::from)
@@ -1984,14 +1992,17 @@ fn run() -> Result<(), CliError> {
 
                     let wait = value_t!(m, "wait", u64).unwrap_or(0);
 
-                    let actions = products::create_product_payloads_from_xml(
-                        m.value_of("xml").unwrap(),
-                        m.value_of("owner").unwrap(),
+                    let actions = products::create_product_payloads_from_file(
+                        m.values_of("file").unwrap().collect(),
+                        &url,
+                        service_id.as_deref(),
+                        m.value_of("owner"),
                     )?;
 
-                    info!("Submitting request to create product from XML...");
+                    info!("Submitting request to create product...");
                     products::do_create_products(&url, key, wait, actions, service_id)?;
                 }
+                #[cfg(not(feature = "product-gdsn"))]
                 ("create", Some(m)) if m.is_present("file") => {
                     let key = m
                         .value_of("key")

--- a/sdk/src/products/gdsn/mod.rs
+++ b/sdk/src/products/gdsn/mod.rs
@@ -35,6 +35,9 @@ use crate::protocol::{
 use error::ProductGdsnError;
 use validate::validate_product_definitons;
 
+// Name of the property where GDSN 3.1 XML data will be stored
+pub const GDSN_3_1_PROPERTY_NAME: &str = "GDSN_3_1";
+
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct GridTradeItems {
     #[serde(rename = "tradeItem")]
@@ -51,7 +54,7 @@ pub struct TradeItem {
 impl TradeItem {
     pub fn into_create_payload(self, owner: &str) -> Result<ProductCreateAction, ProductGdsnError> {
         let xml_property = PropertyValueBuilder::new()
-            .with_name("xml_data".to_string())
+            .with_name(GDSN_3_1_PROPERTY_NAME.to_string())
             .with_data_type(DataType::String)
             .with_string_value(self.payload)
             .build()?;


### PR DESCRIPTION
This PR is based on #640 

This PR updates the product create CLI command to take any number of occurrences of --file. The resulting payloads will have all properties specified across the files for each product ID.

For instance, you can submit an XML file with a GDSN trade item definition in one file, and then submit a yaml file with the same GTIN as the product ID to supply additional attributes.

To test:
1. start up the `examples/splinter/docker-compose.yaml` network and create a Grid circuit between alpha and beta
2. Set up agents and organizations as follows:

```
grid keygen alpha-agent

export GRID_SERVICE_ID=<circuit ID>::gsAA

grid organization create crgl Cargill --alternate-ids gs1_company_prefix:0
grid role create crgl productowner --permissions schema::can-create-schema,product::can-create-product --active
grid agent update crgl $(cat ~/.grid/keys/alpha-agent.pub) --active --role productowner --role admin
```
3. submit a transaction to create a schema with the following schema definition:

```yaml
- name: gs1_product
  description: GS1 product schema
  owner: crgl
  properties:
    - name: GDSN_3_1
      data_type: STRING
      description: A string containing a GDSN 3.1 Trade Item product definition in XML format.
      required: true
    - name: another_thing
      data_type: STRING
      description: Additional attribute
      required: true
    - name: optional_thing
      data_type: STRING
      description: Optional additional attribute

```
This is the same schema as in `grid/cli/schemas/gdsn_3_1_schema.yaml`, but with two additional attributes.

`$ grid schema create xsd-schema.yaml`
4. Create a product using some example XML data that conforms to the GridTradeItems XSD as well as some corresponding additional data
`$ grid product create --file tradeItems.xml --file additionalTradeItemAttrs.yaml`

The resulting products should have properties called `GDSN_3_1` which include the full XML GDSN string, as well as properties for what is defined in additionalTradeItemAttrs.