### PR TITLE
Add cross-cutting db features

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -86,8 +86,10 @@ experimental = [
     "batch-store",
     "client",
     "client-reqwest",
-    "postgres",
+    "location-store-postgres",
+    "location-store-sqlite",
     "pike-rest-api",
+    "postgres",
     "product-gdsn",
     "purchase-order",
     "rest-api-resources",
@@ -101,6 +103,8 @@ experimental = [
 client = []
 client-reqwest = ["client", "reqwest"]
 location = ["pike", "schema"]
+location-store-postgres = ["postgres"]
+location-store-sqlite = ["sqlite"]
 pike = []
 pike-rest-api = ["pike", "serde_json", "rest-api-resources"]
 product-gdsn = [

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -97,6 +97,8 @@ experimental = [
     "rest-api-resources",
     "rest-api-actix-web-3",
     "sawtooth-compat",
+    "schema-store-postgres",
+    "schema-store-sqlite",
     "sqlite",
     "track-and-trace",
     "workflow"
@@ -117,6 +119,8 @@ product = ["pike", "schema"]
 product-store-postgres = ["postgres"]
 product-store-sqlite = ["sqlite"]
 schema = ["pike"]
+schema-store-postgres = ["postgres"]
+schema-store-sqlite = ["sqlite"]
 track-and-trace = ["base64"]
 batch-processor = ["batch-store", "batch-submitter", "log"]
 batch-store = []

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -91,6 +91,8 @@ experimental = [
     "pike-rest-api",
     "postgres",
     "product-gdsn",
+    "product-store-postgres",
+    "product-store-sqlite",
     "purchase-order",
     "rest-api-resources",
     "rest-api-actix-web-3",
@@ -112,6 +114,8 @@ product-gdsn = [
 ]
 purchase-order = []
 product = ["pike", "schema"]
+product-store-postgres = ["postgres"]
+product-store-sqlite = ["sqlite"]
 schema = ["pike"]
 track-and-trace = ["base64"]
 batch-processor = ["batch-store", "batch-submitter", "log"]

--- a/sdk/src/locations/mod.rs
+++ b/sdk/src/locations/mod.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 pub mod addressing;
+#[cfg(any(feature = "location-store-postgres", feature = "location-store-sqlite"))]
 pub mod store;
 
-#[cfg(feature = "diesel")]
+#[cfg(any(feature = "location-store-postgres", feature = "location-store-sqlite"))]
 pub use store::diesel::DieselLocationStore;
+#[cfg(any(feature = "location-store-postgres", feature = "location-store-sqlite"))]
 pub use store::LocationStore;

--- a/sdk/src/migrations/diesel/postgres/mod.rs
+++ b/sdk/src/migrations/diesel/postgres/mod.rs
@@ -27,7 +27,7 @@ use crate::pike::store::diesel::schema::{
 };
 #[cfg(feature = "product-store-postgres")]
 use crate::products::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*};
-#[cfg(feature = "schema")]
+#[cfg(feature = "schema-store-postgres")]
 use crate::schemas::store::diesel::schema::{
     grid_property_definition::dsl::grid_property_definition, grid_schema::dsl::*,
 };
@@ -94,7 +94,7 @@ pub fn clear_database(conn: &PgConnection) -> Result<(), MigrationsError> {
             diesel::delete(product).execute(conn)?;
             diesel::delete(product_property_value).execute(conn)?;
         }
-        #[cfg(feature = "schema")]
+        #[cfg(feature = "schema-store-postgres")]
         {
             diesel::delete(grid_property_definition).execute(conn)?;
             diesel::delete(grid_schema).execute(conn)?;

--- a/sdk/src/migrations/diesel/postgres/mod.rs
+++ b/sdk/src/migrations/diesel/postgres/mod.rs
@@ -25,7 +25,7 @@ use crate::pike::store::diesel::schema::{
     pike_inherit_from::dsl::*, pike_organization::dsl::*, pike_organization_alternate_id::dsl::*,
     pike_organization_metadata::dsl::*, pike_permissions::dsl::*, pike_role::dsl::*,
 };
-#[cfg(feature = "product")]
+#[cfg(feature = "product-store-postgres")]
 use crate::products::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*};
 #[cfg(feature = "schema")]
 use crate::schemas::store::diesel::schema::{
@@ -89,7 +89,7 @@ pub fn clear_database(conn: &PgConnection) -> Result<(), MigrationsError> {
         {
             diesel::delete(pike_organization_location_assoc).execute(conn)?;
         }
-        #[cfg(feature = "product")]
+        #[cfg(feature = "product-store-postgres")]
         {
             diesel::delete(product).execute(conn)?;
             diesel::delete(product_property_value).execute(conn)?;

--- a/sdk/src/migrations/diesel/postgres/mod.rs
+++ b/sdk/src/migrations/diesel/postgres/mod.rs
@@ -15,9 +15,9 @@
 //! Defines methods and utilities to interact with user tables in the database.
 
 use crate::commits::store::diesel::schema::{chain_record::dsl::*, commits::dsl::*};
-#[cfg(feature = "location")]
+#[cfg(feature = "location-store-postgres")]
 use crate::locations::store::diesel::schema::{location::dsl::*, location_attribute::dsl::*};
-#[cfg(all(feature = "pike", feature = "location"))]
+#[cfg(all(feature = "pike", feature = "location-store-postgres"))]
 use crate::pike::store::diesel::schema::pike_organization_location_assoc::dsl::*;
 #[cfg(feature = "pike")]
 use crate::pike::store::diesel::schema::{
@@ -80,12 +80,12 @@ pub fn clear_database(conn: &PgConnection) -> Result<(), MigrationsError> {
             diesel::delete(pike_organization).execute(conn)?;
             diesel::delete(pike_role).execute(conn)?;
         }
-        #[cfg(feature = "location")]
+        #[cfg(feature = "location-store-postgres")]
         {
             diesel::delete(location_attribute).execute(conn)?;
             diesel::delete(location).execute(conn)?;
         }
-        #[cfg(all(feature = "pike", feature = "location"))]
+        #[cfg(all(feature = "pike", feature = "location-store-postgres"))]
         {
             diesel::delete(pike_organization_location_assoc).execute(conn)?;
         }

--- a/sdk/src/migrations/diesel/sqlite/mod.rs
+++ b/sdk/src/migrations/diesel/sqlite/mod.rs
@@ -25,7 +25,7 @@ use crate::pike::store::diesel::schema::{
 };
 #[cfg(feature = "product-store-sqlite")]
 use crate::products::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*};
-#[cfg(feature = "schema")]
+#[cfg(feature = "schema-store-sqlite")]
 use crate::schemas::store::diesel::schema::{
     grid_property_definition::dsl::grid_property_definition, grid_schema::dsl::*,
 };
@@ -92,7 +92,7 @@ pub fn clear_database(conn: &SqliteConnection) -> Result<(), MigrationsError> {
             diesel::delete(product).execute(conn)?;
             diesel::delete(product_property_value).execute(conn)?;
         }
-        #[cfg(feature = "schema")]
+        #[cfg(feature = "schema-store-sqlite")]
         {
             diesel::delete(grid_property_definition).execute(conn)?;
             diesel::delete(grid_schema).execute(conn)?;

--- a/sdk/src/migrations/diesel/sqlite/mod.rs
+++ b/sdk/src/migrations/diesel/sqlite/mod.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use crate::commits::store::diesel::schema::{chain_record::dsl::*, commits::dsl::*};
-#[cfg(feature = "location")]
+#[cfg(feature = "location-store-sqlite")]
 use crate::locations::store::diesel::schema::{location::dsl::*, location_attribute::dsl::*};
-#[cfg(all(feature = "pike", feature = "location"))]
+#[cfg(all(feature = "pike", feature = "location-store-sqlite"))]
 use crate::pike::store::diesel::schema::pike_organization_location_assoc::dsl::*;
 #[cfg(feature = "pike")]
 use crate::pike::store::diesel::schema::{
@@ -78,12 +78,12 @@ pub fn clear_database(conn: &SqliteConnection) -> Result<(), MigrationsError> {
             diesel::delete(pike_organization).execute(conn)?;
             diesel::delete(pike_role).execute(conn)?;
         }
-        #[cfg(feature = "location")]
+        #[cfg(feature = "location-store-sqlite")]
         {
             diesel::delete(location_attribute).execute(conn)?;
             diesel::delete(location).execute(conn)?;
         }
-        #[cfg(all(feature = "pike", feature = "location"))]
+        #[cfg(all(feature = "pike", feature = "location-store-sqlite"))]
         {
             diesel::delete(pike_organization_location_assoc).execute(conn)?;
         }

--- a/sdk/src/migrations/diesel/sqlite/mod.rs
+++ b/sdk/src/migrations/diesel/sqlite/mod.rs
@@ -23,7 +23,7 @@ use crate::pike::store::diesel::schema::{
     pike_inherit_from::dsl::*, pike_organization::dsl::*, pike_organization_alternate_id::dsl::*,
     pike_organization_metadata::dsl::*, pike_permissions::dsl::*, pike_role::dsl::*,
 };
-#[cfg(feature = "product")]
+#[cfg(feature = "product-store-sqlite")]
 use crate::products::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*};
 #[cfg(feature = "schema")]
 use crate::schemas::store::diesel::schema::{
@@ -87,7 +87,7 @@ pub fn clear_database(conn: &SqliteConnection) -> Result<(), MigrationsError> {
         {
             diesel::delete(pike_organization_location_assoc).execute(conn)?;
         }
-        #[cfg(feature = "product")]
+        #[cfg(feature = "product-store-sqlite")]
         {
             diesel::delete(product).execute(conn)?;
             diesel::delete(product_property_value).execute(conn)?;

--- a/sdk/src/products/mod.rs
+++ b/sdk/src/products/mod.rs
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 pub mod addressing;
+#[cfg(any(feature = "product-store-postgres", feature = "product-store-sqlite"))]
 pub mod store;
 
 pub const MAX_COMMIT_NUM: i64 = i64::MAX;
 
-#[cfg(feature = "diesel")]
+#[cfg(any(feature = "product-store-postgres", feature = "product-store-sqlite"))]
 pub use store::diesel::DieselProductStore;
+#[cfg(any(feature = "product-store-postgres", feature = "product-store-sqlite"))]
 pub use store::ProductStore;
 
 #[cfg(feature = "product-gdsn")]

--- a/sdk/src/schemas/mod.rs
+++ b/sdk/src/schemas/mod.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 pub mod addressing;
+#[cfg(any(feature = "schema-store-postgres", feature = "schema-store-sqlite"))]
 pub mod store;
 
 pub const MAX_COMMIT_NUM: i64 = i64::MAX;
 
-#[cfg(feature = "diesel")]
+#[cfg(any(feature = "schema-store-postgres", feature = "schema-store-sqlite"))]
 pub use store::diesel::DieselSchemaStore;
+#[cfg(any(feature = "schema-store-postgres", feature = "schema-store-sqlite"))]
 pub use store::SchemaStore;

--- a/sdk/src/store/mod.rs
+++ b/sdk/src/store/mod.rs
@@ -32,7 +32,7 @@ pub trait StoreFactory {
     #[cfg(feature = "pike")]
     fn get_grid_pike_store(&self) -> Box<dyn crate::pike::PikeStore>;
     /// Get a new `LocationStore`
-    #[cfg(feature = "location")]
+    #[cfg(any(feature = "location-store-postgres", feature = "location-store-sqlite"))]
     fn get_grid_location_store(&self) -> Box<dyn crate::locations::LocationStore>;
     /// Get a new `ProductStore`
     #[cfg(feature = "product")]

--- a/sdk/src/store/mod.rs
+++ b/sdk/src/store/mod.rs
@@ -38,7 +38,7 @@ pub trait StoreFactory {
     #[cfg(any(feature = "product-store-postgres", feature = "product-store-sqlite"))]
     fn get_grid_product_store(&self) -> Box<dyn crate::products::ProductStore>;
     /// Get a new `SchemaStore`
-    #[cfg(feature = "schema")]
+    #[cfg(any(feature = "schema-store-postgres", feature = "schema-store-sqlite"))]
     fn get_grid_schema_store(&self) -> Box<dyn crate::schemas::SchemaStore>;
     /// Get a new `TrackAndTraceStore`
     #[cfg(feature = "track-and-trace")]

--- a/sdk/src/store/mod.rs
+++ b/sdk/src/store/mod.rs
@@ -35,7 +35,7 @@ pub trait StoreFactory {
     #[cfg(any(feature = "location-store-postgres", feature = "location-store-sqlite"))]
     fn get_grid_location_store(&self) -> Box<dyn crate::locations::LocationStore>;
     /// Get a new `ProductStore`
-    #[cfg(feature = "product")]
+    #[cfg(any(feature = "product-store-postgres", feature = "product-store-sqlite"))]
     fn get_grid_product_store(&self) -> Box<dyn crate::products::ProductStore>;
     /// Get a new `SchemaStore`
     #[cfg(feature = "schema")]

--- a/sdk/src/store/postgres.rs
+++ b/sdk/src/store/postgres.rs
@@ -47,7 +47,7 @@ impl StoreFactory for PgStoreFactory {
         ))
     }
 
-    #[cfg(feature = "product")]
+    #[cfg(all(feature = "diesel", feature = "product-store-postgres"))]
     fn get_grid_product_store(&self) -> Box<dyn crate::products::ProductStore> {
         Box::new(crate::products::DieselProductStore::new(self.pool.clone()))
     }

--- a/sdk/src/store/postgres.rs
+++ b/sdk/src/store/postgres.rs
@@ -52,7 +52,7 @@ impl StoreFactory for PgStoreFactory {
         Box::new(crate::products::DieselProductStore::new(self.pool.clone()))
     }
 
-    #[cfg(feature = "schema")]
+    #[cfg(all(feature = "diesel", feature = "schema-store-postgres"))]
     fn get_grid_schema_store(&self) -> Box<dyn crate::schemas::SchemaStore> {
         Box::new(crate::schemas::DieselSchemaStore::new(self.pool.clone()))
     }

--- a/sdk/src/store/postgres.rs
+++ b/sdk/src/store/postgres.rs
@@ -40,7 +40,7 @@ impl StoreFactory for PgStoreFactory {
         Box::new(crate::pike::DieselPikeStore::new(self.pool.clone()))
     }
 
-    #[cfg(feature = "location")]
+    #[cfg(all(feature = "diesel", feature = "location-store-postgres"))]
     fn get_grid_location_store(&self) -> Box<dyn crate::locations::LocationStore> {
         Box::new(crate::locations::DieselLocationStore::new(
             self.pool.clone(),

--- a/sdk/src/store/sqlite.rs
+++ b/sdk/src/store/sqlite.rs
@@ -40,7 +40,7 @@ impl StoreFactory for SqliteStoreFactory {
         Box::new(crate::pike::DieselPikeStore::new(self.pool.clone()))
     }
 
-    #[cfg(feature = "location")]
+    #[cfg(all(feature = "diesel", feature = "location-store-sqlite"))]
     fn get_grid_location_store(&self) -> Box<dyn crate::locations::LocationStore> {
         Box::new(crate::locations::DieselLocationStore::new(
             self.pool.clone(),

--- a/sdk/src/store/sqlite.rs
+++ b/sdk/src/store/sqlite.rs
@@ -47,7 +47,7 @@ impl StoreFactory for SqliteStoreFactory {
         ))
     }
 
-    #[cfg(feature = "product")]
+    #[cfg(all(feature = "diesel", feature = "product-store-sqlite"))]
     fn get_grid_product_store(&self) -> Box<dyn crate::products::ProductStore> {
         Box::new(crate::products::DieselProductStore::new(self.pool.clone()))
     }

--- a/sdk/src/store/sqlite.rs
+++ b/sdk/src/store/sqlite.rs
@@ -52,7 +52,7 @@ impl StoreFactory for SqliteStoreFactory {
         Box::new(crate::products::DieselProductStore::new(self.pool.clone()))
     }
 
-    #[cfg(feature = "schema")]
+    #[cfg(all(feature = "diesel", feature = "schema-store-sqlite"))]
     fn get_grid_schema_store(&self) -> Box<dyn crate::schemas::SchemaStore> {
         Box::new(crate::schemas::DieselSchemaStore::new(self.pool.clone()))
     }


### PR DESCRIPTION
This adds cross-cutting features to the Grid SDK for the locations, products, and schemas modules. These features control whether the db code for each module gets compiled.