### PR TITLE
Add last_updated field to rest api resources

### DIFF
--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -656,6 +656,8 @@ components:
             $ref: "#/components/schemas/PropertyValue"
         service_id:
           $ref: "#/components/schemas/ServiceID"
+        last_updated:
+          $ref: "#/components/schemas/Timestamp"
 
     # Pike models
     AgentList:
@@ -687,6 +689,8 @@ components:
             $ref: "#/components/schemas/Metadata"
         service_id:
           $ref: "#/components/schemas/ServiceID"
+        last_updated:
+          $ref: "#/components/schemas/Timestamp"
     OrganizationList:
       properties:
         data:
@@ -720,6 +724,8 @@ components:
             $ref: "#/components/schemas/Metadata"
         service_id:
           $ref: "#/components/schemas/ServiceID"
+        last_updated:
+          $ref: "#/components/schemas/Timestamp"
     RoleList:
       properties:
         data:
@@ -757,6 +763,8 @@ components:
           items:
             type: string
             example: beta.Tank
+        last_updated:
+          $ref: "#/components/schemas/Timestamp"
 
     # Product models
     ProductList:
@@ -787,6 +795,8 @@ components:
             $ref: "#/components/schemas/PropertyValue"
         service_id:
           $ref: "#/components/schemas/ServiceID"
+        last_updated:
+          $ref: "#/components/schemas/Timestamp"
 
     # Schema models
     SchemaList:
@@ -814,6 +824,8 @@ components:
             $ref: "#/components/schemas/PropertyDefinition"
         service_id:
           $ref: "#/components/schemas/ServiceID"
+        last_updated:
+          $ref: "#/components/schemas/Timestamp"
     PropertyDefinition:
       properties:
         name:

--- a/daemon/src/event/db_handler.rs
+++ b/daemon/src/event/db_handler.rs
@@ -525,6 +525,7 @@ fn state_change_to_db_operation(
                             start_commit_num: commit_num,
                             end_commit_num: MAX_COMMIT_NUM,
                             service_id: service_id.cloned(),
+                            last_updated: None,
                         })
                         .collect::<Vec<Agent>>();
 
@@ -567,6 +568,7 @@ fn state_change_to_db_operation(
                             start_commit_num: commit_num,
                             end_commit_num: MAX_COMMIT_NUM,
                             service_id: service_id.cloned(),
+                            last_updated: None,
                         })
                         .collect::<Vec<Organization>>();
 
@@ -588,6 +590,7 @@ fn state_change_to_db_operation(
                             start_commit_num: commit_num,
                             end_commit_num: MAX_COMMIT_NUM,
                             service_id: service_id.cloned(),
+                            last_updated: None,
                         })
                         .collect::<Vec<Role>>();
 
@@ -611,6 +614,7 @@ fn state_change_to_db_operation(
                         start_commit_num: commit_num,
                         end_commit_num: MAX_COMMIT_NUM,
                         service_id: service_id.cloned(),
+                        last_updated: None,
                         properties: make_property_definitions(
                             commit_num,
                             service_id,
@@ -815,6 +819,7 @@ fn state_change_to_db_operation(
                         start_commit_num: commit_num,
                         end_commit_num: MAX_COMMIT_NUM,
                         service_id: service_id.cloned(),
+                        last_updated: None,
                     })
                     .collect();
 
@@ -834,6 +839,7 @@ fn state_change_to_db_operation(
                         start_commit_num: commit_num,
                         end_commit_num: MAX_COMMIT_NUM,
                         service_id: service_id.cloned(),
+                        last_updated: None,
                         properties: make_product_property_values(
                             commit_num,
                             service_id,

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -2983,6 +2983,7 @@ mod test {
             metadata: vec![],
             start_commit_num: 0,
             end_commit_num: i64::MAX,
+            last_updated: None,
             service_id,
         }]
     }
@@ -2999,6 +3000,7 @@ mod test {
                 start_commit_num: 0,
                 end_commit_num: i64::MAX,
                 service_id: service_id.clone(),
+                last_updated: None,
             },
             Agent {
                 public_key: KEY2.to_string(),
@@ -3009,6 +3011,7 @@ mod test {
                 start_commit_num: 0,
                 end_commit_num: i64::MAX,
                 service_id,
+                last_updated: None,
             },
         ]
     }
@@ -3031,6 +3034,7 @@ mod test {
             start_commit_num: 1,
             end_commit_num: i64::MAX,
             service_id: service_id.clone(),
+            last_updated: None,
         }]
     }
 
@@ -3045,6 +3049,7 @@ mod test {
                 start_commit_num: 2,
                 end_commit_num: 4,
                 service_id: None,
+                last_updated: None,
             },
             Organization {
                 org_id: KEY3.to_string(),
@@ -3055,6 +3060,7 @@ mod test {
                 start_commit_num: 4,
                 end_commit_num: i64::MAX,
                 service_id: None,
+                last_updated: None,
             },
         ]
     }
@@ -3076,6 +3082,7 @@ mod test {
             description: "Example test grid schema".to_string(),
             owner: "phillips001".to_string(),
             service_id,
+            last_updated: None,
         }]
     }
 
@@ -3089,6 +3096,7 @@ mod test {
             end_commit_num: i64::MAX,
             properties: get_product_property_value(service_id.clone()),
             service_id,
+            last_updated: None,
         }]
     }
 
@@ -3110,6 +3118,7 @@ mod test {
             start_commit_num: 0,
             end_commit_num: i64::MAX,
             service_id,
+            last_updated: None,
         }]
     }
 
@@ -3566,6 +3575,7 @@ mod test {
             description: "Example test grid schema".to_string(),
             owner: "phillips001".to_string(),
             service_id,
+            last_updated: None,
         }]
     }
 
@@ -3598,6 +3608,7 @@ mod test {
             description: "Example test grid schema".to_string(),
             owner: "phillips001".to_string(),
             service_id,
+            last_updated: None,
         }]
     }
 

--- a/sdk/src/locations/store/diesel/mod.rs
+++ b/sdk/src/locations/store/diesel/mod.rs
@@ -294,6 +294,7 @@ impl From<(LocationModel, Vec<LocationAttribute>)> for Location {
             start_commit_num: location.start_commit_num,
             end_commit_num: location.end_commit_num,
             service_id: location.service_id,
+            last_updated: location.last_updated.map(|d| d.timestamp()),
         }
     }
 }
@@ -309,6 +310,7 @@ impl From<LocationModel> for Location {
             start_commit_num: location.start_commit_num,
             end_commit_num: location.end_commit_num,
             service_id: location.service_id,
+            last_updated: location.last_updated.map(|d| d.timestamp()),
         }
     }
 }
@@ -324,6 +326,7 @@ impl From<NewLocationModel> for Location {
             start_commit_num: location.start_commit_num,
             end_commit_num: location.end_commit_num,
             service_id: location.service_id,
+            last_updated: None,
         }
     }
 }

--- a/sdk/src/locations/store/diesel/models.rs
+++ b/sdk/src/locations/store/diesel/models.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use chrono::NaiveDateTime;
+
 use crate::locations::store::diesel::schema::{location, location_attribute};
 
 #[derive(Insertable, PartialEq, Queryable, Debug)]
@@ -43,6 +45,7 @@ pub struct LocationModel {
     pub end_commit_num: i64,
 
     pub service_id: Option<String>,
+    pub last_updated: Option<NaiveDateTime>,
 }
 
 #[derive(Insertable, PartialEq, Queryable, Debug)]

--- a/sdk/src/locations/store/diesel/schema.rs
+++ b/sdk/src/locations/store/diesel/schema.rs
@@ -22,6 +22,7 @@ table! {
         start_commit_num -> Int8,
         end_commit_num -> Int8,
         service_id -> Nullable<Text>,
+        last_updated -> Nullable<Timestamp>,
     }
 }
 

--- a/sdk/src/locations/store/mod.rs
+++ b/sdk/src/locations/store/mod.rs
@@ -32,6 +32,7 @@ pub struct Location {
     pub start_commit_num: i64,
     pub end_commit_num: i64,
     pub service_id: Option<String>,
+    pub last_updated: Option<i64>,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq)]

--- a/sdk/src/migrations/diesel/postgres/migrations/2021-04-23-151946_add_timestamp/down.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-04-23-151946_add_timestamp/down.sql
@@ -1,0 +1,32 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE pike_agent
+DROP COLUMN last_updated;
+
+ALTER TABLE pike_organization
+DROP COLUMN last_updated;
+
+ALTER TABLE pike_role
+DROP COLUMN last_updated;
+
+ALTER TABLE grid_schema
+DROP COLUMN last_updated;
+
+ALTER TABLE product
+DROP COLUMN last_updated;
+
+ALTER TABLE location
+DROP COLUMN last_updated;

--- a/sdk/src/migrations/diesel/postgres/migrations/2021-04-23-151946_add_timestamp/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-04-23-151946_add_timestamp/up.sql
@@ -1,0 +1,32 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE pike_agent
+ADD COLUMN last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE pike_organization
+ADD COLUMN last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE pike_role
+ADD COLUMN last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE grid_schema
+ADD COLUMN last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE product 
+ADD COLUMN last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE location
+ADD COLUMN last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP;

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-04-23-151946_add_timestamp/down.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-04-23-151946_add_timestamp/down.sql
@@ -1,0 +1,39 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER set_pike_agent_timestamp;
+DROP TRIGGER set_pike_organization_timestamp;
+DROP TRIGGER set_pike_role_timestamp;
+DROP TRIGGER set_grid_schema_timestamp;
+DROP TRIGGER set_product_timestamp;
+DROP TRIGGER set_location_timestamp;
+
+ALTER TABLE pike_agent
+DROP COLUMN last_updated;
+
+ALTER TABLE pike_organization
+DROP COLUMN last_updated;
+
+ALTER TABLE pike_role
+DROP COLUMN last_updated;
+
+ALTER TABLE grid_schema
+DROP COLUMN last_updated;
+
+ALTER TABLE product
+DROP COLUMN last_updated;
+
+ALTER TABLE location
+DROP COLUMN last_updated;

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-04-23-151946_add_timestamp/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-04-23-151946_add_timestamp/up.sql
@@ -1,0 +1,92 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE pike_agent
+ADD COLUMN last_updated TIMESTAMP DEFAULT NULL;
+
+ALTER TABLE pike_organization
+ADD COLUMN last_updated TIMESTAMP DEFAULT NULL;
+
+ALTER TABLE pike_role
+ADD COLUMN last_updated TIMESTAMP DEFAULT NULL;
+
+ALTER TABLE grid_schema
+ADD COLUMN last_updated TIMESTAMP DEFAULT NULL;
+
+ALTER TABLE product
+ADD COLUMN last_updated TIMESTAMP DEFAULT NULL;
+
+ALTER TABLE location
+ADD COLUMN last_updated TIMESTAMP DEFAULT NULL;
+
+CREATE TRIGGER set_pike_agent_timestamp
+AFTER INSERT ON pike_agent
+FOR EACH ROW
+WHEN NEW.last_updated IS NULL
+BEGIN
+    UPDATE pike_agent
+    SET last_updated = CURRENT_TIMESTAMP
+    WHERE rowid = NEW.rowid;
+END;
+
+CREATE TRIGGER set_pike_organization_timestamp
+AFTER INSERT ON pike_organization
+FOR EACH ROW
+WHEN NEW.last_updated IS NULL
+BEGIN
+    UPDATE pike_organization
+    SET last_updated = CURRENT_TIMESTAMP
+    WHERE rowid = NEW.rowid;
+END;
+
+CREATE TRIGGER set_pike_role_timestamp
+AFTER INSERT ON pike_role
+FOR EACH ROW
+WHEN NEW.last_updated IS NULL
+BEGIN
+    UPDATE pike_role
+    SET last_updated = CURRENT_TIMESTAMP
+    WHERE rowid = NEW.rowid;
+END;
+
+CREATE TRIGGER set_grid_schema_timestamp
+AFTER INSERT ON grid_schema
+FOR EACH ROW
+WHEN NEW.last_updated IS NULL
+BEGIN
+    UPDATE grid_schema
+    SET last_updated = CURRENT_TIMESTAMP
+    WHERE rowid = NEW.rowid;
+END;
+
+CREATE TRIGGER set_product_timestamp
+AFTER INSERT ON product
+FOR EACH ROW
+WHEN NEW.last_updated IS NULL
+BEGIN
+    UPDATE product
+    SET last_updated = CURRENT_TIMESTAMP
+    WHERE rowid = NEW.rowid;
+END;
+
+CREATE TRIGGER set_location_timestamp
+AFTER INSERT ON location
+FOR EACH ROW
+WHEN NEW.last_updated IS NULL
+BEGIN
+    UPDATE location
+    SET last_updated = CURRENT_TIMESTAMP
+    WHERE rowid = NEW.rowid;
+END;

--- a/sdk/src/pike/store/diesel/models.rs
+++ b/sdk/src/pike/store/diesel/models.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use chrono::NaiveDateTime;
+
 use super::{Agent, AlternateId, Organization, OrganizationMetadata, Role};
 use crate::commits::MAX_COMMIT_NUM;
 use crate::pike::addressing::{
@@ -44,6 +46,7 @@ pub struct AgentModel {
     pub start_commit_num: i64,
     pub end_commit_num: i64,
     pub service_id: Option<String>,
+    pub last_updated: Option<NaiveDateTime>,
 }
 
 #[derive(Insertable, PartialEq, Queryable, Debug)]
@@ -71,6 +74,7 @@ pub struct RoleModel {
     pub start_commit_num: i64,
     pub end_commit_num: i64,
     pub service_id: Option<String>,
+    pub last_updated: Option<NaiveDateTime>,
 }
 
 #[derive(Insertable, PartialEq, Queryable, Debug)]
@@ -212,6 +216,7 @@ pub struct OrganizationModel {
     pub start_commit_num: i64,
     pub end_commit_num: i64,
     pub service_id: Option<String>,
+    pub last_updated: Option<NaiveDateTime>,
 }
 
 #[derive(Insertable, PartialEq, Queryable, Debug)]
@@ -352,6 +357,7 @@ impl
             start_commit_num: role.start_commit_num,
             end_commit_num: role.end_commit_num,
             service_id: role.service_id,
+            last_updated: role.last_updated.map(|d| d.timestamp()),
         }
     }
 }
@@ -474,6 +480,7 @@ impl From<(AgentModel, Vec<RoleAssociationModel>)> for Agent {
             start_commit_num: agent_model.start_commit_num,
             end_commit_num: agent_model.end_commit_num,
             service_id: agent_model.service_id,
+            last_updated: agent_model.last_updated.map(|d| d.timestamp()),
         }
     }
 }
@@ -533,6 +540,7 @@ impl
             start_commit_num: org.start_commit_num,
             end_commit_num: org.end_commit_num,
             service_id: org.service_id,
+            last_updated: org.last_updated.map(|d| d.timestamp()),
         }
     }
 }
@@ -560,6 +568,7 @@ impl
             start_commit_num: org.start_commit_num,
             end_commit_num: org.end_commit_num,
             service_id: org.service_id,
+            last_updated: None,
         }
     }
 }
@@ -592,6 +601,7 @@ impl
             start_commit_num: org.start_commit_num,
             end_commit_num: org.end_commit_num,
             service_id: org.service_id,
+            last_updated: org.last_updated.map(|d| d.timestamp()),
         }
     }
 }

--- a/sdk/src/pike/store/diesel/schema.rs
+++ b/sdk/src/pike/store/diesel/schema.rs
@@ -23,6 +23,7 @@ table! {
         start_commit_num -> Int8,
         end_commit_num -> Int8,
         service_id -> Nullable<Text>,
+        last_updated -> Nullable<Timestamp>,
     }
 }
 
@@ -37,6 +38,7 @@ table! {
         start_commit_num -> Int8,
         end_commit_num -> Int8,
         service_id -> Nullable<Text>,
+        last_updated -> Nullable<Timestamp>,
     }
 }
 
@@ -98,6 +100,7 @@ table! {
         start_commit_num -> Int8,
         end_commit_num -> Int8,
         service_id -> Nullable<Text>,
+        last_updated -> Nullable<Timestamp>,
     }
 }
 

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -33,6 +33,8 @@ pub struct Agent {
     pub end_commit_num: i64,
 
     pub service_id: Option<String>,
+
+    pub last_updated: Option<i64>,
 }
 
 /// Represents a Grid Role
@@ -48,6 +50,7 @@ pub struct Role {
     pub start_commit_num: i64,
     pub end_commit_num: i64,
     pub service_id: Option<String>,
+    pub last_updated: Option<i64>,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq)]
@@ -73,6 +76,7 @@ pub struct Organization {
     pub start_commit_num: i64,
     pub end_commit_num: i64,
     pub service_id: Option<String>,
+    pub last_updated: Option<i64>,
 }
 
 /// Represents a Grid Alternate ID

--- a/sdk/src/products/store/diesel/mod.rs
+++ b/sdk/src/products/store/diesel/mod.rs
@@ -199,6 +199,7 @@ impl From<(ModelProduct, Vec<PropertyValue>)> for Product {
             start_commit_num: model.start_commit_num,
             end_commit_num: model.end_commit_num,
             service_id: model.service_id,
+            last_updated: model.last_updated.map(|d| d.timestamp()),
             properties,
         }
     }

--- a/sdk/src/products/store/diesel/models.rs
+++ b/sdk/src/products/store/diesel/models.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use chrono::NaiveDateTime;
+
 use super::schema::{product, product_property_value};
 
 #[derive(Clone, Insertable, Debug)]
@@ -37,6 +39,7 @@ pub struct Product {
     pub start_commit_num: i64,
     pub end_commit_num: i64,
     pub service_id: Option<String>,
+    pub last_updated: Option<NaiveDateTime>,
 }
 
 #[derive(AsChangeset, Clone, Insertable, Debug)]

--- a/sdk/src/products/store/diesel/schema.rs
+++ b/sdk/src/products/store/diesel/schema.rs
@@ -43,5 +43,6 @@ table! {
         start_commit_num -> Int8,
         end_commit_num -> Int8,
         service_id -> Nullable<Text>,
+        last_updated -> Nullable<Timestamp>,
     }
 }

--- a/sdk/src/products/store/mod.rs
+++ b/sdk/src/products/store/mod.rs
@@ -29,6 +29,7 @@ pub struct Product {
     pub start_commit_num: i64,
     pub end_commit_num: i64,
     pub service_id: Option<String>,
+    pub last_updated: Option<i64>,
     pub properties: Vec<PropertyValue>,
 }
 

--- a/sdk/src/rest_api/resources/agents/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/agents/v1/payloads.rs
@@ -31,6 +31,8 @@ pub struct AgentSlice {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_updated: Option<i64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -60,6 +62,7 @@ impl TryFrom<Agent> for AgentSlice {
             roles: agent.roles.clone(),
             metadata,
             service_id: agent.service_id,
+            last_updated: agent.last_updated,
         })
     }
 }

--- a/sdk/src/rest_api/resources/locations/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/locations/v1/payloads.rs
@@ -26,6 +26,8 @@ pub struct LocationSlice {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_updated: Option<i64>,
 }
 
 impl From<Location> for LocationSlice {
@@ -40,6 +42,7 @@ impl From<Location> for LocationSlice {
                 .map(LocationPropertyValueSlice::from)
                 .collect(),
             service_id: location.service_id,
+            last_updated: location.last_updated,
         }
     }
 }

--- a/sdk/src/rest_api/resources/organizations/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/organizations/v1/payloads.rs
@@ -42,6 +42,8 @@ pub struct OrganizationSlice {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_updated: Option<i64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -80,6 +82,7 @@ impl From<Organization> for OrganizationSlice {
                 .map(OrganizationMetadataSlice::from)
                 .collect(),
             service_id: organization.service_id,
+            last_updated: organization.last_updated,
         }
     }
 }

--- a/sdk/src/rest_api/resources/products/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/products/v1/payloads.rs
@@ -24,9 +24,10 @@ pub struct ProductSlice {
     pub product_namespace: String,
     pub owner: String,
     pub properties: Vec<ProductPropertyValueSlice>,
-    #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_updated: Option<i64>,
 }
 
 impl From<Product> for ProductSlice {
@@ -42,6 +43,7 @@ impl From<Product> for ProductSlice {
                 .map(ProductPropertyValueSlice::from)
                 .collect(),
             service_id: product.service_id,
+            last_updated: product.last_updated,
         }
     }
 }

--- a/sdk/src/rest_api/resources/roles/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/roles/v1/payloads.rs
@@ -26,6 +26,8 @@ pub struct RoleSlice {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_updated: Option<i64>,
 }
 
 impl From<Role> for RoleSlice {
@@ -49,6 +51,7 @@ impl From<Role> for RoleSlice {
             allowed_organizations,
             inherit_from,
             service_id: role.service_id,
+            last_updated: role.last_updated,
         }
     }
 }

--- a/sdk/src/rest_api/resources/schemas/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/schemas/v1/payloads.rs
@@ -26,6 +26,8 @@ pub struct SchemaSlice {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_updated: Option<i64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -46,6 +48,7 @@ impl From<Schema> for SchemaSlice {
                 .map(PropertyDefinitionSlice::from)
                 .collect(),
             service_id: schema.service_id,
+            last_updated: schema.last_updated,
         }
     }
 }

--- a/sdk/src/schemas/store/diesel/mod.rs
+++ b/sdk/src/schemas/store/diesel/mod.rs
@@ -229,6 +229,7 @@ impl From<(GridSchema, Vec<PropertyDefinition>)> for Schema {
             service_id: model.service_id,
             start_commit_num: model.start_commit_num,
             end_commit_num: model.end_commit_num,
+            last_updated: model.last_updated.map(|d| d.timestamp()),
         }
     }
 }

--- a/sdk/src/schemas/store/diesel/models.rs
+++ b/sdk/src/schemas/store/diesel/models.rs
@@ -15,6 +15,8 @@
  * -----------------------------------------------------------------------------
  */
 
+use chrono::NaiveDateTime;
+
 use super::schema::{grid_property_definition, grid_schema};
 
 #[derive(Clone, Insertable, Debug)]
@@ -37,6 +39,7 @@ pub struct GridSchema {
     pub description: String,
     pub owner: String,
     pub service_id: Option<String>,
+    pub last_updated: Option<NaiveDateTime>,
 }
 
 #[derive(Clone, Insertable, Debug)]

--- a/sdk/src/schemas/store/diesel/schema.rs
+++ b/sdk/src/schemas/store/diesel/schema.rs
@@ -24,6 +24,7 @@ table! {
         description -> Text,
         owner -> Text,
         service_id -> Nullable<Text>,
+        last_updated -> Nullable<Timestamp>,
     }
 }
 

--- a/sdk/src/schemas/store/mod.rs
+++ b/sdk/src/schemas/store/mod.rs
@@ -31,6 +31,7 @@ pub struct Schema {
     pub service_id: Option<String>,
     pub start_commit_num: i64,
     pub end_commit_num: i64,
+    pub last_updated: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Adds database generated timestamp to agent, role, organization, product, location, and schema endpoints.

Example:

```
GET /agent/021bab739fce4133204c8c0bd939d48e4d32e5b29eb87ed871d2666fcd3f51bb3e
{
  "public_key": "021bab739fce4133204c8c0bd939d48e4d32e5b29eb87ed871d2666fcd3f51bb3e",
  "org_id": "crg",
  "active": true,
  "roles": [
    "admin"
  ],
  "metadata": {},
  "last_updated": 1619707637
}
```