### PR TITLE
Update PurchaseOrderStore feature guard

### DIFF
--- a/sdk/src/purchase_order/mod.rs
+++ b/sdk/src/purchase_order/mod.rs
@@ -15,6 +15,6 @@
 pub mod addressing;
 pub mod store;
 
-#[cfg(feature = "postgres")]
+#[cfg(feature = "diesel")]
 pub use store::diesel::DieselPurchaseOrderStore;
 pub use store::PurchaseOrderStore;


### PR DESCRIPTION
This updates the DieselPurchaseOrderStore feature to be guarded by the
`diesel` feature rather than the `postgres` feature. This brings the
module in line with the other Grid data stores. This is part of stabilizing the
postgres and sqlite features.

Signed-off-by: Davey Newhall <newhall@bitwise.io>