### PR TITLE
Make all operations atomic

### DIFF
--- a/daemon/src/event/db_handler.rs
+++ b/daemon/src/event/db_handler.rs
@@ -156,26 +156,26 @@ impl EventHandler for DatabaseEventHandler<diesel::pg::PgConnection> {
             .get()
             .map_err(|err| EventError(format!("Unable to connect to database: {}", err)))?;
 
-        let commit = if let Some(commit) = self
-            .commit_store
-            .create_db_commit_from_commit_event(&DbCommitEvent::from(event))
-            .map_err(|err| EventError(format!("{}", err)))?
-        {
-            commit
-        } else {
-            return Err(EventError(
-                "Commit could not be constructed from event data".to_string(),
-            ));
-        };
-        let db_ops = create_db_operations_from_state_changes(
-            &event.state_changes,
-            commit.commit_num,
-            commit.service_id.as_ref(),
-        )?;
-
-        trace!("The following operations will be performed: {:#?}", db_ops);
-
         conn.build_transaction().run::<_, EventError, _>(|| {
+            let commit = if let Some(commit) = self
+                .commit_store
+                .create_db_commit_from_commit_event(&DbCommitEvent::from(event))
+                .map_err(|err| EventError(format!("{}", err)))?
+            {
+                commit
+            } else {
+                return Err(EventError(
+                    "Commit could not be constructed from event data".to_string(),
+                ));
+            };
+            let db_ops = create_db_operations_from_state_changes(
+                &event.state_changes,
+                commit.commit_num,
+                commit.service_id.as_ref(),
+            )?;
+
+            trace!("The following operations will be performed: {:#?}", db_ops);
+
             match self
                 .commit_store
                 .get_commit_by_commit_num(commit.commit_num)
@@ -338,26 +338,26 @@ impl EventHandler for DatabaseEventHandler<diesel::sqlite::SqliteConnection> {
             .get()
             .map_err(|err| EventError(format!("Unable to connect to database: {}", err)))?;
 
-        let commit = if let Some(commit) = self
-            .commit_store
-            .create_db_commit_from_commit_event(&DbCommitEvent::from(event))
-            .map_err(|err| EventError(format!("{}", err)))?
-        {
-            commit
-        } else {
-            return Err(EventError(
-                "Commit could not be constructed from event data".to_string(),
-            ));
-        };
-        let db_ops = create_db_operations_from_state_changes(
-            &event.state_changes,
-            commit.commit_num,
-            commit.service_id.as_ref(),
-        )?;
-
-        trace!("The following operations will be performed: {:#?}", db_ops);
-
         conn.transaction::<_, EventError, _>(|| {
+            let commit = if let Some(commit) = self
+                .commit_store
+                .create_db_commit_from_commit_event(&DbCommitEvent::from(event))
+                .map_err(|err| EventError(format!("{}", err)))?
+            {
+                commit
+            } else {
+                return Err(EventError(
+                    "Commit could not be constructed from event data".to_string(),
+                ));
+            };
+            let db_ops = create_db_operations_from_state_changes(
+                &event.state_changes,
+                commit.commit_num,
+                commit.service_id.as_ref(),
+            )?;
+
+            trace!("The following operations will be performed: {:#?}", db_ops);
+
             match self
                 .commit_store
                 .get_commit_by_commit_num(commit.commit_num)

--- a/sdk/src/commits/store/diesel/operations/create_db_commit_from_commit_event.rs
+++ b/sdk/src/commits/store/diesel/operations/create_db_commit_from_commit_event.rs
@@ -35,28 +35,30 @@ impl<'a> CommitStoreCreateDbCommitFromCommitEventOperation
         &self,
         event: &CommitEvent,
     ) -> Result<Option<Commit>, CommitEventError> {
-        let commit_id = event.id.clone();
-        let commit_num = match event.height {
-            Some(height_u64) => height_u64.try_into().map_err(|err| {
-                CommitEventError::InternalError(InternalError::from_source(Box::new(err)))
-            })?,
-            None => commits::table
-                .select(max(commits::commit_num))
-                .first(self.conn)
-                .map(|option: Option<i64>| match option {
-                    Some(num) => num + 1,
-                    None => 0,
-                })
-                .map_err(|err| {
+        self.conn.transaction::<_, CommitEventError, _>(|| {
+            let commit_id = event.id.clone();
+            let commit_num = match event.height {
+                Some(height_u64) => height_u64.try_into().map_err(|err| {
                     CommitEventError::InternalError(InternalError::from_source(Box::new(err)))
                 })?,
-        };
-        let service_id = event.service_id.clone();
-        Ok(Some(Commit {
-            commit_id,
-            commit_num,
-            service_id,
-        }))
+                None => commits::table
+                    .select(max(commits::commit_num))
+                    .first(self.conn)
+                    .map(|option: Option<i64>| match option {
+                        Some(num) => num + 1,
+                        None => 0,
+                    })
+                    .map_err(|err| {
+                        CommitEventError::InternalError(InternalError::from_source(Box::new(err)))
+                    })?,
+            };
+            let service_id = event.service_id.clone();
+            Ok(Some(Commit {
+                commit_id,
+                commit_num,
+                service_id,
+            }))
+        })
     }
 }
 
@@ -68,27 +70,29 @@ impl<'a> CommitStoreCreateDbCommitFromCommitEventOperation
         &self,
         event: &CommitEvent,
     ) -> Result<Option<Commit>, CommitEventError> {
-        let commit_id = event.id.clone();
-        let commit_num = match event.height {
-            Some(height_u64) => height_u64.try_into().map_err(|err| {
-                CommitEventError::InternalError(InternalError::from_source(Box::new(err)))
-            })?,
-            None => commits::table
-                .select(max(commits::commit_num))
-                .first(self.conn)
-                .map(|option: Option<i64>| match option {
-                    Some(num) => num + 1,
-                    None => 0,
-                })
-                .map_err(|err| {
+        self.conn.transaction::<_, CommitEventError, _>(|| {
+            let commit_id = event.id.clone();
+            let commit_num = match event.height {
+                Some(height_u64) => height_u64.try_into().map_err(|err| {
                     CommitEventError::InternalError(InternalError::from_source(Box::new(err)))
                 })?,
-        };
-        let service_id = event.service_id.clone();
-        Ok(Some(Commit {
-            commit_id,
-            commit_num,
-            service_id,
-        }))
+                None => commits::table
+                    .select(max(commits::commit_num))
+                    .first(self.conn)
+                    .map(|option: Option<i64>| match option {
+                        Some(num) => num + 1,
+                        None => 0,
+                    })
+                    .map_err(|err| {
+                        CommitEventError::InternalError(InternalError::from_source(Box::new(err)))
+                    })?,
+            };
+            let service_id = event.service_id.clone();
+            Ok(Some(Commit {
+                commit_id,
+                commit_num,
+                service_id,
+            }))
+        })
     }
 }

--- a/sdk/src/commits/store/diesel/operations/get_commit_by_commit_num.rs
+++ b/sdk/src/commits/store/diesel/operations/get_commit_by_commit_num.rs
@@ -33,15 +33,17 @@ impl<'a> CommitStoreGetCommitByCommitNumOperation
         &self,
         commit_num: i64,
     ) -> Result<Option<Commit>, CommitStoreError> {
-        commits::table
-            .select(commits::all_columns)
-            .filter(commits::commit_num.eq(&commit_num))
-            .first::<CommitModel>(self.conn)
-            .map(|commit| Some(Commit::from(commit)))
-            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
-            .map_err(|err| {
-                CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })
+        self.conn.transaction::<_, CommitStoreError, _>(|| {
+            commits::table
+                .select(commits::all_columns)
+                .filter(commits::commit_num.eq(&commit_num))
+                .first::<CommitModel>(self.conn)
+                .map(|commit| Some(Commit::from(commit)))
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| {
+                    CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })
+        })
     }
 }
 
@@ -53,14 +55,16 @@ impl<'a> CommitStoreGetCommitByCommitNumOperation
         &self,
         commit_num: i64,
     ) -> Result<Option<Commit>, CommitStoreError> {
-        commits::table
-            .select(commits::all_columns)
-            .filter(commits::commit_num.eq(&commit_num))
-            .first::<CommitModel>(self.conn)
-            .map(|commit| Some(Commit::from(commit)))
-            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
-            .map_err(|err| {
-                CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })
+        self.conn.transaction::<_, CommitStoreError, _>(|| {
+            commits::table
+                .select(commits::all_columns)
+                .filter(commits::commit_num.eq(&commit_num))
+                .first::<CommitModel>(self.conn)
+                .map(|commit| Some(Commit::from(commit)))
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| {
+                    CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })
+        })
     }
 }

--- a/sdk/src/commits/store/diesel/operations/get_current_commit_id.rs
+++ b/sdk/src/commits/store/diesel/operations/get_current_commit_id.rs
@@ -27,16 +27,18 @@ impl<'a> CommitStoreGetCurrentCommitIdOperation
     for CommitStoreOperations<'a, diesel::pg::PgConnection>
 {
     fn get_current_commit_id(&self) -> Result<Option<String>, CommitStoreError> {
-        commits::table
-            .select(commits::all_columns)
-            .order_by(commits::commit_num.desc())
-            .limit(1)
-            .first::<CommitModel>(self.conn)
-            .map(|commit| Some(commit.commit_id))
-            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
-            .map_err(|err| {
-                CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })
+        self.conn.transaction::<_, CommitStoreError, _>(|| {
+            commits::table
+                .select(commits::all_columns)
+                .order_by(commits::commit_num.desc())
+                .limit(1)
+                .first::<CommitModel>(self.conn)
+                .map(|commit| Some(commit.commit_id))
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| {
+                    CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })
+        })
     }
 }
 
@@ -45,15 +47,17 @@ impl<'a> CommitStoreGetCurrentCommitIdOperation
     for CommitStoreOperations<'a, diesel::sqlite::SqliteConnection>
 {
     fn get_current_commit_id(&self) -> Result<Option<String>, CommitStoreError> {
-        commits::table
-            .select(commits::all_columns)
-            .order_by(commits::commit_num.desc())
-            .limit(1)
-            .first::<CommitModel>(self.conn)
-            .map(|commit| Some(commit.commit_id))
-            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
-            .map_err(|err| {
-                CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })
+        self.conn.transaction::<_, CommitStoreError, _>(|| {
+            commits::table
+                .select(commits::all_columns)
+                .order_by(commits::commit_num.desc())
+                .limit(1)
+                .first::<CommitModel>(self.conn)
+                .map(|commit| Some(commit.commit_id))
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| {
+                    CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })
+        })
     }
 }

--- a/sdk/src/commits/store/diesel/operations/get_next_commit_num.rs
+++ b/sdk/src/commits/store/diesel/operations/get_next_commit_num.rs
@@ -27,17 +27,19 @@ impl<'a> CommitStoreGetNextCommitNumOperation
     for CommitStoreOperations<'a, diesel::pg::PgConnection>
 {
     fn get_next_commit_num(&self) -> Result<i64, CommitStoreError> {
-        let commit_num = commits::table
-            .select(max(commits::commit_num))
-            .first(self.conn)
-            .map(|option: Option<i64>| match option {
-                Some(num) => num + 1,
-                None => 0,
-            })
-            .map_err(|err| {
-                CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })?;
-        Ok(commit_num)
+        self.conn.transaction::<_, CommitStoreError, _>(|| {
+            let commit_num = commits::table
+                .select(max(commits::commit_num))
+                .first(self.conn)
+                .map(|option: Option<i64>| match option {
+                    Some(num) => num + 1,
+                    None => 0,
+                })
+                .map_err(|err| {
+                    CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })?;
+            Ok(commit_num)
+        })
     }
 }
 
@@ -46,16 +48,18 @@ impl<'a> CommitStoreGetNextCommitNumOperation
     for CommitStoreOperations<'a, diesel::sqlite::SqliteConnection>
 {
     fn get_next_commit_num(&self) -> Result<i64, CommitStoreError> {
-        let commit_num = commits::table
-            .select(max(commits::commit_num))
-            .first(self.conn)
-            .map(|option: Option<i64>| match option {
-                Some(num) => num + 1,
-                None => 0,
-            })
-            .map_err(|err| {
-                CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })?;
-        Ok(commit_num)
+        self.conn.transaction::<_, CommitStoreError, _>(|| {
+            let commit_num = commits::table
+                .select(max(commits::commit_num))
+                .first(self.conn)
+                .map(|option: Option<i64>| match option {
+                    Some(num) => num + 1,
+                    None => 0,
+                })
+                .map_err(|err| {
+                    CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })?;
+            Ok(commit_num)
+        })
     }
 }

--- a/sdk/src/commits/store/diesel/operations/resolve_fork.rs
+++ b/sdk/src/commits/store/diesel/operations/resolve_fork.rs
@@ -31,80 +31,82 @@ pub(in crate::commits) trait CommitStoreResolveForkOperation {
 #[cfg(feature = "postgres")]
 impl<'a> CommitStoreResolveForkOperation for CommitStoreOperations<'a, diesel::pg::PgConnection> {
     fn resolve_fork(&self, commit_num: i64) -> Result<(), CommitStoreError> {
-        delete(chain_record::table)
-            .filter(chain_record::start_commit_num.ge(commit_num))
-            .execute(self.conn)
-            .map(|_| ())
-            .map_err(|err| match err {
-                dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::Unique,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::ForeignKey,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-            })?;
+        self.conn.transaction::<_, CommitStoreError, _>(|| {
+            delete(chain_record::table)
+                .filter(chain_record::start_commit_num.ge(commit_num))
+                .execute(self.conn)
+                .map(|_| ())
+                .map_err(|err| match err {
+                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::Unique,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::ForeignKey,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
+                })?;
 
-        update(chain_record::table)
-            .filter(chain_record::end_commit_num.ge(commit_num))
-            .set(chain_record::end_commit_num.eq(MAX_COMMIT_NUM))
-            .execute(self.conn)
-            .map(|_| ())
-            .map_err(|err| match err {
-                dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::Unique,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::ForeignKey,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-            })?;
+            update(chain_record::table)
+                .filter(chain_record::end_commit_num.ge(commit_num))
+                .set(chain_record::end_commit_num.eq(MAX_COMMIT_NUM))
+                .execute(self.conn)
+                .map(|_| ())
+                .map_err(|err| match err {
+                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::Unique,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::ForeignKey,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
+                })?;
 
-        delete(commits::table)
-            .filter(commits::commit_num.ge(commit_num))
-            .execute(self.conn)
-            .map(|_| ())
-            .map_err(|err| match err {
-                dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::Unique,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::ForeignKey,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-            })?;
+            delete(commits::table)
+                .filter(commits::commit_num.ge(commit_num))
+                .execute(self.conn)
+                .map(|_| ())
+                .map_err(|err| match err {
+                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::Unique,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::ForeignKey,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
+                })?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -113,79 +115,81 @@ impl<'a> CommitStoreResolveForkOperation
     for CommitStoreOperations<'a, diesel::sqlite::SqliteConnection>
 {
     fn resolve_fork(&self, commit_num: i64) -> Result<(), CommitStoreError> {
-        delete(chain_record::table)
-            .filter(chain_record::start_commit_num.ge(commit_num))
-            .execute(self.conn)
-            .map(|_| ())
-            .map_err(|err| match err {
-                dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::Unique,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::ForeignKey,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-            })?;
+        self.conn.transaction::<_, CommitStoreError, _>(|| {
+            delete(chain_record::table)
+                .filter(chain_record::start_commit_num.ge(commit_num))
+                .execute(self.conn)
+                .map(|_| ())
+                .map_err(|err| match err {
+                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::Unique,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::ForeignKey,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
+                })?;
 
-        update(chain_record::table)
-            .filter(chain_record::end_commit_num.ge(commit_num))
-            .set(chain_record::end_commit_num.eq(MAX_COMMIT_NUM))
-            .execute(self.conn)
-            .map(|_| ())
-            .map_err(|err| match err {
-                dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::Unique,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::ForeignKey,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-            })?;
+            update(chain_record::table)
+                .filter(chain_record::end_commit_num.ge(commit_num))
+                .set(chain_record::end_commit_num.eq(MAX_COMMIT_NUM))
+                .execute(self.conn)
+                .map(|_| ())
+                .map_err(|err| match err {
+                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::Unique,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::ForeignKey,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
+                })?;
 
-        delete(commits::table)
-            .filter(commits::commit_num.ge(commit_num))
-            .execute(self.conn)
-            .map(|_| ())
-            .map_err(|err| match err {
-                dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::Unique,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                    CommitStoreError::ConstraintViolationError(
-                        ConstraintViolationError::from_source_with_violation_type(
-                            ConstraintViolationType::ForeignKey,
-                            Box::new(err),
-                        ),
-                    )
-                }
-                _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-            })?;
+            delete(commits::table)
+                .filter(commits::commit_num.ge(commit_num))
+                .execute(self.conn)
+                .map(|_| ())
+                .map_err(|err| match err {
+                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::Unique,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
+                        CommitStoreError::ConstraintViolationError(
+                            ConstraintViolationError::from_source_with_violation_type(
+                                ConstraintViolationType::ForeignKey,
+                                Box::new(err),
+                            ),
+                        )
+                    }
+                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
+                })?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }

--- a/sdk/src/pike/store/diesel/operations/get_role.rs
+++ b/sdk/src/pike/store/diesel/operations/get_role.rs
@@ -42,96 +42,93 @@ impl<'a> PikeStoreGetRoleOperation for PikeStoreOperations<'a, diesel::pg::PgCon
         org_id: &str,
         service_id: Option<&str>,
     ) -> Result<Option<Role>, PikeStoreError> {
-        self.conn
-            .build_transaction()
-            .read_write()
-            .run::<_, PikeStoreError, _>(|| {
-                let mut query = pike_role::table
-                    .into_boxed()
-                    .select(pike_role::all_columns)
-                    .filter(
-                        pike_role::name
-                            .eq(&name)
-                            .and(pike_role::org_id.eq(&org_id))
-                            .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    );
+        self.conn.transaction::<_, PikeStoreError, _>(|| {
+            let mut query = pike_role::table
+                .into_boxed()
+                .select(pike_role::all_columns)
+                .filter(
+                    pike_role::name
+                        .eq(&name)
+                        .and(pike_role::org_id.eq(&org_id))
+                        .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
 
-                if let Some(service_id) = service_id {
-                    query = query.filter(pike_role::service_id.eq(service_id));
-                } else {
-                    query = query.filter(pike_role::service_id.is_null());
-                }
+            if let Some(service_id) = service_id {
+                query = query.filter(pike_role::service_id.eq(service_id));
+            } else {
+                query = query.filter(pike_role::service_id.is_null());
+            }
 
-                let role = query
-                    .first::<RoleModel>(self.conn)
-                    .map(Some)
-                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
-                    .map_err(|err| {
-                        PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
-                    })?;
-
-                let mut query = pike_inherit_from::table
-                    .into_boxed()
-                    .select(pike_inherit_from::all_columns)
-                    .filter(
-                        pike_inherit_from::role_name
-                            .eq(&name)
-                            .and(pike_inherit_from::org_id.eq(&org_id))
-                            .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    );
-
-                if let Some(service_id) = service_id {
-                    query = query.filter(pike_inherit_from::service_id.eq(service_id));
-                } else {
-                    query = query.filter(pike_inherit_from::service_id.is_null());
-                }
-
-                let inherit_from = query.load::<InheritFromModel>(self.conn).map_err(|err| {
+            let role = query
+                .first::<RoleModel>(self.conn)
+                .map(Some)
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| {
                     PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
                 })?;
 
-                let mut query = pike_permissions::table
-                    .into_boxed()
-                    .select(pike_permissions::all_columns)
-                    .filter(
-                        pike_permissions::role_name
-                            .eq(&name)
-                            .and(pike_permissions::org_id.eq(&org_id))
-                            .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    );
+            let mut query = pike_inherit_from::table
+                .into_boxed()
+                .select(pike_inherit_from::all_columns)
+                .filter(
+                    pike_inherit_from::role_name
+                        .eq(&name)
+                        .and(pike_inherit_from::org_id.eq(&org_id))
+                        .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
 
-                if let Some(service_id) = service_id {
-                    query = query.filter(pike_permissions::service_id.eq(service_id));
-                } else {
-                    query = query.filter(pike_permissions::service_id.is_null());
-                }
+            if let Some(service_id) = service_id {
+                query = query.filter(pike_inherit_from::service_id.eq(service_id));
+            } else {
+                query = query.filter(pike_inherit_from::service_id.is_null());
+            }
 
-                let permissions = query.load::<PermissionModel>(self.conn).map_err(|err| {
-                    PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
-                })?;
+            let inherit_from = query.load::<InheritFromModel>(self.conn).map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
-                let mut query = pike_allowed_orgs::table
-                    .into_boxed()
-                    .select(pike_allowed_orgs::all_columns)
-                    .filter(
-                        pike_allowed_orgs::role_name
-                            .eq(&name)
-                            .and(pike_allowed_orgs::org_id.eq(&org_id))
-                            .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    );
+            let mut query = pike_permissions::table
+                .into_boxed()
+                .select(pike_permissions::all_columns)
+                .filter(
+                    pike_permissions::role_name
+                        .eq(&name)
+                        .and(pike_permissions::org_id.eq(&org_id))
+                        .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
 
-                if let Some(service_id) = service_id {
-                    query = query.filter(pike_allowed_orgs::service_id.eq(service_id));
-                } else {
-                    query = query.filter(pike_allowed_orgs::service_id.is_null());
-                }
+            if let Some(service_id) = service_id {
+                query = query.filter(pike_permissions::service_id.eq(service_id));
+            } else {
+                query = query.filter(pike_permissions::service_id.is_null());
+            }
 
-                let allowed_orgs = query.load::<AllowedOrgModel>(self.conn).map_err(|err| {
-                    PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
-                })?;
+            let permissions = query.load::<PermissionModel>(self.conn).map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
-                Ok(role.map(|r| Role::from((r, inherit_from, permissions, allowed_orgs))))
-            })
+            let mut query = pike_allowed_orgs::table
+                .into_boxed()
+                .select(pike_allowed_orgs::all_columns)
+                .filter(
+                    pike_allowed_orgs::role_name
+                        .eq(&name)
+                        .and(pike_allowed_orgs::org_id.eq(&org_id))
+                        .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(pike_allowed_orgs::service_id.eq(service_id));
+            } else {
+                query = query.filter(pike_allowed_orgs::service_id.is_null());
+            }
+
+            let allowed_orgs = query.load::<AllowedOrgModel>(self.conn).map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
+
+            Ok(role.map(|r| Role::from((r, inherit_from, permissions, allowed_orgs))))
+        })
     }
 }
 
@@ -143,7 +140,7 @@ impl<'a> PikeStoreGetRoleOperation for PikeStoreOperations<'a, diesel::sqlite::S
         org_id: &str,
         service_id: Option<&str>,
     ) -> Result<Option<Role>, PikeStoreError> {
-        self.conn.immediate_transaction::<_, PikeStoreError, _>(|| {
+        self.conn.transaction::<_, PikeStoreError, _>(|| {
             let mut query = pike_role::table
                 .into_boxed()
                 .select(pike_role::all_columns)

--- a/sdk/src/products/store/diesel/operations/get_product.rs
+++ b/sdk/src/products/store/diesel/operations/get_product.rs
@@ -42,17 +42,20 @@ impl<'a> GetProductOperation for ProductStoreOperations<'a, diesel::pg::PgConnec
         product_id: &str,
         service_id: Option<&str>,
     ) -> Result<Option<Product>, ProductStoreError> {
-        let product = if let Some(product) = pg::get_product(&*self.conn, product_id, service_id)? {
-            product
-        } else {
-            return Ok(None);
-        };
+        self.conn.transaction::<_, ProductStoreError, _>(|| {
+            let product =
+                if let Some(product) = pg::get_product(&*self.conn, product_id, service_id)? {
+                    product
+                } else {
+                    return Ok(None);
+                };
 
-        let root_values = pg::get_root_values(&*self.conn, product_id)?;
+            let root_values = pg::get_root_values(&*self.conn, product_id)?;
 
-        let values = pg::get_property_values(&*self.conn, root_values)?;
+            let values = pg::get_property_values(&*self.conn, root_values)?;
 
-        Ok(Some(Product::from((product, values))))
+            Ok(Some(Product::from((product, values))))
+        })
     }
 }
 
@@ -63,18 +66,20 @@ impl<'a> GetProductOperation for ProductStoreOperations<'a, diesel::sqlite::Sqli
         product_id: &str,
         service_id: Option<&str>,
     ) -> Result<Option<Product>, ProductStoreError> {
-        let product =
-            if let Some(product) = sqlite::get_product(&*self.conn, product_id, service_id)? {
-                product
-            } else {
-                return Ok(None);
-            };
+        self.conn.transaction::<_, ProductStoreError, _>(|| {
+            let product =
+                if let Some(product) = sqlite::get_product(&*self.conn, product_id, service_id)? {
+                    product
+                } else {
+                    return Ok(None);
+                };
 
-        let root_values = sqlite::get_root_values(&*self.conn, product_id)?;
+            let root_values = sqlite::get_root_values(&*self.conn, product_id)?;
 
-        let values = sqlite::get_property_values(&*self.conn, root_values)?;
+            let values = sqlite::get_property_values(&*self.conn, root_values)?;
 
-        Ok(Some(Product::from((product, values))))
+            Ok(Some(Product::from((product, values))))
+        })
     }
 }
 

--- a/sdk/src/products/store/diesel/operations/update_product.rs
+++ b/sdk/src/products/store/diesel/operations/update_product.rs
@@ -37,14 +37,16 @@ impl<'a> UpdateProductOperation for ProductStoreOperations<'a, diesel::pg::PgCon
         service_id: Option<&str>,
         current_commit_num: i64,
     ) -> Result<(), ProductStoreError> {
-        pg::update_product_property_values(
-            &*self.conn,
-            product_id,
-            service_id,
-            current_commit_num,
-        )?;
+        self.conn.transaction::<_, ProductStoreError, _>(|| {
+            pg::update_product_property_values(
+                &*self.conn,
+                product_id,
+                service_id,
+                current_commit_num,
+            )?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -56,14 +58,16 @@ impl<'a> UpdateProductOperation for ProductStoreOperations<'a, diesel::sqlite::S
         service_id: Option<&str>,
         current_commit_num: i64,
     ) -> Result<(), ProductStoreError> {
-        sqlite::update_product_property_values(
-            &*self.conn,
-            product_id,
-            service_id,
-            current_commit_num,
-        )?;
+        self.conn.transaction::<_, ProductStoreError, _>(|| {
+            sqlite::update_product_property_values(
+                &*self.conn,
+                product_id,
+                service_id,
+                current_commit_num,
+            )?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 

--- a/sdk/src/schemas/store/diesel/operations/get_property_definition_by_name.rs
+++ b/sdk/src/schemas/store/diesel/operations/get_property_definition_by_name.rs
@@ -44,32 +44,34 @@ impl<'a> GetPropertyDefinitionByNameOperation
         definition_name: &str,
         service_id: Option<&str>,
     ) -> Result<Option<PropertyDefinition>, SchemaStoreError> {
-        let mut query = grid_property_definition::table
-            .into_boxed()
-            .select(grid_property_definition::all_columns)
-            .filter(
-                grid_property_definition::schema_name
-                    .eq(&schema_name)
-                    .and(grid_property_definition::name.eq(&definition_name))
-                    .and(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM)),
-            );
+        self.conn.transaction::<_, SchemaStoreError, _>(|| {
+            let mut query = grid_property_definition::table
+                .into_boxed()
+                .select(grid_property_definition::all_columns)
+                .filter(
+                    grid_property_definition::schema_name
+                        .eq(&schema_name)
+                        .and(grid_property_definition::name.eq(&definition_name))
+                        .and(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
 
-        if let Some(service_id) = service_id {
-            query = query.filter(grid_property_definition::service_id.eq(service_id));
-        } else {
-            query = query.filter(grid_property_definition::service_id.is_null());
-        }
+            if let Some(service_id) = service_id {
+                query = query.filter(grid_property_definition::service_id.eq(service_id));
+            } else {
+                query = query.filter(grid_property_definition::service_id.is_null());
+            }
 
-        let defn = query
-            .first::<GridPropertyDefinition>(self.conn)
-            .map(PropertyDefinition::from)
-            .map(Some)
-            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
-            .map_err(|err| {
-                SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })?;
+            let defn = query
+                .first::<GridPropertyDefinition>(self.conn)
+                .map(PropertyDefinition::from)
+                .map(Some)
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| {
+                    SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })?;
 
-        Ok(defn)
+            Ok(defn)
+        })
     }
 }
 
@@ -83,31 +85,33 @@ impl<'a> GetPropertyDefinitionByNameOperation
         definition_name: &str,
         service_id: Option<&str>,
     ) -> Result<Option<PropertyDefinition>, SchemaStoreError> {
-        let mut query = grid_property_definition::table
-            .into_boxed()
-            .select(grid_property_definition::all_columns)
-            .filter(
-                grid_property_definition::schema_name
-                    .eq(&schema_name)
-                    .and(grid_property_definition::name.eq(&definition_name))
-                    .and(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM)),
-            );
+        self.conn.transaction::<_, SchemaStoreError, _>(|| {
+            let mut query = grid_property_definition::table
+                .into_boxed()
+                .select(grid_property_definition::all_columns)
+                .filter(
+                    grid_property_definition::schema_name
+                        .eq(&schema_name)
+                        .and(grid_property_definition::name.eq(&definition_name))
+                        .and(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
 
-        if let Some(service_id) = service_id {
-            query = query.filter(grid_property_definition::service_id.eq(service_id));
-        } else {
-            query = query.filter(grid_property_definition::service_id.is_null());
-        }
+            if let Some(service_id) = service_id {
+                query = query.filter(grid_property_definition::service_id.eq(service_id));
+            } else {
+                query = query.filter(grid_property_definition::service_id.is_null());
+            }
 
-        let defn = query
-            .first::<GridPropertyDefinition>(self.conn)
-            .map(PropertyDefinition::from)
-            .map(Some)
-            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
-            .map_err(|err| {
-                SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })?;
+            let defn = query
+                .first::<GridPropertyDefinition>(self.conn)
+                .map(PropertyDefinition::from)
+                .map(Some)
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| {
+                    SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })?;
 
-        Ok(defn)
+            Ok(defn)
+        })
     }
 }

--- a/sdk/src/schemas/store/diesel/operations/list_property_definitions.rs
+++ b/sdk/src/schemas/store/diesel/operations/list_property_definitions.rs
@@ -38,33 +38,35 @@ impl<'a> ListPropertyDefinitionsOperation for SchemaStoreOperations<'a, diesel::
         &self,
         service_id: Option<&str>,
     ) -> Result<Vec<PropertyDefinition>, SchemaStoreError> {
-        let mut query = grid_property_definition::table
-            .into_boxed()
-            .select(grid_property_definition::all_columns)
-            .filter(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM));
+        self.conn.transaction::<_, SchemaStoreError, _>(|| {
+            let mut query = grid_property_definition::table
+                .into_boxed()
+                .select(grid_property_definition::all_columns)
+                .filter(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM));
 
-        if let Some(service_id) = service_id {
-            query = query.filter(grid_property_definition::service_id.eq(service_id));
-        } else {
-            query = query.filter(grid_property_definition::service_id.is_null());
-        }
+            if let Some(service_id) = service_id {
+                query = query.filter(grid_property_definition::service_id.eq(service_id));
+            } else {
+                query = query.filter(grid_property_definition::service_id.is_null());
+            }
 
-        let defns = query
-            .load::<GridPropertyDefinition>(self.conn)
-            .map(Some)
-            .map_err(|err| {
-                SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })?
-            .ok_or_else(|| {
-                SchemaStoreError::NotFoundError(
-                    "Could not get all definitions from storage for schema".to_string(),
-                )
-            })?
-            .into_iter()
-            .map(PropertyDefinition::from)
-            .collect();
+            let defns = query
+                .load::<GridPropertyDefinition>(self.conn)
+                .map(Some)
+                .map_err(|err| {
+                    SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })?
+                .ok_or_else(|| {
+                    SchemaStoreError::NotFoundError(
+                        "Could not get all definitions from storage for schema".to_string(),
+                    )
+                })?
+                .into_iter()
+                .map(PropertyDefinition::from)
+                .collect();
 
-        Ok(defns)
+            Ok(defns)
+        })
     }
 }
 
@@ -76,32 +78,34 @@ impl<'a> ListPropertyDefinitionsOperation
         &self,
         service_id: Option<&str>,
     ) -> Result<Vec<PropertyDefinition>, SchemaStoreError> {
-        let mut query = grid_property_definition::table
-            .into_boxed()
-            .select(grid_property_definition::all_columns)
-            .filter(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM));
+        self.conn.transaction::<_, SchemaStoreError, _>(|| {
+            let mut query = grid_property_definition::table
+                .into_boxed()
+                .select(grid_property_definition::all_columns)
+                .filter(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM));
 
-        if let Some(service_id) = service_id {
-            query = query.filter(grid_property_definition::service_id.eq(service_id));
-        } else {
-            query = query.filter(grid_property_definition::service_id.is_null());
-        }
+            if let Some(service_id) = service_id {
+                query = query.filter(grid_property_definition::service_id.eq(service_id));
+            } else {
+                query = query.filter(grid_property_definition::service_id.is_null());
+            }
 
-        let defns = query
-            .load::<GridPropertyDefinition>(self.conn)
-            .map(Some)
-            .map_err(|err| {
-                SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })?
-            .ok_or_else(|| {
-                SchemaStoreError::NotFoundError(
-                    "Could not get all definitions from storage for schema".to_string(),
-                )
-            })?
-            .into_iter()
-            .map(PropertyDefinition::from)
-            .collect();
+            let defns = query
+                .load::<GridPropertyDefinition>(self.conn)
+                .map(Some)
+                .map_err(|err| {
+                    SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })?
+                .ok_or_else(|| {
+                    SchemaStoreError::NotFoundError(
+                        "Could not get all definitions from storage for schema".to_string(),
+                    )
+                })?
+                .into_iter()
+                .map(PropertyDefinition::from)
+                .collect();
 
-        Ok(defns)
+            Ok(defns)
+        })
     }
 }

--- a/sdk/src/schemas/store/diesel/operations/list_property_definitions_with_schema_name.rs
+++ b/sdk/src/schemas/store/diesel/operations/list_property_definitions_with_schema_name.rs
@@ -42,38 +42,40 @@ impl<'a> ListPropertyDefinitionsWithSchemaNameOperation
         schema_name: &str,
         service_id: Option<&str>,
     ) -> Result<Vec<PropertyDefinition>, SchemaStoreError> {
-        let mut query = grid_property_definition::table
-            .into_boxed()
-            .select(grid_property_definition::all_columns)
-            .filter(
-                grid_property_definition::schema_name
-                    .eq(&schema_name)
-                    .and(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM)),
-            );
+        self.conn.transaction::<_, SchemaStoreError, _>(|| {
+            let mut query = grid_property_definition::table
+                .into_boxed()
+                .select(grid_property_definition::all_columns)
+                .filter(
+                    grid_property_definition::schema_name
+                        .eq(&schema_name)
+                        .and(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
 
-        if let Some(service_id) = service_id {
-            query = query.filter(grid_property_definition::service_id.eq(service_id));
-        } else {
-            query = query.filter(grid_property_definition::service_id.is_null());
-        }
+            if let Some(service_id) = service_id {
+                query = query.filter(grid_property_definition::service_id.eq(service_id));
+            } else {
+                query = query.filter(grid_property_definition::service_id.is_null());
+            }
 
-        let defns = query
-            .load::<GridPropertyDefinition>(self.conn)
-            .map(Some)
-            .map_err(|err| {
-                SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })?
-            .ok_or_else(|| {
-                SchemaStoreError::NotFoundError(format!(
-                    "Could not get all definitions from storage for schema: {}",
-                    schema_name,
-                ))
-            })?
-            .into_iter()
-            .map(PropertyDefinition::from)
-            .collect();
+            let defns = query
+                .load::<GridPropertyDefinition>(self.conn)
+                .map(Some)
+                .map_err(|err| {
+                    SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })?
+                .ok_or_else(|| {
+                    SchemaStoreError::NotFoundError(format!(
+                        "Could not get all definitions from storage for schema: {}",
+                        schema_name,
+                    ))
+                })?
+                .into_iter()
+                .map(PropertyDefinition::from)
+                .collect();
 
-        Ok(defns)
+            Ok(defns)
+        })
     }
 }
 
@@ -86,37 +88,39 @@ impl<'a> ListPropertyDefinitionsWithSchemaNameOperation
         schema_name: &str,
         service_id: Option<&str>,
     ) -> Result<Vec<PropertyDefinition>, SchemaStoreError> {
-        let mut query = grid_property_definition::table
-            .into_boxed()
-            .select(grid_property_definition::all_columns)
-            .filter(
-                grid_property_definition::schema_name
-                    .eq(&schema_name)
-                    .and(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM)),
-            );
+        self.conn.transaction::<_, SchemaStoreError, _>(|| {
+            let mut query = grid_property_definition::table
+                .into_boxed()
+                .select(grid_property_definition::all_columns)
+                .filter(
+                    grid_property_definition::schema_name
+                        .eq(&schema_name)
+                        .and(grid_property_definition::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
 
-        if let Some(service_id) = service_id {
-            query = query.filter(grid_property_definition::service_id.eq(service_id));
-        } else {
-            query = query.filter(grid_property_definition::service_id.is_null());
-        }
+            if let Some(service_id) = service_id {
+                query = query.filter(grid_property_definition::service_id.eq(service_id));
+            } else {
+                query = query.filter(grid_property_definition::service_id.is_null());
+            }
 
-        let defns = query
-            .load::<GridPropertyDefinition>(self.conn)
-            .map(Some)
-            .map_err(|err| {
-                SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
-            })?
-            .ok_or_else(|| {
-                SchemaStoreError::NotFoundError(format!(
-                    "Could not get all definitions from storage for schema: {}",
-                    schema_name,
-                ))
-            })?
-            .into_iter()
-            .map(PropertyDefinition::from)
-            .collect();
+            let defns = query
+                .load::<GridPropertyDefinition>(self.conn)
+                .map(Some)
+                .map_err(|err| {
+                    SchemaStoreError::InternalError(InternalError::from_source(Box::new(err)))
+                })?
+                .ok_or_else(|| {
+                    SchemaStoreError::NotFoundError(format!(
+                        "Could not get all definitions from storage for schema: {}",
+                        schema_name,
+                    ))
+                })?
+                .into_iter()
+                .map(PropertyDefinition::from)
+                .collect();
 
-        Ok(defns)
+            Ok(defns)
+        })
     }
 }


### PR DESCRIPTION
This makes all operations atomic. Previously, this was done in a sort of
piecemeal fashion. This just cleans this up and makes sure all
operations are wrapped in the generic diesel transaction. This is
available for all Diesel backends that implement Diesel::Connection.
This depends on PR #656.