### PR TITLE
Improve validation error reporting

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -127,6 +127,6 @@ impl From<sabre_sdk::protos::ProtoConversionError> for CliError {
 #[cfg(feature = "product-gdsn")]
 impl From<grid_sdk::products::gdsn::error::ProductGdsnError> for CliError {
     fn from(err: grid_sdk::products::gdsn::error::ProductGdsnError) -> Self {
-        CliError::PayloadError(err.to_string())
+        CliError::UserError(err.to_string())
     }
 }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -56,7 +56,7 @@ cylinder = { version = "0.2.2", features = ["key-load"], optional = true}
 rust-crypto = "0.2"
 sawtooth-sdk = "0.4"
 quick-xml = { version = "0.22", features = [ "serialize" ] }
-libxml = "0.2.16"
+libc = "0.2.94"
 tempfile = "3"
 
 [build-dependencies]

--- a/sdk/src/products/gdsn/mod.rs
+++ b/sdk/src/products/gdsn/mod.rs
@@ -68,7 +68,6 @@ impl TradeItem {
 }
 
 pub fn get_trade_items_from_xml(path: &str) -> Result<Vec<TradeItem>, ProductGdsnError> {
-    validate_product_definitons(path)?;
     let mut xml_file = std::fs::File::open(path).map_err(|error| {
         ProductGdsnError::InvalidArgument(InvalidArgumentError::new(
             path.to_string(),
@@ -90,6 +89,8 @@ pub fn get_trade_items_from_xml(path: &str) -> Result<Vec<TradeItem>, ProductGds
             error.to_string(),
         ))
     })?;
+
+    validate_product_definitons(path)?;
 
     let mut reader = Reader::from_str(&xml_str);
     reader.trim_text(true);

--- a/sdk/src/products/gdsn/validate.rs
+++ b/sdk/src/products/gdsn/validate.rs
@@ -12,54 +12,74 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use libxml::{
-    parser::Parser,
-    schemas::{SchemaParserContext, SchemaValidationContext},
-};
+use std::cmp::Ordering;
+use std::ffi::CString;
 
 use crate::error::{InternalError, InvalidArgumentError};
 use crate::products::gdsn::error::ProductGdsnError;
 
+use libc::{c_char, c_int, c_uint};
+
+enum XmlSchema {}
+enum XmlSchemaParserCtxt {}
+enum XmlSchemaValidCtxt {}
+
+#[derive(Clone, Copy)]
+struct XmlSchemaPtr(pub *mut XmlSchema);
+
+#[link(name = "xml2")]
+extern "C" {
+    fn xmlSchemaNewMemParserCtxt(
+        buffer: *const c_char,
+        size: *const c_int,
+    ) -> *mut XmlSchemaParserCtxt;
+    fn xmlSchemaParse(ctxt: *const XmlSchemaParserCtxt) -> *mut XmlSchema;
+    fn xmlSchemaFreeParserCtxt(ctxt: *mut XmlSchemaParserCtxt);
+    fn xmlSchemaNewValidCtxt(schema: *const XmlSchema) -> *mut XmlSchemaValidCtxt;
+    fn xmlSchemaFreeValidCtxt(ctxt: *mut XmlSchemaValidCtxt);
+    fn xmlSchemaValidateFile(
+        ctxt: *const XmlSchemaValidCtxt,
+        file_name: *const c_char,
+        options: c_uint,
+    ) -> c_int;
+}
+
 pub fn validate_product_definitons(xml_path: &str) -> Result<(), ProductGdsnError> {
+    let schema = load_schema();
+    let path = CString::new(xml_path)
+        .map_err(|err| ProductGdsnError::Internal(InternalError::from_source(Box::new(err))))?;
+
+    unsafe {
+        let schema_valid_ctxt = xmlSchemaNewValidCtxt(schema.0);
+        let result = xmlSchemaValidateFile(schema_valid_ctxt, path.as_ptr(), 0);
+        xmlSchemaFreeValidCtxt(schema_valid_ctxt);
+
+        match result.cmp(&0) {
+            Ordering::Equal => Ok(()),
+            Ordering::Greater => Err(ProductGdsnError::InvalidArgument(
+                InvalidArgumentError::new(
+                    xml_path.to_string(),
+                    "file fails to validate".to_string(),
+                ),
+            )),
+            Ordering::Less => Err(ProductGdsnError::Internal(InternalError::with_message(
+                format!("validation generated an internal error: {}", xml_path),
+            ))),
+        }
+    }
+}
+
+fn load_schema() -> XmlSchemaPtr {
     static GRID_TRADE_ITEMS_SCHEMA: &str = include_str!("GridTradeItems.xsd");
 
-    let xml = Parser::default().parse_file(&xml_path).map_err(|err| {
-        ProductGdsnError::InvalidArgument(InvalidArgumentError::new(
-            xml_path.to_string(),
-            err.to_string(),
-        ))
-    })?;
+    let buff = GRID_TRADE_ITEMS_SCHEMA.as_ptr() as *const c_char;
+    let size = GRID_TRADE_ITEMS_SCHEMA.len() as *const i32;
 
-    let mut xsd_parser = SchemaParserContext::from_buffer(GRID_TRADE_ITEMS_SCHEMA);
-    let xsd = SchemaValidationContext::from_parser(&mut xsd_parser);
+    unsafe {
+        let schema_parser_ctxt = xmlSchemaNewMemParserCtxt(buff, size);
+        let schema = xmlSchemaParse(schema_parser_ctxt);
+        xmlSchemaFreeParserCtxt(schema_parser_ctxt);
 
-    if let Err(errors) = xsd {
-        let mut xsd_errors: Vec<String> = vec![];
-
-        for err in &errors {
-            xsd_errors.push(err.message().to_string())
-        }
-
-        return Err(ProductGdsnError::Internal(InternalError::with_message(
-            format!("Error creating validation context: {:#?}", xsd_errors),
-        )));
+        XmlSchemaPtr(schema)
     }
-    let mut xsd = xsd.unwrap();
-
-    if let Err(errors) = xsd.validate_document(&xml) {
-        let mut validation_errors: Vec<String> = vec![];
-
-        for err in &errors {
-            validation_errors.push(err.message().to_string())
-        }
-
-        return Err(ProductGdsnError::InvalidArgument(
-            InvalidArgumentError::new(
-                xml_path.to_string(),
-                format!("Invalid product definition: {:#?}", validation_errors),
-            ),
-        ));
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
The rust-libxml bindings library did not handle validation errors properly. Instead of reporting all of the validation errors for a file, the library would return the correct number of errors but all of the error messages would be the same. This issue seems to be due to the implementation of the StructuredError handler in the rust-libxml bindings library.

This PR removes the bindings library and just implements bindings for the specific libxml2 functions needed for validation.

This PR also moves the validation step to after the XML files have been parsed so that parsing errors can be reported before validation.

Example output:

```
$ grid product create --owner crgl --file .myfiles/valid_example.xml --file .myfiles/invalid_example.xml 
Entity: line 10: Schemas validity error : Element 'isTradeItemAnInvoiceUnit': 'ERROR' is not a valid value of the atomic type 'xs:boolean'.
Entity: line 11: Schemas validity error : Element 'isTradeItemAnOrderableUnit': 'ERROR' is not a valid value of the atomic type 'xs:boolean'.
Error: File fails to validate (.myfiles/invalid_example.xml)
```

Implementation was inspired by [FranklinChen/validate-xml-rust](https://github.com/FranklinChen/validate-xml-rust) and [xmllint](https://github.com/GNOME/libxml2/blob/master/xmllint.c)
