### PR TITLE
Fix lint and dependency

### DIFF
--- a/sdk/src/batch_processor/mod.rs
+++ b/sdk/src/batch_processor/mod.rs
@@ -234,8 +234,8 @@ impl BatchProcessorBuilder {
 
         Ok(BatchProcessor {
             join_handle,
-            pacemaker,
             sender,
+            pacemaker,
         })
     }
 }

--- a/ui/saplings/product/package.json
+++ b/ui/saplings/product/package.json
@@ -52,7 +52,7 @@
     "react-dom": "^16.13.0",
     "react-router-dom": "^5.1.2",
     "react-toast-notifications": "^2.4.0",
-    "splinter-saplingjs": "github:cargill/splinter-saplingjs#master",
+    "splinter-saplingjs": "github:cargill/splinter-saplingjs#main",
     "transact-sdk": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The Batch Processor constructor was merged after this lint was fixed elsewhere in Grid. Also updates saplingjs to get the dependency from the proper branch.