### PR TITLE
Update product man pages

### DIFF
--- a/cli/man/grid-product-create.md
+++ b/cli/man/grid-product-create.md
@@ -63,7 +63,7 @@ OPTIONS
 : A product property (format: key=value)
 
 `--file, -f`
-: Path or URL to a YAML file containing a list of products
+: Path to file containing a list of products
 
 ARGS
 ====

--- a/cli/man/grid-product-update.md
+++ b/cli/man/grid-product-update.md
@@ -53,9 +53,6 @@ FLAGS
 OPTIONS
 =======
 
-`--owner`
-: Organization ID of the owner
-
 `--namespace`
 : Namespace of the product (default: "GS1")
 


### PR DESCRIPTION
Update explanation for --file flag for product

Remove `--owner` option from `grid product update` man page

Signed-off-by: Ryan Banks <rbanks@bitwise.io>