### PR TITLE
BACKPORT 0-1:  Fix Grid docker builds with Docker Compose 1.28+

### DIFF
--- a/docker/compose/.env
+++ b/docker/compose/.env
@@ -1,0 +1,3 @@
+ISOLATION_ID=latest
+DISTRO=focal
+REPO_VERSION=0.1.3-dev

--- a/examples/sawtooth/.env
+++ b/examples/sawtooth/.env
@@ -1,0 +1,3 @@
+ISOLATION_ID=latest
+DISTRO=focal
+REPO_VERSION=0.1.3-dev

--- a/examples/splinter/.env
+++ b/examples/splinter/.env
@@ -1,0 +1,3 @@
+ISOLATION_ID=latest
+DISTRO=focal
+REPO_VERSION=0.1.3-dev

--- a/ui/grid-ui/docker/.env
+++ b/ui/grid-ui/docker/.env
@@ -1,0 +1,3 @@
+ISOLATION_ID=latest
+DISTRO=focal
+REPO_VERSION=0.1.3-dev


### PR DESCRIPTION
As of version 1.28.0, Docker Compose expects .env files to reside in the same
directory as the compose files or to have their path specicified with an
additional argument to the compose command. Duplicating the .env files
whereever they're needed was deemed to be the least disruptive solution.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>