### PR TITLE
Have fetch_role use transaction

### DIFF
--- a/sdk/src/pike/store/diesel/operations/fetch_role.rs
+++ b/sdk/src/pike/store/diesel/operations/fetch_role.rs
@@ -42,96 +42,93 @@ impl<'a> PikeStoreFetchRoleOperation for PikeStoreOperations<'a, diesel::pg::PgC
         org_id: &str,
         service_id: Option<&str>,
     ) -> Result<Option<Role>, PikeStoreError> {
-        self.conn
-            .build_transaction()
-            .read_write()
-            .run::<_, PikeStoreError, _>(|| {
-                let mut query = pike_role::table
-                    .into_boxed()
-                    .select(pike_role::all_columns)
-                    .filter(
-                        pike_role::name
-                            .eq(&name)
-                            .and(pike_role::org_id.eq(&org_id))
-                            .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    );
+        self.conn.transaction::<_, PikeStoreError, _>(|| {
+            let mut query = pike_role::table
+                .into_boxed()
+                .select(pike_role::all_columns)
+                .filter(
+                    pike_role::name
+                        .eq(&name)
+                        .and(pike_role::org_id.eq(&org_id))
+                        .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
 
-                if let Some(service_id) = service_id {
-                    query = query.filter(pike_role::service_id.eq(service_id));
-                } else {
-                    query = query.filter(pike_role::service_id.is_null());
-                }
+            if let Some(service_id) = service_id {
+                query = query.filter(pike_role::service_id.eq(service_id));
+            } else {
+                query = query.filter(pike_role::service_id.is_null());
+            }
 
-                let role = query
-                    .first::<RoleModel>(self.conn)
-                    .map(Some)
-                    .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
-                    .map_err(|err| {
-                        PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
-                    })?;
-
-                let mut query = pike_inherit_from::table
-                    .into_boxed()
-                    .select(pike_inherit_from::all_columns)
-                    .filter(
-                        pike_inherit_from::role_name
-                            .eq(&name)
-                            .and(pike_inherit_from::org_id.eq(&org_id))
-                            .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    );
-
-                if let Some(service_id) = service_id {
-                    query = query.filter(pike_inherit_from::service_id.eq(service_id));
-                } else {
-                    query = query.filter(pike_inherit_from::service_id.is_null());
-                }
-
-                let inherit_from = query.load::<InheritFromModel>(self.conn).map_err(|err| {
+            let role = query
+                .first::<RoleModel>(self.conn)
+                .map(Some)
+                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map_err(|err| {
                     PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
                 })?;
 
-                let mut query = pike_permissions::table
-                    .into_boxed()
-                    .select(pike_permissions::all_columns)
-                    .filter(
-                        pike_permissions::role_name
-                            .eq(&name)
-                            .and(pike_permissions::org_id.eq(&org_id))
-                            .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    );
+            let mut query = pike_inherit_from::table
+                .into_boxed()
+                .select(pike_inherit_from::all_columns)
+                .filter(
+                    pike_inherit_from::role_name
+                        .eq(&name)
+                        .and(pike_inherit_from::org_id.eq(&org_id))
+                        .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
 
-                if let Some(service_id) = service_id {
-                    query = query.filter(pike_permissions::service_id.eq(service_id));
-                } else {
-                    query = query.filter(pike_permissions::service_id.is_null());
-                }
+            if let Some(service_id) = service_id {
+                query = query.filter(pike_inherit_from::service_id.eq(service_id));
+            } else {
+                query = query.filter(pike_inherit_from::service_id.is_null());
+            }
 
-                let permissions = query.load::<PermissionModel>(self.conn).map_err(|err| {
-                    PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
-                })?;
+            let inherit_from = query.load::<InheritFromModel>(self.conn).map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
-                let mut query = pike_allowed_orgs::table
-                    .into_boxed()
-                    .select(pike_allowed_orgs::all_columns)
-                    .filter(
-                        pike_allowed_orgs::role_name
-                            .eq(&name)
-                            .and(pike_allowed_orgs::org_id.eq(&org_id))
-                            .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    );
+            let mut query = pike_permissions::table
+                .into_boxed()
+                .select(pike_permissions::all_columns)
+                .filter(
+                    pike_permissions::role_name
+                        .eq(&name)
+                        .and(pike_permissions::org_id.eq(&org_id))
+                        .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
 
-                if let Some(service_id) = service_id {
-                    query = query.filter(pike_allowed_orgs::service_id.eq(service_id));
-                } else {
-                    query = query.filter(pike_allowed_orgs::service_id.is_null());
-                }
+            if let Some(service_id) = service_id {
+                query = query.filter(pike_permissions::service_id.eq(service_id));
+            } else {
+                query = query.filter(pike_permissions::service_id.is_null());
+            }
 
-                let allowed_orgs = query.load::<AllowedOrgModel>(self.conn).map_err(|err| {
-                    PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
-                })?;
+            let permissions = query.load::<PermissionModel>(self.conn).map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
-                Ok(role.map(|r| Role::from((r, inherit_from, permissions, allowed_orgs))))
-            })
+            let mut query = pike_allowed_orgs::table
+                .into_boxed()
+                .select(pike_allowed_orgs::all_columns)
+                .filter(
+                    pike_allowed_orgs::role_name
+                        .eq(&name)
+                        .and(pike_allowed_orgs::org_id.eq(&org_id))
+                        .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(pike_allowed_orgs::service_id.eq(service_id));
+            } else {
+                query = query.filter(pike_allowed_orgs::service_id.is_null());
+            }
+
+            let allowed_orgs = query.load::<AllowedOrgModel>(self.conn).map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
+
+            Ok(role.map(|r| Role::from((r, inherit_from, permissions, allowed_orgs))))
+        })
     }
 }
 
@@ -143,7 +140,7 @@ impl<'a> PikeStoreFetchRoleOperation for PikeStoreOperations<'a, diesel::sqlite:
         org_id: &str,
         service_id: Option<&str>,
     ) -> Result<Option<Role>, PikeStoreError> {
-        self.conn.immediate_transaction::<_, PikeStoreError, _>(|| {
+        self.conn.transaction::<_, PikeStoreError, _>(|| {
             let mut query = pike_role::table
                 .into_boxed()
                 .select(pike_role::all_columns)


### PR DESCRIPTION
Have postgres implementation of fetch_role use transaction instead of
the transaction build, and have the sqlite implementation use
transaction instead of immediate_transaction. This is to make the
implementations consistent with the other store operations.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>