### PR TITLE
List and show agents in the CLI

### DIFF
--- a/cli/man/grid-agent-create.1.md
+++ b/cli/man/grid-agent-create.1.md
@@ -1,4 +1,5 @@
 % GRID-AGENT-CREATE(1) Cargill, Incorporated | Grid
+
 <!--
   Copyright 2021 Cargill Incorporated
   Licensed under Creative Commons Attribution 4.0 International License
@@ -79,6 +80,9 @@ SEE ALSO
 ========
 | `grid organization(1)`
 | `grid agent(1)`
+| `grid agent create(1)`
+| `grid agent list(1)`
+| `grid agent show(1)`
 | `grid agent update(1)`
 | `grid role(1)`
 |

--- a/cli/man/grid-agent-list.1.md
+++ b/cli/man/grid-agent-list.1.md
@@ -1,0 +1,105 @@
+% GRID-agent-LIST(1) Cargill, Incorporated | Grid Commands
+
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-agent-list** — List all agents
+
+SYNOPSIS
+========
+
+**grid agent list** \[**FLAGS**\]
+
+DESCRIPTION
+===========
+
+List all agents in grid. If the `service_id` flag is specified, only
+agents corresponding to that `service_id` will be shown.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+output
+
+`--url`
+: URL for the REST API
+
+`--line-per-role`
+: Displays agent information for each role on it's own line. Useful when filtering by role.
+
+`-F`, `--format=FORMAT`
+: Specifies the output format of the list. Possible values for formatting are `human` and `csv`. Defaults to `human`.
+
+EXAMPLES
+========
+
+The command
+
+```
+$ grid agent list
+```
+
+Will list all agents and their associated roles
+
+```
+PUBLIC_KEY     ORG_ID ACTIVE ROLES              
+03a3374bc95... crgl   true   productowner, admin
+```
+
+```
+$ grid agent list --line-per-role
+```
+
+Will list all agents with roles on their own lines.
+
+```
+PUBLIC_KEY     ORG_ID ACTIVE ROLES              
+03a3374bc95... crgl   true   productowner
+03a3374bc95... crgl   true   admin
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+if `-U` or `--url` is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+
+| `grid organization(1)`
+| `grid agent(1)`
+| `grid agent create(1)`
+| `grid agent show(1)`
+| `grid agent update(1)`
+| `grid role(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/cli/man/grid-agent-show.1.md
+++ b/cli/man/grid-agent-show.1.md
@@ -1,0 +1,91 @@
+% GRID-agent-SHOW(1) Cargill, Incorporated | Grid Commands
+
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+# NAME
+
+**grid-agent-show** — Show the details of a specific agent
+
+# SYNOPSIS
+
+**grid agent show** \[**FLAGS**\] \[**OPTIONS**\] <public_key>
+
+# DESCRIPTION
+
+Show the complete details of a specific agent. This command requires the
+`<public_key>` argument to specify the unique identifier for the agent that is to be retrieved.
+
+# FLAGS
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+output
+
+`--url`
+: URL for the REST API
+
+# ARGS
+
+`<public_key>`
+: A public key that is used as an unique identifier for agents
+
+# EXAMPLES
+
+The command
+
+```
+$ grid agent show 03a3374bc95109d0fe4be641fa0100853de34f46452bd688936f73ad986729e9c0
+```
+
+Will show the details of the specified agent
+
+```
+Public Key: 03a3374bc95109d0fe4be641fa0100853de34f46452bd688936f73ad986729e9c0
+Organization Id: crgl
+Active: true
+Service ID: b8xWJ-0QcMy::gsAA
+Roles: productowner, admin
+Metadata:
+    field1: value1
+    field2: value2
+```
+
+# ENVIRONMENT VARIABLES
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+if `-U` or `--url` is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+# SEE ALSO
+
+| `grid organization(1)`
+| `grid agent(1)`
+| `grid agent create(1)`
+| `grid agent list(1)`
+| `grid agent update(1)`
+| `grid role(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/cli/man/grid-agent-update.1.md
+++ b/cli/man/grid-agent-update.1.md
@@ -80,6 +80,8 @@ SEE ALSO
 | `grid organization(1)`
 | `grid agent(1)`
 | `grid agent create(1)`
+| `grid agent list(1)`
+| `grid agent show(1)`
 | `grid role(1)`
 |
 | Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/src/actions/agents.rs
+++ b/cli/src/actions/agents.rs
@@ -15,14 +15,30 @@
  * -----------------------------------------------------------------------------
  */
 
+use crate::actions::ListSlice;
 use crate::error::CliError;
 use crate::http::submit_batches;
 use crate::transaction::pike_batch_builder;
+use reqwest::Client;
+use serde::Deserialize;
+use std::cmp;
+use std::collections::HashMap;
+
 use grid_sdk::{
     pike::addressing::PIKE_NAMESPACE,
     protocol::pike::payload::{Action, CreateAgentAction, PikePayloadBuilder, UpdateAgentAction},
     protos::IntoProto,
 };
+
+#[derive(Debug, Deserialize)]
+pub struct AgentSlice {
+    pub public_key: String,
+    pub org_id: String,
+    pub active: bool,
+    pub roles: Vec<String>,
+    pub service_id: Option<String>,
+    pub metadata: HashMap<String, String>,
+}
 
 pub fn do_create_agent(
     url: &str,
@@ -70,4 +86,177 @@ pub fn do_update_agent(
         .create_batch_list();
 
     submit_batches(url, wait, &batch_list, service_id.as_deref())
+}
+
+pub fn do_list_agents(
+    url: &str,
+    service_id: Option<String>,
+    format: &str,
+    line_per_role: bool,
+) -> Result<(), CliError> {
+    let client = Client::new();
+    let mut final_url = format!("{}/agent", url);
+    if let Some(service_id) = service_id {
+        final_url = format!("{}?service_id={}", final_url, service_id);
+    }
+
+    let mut agents = Vec::new();
+
+    loop {
+        let mut response = client.get(&final_url).send()?;
+
+        if !response.status().is_success() {
+            return Err(CliError::DaemonError(response.text()?));
+        }
+
+        let mut agents_list = response.json::<ListSlice<AgentSlice>>()?;
+
+        agents.append(&mut agents_list.data);
+
+        if let Some(next) = agents_list.paging.next {
+            final_url = format!("{}{}", url, next);
+        } else {
+            break;
+        }
+    }
+
+    display_agents_info(&agents, format, line_per_role);
+    Ok(())
+}
+
+pub fn do_show_agents(
+    url: &str,
+    public_key: &str,
+    service_id: Option<String>,
+) -> Result<(), CliError> {
+    let client = Client::new();
+    let mut final_url = format!("{}/agent/{}", url, public_key);
+    if let Some(service_id) = service_id {
+        final_url = format!("{}?service_id={}", final_url, service_id);
+    }
+
+    let mut response = client.get(&final_url).send()?;
+
+    if !response.status().is_success() {
+        return Err(CliError::DaemonError(response.text()?));
+    }
+
+    let agent = response.json::<AgentSlice>()?;
+
+    display_agent(&agent);
+
+    Ok(())
+}
+
+pub fn display_agent(agent: &AgentSlice) {
+    println!(
+        "{}",
+        vec![
+            ("Public Key", &agent.public_key),
+            ("Org ID", &agent.org_id),
+            ("Active", &agent.active.to_string()),
+            ("Roles", &agent.roles.join(", ")),
+            (
+                "Metadata",
+                &agent
+                    .metadata
+                    .iter()
+                    .map(|(key, value)| { format!("\n\t{}: {}", key, value) })
+                    .collect::<Vec<String>>()
+                    .join("")
+            ),
+        ]
+        .iter()
+        .map(|tuple| { format!("{}: {}", tuple.0, tuple.1) })
+        .collect::<Vec<String>>()
+        .join("\n")
+    );
+}
+
+pub fn display_agents_info(agents: &[AgentSlice], format: &str, line_per_role: bool) {
+    let column_names = if line_per_role {
+        vec!["PUBLIC_KEY", "ORG_ID", "ACTIVE", "ROLE"]
+    } else {
+        vec!["PUBLIC_KEY", "ORG_ID", "ACTIVE", "ROLES"]
+    };
+
+    let row_values: Vec<Vec<String>> = if line_per_role {
+        agents
+            .iter()
+            .flat_map(|agent| {
+                agent.roles.iter().map(move |role| {
+                    vec![
+                        agent.public_key.to_string(),
+                        agent.org_id.to_string(),
+                        agent.active.to_string(),
+                        role.to_string(),
+                    ]
+                })
+            })
+            .collect()
+    } else {
+        agents
+            .iter()
+            .map(|agent| {
+                vec![
+                    agent.public_key.to_string(),
+                    agent.org_id.to_string(),
+                    agent.active.to_string(),
+                    agent.roles.join(", "),
+                ]
+            })
+            .collect()
+    };
+
+    if format == "csv" {
+        print_csv(column_names, row_values);
+    } else {
+        print_human_readable(column_names, row_values);
+    }
+}
+
+fn print_csv(column_names: Vec<&str>, row_values: Vec<Vec<String>>) {
+    // print header row
+    let mut header_row = "".to_owned();
+    for column in &column_names {
+        header_row += &format!("\"{}\",", column);
+    }
+    header_row.pop();
+    println!("{}", header_row);
+
+    // print each row
+    for row in row_values {
+        let mut print_row = "".to_owned();
+        for cell in row.iter().take(column_names.len()) {
+            print_row += &format!("\"{}\",", cell);
+        }
+        print_row.pop();
+        println!("{}", print_row);
+    }
+}
+
+fn print_human_readable(column_names: Vec<&str>, row_values: Vec<Vec<String>>) {
+    // Calculate max-widths for columns
+    let mut widths: Vec<usize> = column_names.iter().map(|name| name.len()).collect();
+    row_values.iter().for_each(|row| {
+        for i in 0..widths.len() {
+            widths[i] = cmp::max(widths[i], row[i].len())
+        }
+    });
+
+    // print header row
+    let mut header_row = "".to_owned();
+    for i in 0..column_names.len() {
+        header_row += &format!("{:width$} ", column_names[i], width = widths[i]);
+    }
+    println!("{}", header_row);
+
+    // print each row
+    for row in row_values {
+        let mut print_row = "".to_owned();
+        for i in 0..column_names.len() {
+            print_row += &format!("{:width$} ", row[i], width = widths[i]);
+        }
+        println!("{}", print_row);
+    }
 }

--- a/cli/src/actions/mod.rs
+++ b/cli/src/actions/mod.rs
@@ -48,6 +48,12 @@ pub struct Paging {
     last: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct ListSlice<T> {
+    pub data: Vec<T>,
+    pub paging: Paging,
+}
+
 #[cfg(feature = "admin-keygen")]
 pub mod admin;
 pub mod agents;


### PR DESCRIPTION
Includes man-pages. List includes formatting human and csv types, along
with the ability to list roles on their own lines. The Show command
gives additional information, and requires a public key as the
identifier. (Agent ID is synonymous with public key.)