### PR TITLE
Run cron builds at 1am

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     }
 
     triggers {
-        cron(env.BRANCH_NAME == 'main' ? 'H 2 * * *' : '')
+        cron(env.BRANCH_NAME == 'main' ? 'H 1 * * *' : '')
     }
 
     options {


### PR DESCRIPTION
Cron builds running at 2am are failing regularly. Moving the build to
run earlier will either fix the problem or disprove a theory.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>