### PR TITLE
Fix typos in Pike smart contract

### DIFF
--- a/contracts/pike/src/handler.rs
+++ b/contracts/pike/src/handler.rs
@@ -860,7 +860,7 @@ fn update_agent(
     let mut agent = match state.get_agent(payload.get_public_key()) {
         Ok(None) => {
             return Err(ApplyError::InvalidTransaction(format!(
-                "Agent does not exists: {}",
+                "Agent does not exist: {}",
                 payload.get_public_key(),
             )))
         }
@@ -1127,7 +1127,7 @@ fn update_org(
     let mut organization = match state.get_organization(payload.get_id()) {
         Ok(None) => {
             return Err(ApplyError::InvalidTransaction(format!(
-                "Organization does not exist exists: {}",
+                "Organization does not exist: {}",
                 payload.get_id(),
             )))
         }


### PR DESCRIPTION
This change fixes several typos present in the Pike smart contract's
`handler` module.

Signed-off-by: Shannyn Telander <telander@bitwise.io>