### PR TITLE
Move sdk permissions into pike/permissions module

### DIFF
--- a/contracts/location/src/handler.rs
+++ b/contracts/location/src/handler.rs
@@ -29,7 +29,7 @@ cfg_if! {
 
 use grid_sdk::{
     location::addressing::GRID_NAMESPACE,
-    permissions::PermissionChecker,
+    pike::permissions::PermissionChecker,
     protocol::location::{
         payload::{
             Action, LocationCreateAction, LocationDeleteAction, LocationNamespace, LocationPayload,

--- a/contracts/pike/src/handler.rs
+++ b/contracts/pike/src/handler.rs
@@ -30,8 +30,8 @@ cfg_if! {
 }
 
 use grid_sdk::{
-    permissions::PermissionChecker,
     pike::addressing::PIKE_NAMESPACE,
+    pike::permissions::PermissionChecker,
     protocol::pike::state::{AlternateIdIndexEntryBuilder, RoleBuilder},
     protos::{
         pike_payload::{

--- a/contracts/product/src/handler.rs
+++ b/contracts/product/src/handler.rs
@@ -28,7 +28,7 @@ cfg_if! {
 }
 
 use grid_sdk::{
-    permissions::PermissionChecker,
+    pike::permissions::PermissionChecker,
     product::addressing::GRID_NAMESPACE,
     protocol::product::{
         payload::{

--- a/contracts/schema/src/handler.rs
+++ b/contracts/schema/src/handler.rs
@@ -27,7 +27,7 @@ cfg_if! {
     }
 }
 
-use grid_sdk::permissions::PermissionChecker;
+use grid_sdk::pike::permissions::PermissionChecker;
 use grid_sdk::protocol::schema::payload::{
     Action, SchemaCreateAction, SchemaPayload, SchemaUpdateAction,
 };

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -47,8 +47,6 @@ pub mod location;
 pub mod migrations;
 pub mod paging;
 #[cfg(feature = "pike")]
-pub mod permissions;
-#[cfg(feature = "pike")]
 pub mod pike;
 #[cfg(feature = "product")]
 pub mod product;

--- a/sdk/src/pike/mod.rs
+++ b/sdk/src/pike/mod.rs
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 pub mod addressing;
+pub mod permissions;
 pub mod store;

--- a/sdk/src/pike/permissions/error.rs
+++ b/sdk/src/pike/permissions/error.rs
@@ -1,0 +1,73 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::protos::ProtoConversionError;
+use std::error::Error;
+use std::fmt;
+
+cfg_if! {
+  if #[cfg(target_arch = "wasm32")] {
+      use sabre_sdk::WasmSdkError as ContextError;
+  } else {
+      use sawtooth_sdk::processor::handler::ContextError;
+  }
+}
+
+#[derive(Debug)]
+pub enum PermissionCheckerError {
+    /// Returned for an error originating at the TransactionContext.
+    Context(ContextError),
+    /// Returned for an invalid agent public key.
+    InvalidPublicKey(String),
+    /// Returned for an invalid role.
+    InvalidRole(String),
+    /// Returned for an error in the protobuf data.
+    ProtoConversion(ProtoConversionError),
+}
+
+impl fmt::Display for PermissionCheckerError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            PermissionCheckerError::Context(ref e) => e.fmt(f),
+            PermissionCheckerError::InvalidPublicKey(ref msg) => {
+                write!(f, "InvalidPublicKey: {}", msg)
+            }
+            PermissionCheckerError::InvalidRole(ref msg) => write!(f, "InvalidRole: {}", msg),
+            PermissionCheckerError::ProtoConversion(ref e) => e.fmt(f),
+        }
+    }
+}
+
+impl Error for PermissionCheckerError {
+    fn cause(&self) -> Option<&dyn Error> {
+        match *self {
+            PermissionCheckerError::Context(_) => None,
+            PermissionCheckerError::InvalidPublicKey(_) => None,
+            PermissionCheckerError::InvalidRole(_) => None,
+            PermissionCheckerError::ProtoConversion(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<ContextError> for PermissionCheckerError {
+    fn from(err: ContextError) -> PermissionCheckerError {
+        PermissionCheckerError::Context(err)
+    }
+}
+
+impl From<ProtoConversionError> for PermissionCheckerError {
+    fn from(err: ProtoConversionError) -> PermissionCheckerError {
+        PermissionCheckerError::ProtoConversion(err)
+    }
+}


### PR DESCRIPTION
/sdk/src/permissions.rs was split apart into two separate files,
"/sdk/pike/permissions/mod.rs" which contains the PermissionChecker
implementation, and "/sdk/pike/permissions/error.rs" which contains the
PermissionCheckerError implementation. This means also that the import
path changed from grid_sdk::permissions to grid_sdk::pike::permissions,
so the handler files requesting permissions has also updated.

Signed-off-by: Kevin Johnson <kevin_johnson@cargill.com>