### PR TITLE
Update copyright for pike modules

### DIFF
--- a/sdk/protos/pike_payload.proto
+++ b/sdk/protos/pike_payload.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Intel Corporation
+// Copyright 2017-2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/protos/pike_state.proto
+++ b/sdk/protos/pike_state.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Intel Corporation
+// Copyright 2017-2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/migrations/diesel/postgres/mod.rs
+++ b/sdk/src/migrations/diesel/postgres/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/migrations/diesel/sqlite/mod.rs
+++ b/sdk/src/migrations/diesel/sqlite/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/pike/store/diesel/operations/add_agent.rs
+++ b/sdk/src/pike/store/diesel/operations/add_agent.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/pike/store/diesel/operations/add_organization.rs
+++ b/sdk/src/pike/store/diesel/operations/add_organization.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/pike/store/diesel/operations/add_role.rs
+++ b/sdk/src/pike/store/diesel/operations/add_role.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/pike/store/diesel/operations/get_agent.rs
+++ b/sdk/src/pike/store/diesel/operations/get_agent.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/pike/store/diesel/operations/get_organization.rs
+++ b/sdk/src/pike/store/diesel/operations/get_organization.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/pike/store/diesel/operations/get_role.rs
+++ b/sdk/src/pike/store/diesel/operations/get_role.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/pike/store/diesel/operations/list_agents.rs
+++ b/sdk/src/pike/store/diesel/operations/list_agents.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/pike/store/diesel/operations/list_organizations.rs
+++ b/sdk/src/pike/store/diesel/operations/list_organizations.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/pike/store/diesel/operations/list_roles_for_organization.rs
+++ b/sdk/src/pike/store/diesel/operations/list_roles_for_organization.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/pike/store/diesel/operations/update_agent.rs
+++ b/sdk/src/pike/store/diesel/operations/update_agent.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/protocol/pike/payload.rs
+++ b/sdk/src/protocol/pike/payload.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Cargill Incorporated
+// Copyright 2019-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/src/protocol/pike/state.rs
+++ b/sdk/src/protocol/pike/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Cargill Incorporated
+// Copyright 2019-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
All of these files were substantially updated in 2021 and the copyright
header needs to reflect that.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>