### PR TITLE
Update Commit store errors

### DIFF
--- a/sdk/src/commits/store/diesel/operations/add_commit.rs
+++ b/sdk/src/commits/store/diesel/operations/add_commit.rs
@@ -17,11 +17,7 @@ use crate::commits::store::diesel::models::{CommitModel, NewCommitModel};
 use crate::commits::store::diesel::{schema::commits, CommitStoreError};
 use crate::error::{ConstraintViolationError, ConstraintViolationType, InternalError};
 
-use diesel::{
-    dsl::insert_into,
-    prelude::*,
-    result::{DatabaseErrorKind, Error as dsl_error},
-};
+use diesel::{dsl::insert_into, prelude::*, result::Error as dsl_error};
 
 pub(in crate::commits) trait CommitStoreAddCommitOperation {
     fn add_commit(&self, commit: NewCommitModel) -> Result<(), CommitStoreError>;
@@ -54,26 +50,7 @@ impl<'a> CommitStoreAddCommitOperation for CommitStoreOperations<'a, diesel::pg:
             insert_into(commits::table)
                 .values(commit)
                 .execute(self.conn)
-                .map(|_| ())
-                .map_err(|err| match err {
-                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::Unique,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::ForeignKey,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-                })?;
+                .map(|_| ())?;
             Ok(())
         })
     }
@@ -108,26 +85,7 @@ impl<'a> CommitStoreAddCommitOperation
             insert_into(commits::table)
                 .values(commit)
                 .execute(self.conn)
-                .map(|_| ())
-                .map_err(|err| match err {
-                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::Unique,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::ForeignKey,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-                })?;
+                .map(|_| ())?;
             Ok(())
         })
     }

--- a/sdk/src/commits/store/diesel/operations/create_db_commit_from_commit_event.rs
+++ b/sdk/src/commits/store/diesel/operations/create_db_commit_from_commit_event.rs
@@ -15,7 +15,7 @@
 use std::convert::TryInto;
 
 use super::CommitStoreOperations;
-use crate::commits::store::diesel::{schema::commits, Commit, CommitEvent, CommitEventError};
+use crate::commits::store::diesel::{schema::commits, Commit, CommitEvent, CommitStoreError};
 use crate::error::InternalError;
 
 use diesel::{dsl::max, prelude::*};
@@ -24,7 +24,7 @@ pub(in crate::commits) trait CommitStoreCreateDbCommitFromCommitEventOperation {
     fn create_db_commit_from_commit_event(
         &self,
         event: &CommitEvent,
-    ) -> Result<Option<Commit>, CommitEventError>;
+    ) -> Result<Option<Commit>, CommitStoreError>;
 }
 
 #[cfg(feature = "postgres")]
@@ -34,12 +34,12 @@ impl<'a> CommitStoreCreateDbCommitFromCommitEventOperation
     fn create_db_commit_from_commit_event(
         &self,
         event: &CommitEvent,
-    ) -> Result<Option<Commit>, CommitEventError> {
-        self.conn.transaction::<_, CommitEventError, _>(|| {
+    ) -> Result<Option<Commit>, CommitStoreError> {
+        self.conn.transaction::<_, CommitStoreError, _>(|| {
             let commit_id = event.id.clone();
             let commit_num = match event.height {
                 Some(height_u64) => height_u64.try_into().map_err(|err| {
-                    CommitEventError::InternalError(InternalError::from_source(Box::new(err)))
+                    CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
                 })?,
                 None => commits::table
                     .select(max(commits::commit_num))
@@ -49,7 +49,7 @@ impl<'a> CommitStoreCreateDbCommitFromCommitEventOperation
                         None => 0,
                     })
                     .map_err(|err| {
-                        CommitEventError::InternalError(InternalError::from_source(Box::new(err)))
+                        CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
                     })?,
             };
             let service_id = event.service_id.clone();
@@ -69,12 +69,12 @@ impl<'a> CommitStoreCreateDbCommitFromCommitEventOperation
     fn create_db_commit_from_commit_event(
         &self,
         event: &CommitEvent,
-    ) -> Result<Option<Commit>, CommitEventError> {
-        self.conn.transaction::<_, CommitEventError, _>(|| {
+    ) -> Result<Option<Commit>, CommitStoreError> {
+        self.conn.transaction::<_, CommitStoreError, _>(|| {
             let commit_id = event.id.clone();
             let commit_num = match event.height {
                 Some(height_u64) => height_u64.try_into().map_err(|err| {
-                    CommitEventError::InternalError(InternalError::from_source(Box::new(err)))
+                    CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
                 })?,
                 None => commits::table
                     .select(max(commits::commit_num))
@@ -84,7 +84,7 @@ impl<'a> CommitStoreCreateDbCommitFromCommitEventOperation
                         None => 0,
                     })
                     .map_err(|err| {
-                        CommitEventError::InternalError(InternalError::from_source(Box::new(err)))
+                        CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
                     })?,
             };
             let service_id = event.service_id.clone();

--- a/sdk/src/commits/store/diesel/operations/resolve_fork.rs
+++ b/sdk/src/commits/store/diesel/operations/resolve_fork.rs
@@ -16,12 +16,10 @@ use super::CommitStoreOperations;
 use crate::commits::store::diesel::{schema::chain_record, schema::commits};
 use crate::commits::store::CommitStoreError;
 use crate::commits::MAX_COMMIT_NUM;
-use crate::error::{ConstraintViolationError, ConstraintViolationType, InternalError};
 
 use diesel::{
     dsl::{delete, update},
     prelude::*,
-    result::{DatabaseErrorKind, Error as dsl_error},
 };
 
 pub(in crate::commits) trait CommitStoreResolveForkOperation {
@@ -35,75 +33,18 @@ impl<'a> CommitStoreResolveForkOperation for CommitStoreOperations<'a, diesel::p
             delete(chain_record::table)
                 .filter(chain_record::start_commit_num.ge(commit_num))
                 .execute(self.conn)
-                .map(|_| ())
-                .map_err(|err| match err {
-                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::Unique,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::ForeignKey,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-                })?;
+                .map(|_| ())?;
 
             update(chain_record::table)
                 .filter(chain_record::end_commit_num.ge(commit_num))
                 .set(chain_record::end_commit_num.eq(MAX_COMMIT_NUM))
                 .execute(self.conn)
-                .map(|_| ())
-                .map_err(|err| match err {
-                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::Unique,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::ForeignKey,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-                })?;
+                .map(|_| ())?;
 
             delete(commits::table)
                 .filter(commits::commit_num.ge(commit_num))
                 .execute(self.conn)
-                .map(|_| ())
-                .map_err(|err| match err {
-                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::Unique,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::ForeignKey,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-                })?;
+                .map(|_| ())?;
 
             Ok(())
         })
@@ -119,75 +60,18 @@ impl<'a> CommitStoreResolveForkOperation
             delete(chain_record::table)
                 .filter(chain_record::start_commit_num.ge(commit_num))
                 .execute(self.conn)
-                .map(|_| ())
-                .map_err(|err| match err {
-                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::Unique,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::ForeignKey,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-                })?;
+                .map(|_| ())?;
 
             update(chain_record::table)
                 .filter(chain_record::end_commit_num.ge(commit_num))
                 .set(chain_record::end_commit_num.eq(MAX_COMMIT_NUM))
                 .execute(self.conn)
-                .map(|_| ())
-                .map_err(|err| match err {
-                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::Unique,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::ForeignKey,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-                })?;
+                .map(|_| ())?;
 
             delete(commits::table)
                 .filter(commits::commit_num.ge(commit_num))
                 .execute(self.conn)
-                .map(|_| ())
-                .map_err(|err| match err {
-                    dsl_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::Unique,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    dsl_error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, _) => {
-                        CommitStoreError::ConstraintViolationError(
-                            ConstraintViolationError::from_source_with_violation_type(
-                                ConstraintViolationType::ForeignKey,
-                                Box::new(err),
-                            ),
-                        )
-                    }
-                    _ => CommitStoreError::InternalError(InternalError::from_source(Box::new(err))),
-                })?;
+                .map(|_| ())?;
 
             Ok(())
         })

--- a/sdk/src/commits/store/mod.rs
+++ b/sdk/src/commits/store/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 pub mod diesel;
 mod error;
 
-pub use error::{CommitEventError, CommitStoreError};
+pub use error::CommitStoreError;
 
 /// Represents a Grid commit
 #[derive(Clone, Debug, Serialize, PartialEq)]
@@ -91,7 +91,7 @@ pub trait CommitStore: Send + Sync {
     fn create_db_commit_from_commit_event(
         &self,
         event: &CommitEvent,
-    ) -> Result<Option<Commit>, CommitEventError>;
+    ) -> Result<Option<Commit>, CommitStoreError>;
 }
 
 impl<CS> CommitStore for Box<CS>
@@ -124,7 +124,7 @@ where
     fn create_db_commit_from_commit_event(
         &self,
         event: &CommitEvent,
-    ) -> Result<Option<Commit>, CommitEventError> {
+    ) -> Result<Option<Commit>, CommitStoreError> {
         (**self).create_db_commit_from_commit_event(event)
     }
 }


### PR DESCRIPTION
This updates the commit store error module. This removes the
CommitEventError error type as it was a duplicate of CommitStoreError.
This also moves the From implementations of CommitStoreError to the
error.rs file to be in line with the best practices. Lastly, this
updates the CommitStore implementations to use the From implementations.

Signed-off-by: Davey Newhall <newhall@bitwise.io>