### PR TITLE
Use `optional()` method to convert results

### DIFF
--- a/sdk/src/commits/store/diesel/operations/add_commit.rs
+++ b/sdk/src/commits/store/diesel/operations/add_commit.rs
@@ -35,13 +35,7 @@ impl<'a> CommitStoreAddCommitOperation for CommitStoreOperations<'a, diesel::pg:
                 .filter(commits::commit_id.eq(&commit.commit_id))
                 .first::<CommitModel>(self.conn)
                 .map(Some)
-                .or_else(|err| {
-                    if err == dsl_error::NotFound {
-                        Ok(None)
-                    } else {
-                        Err(err)
-                    }
-                })
+                .optional()
                 .map_err(|err| {
                     CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
                 })?;
@@ -89,13 +83,7 @@ impl<'a> CommitStoreAddCommitOperation
                 .filter(commits::commit_id.eq(&commit.commit_id))
                 .first::<CommitModel>(self.conn)
                 .map(Some)
-                .or_else(|err| {
-                    if err == dsl_error::NotFound {
-                        Ok(None)
-                    } else {
-                        Err(err)
-                    }
-                })
+                .optional()
                 .map_err(|err| {
                     CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
                 })?;

--- a/sdk/src/commits/store/diesel/operations/get_commit_by_commit_num.rs
+++ b/sdk/src/commits/store/diesel/operations/get_commit_by_commit_num.rs
@@ -18,7 +18,7 @@ use crate::commits::store::diesel::{
 };
 use crate::error::InternalError;
 
-use diesel::{prelude::*, result::Error::NotFound};
+use diesel::prelude::*;
 
 pub(in crate::commits) trait CommitStoreGetCommitByCommitNumOperation {
     fn get_commit_by_commit_num(&self, commit_num: i64)
@@ -38,8 +38,8 @@ impl<'a> CommitStoreGetCommitByCommitNumOperation
                 .select(commits::all_columns)
                 .filter(commits::commit_num.eq(&commit_num))
                 .first::<CommitModel>(self.conn)
-                .map(|commit| Some(Commit::from(commit)))
-                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map(Commit::from)
+                .optional()
                 .map_err(|err| {
                     CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
                 })
@@ -60,8 +60,8 @@ impl<'a> CommitStoreGetCommitByCommitNumOperation
                 .select(commits::all_columns)
                 .filter(commits::commit_num.eq(&commit_num))
                 .first::<CommitModel>(self.conn)
-                .map(|commit| Some(Commit::from(commit)))
-                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map(Commit::from)
+                .optional()
                 .map_err(|err| {
                     CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
                 })

--- a/sdk/src/commits/store/diesel/operations/get_current_commit_id.rs
+++ b/sdk/src/commits/store/diesel/operations/get_current_commit_id.rs
@@ -16,7 +16,7 @@ use super::CommitStoreOperations;
 use crate::commits::store::diesel::{models::CommitModel, schema::commits, CommitStoreError};
 use crate::error::InternalError;
 
-use diesel::{prelude::*, result::Error::NotFound};
+use diesel::prelude::*;
 
 pub(in crate::commits) trait CommitStoreGetCurrentCommitIdOperation {
     fn get_current_commit_id(&self) -> Result<Option<String>, CommitStoreError>;
@@ -33,8 +33,8 @@ impl<'a> CommitStoreGetCurrentCommitIdOperation
                 .order_by(commits::commit_num.desc())
                 .limit(1)
                 .first::<CommitModel>(self.conn)
-                .map(|commit| Some(commit.commit_id))
-                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map(|commit| commit.commit_id)
+                .optional()
                 .map_err(|err| {
                     CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
                 })
@@ -53,8 +53,8 @@ impl<'a> CommitStoreGetCurrentCommitIdOperation
                 .order_by(commits::commit_num.desc())
                 .limit(1)
                 .first::<CommitModel>(self.conn)
-                .map(|commit| Some(commit.commit_id))
-                .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+                .map(|commit| commit.commit_id)
+                .optional()
                 .map_err(|err| {
                     CommitStoreError::InternalError(InternalError::from_source(Box::new(err)))
                 })


### PR DESCRIPTION
This updates the commit store operations to use the `optional()` method
to handle Diesel Results. This method handles converting the results
into Options or the appropriate NotFound errors.

Signed-off-by: Davey Newhall <newhall@bitwise.io>