### PR TITLE
Add Schema namespace to location txn inputs

### DIFF
--- a/cli/src/actions/locations.rs
+++ b/cli/src/actions/locations.rs
@@ -31,6 +31,7 @@ use grid_sdk::{
         schema::state::{LatLongBuilder, PropertyValue, PropertyValueBuilder},
     },
     protos::IntoProto,
+    schemas::addressing::GRID_SCHEMA_NAMESPACE,
 };
 use reqwest::Client;
 use serde::Deserialize;
@@ -170,6 +171,7 @@ fn submit_payloads(
         builder.add_transaction(
             &action.into_proto()?,
             &[
+                GRID_SCHEMA_NAMESPACE.to_string(),
                 PIKE_NAMESPACE.to_string(),
                 GRID_LOCATION_NAMESPACE.to_string(),
             ],


### PR DESCRIPTION
This was causing location transactions to fail when the smart contract
attempted to read the location schema.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>