### PR TITLE
Add brief CommitStore module doc comment

### DIFF
--- a/sdk/src/commits/store/diesel/mod.rs
+++ b/sdk/src/commits/store/diesel/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//! Database-backed implementation of the [CommitStore], powered by [diesel].
 
 pub(in crate::commits) mod models;
 mod operations;

--- a/sdk/src/commits/store/diesel/operations/resolve_fork.rs
+++ b/sdk/src/commits/store/diesel/operations/resolve_fork.rs
@@ -24,6 +24,19 @@ use diesel::{
     result::{DatabaseErrorKind, Error as dsl_error},
 };
 
+/// This database operation takes one argument: `commit_num`. This argument is
+/// the height of the commit that will be replaced. The commit is only replaced
+/// if it is not a duplicate.
+///
+/// If a fork is detected when attempting to add a commit, and the existing
+/// commit in the store is not a duplicate of the commit that is being added,
+/// the existing commit and anything with a `start_commit_num` greater than
+/// the height of the commit being added is removed. Then, the end_commit_num`
+/// for any record that is greater than the height of the commit being added is
+/// set to `MAX_COMMIT_NUM`, meaning it is the current record. Finally, the
+/// commit being replaced is deleted. This allows for the database handler to
+/// call the operation to insert the record at the correct height.
+
 pub(in crate::commits) trait CommitStoreResolveForkOperation {
     fn resolve_fork(&self, commit_num: i64) -> Result<(), CommitStoreError>;
 }


### PR DESCRIPTION
This adds a brief CommitStore module doc comment to the diesel commit
store mod.rs file. This also adds a doc comment explaining the
`resolve_fork` db operation.

Signed-off-by: Davey Newhall <newhall@bitwise.io>