### PR TITLE
Add "rest-api" feature to guard top-level module

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -74,6 +74,7 @@ stable = [
     "location",
     "pike",
     "product",
+    "rest-api",
     "schema",
 ]
 
@@ -126,9 +127,25 @@ batch-store = []
 batch-submitter = ["base64", "futures", "reqwest", "uuid", "url"]
 
 postgres = ["chrono", "diesel/postgres", "diesel_migrations", "log"]
+rest-api = []
 rest-api-actix-web-3 = [
-    "actix-web", "futures", "futures-util", "rest-api-resources", "sqlite", "postgres", "url"]
-rest-api-resources = ["cylinder", "sabre-sdk", "log", "reqwest", "url"]
+    "actix-web",
+    "futures",
+    "futures-util",
+    "postgres",
+    "rest-api",
+    "rest-api-resources",
+    "sqlite",
+    "url"
+]
+rest-api-resources = [
+    "cylinder",
+    "log",
+    "reqwest",
+    "rest-api",
+    "sabre-sdk",
+    "url"
+]
 sawtooth-compat = [
     "sabre-sdk",
     "sawtooth-sdk"

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -57,6 +57,7 @@ pub mod protocol;
 pub mod protos;
 #[cfg(feature = "purchase-order")]
 pub mod purchase_order;
+#[cfg(feature = "rest-api")]
 pub mod rest_api;
 #[cfg(feature = "schema")]
 pub mod schemas;


### PR DESCRIPTION
This top-level "rest-api" feature prevents the rest_api module from
existing unless a REST API feature is enabled.

This is part of a larger effort to cleanup dependencies in the SDK.