### PR TITLE
Fix lint

### DIFF
--- a/sdk/src/commits/store/diesel/operations/add_commit.rs
+++ b/sdk/src/commits/store/diesel/operations/add_commit.rs
@@ -17,7 +17,7 @@ use crate::commits::store::diesel::models::{CommitModel, NewCommitModel};
 use crate::commits::store::diesel::{schema::commits, CommitStoreError};
 use crate::error::{ConstraintViolationError, ConstraintViolationType, InternalError};
 
-use diesel::{dsl::insert_into, prelude::*, result::Error as dsl_error};
+use diesel::{dsl::insert_into, prelude::*};
 
 pub(in crate::commits) trait CommitStoreAddCommitOperation {
     fn add_commit(&self, commit: NewCommitModel) -> Result<(), CommitStoreError>;


### PR DESCRIPTION
This fixes a lint errors in the add_commit.rs file. This was just an
unused import that needed to get cleaned up.

Signed-off-by: Davey Newhall <newhall@bitwise.io>