### PR TITLE
Add database-* feature guards to the daemon

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -42,7 +42,7 @@ diesel = { version = "1.0.0", features = ["r2d2", "serde_json"] }
 diesel_migrations = "1.4"
 flexi_logger = "0.14"
 futures = "0.3"
-grid-sdk = { path = "../sdk", features = ["postgres", "sqlite", "experimental"] }
+grid-sdk = { path = "../sdk", features = ["experimental"] }
 log = "0.4"
 protobuf = "2.19"
 reqwest = { version = "0.10.1", optional = true, features = ["json", "blocking"] }
@@ -63,6 +63,8 @@ features = [ "events" ]
 [features]
 default = [
     "database",
+    "database-postgres",
+    "database-sqlite",
     "event",
     "rest-api",
     "sawtooth-support",
@@ -90,6 +92,8 @@ experimental = [
 
 event = ["database"]
 database = []
+database-postgres = ["grid-sdk/postgres"]
+database-sqlite = ["grid-sdk/sqlite"]
 location = ["pike", "schema"]
 pike = ["serde_json"]
 product = ["pike", "schema"]

--- a/daemon/src/event/db_handler.rs
+++ b/daemon/src/event/db_handler.rs
@@ -296,6 +296,7 @@ impl EventHandler for DatabaseEventHandler<diesel::pg::PgConnection> {
     }
 }
 
+#[cfg(feature = "database-sqlite")]
 impl DatabaseEventHandler<diesel::sqlite::SqliteConnection> {
     pub fn from_sqlite_pool(
         connection_pool: ConnectionPool<diesel::sqlite::SqliteConnection>,
@@ -329,6 +330,7 @@ impl DatabaseEventHandler<diesel::sqlite::SqliteConnection> {
     }
 }
 
+#[cfg(feature = "database-sqlite")]
 impl EventHandler for DatabaseEventHandler<diesel::sqlite::SqliteConnection> {
     fn handle_event(&self, event: &CommitEvent) -> Result<(), EventError> {
         debug!("Received commit event: {}", event);

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -69,7 +69,7 @@ fn run() -> Result<(), DaemonError> {
         (@arg connect: -C --connect +takes_value "connection endpoint for sawtooth or splinter")
         (@arg verbose: -v +multiple "Log verbosely")
         (@arg database_url: --("database-url") +takes_value
-         "specifies the database URL to connect to.")
+        "specifies the database URL to connect to.")
         (@arg bind: -b --bind +takes_value "connection endpoint for rest API")
         (@arg admin_key_dir: --("admin-key-dir") +takes_value
             "directory containing the Scabbard admin key files"));


### PR DESCRIPTION
This adds feature guards for the separate database backends to the Grid
daemon. This allows for conditional compilation of code that pertains to
database functionality. At least one active backend is required for the
daemon to work.

Signed-off-by: Davey Newhall <newhall@bitwise.io>