### PR TITLE
Rename batch submitter to backend client

### DIFF
--- a/daemon/src/sawtooth/run.rs
+++ b/daemon/src/sawtooth/run.rs
@@ -17,7 +17,10 @@
  */
 
 use std::process;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use grid_sdk::backend::SawtoothBackendClient;
 #[cfg(feature = "integration")]
@@ -44,7 +47,7 @@ pub fn run_sawtooth(config: GridConfig) -> Result<(), DaemonError> {
 
     let sawtooth_connection = SawtoothConnection::new(&config.endpoint().url());
     let backend_client = SawtoothBackendClient::new(sawtooth_connection.get_sender());
-    let backend_state = BackendState::with_sawtooth(backend_client);
+    let backend_state = BackendState::new(Arc::new(backend_client));
     let (store_state, evt_processor) = {
         let commit_store = store_factory.get_grid_commit_store();
         let current_commit = commit_store

--- a/daemon/src/splinter/run.rs
+++ b/daemon/src/splinter/run.rs
@@ -23,9 +23,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use cylinder::load_key;
 #[cfg(feature = "integration")]
 use grid_sdk::rest_api::actix_web_3::KeyState;
-use grid_sdk::rest_api::actix_web_3::{BatchSubmitterState, StoreState};
+use grid_sdk::rest_api::actix_web_3::{BackendState, StoreState};
 use grid_sdk::store::ConnectionUri;
-use grid_sdk::submitter::SplinterBatchSubmitter;
+use grid_sdk::backend::SplinterBackendClient;
 use splinter::events::Reactor;
 
 use crate::config::GridConfig;
@@ -83,8 +83,8 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
     )
     .map_err(|err| DaemonError::from_source(Box::new(err)))?;
 
-    let batch_submitter = SplinterBatchSubmitter::new(config.endpoint().url());
-    let batch_submitter_state = BatchSubmitterState::with_splinter(batch_submitter);
+    let backend_client = SplinterBackendClient::new(config.endpoint().url());
+    let backend_state = BackendState::with_splinter(backend_client);
 
     #[cfg(feature = "integration")]
     let key_state = KeyState::new(&config.key_file_name());
@@ -92,7 +92,7 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
     let (rest_api_shutdown_handle, rest_api_join_handle) = rest_api::run(
         config.rest_api_endpoint(),
         store_state,
-        batch_submitter_state,
+        backend_state,
         #[cfg(feature = "integration")]
         key_state,
         config.endpoint().clone(),

--- a/daemon/src/splinter/run.rs
+++ b/daemon/src/splinter/run.rs
@@ -18,14 +18,17 @@
 
 use std::path::PathBuf;
 use std::process;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use cylinder::load_key;
+use grid_sdk::backend::SplinterBackendClient;
 #[cfg(feature = "integration")]
 use grid_sdk::rest_api::actix_web_3::KeyState;
 use grid_sdk::rest_api::actix_web_3::{BackendState, StoreState};
 use grid_sdk::store::ConnectionUri;
-use grid_sdk::backend::SplinterBackendClient;
 use splinter::events::Reactor;
 
 use crate::config::GridConfig;
@@ -84,7 +87,7 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
     .map_err(|err| DaemonError::from_source(Box::new(err)))?;
 
     let backend_client = SplinterBackendClient::new(config.endpoint().url());
-    let backend_state = BackendState::with_splinter(backend_client);
+    let backend_state = BackendState::new(Arc::new(backend_client));
 
     #[cfg(feature = "integration")]
     let key_state = KeyState::new(&config.key_file_name());

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -70,7 +70,9 @@ stable = [
     # The stable feature extends default:
     "default",
     # The following features are stable:
-    "batch-submitter",
+    "backend",
+    "backend-sawtooth",
+    "backend-splinter",
     "location",
     "pike",
     "product",
@@ -96,6 +98,7 @@ experimental = [
     "purchase-order",
     "rest-api-resources",
     "rest-api-actix-web-3",
+    "rest-api-endpoint-batches",
     "sawtooth-compat",
     "schema-store-postgres",
     "schema-store-sqlite",
@@ -104,6 +107,9 @@ experimental = [
     "workflow"
 ]
 
+backend = ["base64", "futures", "url"]
+backend-sawtooth = ["backend", "uuid"]
+backend-splinter = ["backend", "reqwest"]
 client = []
 client-reqwest = ["client", "reqwest"]
 location = ["pike", "schema"]
@@ -122,9 +128,8 @@ schema = ["pike"]
 schema-store-postgres = ["postgres"]
 schema-store-sqlite = ["sqlite"]
 track-and-trace = ["base64"]
-batch-processor = ["batch-store", "batch-submitter", "log"]
+batch-processor = ["batch-store", "backend", "log", "uuid"]
 batch-store = []
-batch-submitter = ["base64", "futures", "reqwest", "uuid", "url"]
 
 postgres = ["chrono", "diesel/postgres", "diesel_migrations", "log"]
 rest-api = []
@@ -138,6 +143,7 @@ rest-api-actix-web-3 = [
     "sqlite",
     "url"
 ]
+rest-api-endpoint-batches = ["backend"]
 rest-api-resources = [
     "cylinder",
     "log",

--- a/sdk/src/backend/error.rs
+++ b/sdk/src/backend/error.rs
@@ -16,26 +16,26 @@ use std::error::Error;
 use std::fmt;
 
 #[derive(Debug)]
-pub enum BatchSubmitterError {
+pub enum BackendClientError {
     BadRequestError(String),
     ConnectionError(String),
     InternalError(String),
     ResourceTemporarilyUnavailableError(String),
 }
 
-impl Error for BatchSubmitterError {
+impl Error for BackendClientError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         None
     }
 }
 
-impl fmt::Display for BatchSubmitterError {
+impl fmt::Display for BackendClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            BatchSubmitterError::BadRequestError(err) => write!(f, "{}", err),
-            BatchSubmitterError::ConnectionError(err) => write!(f, "{}", err),
-            BatchSubmitterError::InternalError(err) => write!(f, "{}", err),
-            BatchSubmitterError::ResourceTemporarilyUnavailableError(err) => write!(f, "{}", err),
+            BackendClientError::BadRequestError(err) => write!(f, "{}", err),
+            BackendClientError::ConnectionError(err) => write!(f, "{}", err),
+            BackendClientError::InternalError(err) => write!(f, "{}", err),
+            BackendClientError::ResourceTemporarilyUnavailableError(err) => write!(f, "{}", err),
         }
     }
 }

--- a/sdk/src/backend/mod.rs
+++ b/sdk/src/backend/mod.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 mod error;
+#[cfg(feature = "backend-sawtooth")]
 pub mod sawtooth;
-pub mod splinter;
+#[cfg(feature = "backend-splinter")]
+mod splinter;
 
 use std::pin::Pin;
 
@@ -23,28 +25,30 @@ use sawtooth_sdk::messages::batch::BatchList;
 use sawtooth_sdk::messages::client_batch_submit::ClientBatchStatus;
 use url::Url;
 
-pub use error::BatchSubmitterError;
-pub use sawtooth::SawtoothBatchSubmitter;
-pub use splinter::SplinterBatchSubmitter;
+pub use error::BackendClientError;
+#[cfg(feature = "backend-sawtooth")]
+pub use sawtooth::SawtoothBackendClient;
+#[cfg(feature = "backend-splinter")]
+pub use splinter::SplinterBackendClient;
 
 pub const DEFAULT_TIME_OUT: u32 = 300; // Max timeout 300 seconds == 5 minutes
 
-pub trait BatchSubmitter: Send + Sync + 'static {
+pub trait BackendClient: Send + Sync + 'static {
     fn submit_batches(
         &self,
         submit_batches: SubmitBatches,
-    ) -> Pin<Box<dyn Future<Output = Result<BatchStatusLink, BatchSubmitterError>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<BatchStatusLink, BackendClientError>> + Send>>;
 
     fn batch_status(
         &self,
         batch_statuses: BatchStatuses,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<BatchStatus>, BatchSubmitterError>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<BatchStatus>, BackendClientError>> + Send>>;
 
-    fn clone_box(&self) -> Box<dyn BatchSubmitter>;
+    fn clone_box(&self) -> Box<dyn BackendClient>;
 }
 
-impl Clone for Box<dyn BatchSubmitter> {
-    fn clone(&self) -> Box<dyn BatchSubmitter> {
+impl Clone for Box<dyn BackendClient> {
+    fn clone(&self) -> Box<dyn BackendClient> {
         self.clone_box()
     }
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -34,6 +34,8 @@ extern crate diesel_migrations;
 #[cfg(feature = "log")]
 extern crate log;
 
+#[cfg(feature = "backend")]
+pub mod backend;
 #[cfg(feature = "batch-processor")]
 pub mod batch_processor;
 #[cfg(feature = "batch-store")]
@@ -62,8 +64,6 @@ pub mod rest_api;
 #[cfg(feature = "schema")]
 pub mod schemas;
 pub mod store;
-#[cfg(feature = "batch-submitter")]
-pub mod submitter;
 #[cfg(feature = "track-and-trace")]
 pub mod track_and_trace;
 #[cfg(feature = "workflow")]

--- a/sdk/src/rest_api/actix_web_3/backend_state.rs
+++ b/sdk/src/rest_api/actix_web_3/backend_state.rs
@@ -14,28 +14,33 @@
 
 use std::sync::Arc;
 
-use crate::submitter::{BatchSubmitter, SawtoothBatchSubmitter, SplinterBatchSubmitter};
+use crate::backend::BackendClient;
+#[cfg(feature = "backend-sawtooth")]
+use crate::backend::SawtoothBackendClient;
+#[cfg(feature = "backend-splinter")]
+use crate::backend::SplinterBackendClient;
 
-#[cfg(feature = "batch-submitter")]
 #[derive(Clone)]
-pub struct BatchSubmitterState {
-    pub batch_submitter: Arc<dyn BatchSubmitter + 'static>,
+pub struct BackendState {
+    pub client: Arc<dyn BackendClient + 'static>,
 }
 
-impl BatchSubmitterState {
-    pub fn new(batch_submitter: Arc<dyn BatchSubmitter + 'static>) -> Self {
-        Self { batch_submitter }
+impl BackendState {
+    pub fn new(client: Arc<dyn BackendClient + 'static>) -> Self {
+        Self { client }
     }
 
-    pub fn with_sawtooth(submitter: SawtoothBatchSubmitter) -> Self {
+    #[cfg(feature = "backend-sawtooth")]
+    pub fn with_sawtooth(client: SawtoothBackendClient) -> Self {
         Self {
-            batch_submitter: Arc::new(submitter),
+            client: Arc::new(client),
         }
     }
 
-    pub fn with_splinter(submitter: SplinterBatchSubmitter) -> Self {
+    #[cfg(feature = "backend-splinter")]
+    pub fn with_splinter(client: SplinterBackendClient) -> Self {
         Self {
-            batch_submitter: Arc::new(submitter),
+            client: Arc::new(client),
         }
     }
 }

--- a/sdk/src/rest_api/actix_web_3/backend_state.rs
+++ b/sdk/src/rest_api/actix_web_3/backend_state.rs
@@ -15,10 +15,6 @@
 use std::sync::Arc;
 
 use crate::backend::BackendClient;
-#[cfg(feature = "backend-sawtooth")]
-use crate::backend::SawtoothBackendClient;
-#[cfg(feature = "backend-splinter")]
-use crate::backend::SplinterBackendClient;
 
 #[derive(Clone)]
 pub struct BackendState {
@@ -28,19 +24,5 @@ pub struct BackendState {
 impl BackendState {
     pub fn new(client: Arc<dyn BackendClient + 'static>) -> Self {
         Self { client }
-    }
-
-    #[cfg(feature = "backend-sawtooth")]
-    pub fn with_sawtooth(client: SawtoothBackendClient) -> Self {
-        Self {
-            client: Arc::new(client),
-        }
-    }
-
-    #[cfg(feature = "backend-splinter")]
-    pub fn with_splinter(client: SplinterBackendClient) -> Self {
-        Self {
-            client: Arc::new(client),
-        }
     }
 }

--- a/sdk/src/rest_api/actix_web_3/mod.rs
+++ b/sdk/src/rest_api/actix_web_3/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod batch_submitter_state;
+mod backend_state;
 mod endpoint;
 mod key_state;
 mod paging;
@@ -21,7 +21,7 @@ mod run;
 mod service;
 mod store_state;
 
-pub use batch_submitter_state::BatchSubmitterState;
+pub use backend_state::BackendState;
 pub use endpoint::{Backend, Endpoint};
 pub use key_state::KeyState;
 pub use paging::QueryPaging;

--- a/sdk/src/rest_api/actix_web_3/routes/mod.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/mod.rs
@@ -14,7 +14,7 @@
 
 #[cfg(feature = "pike")]
 mod agents;
-#[cfg(feature = "batch-submitter")]
+#[cfg(feature = "rest-api-endpoint-batches")]
 mod batches;
 #[cfg(feature = "location")]
 mod locations;
@@ -34,7 +34,7 @@ mod submit;
 
 #[cfg(feature = "pike")]
 pub use agents::*;
-#[cfg(feature = "batch-submitter")]
+#[cfg(feature = "rest-api-endpoint-batches")]
 pub use batches::*;
 #[cfg(feature = "location")]
 pub use locations::*;

--- a/sdk/src/rest_api/actix_web_3/store_state.rs
+++ b/sdk/src/rest_api/actix_web_3/store_state.rs
@@ -28,7 +28,6 @@ use crate::products::{store::diesel::DieselProductStore, ProductStore};
 use crate::purchase_order::{store::diesel::DieselPurchaseOrderStore, PurchaseOrderStore};
 #[cfg(feature = "schema")]
 use crate::schemas::{store::diesel::DieselSchemaStore, SchemaStore};
-#[cfg(feature = "batch-submitter")]
 #[cfg(feature = "track-and-trace")]
 use crate::track_and_trace::{store::diesel::DieselTrackAndTraceStore, TrackAndTraceStore};
 

--- a/sdk/src/rest_api/resources/batches/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/batches/v1/payloads.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::submitter;
+use crate::backend;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BatchStatus {
@@ -21,8 +21,8 @@ pub struct BatchStatus {
     pub status: String,
 }
 
-impl From<submitter::BatchStatus> for BatchStatus {
-    fn from(batch_status: submitter::BatchStatus) -> Self {
+impl From<backend::BatchStatus> for BatchStatus {
+    fn from(batch_status: backend::BatchStatus) -> Self {
         Self {
             id: batch_status.id,
             invalid_transactions: batch_status
@@ -42,8 +42,8 @@ pub struct InvalidTransaction {
     pub extended_data: String,
 }
 
-impl From<submitter::InvalidTransaction> for InvalidTransaction {
-    fn from(invalid_transaction: submitter::InvalidTransaction) -> Self {
+impl From<backend::InvalidTransaction> for InvalidTransaction {
+    fn from(invalid_transaction: backend::InvalidTransaction) -> Self {
         Self {
             id: invalid_transaction.id,
             message: invalid_transaction.message,
@@ -63,8 +63,8 @@ pub struct BatchStatusLink {
     pub link: String,
 }
 
-impl From<submitter::BatchStatusLink> for BatchStatusLink {
-    fn from(batch_status_link: submitter::BatchStatusLink) -> Self {
+impl From<backend::BatchStatusLink> for BatchStatusLink {
+    fn from(batch_status_link: backend::BatchStatusLink) -> Self {
         Self {
             link: batch_status_link.link,
         }

--- a/sdk/src/rest_api/resources/mod.rs
+++ b/sdk/src/rest_api/resources/mod.rs
@@ -14,7 +14,7 @@
 
 #[cfg(feature = "pike")]
 pub mod agents;
-#[cfg(feature = "batch-submitter")]
+#[cfg(feature = "rest-api-endpoint-batches")]
 pub mod batches;
 pub mod error;
 #[cfg(feature = "location")]


### PR DESCRIPTION
The trait formerly known as "BatchSubmitter" was really a client to the backend (Sawtooth or Splinter). This gives it distinction from other batch-related functionality within the sdk and daemon.
