### PR TITLE
Remove sqlite and postgres from rest api feature

### DIFF
--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -11,7 +11,7 @@ description = "Grid integration component"
 [dependencies]
 actix-web = "3"
 clap = "2.33.3"
-diesel = { version = "1.0", features = ["r2d2"] }
+diesel = { version = "1.0", features = ["r2d2"], optional = true }
 flexi_logger = "0.14"
 grid-sdk = { path = "../sdk", features = ["rest-api-actix-web-3", "batch-processor"] }
 log = "0.4"
@@ -30,4 +30,9 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "database-postgres",
+    "database-sqlite",
 ]
+
+database-postgres = ["diesel", "grid-sdk/postgres"]
+database-sqlite = ["diesel", "grid-sdk/sqlite"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -129,7 +129,7 @@ schema-store-postgres = ["postgres"]
 schema-store-sqlite = ["sqlite"]
 track-and-trace = ["base64"]
 batch-processor = ["batch-store", "backend", "log", "uuid"]
-batch-store = []
+batch-store = ["chrono"]
 
 postgres = ["chrono", "diesel/postgres", "diesel_migrations", "log"]
 rest-api = []
@@ -137,10 +137,8 @@ rest-api-actix-web-3 = [
     "actix-web",
     "futures",
     "futures-util",
-    "postgres",
     "rest-api",
     "rest-api-resources",
-    "sqlite",
     "url"
 ]
 rest-api-endpoint-batches = ["backend"]

--- a/sdk/src/batches/store/mod.rs
+++ b/sdk/src/batches/store/mod.rs
@@ -115,7 +115,7 @@ pub struct BatchList {
 }
 
 impl BatchList {
-    fn new(data: Vec<Batch>, paging: Paging) -> Self {
+    pub fn new(data: Vec<Batch>, paging: Paging) -> Self {
         Self { data, paging }
     }
 }

--- a/sdk/src/rest_api/actix_web_3/store_state.rs
+++ b/sdk/src/rest_api/actix_web_3/store_state.rs
@@ -14,22 +14,37 @@
 
 use std::sync::Arc;
 
+#[cfg(feature = "diesel")]
 use diesel::r2d2::{ConnectionManager, Pool};
 
+#[cfg(all(feature = "diesel", feature = "batch-store"))]
+use crate::batches::store::diesel::DieselBatchStore;
 #[cfg(feature = "batch-store")]
-use crate::batches::{store::diesel::DieselBatchStore, BatchStore};
+use crate::batches::BatchStore;
+#[cfg(all(feature = "diesel", feature = "location"))]
+use crate::locations::store::diesel::DieselLocationStore;
 #[cfg(feature = "location")]
-use crate::locations::{store::diesel::DieselLocationStore, LocationStore};
+use crate::locations::LocationStore;
+#[cfg(all(feature = "diesel", feature = "pike"))]
+use crate::pike::store::diesel::DieselPikeStore;
 #[cfg(feature = "pike")]
-use crate::pike::{store::diesel::DieselPikeStore, PikeStore};
+use crate::pike::PikeStore;
+#[cfg(all(feature = "diesel", feature = "product"))]
+use crate::products::store::diesel::DieselProductStore;
 #[cfg(feature = "product")]
-use crate::products::{store::diesel::DieselProductStore, ProductStore};
+use crate::products::ProductStore;
+#[cfg(all(feature = "diesel", feature = "purchase-order"))]
+use crate::purchase_order::store::diesel::DieselPurchaseOrderStore;
 #[cfg(feature = "purchase-order")]
-use crate::purchase_order::{store::diesel::DieselPurchaseOrderStore, PurchaseOrderStore};
+use crate::purchase_order::PurchaseOrderStore;
+#[cfg(all(feature = "diesel", feature = "schema"))]
+use crate::schemas::store::diesel::DieselSchemaStore;
 #[cfg(feature = "schema")]
-use crate::schemas::{store::diesel::DieselSchemaStore, SchemaStore};
+use crate::schemas::SchemaStore;
+#[cfg(all(feature = "diesel", feature = "track-and-trace"))]
+use crate::track_and_trace::store::diesel::DieselTrackAndTraceStore;
 #[cfg(feature = "track-and-trace")]
-use crate::track_and_trace::{store::diesel::DieselTrackAndTraceStore, TrackAndTraceStore};
+use crate::track_and_trace::TrackAndTraceStore;
 
 #[derive(Clone)]
 pub struct StoreState {
@@ -50,6 +65,7 @@ pub struct StoreState {
 }
 
 #[allow(clippy::redundant_clone)]
+#[cfg(feature = "postgres")]
 impl StoreState {
     pub fn with_pg_pool(
         connection_pool: Pool<ConnectionManager<diesel::pg::PgConnection>>,
@@ -87,6 +103,7 @@ impl StoreState {
         }
     }
 
+    #[cfg(feature = "sqlite")]
     pub fn with_sqlite_pool(
         connection_pool: Pool<ConnectionManager<diesel::sqlite::SqliteConnection>>,
     ) -> Self {


### PR DESCRIPTION
This removes sqlite and postgres from the sdk's rest-api-actix-web-3
feature, which will make it possible to conditionally use the sqlite or
postgresql when using the rest api.

This commit makes BatchList pub, because without pub, it would be
necessary to put a conditional of the underlying implementations being
enabled; it seems cleaner to simply make it pub since it does not seem
intentional to prevent creation of BatchList (which itself is pub).

Features are added to griddle for sqlite/postgres to pull in the
associated sdk features.