### PR TITLE
Update copyright headers in `splinter` module

### DIFF
--- a/daemon/src/splinter/app_auth_handler/error.rs
+++ b/daemon/src/splinter/app_auth_handler/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Cargill Incorporated
+ * Copyright 2020-2021 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/daemon/src/splinter/app_auth_handler/mod.rs
+++ b/daemon/src/splinter/app_auth_handler/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Cargill Incorporated
+ * Copyright 2020-2021 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/daemon/src/splinter/app_auth_handler/node.rs
+++ b/daemon/src/splinter/app_auth_handler/node.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Cargill Incorporated
+ * Copyright 2020-2021 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/daemon/src/splinter/app_auth_handler/sabre.rs
+++ b/daemon/src/splinter/app_auth_handler/sabre.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Cargill Incorporated
+ * Copyright 2020-2021 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This change updates the copyright headers of files in the `splinter`
module to reflect the current year.

Signed-off-by: Shannyn Telander <telander@bitwise.io>