### PR TITLE
Add "backend" as dependency for "rest-api-actix-web-3"

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -135,6 +135,7 @@ postgres = ["chrono", "diesel/postgres", "diesel_migrations", "log"]
 rest-api = []
 rest-api-actix-web-3 = [
     "actix-web",
+    "backend",
     "futures",
     "futures-util",
     "rest-api",


### PR DESCRIPTION
This was an error in the dependency list for rest-api-actix-web-3 and
isn't intended to be a functional change (other than fixing compilation
if specifying this feature in isolation).