### PR TITLE
Add feature guards for each REST API endpoint

### DIFF
--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -13,7 +13,7 @@ actix-web = "3"
 clap = "2.33.3"
 diesel = { version = "1.0", features = ["r2d2"], optional = true }
 flexi_logger = "0.14"
-grid-sdk = { path = "../sdk", features = ["rest-api-actix-web-3", "batch-processor"] }
+grid-sdk = { path = "../sdk", features = ["rest-api-actix-web-3", "rest-api-actix-web-3-run", "batch-processor"] }
 log = "0.4"
 users = "0.11"
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -77,6 +77,13 @@ stable = [
     "pike",
     "product",
     "rest-api",
+    "rest-api-endpoint-agent",
+    "rest-api-endpoint-batches",
+    "rest-api-endpoint-location",
+    "rest-api-endpoint-organization",
+    "rest-api-endpoint-product",
+    "rest-api-endpoint-role",
+    "rest-api-endpoint-schema",
     "schema",
 ]
 
@@ -98,7 +105,10 @@ experimental = [
     "purchase-order",
     "rest-api-resources",
     "rest-api-actix-web-3",
-    "rest-api-endpoint-batches",
+    "rest-api-actix-web-3-run",
+    "rest-api-endpoint-purchase-order",
+    "rest-api-endpoint-record",
+    "rest-api-endpoint-submit",
     "sawtooth-compat",
     "schema-store-postgres",
     "schema-store-sqlite",
@@ -141,7 +151,17 @@ rest-api-actix-web-3 = [
     "rest-api-resources",
     "url"
 ]
+rest-api-actix-web-3-run = ["rest-api-endpoint-submit"]
+rest-api-endpoint-agent = ["pike"]
 rest-api-endpoint-batches = ["backend"]
+rest-api-endpoint-location = ["location"]
+rest-api-endpoint-organization = ["pike"]
+rest-api-endpoint-product = ["product"]
+rest-api-endpoint-purchase-order = ["purchase-order"]
+rest-api-endpoint-record = ["track-and-trace"]
+rest-api-endpoint-role = ["pike"]
+rest-api-endpoint-schema = ["schema"]
+rest-api-endpoint-submit = ["batch-store"]
 rest-api-resources = [
     "cylinder",
     "log",

--- a/sdk/src/rest_api/actix_web_3/mod.rs
+++ b/sdk/src/rest_api/actix_web_3/mod.rs
@@ -17,6 +17,7 @@ mod endpoint;
 mod key_state;
 mod paging;
 pub mod routes;
+#[cfg(feature = "rest-api-actix-web-3-run")]
 mod run;
 mod service;
 mod store_state;
@@ -25,7 +26,7 @@ pub use backend_state::BackendState;
 pub use endpoint::{Backend, Endpoint};
 pub use key_state::KeyState;
 pub use paging::QueryPaging;
-pub use routes::submit;
+#[cfg(feature = "rest-api-actix-web-3-run")]
 pub use run::run;
 pub use service::{AcceptServiceIdParam, QueryServiceId};
 pub use store_state::StoreState;

--- a/sdk/src/rest_api/actix_web_3/routes/mod.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/mod.rs
@@ -12,44 +12,46 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "pike")]
+#[cfg(feature = "rest-api-endpoint-agent")]
 mod agents;
 #[cfg(feature = "rest-api-endpoint-batches")]
 mod batches;
-#[cfg(feature = "location")]
+#[cfg(feature = "rest-api-endpoint-location")]
 mod locations;
-#[cfg(feature = "pike")]
+#[cfg(feature = "rest-api-endpoint-organization")]
 mod organizations;
-#[cfg(feature = "product")]
+#[cfg(feature = "rest-api-endpoint-product")]
 mod products;
-#[cfg(feature = "purchase-order")]
+#[cfg(feature = "rest-api-endpoint-purchase-order")]
 mod purchase_orders;
-#[cfg(feature = "track-and-trace")]
+#[cfg(feature = "rest-api-endpoint-record")]
 mod records;
-#[cfg(feature = "pike")]
+#[cfg(feature = "rest-api-endpoint-role")]
 mod roles;
-#[cfg(feature = "schema")]
+#[cfg(feature = "rest-api-endpoint-schema")]
 mod schemas;
+#[cfg(feature = "rest-api-endpoint-submit")]
 mod submit;
 
-#[cfg(feature = "pike")]
+#[cfg(feature = "rest-api-endpoint-agent")]
 pub use agents::*;
 #[cfg(feature = "rest-api-endpoint-batches")]
 pub use batches::*;
-#[cfg(feature = "location")]
+#[cfg(feature = "rest-api-endpoint-location")]
 pub use locations::*;
-#[cfg(feature = "pike")]
+#[cfg(feature = "rest-api-endpoint-organization")]
 pub use organizations::*;
-#[cfg(feature = "product")]
+#[cfg(feature = "rest-api-endpoint-product")]
 pub use products::*;
-#[cfg(feature = "purchase-order")]
+#[cfg(feature = "rest-api-endpoint-purchase-order")]
 pub use purchase_orders::*;
-#[cfg(feature = "track-and-trace")]
+#[cfg(feature = "rest-api-endpoint-record")]
 pub use records::*;
-#[cfg(feature = "pike")]
+#[cfg(feature = "rest-api-endpoint-role")]
 pub use roles::*;
-#[cfg(feature = "schema")]
+#[cfg(feature = "rest-api-endpoint-schema")]
 pub use schemas::*;
+#[cfg(feature = "rest-api-endpoint-submit")]
 pub use submit::*;
 
 pub(in crate::rest_api) const DEFAULT_GRID_PROTOCOL_VERSION: &str = "1";

--- a/sdk/src/rest_api/actix_web_3/run.rs
+++ b/sdk/src/rest_api/actix_web_3/run.rs
@@ -16,7 +16,7 @@ use actix_web::{App, HttpServer};
 
 use crate::error::InternalError;
 
-use super::{submit, KeyState, StoreState};
+use super::{routes::submit, KeyState, StoreState};
 
 pub async fn run(
     bind: &str,

--- a/sdk/src/rest_api/resources/mod.rs
+++ b/sdk/src/rest_api/resources/mod.rs
@@ -12,25 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "pike")]
+#[cfg(feature = "rest-api-endpoint-agent")]
 pub mod agents;
 #[cfg(feature = "rest-api-endpoint-batches")]
 pub mod batches;
 pub mod error;
-#[cfg(feature = "location")]
+#[cfg(feature = "rest-api-endpoint-location")]
 pub mod locations;
-#[cfg(feature = "pike")]
+#[cfg(feature = "rest-api-endpoint-organization")]
 pub mod organizations;
 pub mod paging;
-#[cfg(feature = "product")]
+#[cfg(feature = "rest-api-endpoint-product")]
 pub mod products;
-#[cfg(feature = "purchase-order")]
+#[cfg(feature = "rest-api-endpoint-purchase-order")]
 pub mod purchase_order;
-#[cfg(feature = "pike")]
+#[cfg(feature = "rest-api-endpoint-role")]
 pub mod roles;
-#[cfg(feature = "schema")]
+#[cfg(feature = "rest-api-endpoint-schema")]
 pub mod schemas;
-#[cfg(feature = "batch-store")]
+#[cfg(feature = "rest-api-endpoint-submit")]
 pub mod submit;
-#[cfg(feature = "track-and-trace")]
+#[cfg(feature = "rest-api-endpoint-record")]
 pub mod track_and_trace;


### PR DESCRIPTION
This adds several features which guard the REST API endpoint; this
will allow the daemon processes to individually pull in the specific
endpoints supported. It also allows enabling the underlying features
without enabling the associated endpoints.