### PR TITLE
Move `clear_database` fns to new `testing` module

### DIFF
--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -176,14 +176,18 @@ mod test {
         SubmitBatches,
     };
     #[cfg(feature = "test-postgres")]
-    use grid_sdk::migrations::{clear_postgres_database, run_postgres_migrations};
+    use grid_sdk::migrations::run_postgres_migrations;
     #[cfg(not(feature = "test-postgres"))]
-    use grid_sdk::migrations::{clear_sqlite_database, run_sqlite_migrations};
+    use grid_sdk::migrations::run_sqlite_migrations;
     #[cfg(feature = "track-and-trace")]
     use grid_sdk::rest_api::resources::track_and_trace::v1::*;
     use grid_sdk::rest_api::resources::{
         agents::v1::*, locations::v1::*, organizations::v1::*, products::v1::*, schemas::v1::*,
     };
+    #[cfg(feature = "test-postgres")]
+    use grid_sdk::testing::clear_postgres_database;
+    #[cfg(not(feature = "test-postgres"))]
+    use grid_sdk::testing::clear_sqlite_database;
     #[cfg(feature = "track-and-trace")]
     use grid_sdk::track_and_trace::store::{
         AssociatedAgent, DieselTrackAndTraceStore, LatLongValue, Property, Proposal, Record,

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -113,6 +113,8 @@ experimental = [
     "schema-store-postgres",
     "schema-store-sqlite",
     "sqlite",
+    "test-postgres",
+    "test-sqlite",
     "track-and-trace",
     "workflow"
 ]
@@ -137,6 +139,8 @@ product-store-sqlite = ["sqlite"]
 schema = ["pike"]
 schema-store-postgres = ["postgres"]
 schema-store-sqlite = ["sqlite"]
+test-postgres = ["postgres", "diesel"]
+test-sqlite = ["sqlite", "diesel"]
 track-and-trace = ["base64"]
 batch-processor = ["batch-store", "backend", "log", "uuid"]
 batch-store = ["chrono"]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Required due to a bug in rust-protobuf: https://github.com/stepancheg/rust-protobuf/issues/331
-#![allow(renamed_and_removed_lints)]
-
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -64,6 +61,8 @@ pub mod rest_api;
 #[cfg(feature = "schema")]
 pub mod schema;
 pub mod store;
+#[cfg(any(feature = "test-postgres", feature = "test-sqlite"))]
+pub mod testing;
 #[cfg(feature = "track-and-trace")]
 pub mod track_and_trace;
 #[cfg(feature = "workflow")]

--- a/sdk/src/migrations/diesel/postgres/mod.rs
+++ b/sdk/src/migrations/diesel/postgres/mod.rs
@@ -14,32 +14,8 @@
 
 //! Defines methods and utilities to interact with user tables in the database.
 
-use crate::commits::store::diesel::schema::{chain_record::dsl::*, commits::dsl::*};
-#[cfg(feature = "location-store-postgres")]
-use crate::location::store::diesel::schema::{location::dsl::*, location_attribute::dsl::*};
-#[cfg(all(feature = "pike", feature = "location-store-postgres"))]
-use crate::pike::store::diesel::schema::pike_organization_location_assoc::dsl::*;
-#[cfg(feature = "pike")]
-use crate::pike::store::diesel::schema::{
-    pike_agent::dsl::*, pike_agent_role_assoc::dsl::*, pike_allowed_orgs::dsl::*,
-    pike_inherit_from::dsl::*, pike_organization::dsl::*, pike_organization_alternate_id::dsl::*,
-    pike_organization_metadata::dsl::*, pike_permissions::dsl::*, pike_role::dsl::*,
-};
-#[cfg(feature = "product-store-postgres")]
-use crate::product::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*};
-#[cfg(feature = "schema-store-postgres")]
-use crate::schema::store::diesel::schema::{
-    grid_property_definition::dsl::grid_property_definition, grid_schema::dsl::*,
-};
-#[cfg(feature = "track-and-trace")]
-use crate::track_and_trace::store::diesel::schema::{
-    associated_agent::dsl::*, property::dsl::*, proposal::dsl::*, record::dsl::*,
-    reported_value::dsl::*, reporter::dsl::*,
-};
-
-use diesel::RunQueryDsl;
 #[cfg(feature = "postgres")]
-use diesel::{pg::PgConnection, Connection};
+use diesel::pg::PgConnection;
 
 use crate::error::ResourceTemporarilyUnavailableError;
 use crate::migrations::error::MigrationsError;
@@ -61,58 +37,6 @@ pub fn run_migrations(conn: &PgConnection) -> Result<(), MigrationsError> {
     })?;
 
     info!("Successfully applied Grid migrations");
-
-    Ok(())
-}
-
-#[cfg(all(feature = "postgres", feature = "diesel"))]
-pub fn clear_database(conn: &PgConnection) -> Result<(), MigrationsError> {
-    conn.transaction::<_, MigrationsError, _>(|| {
-        #[cfg(feature = "pike")]
-        {
-            diesel::delete(pike_agent).execute(conn)?;
-            diesel::delete(pike_inherit_from).execute(conn)?;
-            diesel::delete(pike_permissions).execute(conn)?;
-            diesel::delete(pike_allowed_orgs).execute(conn)?;
-            diesel::delete(pike_agent_role_assoc).execute(conn)?;
-            diesel::delete(pike_organization_metadata).execute(conn)?;
-            diesel::delete(pike_organization_alternate_id).execute(conn)?;
-            diesel::delete(pike_organization).execute(conn)?;
-            diesel::delete(pike_role).execute(conn)?;
-        }
-        #[cfg(feature = "location-store-postgres")]
-        {
-            diesel::delete(location_attribute).execute(conn)?;
-            diesel::delete(location).execute(conn)?;
-        }
-        #[cfg(all(feature = "pike", feature = "location-store-postgres"))]
-        {
-            diesel::delete(pike_organization_location_assoc).execute(conn)?;
-        }
-        #[cfg(feature = "product-store-postgres")]
-        {
-            diesel::delete(product).execute(conn)?;
-            diesel::delete(product_property_value).execute(conn)?;
-        }
-        #[cfg(feature = "schema-store-postgres")]
-        {
-            diesel::delete(grid_property_definition).execute(conn)?;
-            diesel::delete(grid_schema).execute(conn)?;
-        }
-        #[cfg(feature = "track-and-trace")]
-        {
-            diesel::delete(associated_agent).execute(conn)?;
-            diesel::delete(property).execute(conn)?;
-            diesel::delete(proposal).execute(conn)?;
-            diesel::delete(record).execute(conn)?;
-            diesel::delete(reported_value).execute(conn)?;
-            diesel::delete(reporter).execute(conn)?;
-        }
-        diesel::delete(chain_record).execute(conn)?;
-        diesel::delete(commits).execute(conn)?;
-
-        Ok(())
-    })?;
 
     Ok(())
 }

--- a/sdk/src/migrations/diesel/sqlite/mod.rs
+++ b/sdk/src/migrations/diesel/sqlite/mod.rs
@@ -12,32 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::commits::store::diesel::schema::{chain_record::dsl::*, commits::dsl::*};
-#[cfg(feature = "location-store-sqlite")]
-use crate::location::store::diesel::schema::{location::dsl::*, location_attribute::dsl::*};
-#[cfg(all(feature = "pike", feature = "location-store-sqlite"))]
-use crate::pike::store::diesel::schema::pike_organization_location_assoc::dsl::*;
-#[cfg(feature = "pike")]
-use crate::pike::store::diesel::schema::{
-    pike_agent::dsl::*, pike_agent_role_assoc::dsl::*, pike_allowed_orgs::dsl::*,
-    pike_inherit_from::dsl::*, pike_organization::dsl::*, pike_organization_alternate_id::dsl::*,
-    pike_organization_metadata::dsl::*, pike_permissions::dsl::*, pike_role::dsl::*,
-};
-#[cfg(feature = "product-store-sqlite")]
-use crate::product::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*};
-#[cfg(feature = "schema-store-sqlite")]
-use crate::schema::store::diesel::schema::{
-    grid_property_definition::dsl::grid_property_definition, grid_schema::dsl::*,
-};
-#[cfg(feature = "track-and-trace")]
-use crate::track_and_trace::store::diesel::schema::{
-    associated_agent::dsl::*, property::dsl::*, proposal::dsl::*, record::dsl::*,
-    reported_value::dsl::*, reporter::dsl::*,
-};
-
-use diesel::RunQueryDsl;
 #[cfg(feature = "sqlite")]
-use diesel::{sqlite::SqliteConnection, Connection};
+use diesel::sqlite::SqliteConnection;
 
 use crate::error::ResourceTemporarilyUnavailableError;
 use crate::migrations::error::MigrationsError;
@@ -59,58 +35,6 @@ pub fn run_migrations(conn: &SqliteConnection) -> Result<(), MigrationsError> {
     })?;
 
     info!("Successfully applied Grid migrations");
-
-    Ok(())
-}
-
-#[cfg(all(feature = "sqlite", feature = "diesel"))]
-pub fn clear_database(conn: &SqliteConnection) -> Result<(), MigrationsError> {
-    conn.transaction::<_, MigrationsError, _>(|| {
-        #[cfg(feature = "pike")]
-        {
-            diesel::delete(pike_agent).execute(conn)?;
-            diesel::delete(pike_inherit_from).execute(conn)?;
-            diesel::delete(pike_permissions).execute(conn)?;
-            diesel::delete(pike_allowed_orgs).execute(conn)?;
-            diesel::delete(pike_agent_role_assoc).execute(conn)?;
-            diesel::delete(pike_organization_metadata).execute(conn)?;
-            diesel::delete(pike_organization_alternate_id).execute(conn)?;
-            diesel::delete(pike_organization).execute(conn)?;
-            diesel::delete(pike_role).execute(conn)?;
-        }
-        #[cfg(feature = "location-store-sqlite")]
-        {
-            diesel::delete(location_attribute).execute(conn)?;
-            diesel::delete(location).execute(conn)?;
-        }
-        #[cfg(all(feature = "pike", feature = "location-store-sqlite"))]
-        {
-            diesel::delete(pike_organization_location_assoc).execute(conn)?;
-        }
-        #[cfg(feature = "product-store-sqlite")]
-        {
-            diesel::delete(product).execute(conn)?;
-            diesel::delete(product_property_value).execute(conn)?;
-        }
-        #[cfg(feature = "schema-store-sqlite")]
-        {
-            diesel::delete(grid_property_definition).execute(conn)?;
-            diesel::delete(grid_schema).execute(conn)?;
-        }
-        #[cfg(feature = "track-and-trace")]
-        {
-            diesel::delete(associated_agent).execute(conn)?;
-            diesel::delete(property).execute(conn)?;
-            diesel::delete(proposal).execute(conn)?;
-            diesel::delete(record).execute(conn)?;
-            diesel::delete(reported_value).execute(conn)?;
-            diesel::delete(reporter).execute(conn)?;
-        }
-        diesel::delete(chain_record).execute(conn)?;
-        diesel::delete(commits).execute(conn)?;
-
-        Ok(())
-    })?;
 
     Ok(())
 }

--- a/sdk/src/migrations/mod.rs
+++ b/sdk/src/migrations/mod.rs
@@ -31,11 +31,7 @@ mod diesel;
 pub mod error;
 
 #[cfg(feature = "postgres")]
-pub use self::diesel::postgres::clear_database as clear_postgres_database;
-#[cfg(feature = "postgres")]
 pub use self::diesel::postgres::run_migrations as run_postgres_migrations;
 
-#[cfg(feature = "sqlite")]
-pub use self::diesel::sqlite::clear_database as clear_sqlite_database;
 #[cfg(feature = "sqlite")]
 pub use self::diesel::sqlite::run_migrations as run_sqlite_migrations;

--- a/sdk/src/testing/mod.rs
+++ b/sdk/src/testing/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "test-postgres")]
+mod postgres;
+#[cfg(feature = "test-sqlite")]
+mod sqlite;
+
+#[cfg(feature = "test-postgres")]
+pub use self::postgres::clear_database as clear_postgres_database;
+#[cfg(feature = "test-sqlite")]
+pub use self::sqlite::clear_database as clear_sqlite_database;

--- a/sdk/src/testing/postgres/mod.rs
+++ b/sdk/src/testing/postgres/mod.rs
@@ -1,0 +1,94 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::commits::store::diesel::schema::{chain_record::dsl::*, commits::dsl::*};
+#[cfg(feature = "location-store-postgres")]
+use crate::location::store::diesel::schema::{location::dsl::*, location_attribute::dsl::*};
+#[cfg(all(feature = "pike", feature = "location-store-postgres"))]
+use crate::pike::store::diesel::schema::pike_organization_location_assoc::dsl::*;
+#[cfg(feature = "pike")]
+use crate::pike::store::diesel::schema::{
+    pike_agent::dsl::*, pike_agent_role_assoc::dsl::*, pike_allowed_orgs::dsl::*,
+    pike_inherit_from::dsl::*, pike_organization::dsl::*, pike_organization_alternate_id::dsl::*,
+    pike_organization_metadata::dsl::*, pike_permissions::dsl::*, pike_role::dsl::*,
+};
+#[cfg(feature = "product-store-postgres")]
+use crate::product::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*};
+#[cfg(feature = "schema-store-postgres")]
+use crate::schema::store::diesel::schema::{
+    grid_property_definition::dsl::grid_property_definition, grid_schema::dsl::*,
+};
+#[cfg(feature = "track-and-trace")]
+use crate::track_and_trace::store::diesel::schema::{
+    associated_agent::dsl::*, property::dsl::*, proposal::dsl::*, record::dsl::*,
+    reported_value::dsl::*, reporter::dsl::*,
+};
+
+use crate::diesel::RunQueryDsl;
+use diesel::{pg::PgConnection, Connection};
+
+use crate::migrations::error::MigrationsError;
+
+/// This function is used to clear the postgres database when running tests
+/// against it. This just removes all the records for the active features.
+pub fn clear_database(conn: &PgConnection) -> Result<(), MigrationsError> {
+    conn.transaction::<_, MigrationsError, _>(|| {
+        #[cfg(feature = "pike")]
+        {
+            diesel::delete(pike_agent).execute(conn)?;
+            diesel::delete(pike_inherit_from).execute(conn)?;
+            diesel::delete(pike_permissions).execute(conn)?;
+            diesel::delete(pike_allowed_orgs).execute(conn)?;
+            diesel::delete(pike_agent_role_assoc).execute(conn)?;
+            diesel::delete(pike_organization_metadata).execute(conn)?;
+            diesel::delete(pike_organization_alternate_id).execute(conn)?;
+            diesel::delete(pike_organization).execute(conn)?;
+            diesel::delete(pike_role).execute(conn)?;
+        }
+        #[cfg(feature = "location-store-postgres")]
+        {
+            diesel::delete(location_attribute).execute(conn)?;
+            diesel::delete(location).execute(conn)?;
+        }
+        #[cfg(all(feature = "pike", feature = "location-store-postgres"))]
+        {
+            diesel::delete(pike_organization_location_assoc).execute(conn)?;
+        }
+        #[cfg(feature = "product-store-postgres")]
+        {
+            diesel::delete(product).execute(conn)?;
+            diesel::delete(product_property_value).execute(conn)?;
+        }
+        #[cfg(feature = "schema-store-postgres")]
+        {
+            diesel::delete(grid_property_definition).execute(conn)?;
+            diesel::delete(grid_schema).execute(conn)?;
+        }
+        #[cfg(feature = "track-and-trace")]
+        {
+            diesel::delete(associated_agent).execute(conn)?;
+            diesel::delete(property).execute(conn)?;
+            diesel::delete(proposal).execute(conn)?;
+            diesel::delete(record).execute(conn)?;
+            diesel::delete(reported_value).execute(conn)?;
+            diesel::delete(reporter).execute(conn)?;
+        }
+        diesel::delete(chain_record).execute(conn)?;
+        diesel::delete(commits).execute(conn)?;
+
+        Ok(())
+    })?;
+
+    Ok(())
+}

--- a/sdk/src/testing/sqlite/mod.rs
+++ b/sdk/src/testing/sqlite/mod.rs
@@ -1,0 +1,94 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::commits::store::diesel::schema::{chain_record::dsl::*, commits::dsl::*};
+#[cfg(feature = "location-store-sqlite")]
+use crate::location::store::diesel::schema::{location::dsl::*, location_attribute::dsl::*};
+#[cfg(all(feature = "pike", feature = "location-store-sqlite"))]
+use crate::pike::store::diesel::schema::pike_organization_location_assoc::dsl::*;
+#[cfg(feature = "pike")]
+use crate::pike::store::diesel::schema::{
+    pike_agent::dsl::*, pike_agent_role_assoc::dsl::*, pike_allowed_orgs::dsl::*,
+    pike_inherit_from::dsl::*, pike_organization::dsl::*, pike_organization_alternate_id::dsl::*,
+    pike_organization_metadata::dsl::*, pike_permissions::dsl::*, pike_role::dsl::*,
+};
+#[cfg(feature = "product-store-sqlite")]
+use crate::product::store::diesel::schema::{product::dsl::*, product_property_value::dsl::*};
+#[cfg(feature = "schema-store-sqlite")]
+use crate::schema::store::diesel::schema::{
+    grid_property_definition::dsl::grid_property_definition, grid_schema::dsl::*,
+};
+#[cfg(feature = "track-and-trace")]
+use crate::track_and_trace::store::diesel::schema::{
+    associated_agent::dsl::*, property::dsl::*, proposal::dsl::*, record::dsl::*,
+    reported_value::dsl::*, reporter::dsl::*,
+};
+
+use crate::diesel::RunQueryDsl;
+use diesel::{sqlite::SqliteConnection, Connection};
+
+use crate::migrations::error::MigrationsError;
+
+/// This function is used to clear the sqlite database when running tests
+/// against it. This just removes all the records for the active features.
+pub fn clear_database(conn: &SqliteConnection) -> Result<(), MigrationsError> {
+    conn.transaction::<_, MigrationsError, _>(|| {
+        #[cfg(feature = "pike")]
+        {
+            diesel::delete(pike_agent).execute(conn)?;
+            diesel::delete(pike_inherit_from).execute(conn)?;
+            diesel::delete(pike_permissions).execute(conn)?;
+            diesel::delete(pike_allowed_orgs).execute(conn)?;
+            diesel::delete(pike_agent_role_assoc).execute(conn)?;
+            diesel::delete(pike_organization_metadata).execute(conn)?;
+            diesel::delete(pike_organization_alternate_id).execute(conn)?;
+            diesel::delete(pike_organization).execute(conn)?;
+            diesel::delete(pike_role).execute(conn)?;
+        }
+        #[cfg(feature = "location-store-sqlite")]
+        {
+            diesel::delete(location_attribute).execute(conn)?;
+            diesel::delete(location).execute(conn)?;
+        }
+        #[cfg(all(feature = "pike", feature = "location-store-sqlite"))]
+        {
+            diesel::delete(pike_organization_location_assoc).execute(conn)?;
+        }
+        #[cfg(feature = "product-store-sqlite")]
+        {
+            diesel::delete(product).execute(conn)?;
+            diesel::delete(product_property_value).execute(conn)?;
+        }
+        #[cfg(feature = "schema-store-sqlite")]
+        {
+            diesel::delete(grid_property_definition).execute(conn)?;
+            diesel::delete(grid_schema).execute(conn)?;
+        }
+        #[cfg(feature = "track-and-trace")]
+        {
+            diesel::delete(associated_agent).execute(conn)?;
+            diesel::delete(property).execute(conn)?;
+            diesel::delete(proposal).execute(conn)?;
+            diesel::delete(record).execute(conn)?;
+            diesel::delete(reported_value).execute(conn)?;
+            diesel::delete(reporter).execute(conn)?;
+        }
+        diesel::delete(chain_record).execute(conn)?;
+        diesel::delete(commits).execute(conn)?;
+
+        Ok(())
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION
This moves the `clear_database` functions for clearing the postgres and
sqlite databases to a new testing module. These are guarded behind new
features `test-postgres` and `test-sqlite` respectively. This does not
change any functionality.

Signed-off-by: Davey Newhall <newhall@bitwise.io>