### PR TITLE
Update CLI PO create to include not-draft option

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1170,10 +1170,24 @@ fn run() -> Result<(), CliError> {
                             .takes_value(true)
                             .help("Workflow status of this Purchase Order version"),
                     )
-                    .arg(Arg::with_name("draft").long("draft").help(
-                        "Specify this Purchase Order version is not a draft. \
-                        By default, a newly created version is a draft.",
-                    ))
+                    .arg(
+                        Arg::with_name("draft")
+                            .long("draft")
+                            .conflicts_with("not-draft")
+                            .help(
+                                "Specify this Purchase Order version is a draft. \
+                                By default, a newly created version is a draft.",
+                            ),
+                    )
+                    .arg(
+                        Arg::with_name("not_draft")
+                            .long("not-draft")
+                            .conflicts_with("draft")
+                            .help(
+                                "Specify this Purchase Order version is not a draft. \
+                                By default, a newly created version is a draft.",
+                            ),
+                    )
                     .arg(
                         Arg::with_name("order_xml")
                             .value_name("file")


### PR DESCRIPTION
The Man page specifies that there would be both a draft - which is by
default, and a not-draft flag. Updated this implementation to match the
man-page, because draft is a flag and is set to true by default, there
would be no way of setting it to false. Also draft and not-draft is
the convention used for other components. This method is not yet
implemented so it should have no impact on the application.

Signed-off-by: Kevin Johnson <kevin_johnson@cargill.com>