### PR TITLE
Check all required schema for product / location

### DIFF
--- a/cli/src/actions/products.rs
+++ b/cli/src/actions/products.rs
@@ -501,118 +501,140 @@ fn yaml_to_property_values(
     definitions: Vec<PropertyDefinition>,
 ) -> Result<Vec<PropertyValue>, CliError> {
     let mut property_values = Vec::new();
+    let mut property_error_messages = Vec::new();
 
     for def in definitions {
-        let value = if let Some(value) = properties.get(&def.name) {
-            value
-        } else if !def.required {
-            continue;
-        } else {
-            if def.name == GDSN_3_1_PROPERTY_NAME {
-                continue;
+        match get_property_value_from_property_definition(properties, def) {
+            Ok(Some(property_value)) => property_values.push(property_value),
+            Ok(None) => (),
+            Err(CliError::YamlProcessingError(mut messages)) => {
+                property_error_messages.append(&mut messages);
             }
-            return Err(CliError::UserError(format!("Field {} not found", def.name)));
-        };
-
-        match def.data_type {
-            DataType::Bytes => {
-                let mut f = File::open(&serde_yaml::from_value::<String>(value.clone())?)?;
-                let mut buffer = Vec::new();
-                f.read_to_end(&mut buffer)?;
-
-                let property_value = PropertyValueBuilder::new()
-                    .with_name(def.name)
-                    .with_data_type(def.data_type.into())
-                    .with_bytes_value(buffer)
-                    .build()
-                    .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
-
-                property_values.push(property_value);
+            Err(CliError::PayloadError(message)) => {
+                property_error_messages.push(message);
             }
-            DataType::Boolean => {
-                let property_value = PropertyValueBuilder::new()
-                    .with_name(def.name.clone())
-                    .with_data_type(def.data_type.into())
-                    .with_boolean_value(serde_yaml::from_value(value.clone())?)
-                    .build()
-                    .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
-                property_values.push(property_value);
-            }
-            DataType::Number => {
-                let property_value = PropertyValueBuilder::new()
-                    .with_name(def.name.clone())
-                    .with_data_type(def.data_type.into())
-                    .with_number_value(serde_yaml::from_value(value.clone())?)
-                    .build()
-                    .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
-                property_values.push(property_value);
-            }
-            DataType::String => {
-                let property_value = PropertyValueBuilder::new()
-                    .with_name(def.name.clone())
-                    .with_data_type(def.data_type.into())
-                    .with_string_value(serde_yaml::from_value(value.clone())?)
-                    .build()
-                    .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
-                property_values.push(property_value);
-            }
-            DataType::Enum => {
-                let property_value = PropertyValueBuilder::new()
-                    .with_name(def.name.clone())
-                    .with_data_type(def.data_type.into())
-                    .with_enum_value(serde_yaml::from_value(value.clone())?)
-                    .build()
-                    .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
-                property_values.push(property_value);
-            }
-            DataType::Struct => {
-                let properties: HashMap<String, serde_yaml::Value> =
-                    serde_yaml::from_value(value.clone())?;
-                let property_value = PropertyValueBuilder::new()
-                    .with_name(def.name.clone())
-                    .with_data_type(def.data_type.into())
-                    .with_struct_values(yaml_to_property_values(
-                        &properties,
-                        def.struct_properties,
-                    )?)
-                    .build()
-                    .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
-                property_values.push(property_value);
-            }
-            DataType::LatLong => {
-                let lat_long = serde_yaml::from_value::<String>(value.clone())?
-                    .split(',')
-                    .map(|x| {
-                        x.parse::<i64>()
-                            .map_err(|err| CliError::PayloadError(format!("{}", err)))
-                    })
-                    .collect::<Result<Vec<i64>, CliError>>()?;
-
-                if lat_long.len() != 2 {
-                    return Err(CliError::PayloadError(format!(
-                        "{:?} is not a valid latitude longitude",
-                        lat_long
-                    )));
-                }
-
-                let lat_long = LatLongBuilder::new()
-                    .with_lat_long(lat_long[0], lat_long[1])
-                    .build()
-                    .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
-
-                let property_value = PropertyValueBuilder::new()
-                    .with_name(def.name)
-                    .with_data_type(def.data_type.into())
-                    .with_lat_long_value(lat_long)
-                    .build()
-                    .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
-
-                property_values.push(property_value);
+            Err(err) => {
+                return Err(err);
             }
         }
     }
 
-    Ok(property_values)
+    if !property_error_messages.is_empty() {
+        Err(CliError::YamlProcessingError(property_error_messages))
+    } else {
+        Ok(property_values)
+    }
+}
+
+fn get_property_value_from_property_definition(
+    properties: &HashMap<String, serde_yaml::Value>,
+    def: PropertyDefinition,
+) -> Result<Option<PropertyValue>, CliError> {
+    let value = if let Some(value) = properties.get(&def.name) {
+        value
+    } else if !def.required {
+        return Ok(None);
+    } else {
+        if def.name == GDSN_3_1_PROPERTY_NAME {
+            return Ok(None);
+        }
+        return Err(CliError::UserError(format!("Field {} not found", def.name)));
+    };
+
+    match def.data_type {
+        DataType::Bytes => {
+            let mut f = File::open(&serde_yaml::from_value::<String>(value.clone())?)?;
+            let mut buffer = Vec::new();
+            f.read_to_end(&mut buffer)?;
+
+            let property_value = PropertyValueBuilder::new()
+                .with_name(def.name)
+                .with_data_type(def.data_type.into())
+                .with_bytes_value(buffer)
+                .build()
+                .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
+
+            Ok(Some(property_value))
+        }
+        DataType::Boolean => {
+            let property_value = PropertyValueBuilder::new()
+                .with_name(def.name.clone())
+                .with_data_type(def.data_type.into())
+                .with_boolean_value(serde_yaml::from_value(value.clone())?)
+                .build()
+                .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
+
+            Ok(Some(property_value))
+        }
+        DataType::Number => {
+            let property_value = PropertyValueBuilder::new()
+                .with_name(def.name.clone())
+                .with_data_type(def.data_type.into())
+                .with_number_value(serde_yaml::from_value(value.clone())?)
+                .build()
+                .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
+            Ok(Some(property_value))
+        }
+        DataType::String => {
+            let property_value = PropertyValueBuilder::new()
+                .with_name(def.name.clone())
+                .with_data_type(def.data_type.into())
+                .with_string_value(serde_yaml::from_value(value.clone())?)
+                .build()
+                .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
+            Ok(Some(property_value))
+        }
+        DataType::Enum => {
+            let property_value = PropertyValueBuilder::new()
+                .with_name(def.name.clone())
+                .with_data_type(def.data_type.into())
+                .with_enum_value(serde_yaml::from_value(value.clone())?)
+                .build()
+                .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
+            Ok(Some(property_value))
+        }
+        DataType::Struct => {
+            let properties: HashMap<String, serde_yaml::Value> =
+                serde_yaml::from_value(value.clone())?;
+            let property_value = PropertyValueBuilder::new()
+                .with_name(def.name.clone())
+                .with_data_type(def.data_type.into())
+                .with_struct_values(yaml_to_property_values(&properties, def.struct_properties)?)
+                .build()
+                .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
+            Ok(Some(property_value))
+        }
+        DataType::LatLong => {
+            let lat_long = serde_yaml::from_value::<String>(value.clone())?
+                .split(',')
+                .map(|x| {
+                    x.parse::<i64>()
+                        .map_err(|err| CliError::PayloadError(format!("{}", err)))
+                })
+                .collect::<Result<Vec<i64>, CliError>>()?;
+
+            if lat_long.len() != 2 {
+                return Err(CliError::PayloadError(format!(
+                    "{:?} is not a valid latitude longitude",
+                    lat_long
+                )));
+            }
+
+            let lat_long = LatLongBuilder::new()
+                .with_lat_long(lat_long[0], lat_long[1])
+                .build()
+                .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
+
+            let property_value = PropertyValueBuilder::new()
+                .with_name(def.name)
+                .with_data_type(def.data_type.into())
+                .with_lat_long_value(lat_long)
+                .build()
+                .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
+
+            Ok(Some(property_value))
+        }
+    }
 }
 
 fn submit_payloads(

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -51,6 +51,8 @@ pub enum CliError {
         feature = "schema",
     ))]
     DaemonError(String),
+    #[cfg(any(feature = "location", feature = "product",))]
+    YamlProcessingError(Vec<String>),
 }
 
 impl StdError for CliError {
@@ -86,6 +88,8 @@ impl StdError for CliError {
                 feature = "schema",
             ))]
             CliError::DaemonError(_) => None,
+            #[cfg(any(feature = "location", feature = "product",))]
+            CliError::YamlProcessingError(_) => None,
         }
     }
 }
@@ -125,6 +129,10 @@ impl std::fmt::Display for CliError {
                 feature = "schema",
             ))]
             CliError::DaemonError(ref err) => write!(f, "{}", err.replace("\"", "")),
+            #[cfg(any(feature = "location", feature = "product",))]
+            CliError::YamlProcessingError(ref list) => {
+                write!(f, "Errors occurred while proccessing yaml: {:?}", list)
+            }
         }
     }
 }


### PR DESCRIPTION
Instead of short-circuiting at any CliError in yaml_to_property_values
functions, iterate through the entire payload and return a more
comprehensive list of errors. Because we're coalescing the CliError
types, I chose UserError to encapsulate the differing types of CliErrors
that may occur. Also Introduced InternalError to the cli,
already present in grid_sdk.