### PR TITLE
Move batch struct conversion to models file

### DIFF
--- a/sdk/src/batches/store/diesel/mod.rs
+++ b/sdk/src/batches/store/diesel/mod.rs
@@ -19,7 +19,7 @@ pub(in crate) mod schema;
 use diesel::r2d2::{ConnectionManager, Pool};
 
 use super::diesel::models::{BatchModel, TransactionModel};
-use super::{Batch, BatchList, BatchStore, BatchStoreError, BatchSubmitInfo, Transaction};
+use super::{Batch, BatchList, BatchStore, BatchStoreError, BatchSubmitInfo};
 use crate::error::ResourceTemporarilyUnavailableError;
 
 use operations::add_batch::AddBatchOperation as _;
@@ -190,89 +190,5 @@ impl BatchStore for DieselBatchStore<diesel::sqlite::SqliteConnection> {
             )
         })?)
         .relinquish_claim(id)
-    }
-}
-
-impl From<(BatchModel, Vec<TransactionModel>)> for Batch {
-    fn from((batch_model, transaction_models): (BatchModel, Vec<TransactionModel>)) -> Self {
-        Self {
-            header_signature: batch_model.header_signature,
-            data_change_id: batch_model.data_change_id,
-            signer_public_key: batch_model.signer_public_key,
-            trace: batch_model.trace,
-            serialized_batch: batch_model.serialized_batch,
-            submitted: batch_model.submitted,
-            submission_error: batch_model.submission_error,
-            submission_error_message: batch_model.submission_error_message,
-            dlt_status: batch_model.dlt_status,
-            claim_expires: batch_model.claim_expires,
-            created: batch_model.created,
-            service_id: batch_model.service_id,
-            transactions: transaction_models
-                .into_iter()
-                .map(Transaction::from)
-                .collect(),
-        }
-    }
-}
-
-impl From<Batch> for (BatchModel, Vec<TransactionModel>) {
-    fn from(batch: Batch) -> Self {
-        let batch_model = BatchModel {
-            header_signature: batch.header_signature,
-            data_change_id: batch.data_change_id,
-            signer_public_key: batch.signer_public_key,
-            trace: batch.trace,
-            serialized_batch: batch.serialized_batch,
-            submitted: batch.submitted,
-            submission_error: batch.submission_error,
-            submission_error_message: batch.submission_error_message,
-            dlt_status: batch.dlt_status,
-            claim_expires: batch.claim_expires,
-            created: batch.created,
-            service_id: batch.service_id,
-        };
-
-        let transaction_models = batch
-            .transactions
-            .into_iter()
-            .map(TransactionModel::from)
-            .collect();
-
-        (batch_model, transaction_models)
-    }
-}
-
-impl From<TransactionModel> for Transaction {
-    fn from(model: TransactionModel) -> Self {
-        Self {
-            header_signature: model.header_signature,
-            batch_id: model.batch_id,
-            family_name: model.family_name,
-            family_version: model.family_version,
-            signer_public_key: model.signer_public_key,
-        }
-    }
-}
-
-impl From<Transaction> for TransactionModel {
-    fn from(transaction: Transaction) -> Self {
-        Self {
-            header_signature: transaction.header_signature,
-            batch_id: transaction.batch_id,
-            family_name: transaction.family_name,
-            family_version: transaction.family_version,
-            signer_public_key: transaction.signer_public_key,
-        }
-    }
-}
-
-impl From<BatchModel> for BatchSubmitInfo {
-    fn from(model: BatchModel) -> Self {
-        Self {
-            header_signature: model.header_signature,
-            serialized_batch: model.serialized_batch,
-            service_id: model.service_id,
-        }
     }
 }

--- a/sdk/src/batches/store/diesel/models.rs
+++ b/sdk/src/batches/store/diesel/models.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::batches::store::diesel::schema::*;
+use crate::batches::store::{diesel::schema::*, Batch, BatchSubmitInfo, Transaction};
 use chrono::NaiveDateTime;
 
 #[derive(Insertable, Queryable, PartialEq, Debug)]
@@ -52,4 +52,88 @@ pub struct TransactionReceiptModel {
     pub serialized_receipt: String,
     pub external_status: Option<String>,
     pub external_error_message: Option<String>,
+}
+
+impl From<(BatchModel, Vec<TransactionModel>)> for Batch {
+    fn from((batch_model, transaction_models): (BatchModel, Vec<TransactionModel>)) -> Self {
+        Self {
+            header_signature: batch_model.header_signature,
+            data_change_id: batch_model.data_change_id,
+            signer_public_key: batch_model.signer_public_key,
+            trace: batch_model.trace,
+            serialized_batch: batch_model.serialized_batch,
+            submitted: batch_model.submitted,
+            submission_error: batch_model.submission_error,
+            submission_error_message: batch_model.submission_error_message,
+            dlt_status: batch_model.dlt_status,
+            claim_expires: batch_model.claim_expires,
+            created: batch_model.created,
+            service_id: batch_model.service_id,
+            transactions: transaction_models
+                .into_iter()
+                .map(Transaction::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<Batch> for (BatchModel, Vec<TransactionModel>) {
+    fn from(batch: Batch) -> Self {
+        let batch_model = BatchModel {
+            header_signature: batch.header_signature,
+            data_change_id: batch.data_change_id,
+            signer_public_key: batch.signer_public_key,
+            trace: batch.trace,
+            serialized_batch: batch.serialized_batch,
+            submitted: batch.submitted,
+            submission_error: batch.submission_error,
+            submission_error_message: batch.submission_error_message,
+            dlt_status: batch.dlt_status,
+            claim_expires: batch.claim_expires,
+            created: batch.created,
+            service_id: batch.service_id,
+        };
+
+        let transaction_models = batch
+            .transactions
+            .into_iter()
+            .map(TransactionModel::from)
+            .collect();
+
+        (batch_model, transaction_models)
+    }
+}
+
+impl From<TransactionModel> for Transaction {
+    fn from(model: TransactionModel) -> Self {
+        Self {
+            header_signature: model.header_signature,
+            batch_id: model.batch_id,
+            family_name: model.family_name,
+            family_version: model.family_version,
+            signer_public_key: model.signer_public_key,
+        }
+    }
+}
+
+impl From<Transaction> for TransactionModel {
+    fn from(transaction: Transaction) -> Self {
+        Self {
+            header_signature: transaction.header_signature,
+            batch_id: transaction.batch_id,
+            family_name: transaction.family_name,
+            family_version: transaction.family_version,
+            signer_public_key: transaction.signer_public_key,
+        }
+    }
+}
+
+impl From<BatchModel> for BatchSubmitInfo {
+    fn from(model: BatchModel) -> Self {
+        Self {
+            header_signature: model.header_signature,
+            serialized_batch: model.serialized_batch,
+            service_id: model.service_id,
+        }
+    }
 }


### PR DESCRIPTION
This moves the batch store struct conversion implementations to the
models.rs file. This is part of the batch store stabilization effort and
brings the store in line with the others.

Signed-off-by: Davey Newhall <newhall@bitwise.io>