### PR TITLE
Fix typo in gdsn product

### DIFF
--- a/sdk/src/product/gdsn/mod.rs
+++ b/sdk/src/product/gdsn/mod.rs
@@ -36,7 +36,7 @@ use crate::protocol::{
     schema::state::{DataType, PropertyValueBuilder},
 };
 pub use error::ProductGdsnError;
-use validate::validate_product_definitons;
+use validate::validate_product_definitions;
 
 // Name of the property where GDSN 3.1 XML data will be stored
 pub const GDSN_3_1_PROPERTY_NAME: &str = "GDSN_3_1";
@@ -126,7 +126,7 @@ pub fn get_trade_items_from_xml(path: &str) -> Result<Vec<TradeItem>, ProductGds
         ))
     })?;
 
-    validate_product_definitons(path)?;
+    validate_product_definitions(path)?;
 
     let mut reader = Reader::from_str(&xml_str);
     reader.trim_text(true);

--- a/sdk/src/product/gdsn/validate.rs
+++ b/sdk/src/product/gdsn/validate.rs
@@ -59,7 +59,7 @@ extern "C" {
 ///
 /// * `xml_path` - The path to an XML file containing GDSN trade item definitions
 ///
-pub fn validate_product_definitons(xml_path: &str) -> Result<(), ProductGdsnError> {
+pub fn validate_product_definitions(xml_path: &str) -> Result<(), ProductGdsnError> {
     let schema = load_schema();
     let path = CString::new(xml_path)
         .map_err(|err| ProductGdsnError::Internal(InternalError::from_source(Box::new(err))))?;


### PR DESCRIPTION
This fixes a typo in the function name `validate_product_definitons` to
`validate_product_definitions`

Signed-off-by: Davey Newhall <newhall@bitwise.io>