### PR TITLE
Add Pike documentation to Grid SDK

### DIFF
--- a/sdk/src/pike/addressing.rs
+++ b/sdk/src/pike/addressing.rs
@@ -12,21 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides addressing functionality for Pike.
+
 use crypto::digest::Digest;
 use crypto::sha2::Sha512;
 
+/// Namespace for Pike objects, prefixes addresses
 pub const PIKE_NAMESPACE: &str = "621dee05";
 
+/// Address prefix representing Pike agents
 pub const AGENT_PREFIX: &str = "00";
+/// Namespace specific to Pike agents
 pub const PIKE_AGENT_NAMESPACE: &str = "621dee0500";
 
+/// Address prefix representing Pike organizations
 pub const ORG_PREFIX: &str = "01";
+/// Namespace specific to Pike organizations
 pub const PIKE_ORGANIZATION_NAMESPACE: &str = "621dee0501";
 
+/// Address prefix representing Pike roles
 pub const ROLE_PREFIX: &str = "02";
+/// Namespace specific to Pike roles
 pub const PIKE_ROLE_NAMESPACE: &str = "621dee0502";
 
+/// Address prefix representing Pike alternate IDs
 pub const ALTERNATE_ID_INDEX_ENTRY_PREFIX: &str = "03";
+/// Namespace specific to Pike alternate IDs
 pub const PIKE_ALTERNATE_ID_INDEX_ENTRY_NAMESPACE: &str = "621dee0503";
 
 /// Computes the address a Pike Agent is stored at based on its public_key

--- a/sdk/src/pike/store/diesel/mod.rs
+++ b/sdk/src/pike/store/diesel/mod.rs
@@ -12,6 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Database backend support for the PikeStore, powered by
+//! [`Diesel`](https://crates.io/crates/diesel).
+//!
+//! This module contains the [`DieselPikeStore`], which provides an implementation of the
+//! [`PikeStore`] trait.
+//!
+//! [`DieselPikeStore`]: struct.DieselPikeStore.html
+//! [`PikeStore`]: ../trait.PikeStore.html
+
 pub mod models;
 mod operations;
 pub(in crate) mod schema;

--- a/sdk/src/pike/store/diesel/models.rs
+++ b/sdk/src/pike/store/diesel/models.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Database representations used to implement a diesel backend for the `PikeStore`.
+//! These structs differ slightly from their associated native representation to conform to
+//! the requirements for storing data with a diesel backend.
+
 use chrono::NaiveDateTime;
 
 use super::{Agent, AlternateId, Organization, OrganizationMetadata, Role};
@@ -34,9 +38,11 @@ pub struct NewAgentModel {
     pub service_id: Option<String>,
 }
 
+/// Database model representation of a Pike `Agent`
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "pike_agent"]
 pub struct AgentModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
     pub id: i64,
     pub state_address: String,
     pub public_key: String,
@@ -62,9 +68,11 @@ pub struct NewRoleModel {
     pub service_id: Option<String>,
 }
 
+/// Database model representation of a Pike `Role`
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "pike_role"]
 pub struct RoleModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
     pub id: i64,
     pub state_address: String,
     pub org_id: String,
@@ -88,9 +96,11 @@ pub struct NewRoleAssociationModel {
     pub service_id: Option<String>,
 }
 
+/// Database model representation of a Pike `Role` associated with an `Organization` and `Agent`
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "pike_agent_role_assoc"]
 pub struct RoleAssociationModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
     pub id: i64,
     pub agent_public_key: String,
     pub org_id: String,
@@ -111,9 +121,11 @@ pub struct NewRoleStateAddressAssociationModel {
     pub service_id: Option<String>,
 }
 
+/// Database model representation of a Pike `Role` associated with a state address
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "pike_role_state_address_assoc"]
 pub struct RoleStateAddressAssociationModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
     pub id: i64,
     pub state_address: String,
     pub org_id: String,
@@ -134,9 +146,11 @@ pub struct NewPermissionModel {
     pub service_id: Option<String>,
 }
 
+/// Database model representation of a Pike `Permission`
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "pike_permissions"]
 pub struct PermissionModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
     pub id: i64,
     pub role_name: String,
     pub org_id: String,
@@ -158,9 +172,11 @@ pub struct NewInheritFromModel {
     pub service_id: Option<String>,
 }
 
+/// Database model representation of the Pike `roles` that a `role` inherits attributes from
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "pike_inherit_from"]
 pub struct InheritFromModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
     pub id: i64,
     pub role_name: String,
     pub org_id: String,
@@ -182,9 +198,12 @@ pub struct NewAllowedOrgModel {
     pub service_id: Option<String>,
 }
 
+/// Database model representation of Pike `organizations` allowed to use the specified `Role`,
+/// besides the defining `organization`
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "pike_allowed_orgs"]
 pub struct AllowedOrgModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
     pub id: i64,
     pub role_name: String,
     pub org_id: String,
@@ -205,6 +224,7 @@ pub struct NewOrganizationModel {
     pub service_id: Option<String>,
 }
 
+/// Database model representation of a Pike `organization`
 #[derive(Queryable, PartialEq, Identifiable, Debug)]
 #[table_name = "pike_organization"]
 pub struct OrganizationModel {
@@ -230,9 +250,11 @@ pub struct NewOrganizationMetadataModel {
     pub service_id: Option<String>,
 }
 
+/// Database model representation of a Pike `organization`'s `metadata`
 #[derive(Queryable, PartialEq, Identifiable, Debug)]
 #[table_name = "pike_organization_metadata"]
 pub struct OrganizationMetadataModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
     pub id: i64,
     pub org_id: String,
     pub key: String,
@@ -253,9 +275,11 @@ pub struct NewAlternateIdModel {
     pub service_id: Option<String>,
 }
 
+/// Database model representation of a Pike `alternate_id`
 #[derive(Queryable, PartialEq, Identifiable, Debug)]
 #[table_name = "pike_organization_alternate_id"]
 pub struct AlternateIdModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
     pub id: i64,
     pub org_id: String,
     pub alternate_id_type: String,
@@ -293,9 +317,11 @@ pub struct NewLocationAssociationModel {
     pub service_id: Option<String>,
 }
 
+/// Database model representation of a Pike `organization`'s associated `location`
 #[derive(Queryable, PartialEq, Identifiable, Debug)]
 #[table_name = "pike_organization_location_assoc"]
 pub struct LocationAssociationModel {
+    ///  This is the record id for the slowly-changing-dimensions table.
     pub id: i64,
     pub org_id: String,
     pub location_id: String,

--- a/sdk/src/pike/store/diesel/operations/add_agent.rs
+++ b/sdk/src/pike/store/diesel/operations/add_agent.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the "add agent" operation for the `DieselPikeStore`.
+
 use super::PikeStoreOperations;
 use crate::pike::store::diesel::{
     schema::{pike_agent, pike_agent_role_assoc},

--- a/sdk/src/pike/store/diesel/operations/add_organization.rs
+++ b/sdk/src/pike/store/diesel/operations/add_organization.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the "add organization" operation for the `DieselPikeStore`.
+
 use super::PikeStoreOperations;
 use crate::pike::store::diesel::{
     schema::{

--- a/sdk/src/pike/store/diesel/operations/add_role.rs
+++ b/sdk/src/pike/store/diesel/operations/add_role.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the "add role" operation for the `DieselPikeStore`.
+
 use super::PikeStoreOperations;
 use crate::pike::store::diesel::{
     schema::{

--- a/sdk/src/pike/store/diesel/operations/delete_role.rs
+++ b/sdk/src/pike/store/diesel/operations/delete_role.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the "list organizations" operation for the `DieselPikeStore`.
+
 use super::PikeStoreOperations;
 use crate::error::InternalError;
 use crate::pike::store::diesel::{

--- a/sdk/src/pike/store/diesel/operations/get_agent.rs
+++ b/sdk/src/pike/store/diesel/operations/get_agent.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the "get agent" operation for the `DieselPikeStore`.
+
 use super::PikeStoreOperations;
 use crate::pike::store::diesel::{
     schema::{pike_agent, pike_agent_role_assoc},

--- a/sdk/src/pike/store/diesel/operations/get_organization.rs
+++ b/sdk/src/pike/store/diesel/operations/get_organization.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the "get organization" operation for the `DieselPikeStore`.
+
 use super::PikeStoreOperations;
 use crate::commits::MAX_COMMIT_NUM;
 use crate::error::InternalError;

--- a/sdk/src/pike/store/diesel/operations/get_role.rs
+++ b/sdk/src/pike/store/diesel/operations/get_role.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the "get role" operation for the `DieselPikeStore`.
+
 use super::PikeStoreOperations;
 use crate::commits::MAX_COMMIT_NUM;
 use crate::error::InternalError;

--- a/sdk/src/pike/store/diesel/operations/list_agents.rs
+++ b/sdk/src/pike/store/diesel/operations/list_agents.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the "list agents" operation for the `DieselPikeStore`.
+
 use super::PikeStoreOperations;
 use crate::paging::Paging;
 use crate::pike::store::diesel::{

--- a/sdk/src/pike/store/diesel/operations/list_organizations.rs
+++ b/sdk/src/pike/store/diesel/operations/list_organizations.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the "list organizations" operation for the `DieselPikeStore`.
+
 use super::PikeStoreOperations;
 use crate::commits::MAX_COMMIT_NUM;
 use crate::error::InternalError;

--- a/sdk/src/pike/store/diesel/operations/list_roles_for_organization.rs
+++ b/sdk/src/pike/store/diesel/operations/list_roles_for_organization.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the "list roles for an organization" operation for the `DieselPikeStore`.
+
 use super::PikeStoreOperations;
 use crate::commits::MAX_COMMIT_NUM;
 use crate::error::InternalError;

--- a/sdk/src/pike/store/diesel/operations/mod.rs
+++ b/sdk/src/pike/store/diesel/operations/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides database operations for the `DieselPikeStore`.
+
 pub(super) mod add_agent;
 pub(super) mod add_organization;
 pub(super) mod add_role;

--- a/sdk/src/pike/store/diesel/operations/update_agent.rs
+++ b/sdk/src/pike/store/diesel/operations/update_agent.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the "update agent" operation for the `DieselPikeStore`.
+
 use super::PikeStoreOperations;
 use crate::pike::store::diesel::{
     schema::{pike_agent, pike_agent_role_assoc},

--- a/sdk/src/pike/store/error.rs
+++ b/sdk/src/pike/store/error.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Types for errors that can be raised while using a `PikeStore`
+
 #[cfg(feature = "diesel")]
 use diesel::r2d2::PoolError;
 #[cfg(feature = "diesel")]

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -12,6 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Data store for writing and reading Pike smart contract state.
+//!
+//! The [`PikeStore`] trait provides the public interface for storing Pike agents, organizations
+//! and roles Grid provides the following implementations:
+//!
+//! * [`DieselPikeStore`] - A database-backed store, powered by [`Diesel`], that currently
+//!   supports SQLite databases (with the `sqlite` feature) and PostgreSQL databases (with the
+//!   `postgres` feature).
+//!
+//! [`PikeStore`]: trait.PikeStore.html
+//! [`DieselPikeStore`]: diesel/struct.DieselPikeStore.html
+//! [`Diesel`]: https://crates.io/crates/diesel
+
 #[cfg(feature = "diesel")]
 pub(in crate) mod diesel;
 mod error;


### PR DESCRIPTION
Adds module-level comments and docstrings to the Pike module in the Grid
SDK. Mainly adds comments to describe the functionality provided by the
`PikeStore`.

Signed-off-by: Shannyn Telander <telander@bitwise.io>