### PR TITLE
Add missing feature guard

### DIFF
--- a/daemon/src/event/db_handler.rs
+++ b/daemon/src/event/db_handler.rs
@@ -120,6 +120,7 @@ pub struct DatabaseEventHandler<C: diesel::Connection + 'static> {
     tnt_store: DieselTrackAndTraceStore<C>,
 }
 
+#[cfg(feature = "database-postgres")]
 impl DatabaseEventHandler<diesel::pg::PgConnection> {
     pub fn from_pg_pool(connection_pool: ConnectionPool<diesel::pg::PgConnection>) -> Self {
         let commit_store = DieselCommitStore::new(connection_pool.pool.clone());
@@ -151,6 +152,7 @@ impl DatabaseEventHandler<diesel::pg::PgConnection> {
     }
 }
 
+#[cfg(feature = "database-postgres")]
 impl EventHandler for DatabaseEventHandler<diesel::pg::PgConnection> {
     fn handle_event(&self, event: &CommitEvent) -> Result<(), EventError> {
         debug!("Received commit event: {}", event);


### PR DESCRIPTION
This adds a `database-postgres` feature guard to the database event
handler implementations in the daemon's db handler that was missing.

Signed-off-by: Davey Newhall <newhall@bitwise.io>