### PR TITLE
Fix Pike update ops for Sawtooth

### DIFF
--- a/sdk/src/pike/store/diesel/operations/add_agent.rs
+++ b/sdk/src/pike/store/diesel/operations/add_agent.rs
@@ -45,13 +45,19 @@ impl<'a> PikeStoreAddAgentOperation for PikeStoreOperations<'a, diesel::pg::PgCo
         roles: Vec<NewRoleAssociationModel>,
     ) -> Result<(), PikeStoreError> {
         self.conn.transaction::<_, PikeStoreError, _>(|| {
-            let duplicate_agent = pike_agent::table
-                .filter(
-                    pike_agent::public_key
-                        .eq(&agent.public_key)
-                        .and(pike_agent::service_id.eq(&agent.service_id))
-                        .and(pike_agent::end_commit_num.eq(MAX_COMMIT_NUM)),
-                )
+            let mut query = pike_agent::table.into_boxed().filter(
+                pike_agent::public_key
+                    .eq(&agent.public_key)
+                    .and(pike_agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+            if let Some(service_id) = &agent.service_id {
+                query = query.filter(pike_agent::service_id.eq(service_id));
+            } else {
+                query = query.filter(pike_agent::service_id.is_null());
+            }
+
+            let duplicate_agent = query
                 .first::<AgentModel>(self.conn)
                 .map(Some)
                 .or_else(|err| {
@@ -66,17 +72,30 @@ impl<'a> PikeStoreAddAgentOperation for PikeStoreOperations<'a, diesel::pg::PgCo
                 })?;
 
             if duplicate_agent.is_some() {
-                update(pike_agent::table)
-                    .filter(
-                        pike_agent::public_key
-                            .eq(&agent.public_key)
-                            .and(pike_agent::service_id.eq(&agent.service_id))
-                            .and(pike_agent::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    )
-                    .set(pike_agent::end_commit_num.eq(agent.start_commit_num))
-                    .execute(self.conn)
-                    .map(|_| ())
-                    .map_err(PikeStoreError::from)?;
+                if let Some(service_id) = &agent.service_id {
+                    update(pike_agent::table)
+                        .filter(
+                            pike_agent::public_key
+                                .eq(&agent.public_key)
+                                .and(pike_agent::service_id.eq(service_id))
+                                .and(pike_agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(pike_agent::end_commit_num.eq(agent.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
+                } else {
+                    update(pike_agent::table)
+                        .filter(
+                            pike_agent::public_key
+                                .eq(&agent.public_key)
+                                .and(pike_agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(pike_agent::end_commit_num.eq(agent.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
+                }
             }
 
             insert_into(pike_agent::table)
@@ -86,17 +105,24 @@ impl<'a> PikeStoreAddAgentOperation for PikeStoreOperations<'a, diesel::pg::PgCo
                 .map_err(PikeStoreError::from)?;
 
             for role in roles {
-                let duplicate_role = pike_agent_role_assoc::table
-                    .filter(
-                        pike_agent_role_assoc::agent_public_key
-                            .eq(&role.agent_public_key)
-                            .and(pike_agent_role_assoc::agent_public_key.eq(&agent.public_key))
-                            .and(pike_agent_role_assoc::org_id.eq(&agent.org_id))
-                            .and(pike_agent_role_assoc::org_id.eq(&role.org_id))
-                            .and(pike_agent_role_assoc::role_name.eq(&role.role_name))
-                            .and(pike_agent_role_assoc::service_id.eq(&role.service_id))
-                            .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    )
+                let mut query = pike_agent_role_assoc::table.into_boxed().filter(
+                    pike_agent_role_assoc::agent_public_key
+                        .eq(&role.agent_public_key)
+                        .and(pike_agent_role_assoc::agent_public_key.eq(&agent.public_key))
+                        .and(pike_agent_role_assoc::org_id.eq(&agent.org_id))
+                        .and(pike_agent_role_assoc::org_id.eq(&role.org_id))
+                        .and(pike_agent_role_assoc::role_name.eq(&role.role_name))
+                        .and(pike_agent_role_assoc::service_id.eq(&role.service_id))
+                        .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+                if let Some(service_id) = &role.service_id {
+                    query = query.filter(pike_agent_role_assoc::service_id.eq(service_id));
+                } else {
+                    query = query.filter(pike_agent_role_assoc::service_id.is_null());
+                }
+
+                let duplicate_role = query
                     .first::<RoleAssociationModel>(self.conn)
                     .map(Some)
                     .or_else(|err| {
@@ -111,21 +137,44 @@ impl<'a> PikeStoreAddAgentOperation for PikeStoreOperations<'a, diesel::pg::PgCo
                     })?;
 
                 if duplicate_role.is_some() {
-                    update(pike_agent_role_assoc::table)
-                        .filter(
-                            pike_agent_role_assoc::agent_public_key
-                                .eq(&role.agent_public_key)
-                                .and(pike_agent_role_assoc::agent_public_key.eq(&agent.public_key))
-                                .and(pike_agent_role_assoc::org_id.eq(&agent.org_id))
-                                .and(pike_agent_role_assoc::org_id.eq(&role.org_id))
-                                .and(pike_agent_role_assoc::role_name.eq(&role.role_name))
-                                .and(pike_agent_role_assoc::service_id.eq(&role.service_id))
-                                .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
-                        )
-                        .set(pike_agent_role_assoc::end_commit_num.eq(&role.start_commit_num))
-                        .execute(self.conn)
-                        .map(|_| ())
-                        .map_err(PikeStoreError::from)?;
+                    if let Some(service_id) = &role.service_id {
+                        update(pike_agent_role_assoc::table)
+                            .filter(
+                                pike_agent_role_assoc::agent_public_key
+                                    .eq(&role.agent_public_key)
+                                    .and(
+                                        pike_agent_role_assoc::agent_public_key
+                                            .eq(&agent.public_key),
+                                    )
+                                    .and(pike_agent_role_assoc::org_id.eq(&agent.org_id))
+                                    .and(pike_agent_role_assoc::org_id.eq(&role.org_id))
+                                    .and(pike_agent_role_assoc::role_name.eq(&role.role_name))
+                                    .and(pike_agent_role_assoc::service_id.eq(service_id))
+                                    .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_agent_role_assoc::end_commit_num.eq(&role.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    } else {
+                        update(pike_agent_role_assoc::table)
+                            .filter(
+                                pike_agent_role_assoc::agent_public_key
+                                    .eq(&role.agent_public_key)
+                                    .and(
+                                        pike_agent_role_assoc::agent_public_key
+                                            .eq(&agent.public_key),
+                                    )
+                                    .and(pike_agent_role_assoc::org_id.eq(&agent.org_id))
+                                    .and(pike_agent_role_assoc::org_id.eq(&role.org_id))
+                                    .and(pike_agent_role_assoc::role_name.eq(&role.role_name))
+                                    .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_agent_role_assoc::end_commit_num.eq(&role.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    }
                 }
 
                 insert_into(pike_agent_role_assoc::table)
@@ -148,13 +197,19 @@ impl<'a> PikeStoreAddAgentOperation for PikeStoreOperations<'a, diesel::sqlite::
         roles: Vec<NewRoleAssociationModel>,
     ) -> Result<(), PikeStoreError> {
         self.conn.transaction::<_, PikeStoreError, _>(|| {
-            let duplicate_agent = pike_agent::table
-                .filter(
-                    pike_agent::public_key
-                        .eq(&agent.public_key)
-                        .and(pike_agent::service_id.eq(&agent.service_id))
-                        .and(pike_agent::end_commit_num.eq(MAX_COMMIT_NUM)),
-                )
+            let mut query = pike_agent::table.into_boxed().filter(
+                pike_agent::public_key
+                    .eq(&agent.public_key)
+                    .and(pike_agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+            if let Some(service_id) = &agent.service_id {
+                query = query.filter(pike_agent::service_id.eq(service_id));
+            } else {
+                query = query.filter(pike_agent::service_id.is_null());
+            }
+
+            let duplicate_agent = query
                 .first::<AgentModel>(self.conn)
                 .map(Some)
                 .or_else(|err| {
@@ -169,17 +224,30 @@ impl<'a> PikeStoreAddAgentOperation for PikeStoreOperations<'a, diesel::sqlite::
                 })?;
 
             if duplicate_agent.is_some() {
-                update(pike_agent::table)
-                    .filter(
-                        pike_agent::public_key
-                            .eq(&agent.public_key)
-                            .and(pike_agent::service_id.eq(&agent.service_id))
-                            .and(pike_agent::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    )
-                    .set(pike_agent::end_commit_num.eq(agent.start_commit_num))
-                    .execute(self.conn)
-                    .map(|_| ())
-                    .map_err(PikeStoreError::from)?;
+                if let Some(service_id) = &agent.service_id {
+                    update(pike_agent::table)
+                        .filter(
+                            pike_agent::public_key
+                                .eq(&agent.public_key)
+                                .and(pike_agent::service_id.eq(service_id))
+                                .and(pike_agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(pike_agent::end_commit_num.eq(agent.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
+                } else {
+                    update(pike_agent::table)
+                        .filter(
+                            pike_agent::public_key
+                                .eq(&agent.public_key)
+                                .and(pike_agent::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(pike_agent::end_commit_num.eq(agent.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
+                }
             }
 
             insert_into(pike_agent::table)
@@ -189,17 +257,24 @@ impl<'a> PikeStoreAddAgentOperation for PikeStoreOperations<'a, diesel::sqlite::
                 .map_err(PikeStoreError::from)?;
 
             for role in roles {
-                let duplicate_role = pike_agent_role_assoc::table
-                    .filter(
-                        pike_agent_role_assoc::agent_public_key
-                            .eq(&role.agent_public_key)
-                            .and(pike_agent_role_assoc::agent_public_key.eq(&agent.public_key))
-                            .and(pike_agent_role_assoc::org_id.eq(&agent.org_id))
-                            .and(pike_agent_role_assoc::org_id.eq(&role.org_id))
-                            .and(pike_agent_role_assoc::role_name.eq(&role.role_name))
-                            .and(pike_agent_role_assoc::service_id.eq(&role.service_id))
-                            .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    )
+                let mut query = pike_agent_role_assoc::table.into_boxed().filter(
+                    pike_agent_role_assoc::agent_public_key
+                        .eq(&role.agent_public_key)
+                        .and(pike_agent_role_assoc::agent_public_key.eq(&agent.public_key))
+                        .and(pike_agent_role_assoc::org_id.eq(&agent.org_id))
+                        .and(pike_agent_role_assoc::org_id.eq(&role.org_id))
+                        .and(pike_agent_role_assoc::role_name.eq(&role.role_name))
+                        .and(pike_agent_role_assoc::service_id.eq(&role.service_id))
+                        .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+                if let Some(service_id) = &role.service_id {
+                    query = query.filter(pike_agent_role_assoc::service_id.eq(service_id));
+                } else {
+                    query = query.filter(pike_agent_role_assoc::service_id.is_null());
+                }
+
+                let duplicate_role = query
                     .first::<RoleAssociationModel>(self.conn)
                     .map(Some)
                     .or_else(|err| {
@@ -214,21 +289,44 @@ impl<'a> PikeStoreAddAgentOperation for PikeStoreOperations<'a, diesel::sqlite::
                     })?;
 
                 if duplicate_role.is_some() {
-                    update(pike_agent_role_assoc::table)
-                        .filter(
-                            pike_agent_role_assoc::agent_public_key
-                                .eq(&role.agent_public_key)
-                                .and(pike_agent_role_assoc::agent_public_key.eq(&agent.public_key))
-                                .and(pike_agent_role_assoc::org_id.eq(&agent.org_id))
-                                .and(pike_agent_role_assoc::org_id.eq(&role.org_id))
-                                .and(pike_agent_role_assoc::role_name.eq(&role.role_name))
-                                .and(pike_agent_role_assoc::service_id.eq(&role.service_id))
-                                .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
-                        )
-                        .set(pike_agent_role_assoc::end_commit_num.eq(&role.start_commit_num))
-                        .execute(self.conn)
-                        .map(|_| ())
-                        .map_err(PikeStoreError::from)?;
+                    if let Some(service_id) = &role.service_id {
+                        update(pike_agent_role_assoc::table)
+                            .filter(
+                                pike_agent_role_assoc::agent_public_key
+                                    .eq(&role.agent_public_key)
+                                    .and(
+                                        pike_agent_role_assoc::agent_public_key
+                                            .eq(&agent.public_key),
+                                    )
+                                    .and(pike_agent_role_assoc::org_id.eq(&agent.org_id))
+                                    .and(pike_agent_role_assoc::org_id.eq(&role.org_id))
+                                    .and(pike_agent_role_assoc::role_name.eq(&role.role_name))
+                                    .and(pike_agent_role_assoc::service_id.eq(service_id))
+                                    .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_agent_role_assoc::end_commit_num.eq(&role.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    } else {
+                        update(pike_agent_role_assoc::table)
+                            .filter(
+                                pike_agent_role_assoc::agent_public_key
+                                    .eq(&role.agent_public_key)
+                                    .and(
+                                        pike_agent_role_assoc::agent_public_key
+                                            .eq(&agent.public_key),
+                                    )
+                                    .and(pike_agent_role_assoc::org_id.eq(&agent.org_id))
+                                    .and(pike_agent_role_assoc::org_id.eq(&role.org_id))
+                                    .and(pike_agent_role_assoc::role_name.eq(&role.role_name))
+                                    .and(pike_agent_role_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_agent_role_assoc::end_commit_num.eq(&role.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    }
                 }
 
                 insert_into(pike_agent_role_assoc::table)

--- a/sdk/src/pike/store/diesel/operations/add_role.rs
+++ b/sdk/src/pike/store/diesel/operations/add_role.rs
@@ -81,29 +81,67 @@ impl<'a> PikeStoreAddRoleOperation for PikeStoreOperations<'a, diesel::pg::PgCon
                 })?;
 
             if duplicate_role.is_some() {
-                update(pike_role::table)
-                    .filter(
-                        pike_role::name
-                            .eq(&role.name)
-                            .and(pike_role::org_id.eq(&role.org_id))
-                            .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    )
-                    .set(pike_role::end_commit_num.eq(role.start_commit_num))
-                    .execute(self.conn)
-                    .map(|_| ())
-                    .map_err(PikeStoreError::from)?;
+                if let Some(service_id) = &role.service_id {
+                    update(pike_role::table)
+                        .filter(
+                            pike_role::name
+                                .eq(&role.name)
+                                .and(pike_role::org_id.eq(&role.org_id))
+                                .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM))
+                                .and(pike_role::service_id.eq(service_id)),
+                        )
+                        .set(pike_role::end_commit_num.eq(role.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
 
-                update(pike_role_state_address_assoc::table)
-                    .filter(
-                        pike_role_state_address_assoc::name
-                            .eq(&role.name)
-                            .and(pike_role_state_address_assoc::org_id.eq(&role.org_id))
-                            .and(pike_role_state_address_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    )
-                    .set(pike_role_state_address_assoc::end_commit_num.eq(role.start_commit_num))
-                    .execute(self.conn)
-                    .map(|_| ())
-                    .map_err(PikeStoreError::from)?;
+                    update(pike_role_state_address_assoc::table)
+                        .filter(
+                            pike_role_state_address_assoc::name
+                                .eq(&role.name)
+                                .and(pike_role_state_address_assoc::org_id.eq(&role.org_id))
+                                .and(
+                                    pike_role_state_address_assoc::end_commit_num
+                                        .eq(MAX_COMMIT_NUM),
+                                )
+                                .and(pike_role_state_address_assoc::service_id.eq(service_id)),
+                        )
+                        .set(
+                            pike_role_state_address_assoc::end_commit_num.eq(role.start_commit_num),
+                        )
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
+                } else {
+                    update(pike_role::table)
+                        .filter(
+                            pike_role::name
+                                .eq(&role.name)
+                                .and(pike_role::org_id.eq(&role.org_id))
+                                .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(pike_role::end_commit_num.eq(role.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
+
+                    update(pike_role_state_address_assoc::table)
+                        .filter(
+                            pike_role_state_address_assoc::name
+                                .eq(&role.name)
+                                .and(pike_role_state_address_assoc::org_id.eq(&role.org_id))
+                                .and(
+                                    pike_role_state_address_assoc::end_commit_num
+                                        .eq(MAX_COMMIT_NUM),
+                                ),
+                        )
+                        .set(
+                            pike_role_state_address_assoc::end_commit_num.eq(role.start_commit_num),
+                        )
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
+                }
             }
 
             insert_into(pike_role::table)
@@ -151,19 +189,36 @@ impl<'a> PikeStoreAddRoleOperation for PikeStoreOperations<'a, diesel::pg::PgCon
                     })?;
 
                 if duplicate.is_some() {
-                    update(pike_inherit_from::table)
-                        .filter(
-                            pike_inherit_from::role_name
-                                .eq(&role.name)
-                                .and(pike_inherit_from::role_name.eq(&i.role_name))
-                                .and(pike_inherit_from::org_id.eq(&role.org_id))
-                                .and(pike_inherit_from::org_id.eq(&i.org_id))
-                                .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
-                        )
-                        .set(pike_inherit_from::end_commit_num.eq(i.start_commit_num))
-                        .execute(self.conn)
-                        .map(|_| ())
-                        .map_err(PikeStoreError::from)?;
+                    if let Some(service_id) = &i.service_id {
+                        update(pike_inherit_from::table)
+                            .filter(
+                                pike_inherit_from::role_name
+                                    .eq(&role.name)
+                                    .and(pike_inherit_from::role_name.eq(&i.role_name))
+                                    .and(pike_inherit_from::org_id.eq(&role.org_id))
+                                    .and(pike_inherit_from::org_id.eq(&i.org_id))
+                                    .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM))
+                                    .and(pike_inherit_from::service_id.eq(service_id)),
+                            )
+                            .set(pike_inherit_from::end_commit_num.eq(i.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    } else {
+                        update(pike_inherit_from::table)
+                            .filter(
+                                pike_inherit_from::role_name
+                                    .eq(&role.name)
+                                    .and(pike_inherit_from::role_name.eq(&i.role_name))
+                                    .and(pike_inherit_from::org_id.eq(&role.org_id))
+                                    .and(pike_inherit_from::org_id.eq(&i.org_id))
+                                    .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_inherit_from::end_commit_num.eq(i.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    }
                 }
 
                 insert_into(pike_inherit_from::table)
@@ -193,19 +248,36 @@ impl<'a> PikeStoreAddRoleOperation for PikeStoreOperations<'a, diesel::pg::PgCon
 
             for r in removed {
                 if !permissions.iter().any(|p| p.name == r.name) {
-                    update(pike_permissions::table)
-                        .filter(
-                            pike_permissions::role_name
-                                .eq(&role.name)
-                                .and(pike_permissions::role_name.eq(&r.role_name))
-                                .and(pike_permissions::org_id.eq(&role.org_id))
-                                .and(pike_permissions::org_id.eq(&r.org_id))
-                                .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
-                        )
-                        .set(pike_permissions::end_commit_num.eq(&role.start_commit_num))
-                        .execute(self.conn)
-                        .map(|_| ())
-                        .map_err(PikeStoreError::from)?;
+                    if let Some(service_id) = &role.service_id {
+                        update(pike_permissions::table)
+                            .filter(
+                                pike_permissions::role_name
+                                    .eq(&role.name)
+                                    .and(pike_permissions::role_name.eq(&r.role_name))
+                                    .and(pike_permissions::org_id.eq(&role.org_id))
+                                    .and(pike_permissions::org_id.eq(&r.org_id))
+                                    .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM))
+                                    .and(pike_permissions::service_id.eq(service_id)),
+                            )
+                            .set(pike_permissions::end_commit_num.eq(&role.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    } else {
+                        update(pike_permissions::table)
+                            .filter(
+                                pike_permissions::role_name
+                                    .eq(&role.name)
+                                    .and(pike_permissions::role_name.eq(&r.role_name))
+                                    .and(pike_permissions::org_id.eq(&role.org_id))
+                                    .and(pike_permissions::org_id.eq(&r.org_id))
+                                    .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_permissions::end_commit_num.eq(&role.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    }
                 }
             }
 
@@ -241,19 +313,36 @@ impl<'a> PikeStoreAddRoleOperation for PikeStoreOperations<'a, diesel::pg::PgCon
                     })?;
 
                 if duplicate.is_some() {
-                    update(pike_permissions::table)
-                        .filter(
-                            pike_permissions::role_name
-                                .eq(&role.name)
-                                .and(pike_permissions::name.eq(&p.name))
-                                .and(pike_permissions::org_id.eq(&role.org_id))
-                                .and(pike_permissions::org_id.eq(&p.org_id))
-                                .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
-                        )
-                        .set(pike_permissions::end_commit_num.eq(p.start_commit_num))
-                        .execute(self.conn)
-                        .map(|_| ())
-                        .map_err(PikeStoreError::from)?;
+                    if let Some(service_id) = &p.service_id {
+                        update(pike_permissions::table)
+                            .filter(
+                                pike_permissions::role_name
+                                    .eq(&role.name)
+                                    .and(pike_permissions::name.eq(&p.name))
+                                    .and(pike_permissions::org_id.eq(&role.org_id))
+                                    .and(pike_permissions::org_id.eq(&p.org_id))
+                                    .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM))
+                                    .and(pike_permissions::service_id.eq(service_id)),
+                            )
+                            .set(pike_permissions::end_commit_num.eq(p.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    } else {
+                        update(pike_permissions::table)
+                            .filter(
+                                pike_permissions::role_name
+                                    .eq(&role.name)
+                                    .and(pike_permissions::name.eq(&p.name))
+                                    .and(pike_permissions::org_id.eq(&role.org_id))
+                                    .and(pike_permissions::org_id.eq(&p.org_id))
+                                    .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_permissions::end_commit_num.eq(p.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    }
                 }
 
                 insert_into(pike_permissions::table)
@@ -294,19 +383,36 @@ impl<'a> PikeStoreAddRoleOperation for PikeStoreOperations<'a, diesel::pg::PgCon
                     })?;
 
                 if duplicate.is_some() {
-                    update(pike_allowed_orgs::table)
-                        .filter(
-                            pike_allowed_orgs::role_name
-                                .eq(&role.name)
-                                .and(pike_allowed_orgs::role_name.eq(&a.role_name))
-                                .and(pike_allowed_orgs::org_id.eq(&role.org_id))
-                                .and(pike_allowed_orgs::org_id.eq(&a.org_id))
-                                .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM)),
-                        )
-                        .set(pike_allowed_orgs::end_commit_num.eq(a.start_commit_num))
-                        .execute(self.conn)
-                        .map(|_| ())
-                        .map_err(PikeStoreError::from)?;
+                    if let Some(service_id) = &a.service_id {
+                        update(pike_allowed_orgs::table)
+                            .filter(
+                                pike_allowed_orgs::role_name
+                                    .eq(&role.name)
+                                    .and(pike_allowed_orgs::role_name.eq(&a.role_name))
+                                    .and(pike_allowed_orgs::org_id.eq(&role.org_id))
+                                    .and(pike_allowed_orgs::org_id.eq(&a.org_id))
+                                    .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM))
+                                    .and(pike_allowed_orgs::service_id.eq(service_id)),
+                            )
+                            .set(pike_allowed_orgs::end_commit_num.eq(a.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    } else {
+                        update(pike_allowed_orgs::table)
+                            .filter(
+                                pike_allowed_orgs::role_name
+                                    .eq(&role.name)
+                                    .and(pike_allowed_orgs::role_name.eq(&a.role_name))
+                                    .and(pike_allowed_orgs::org_id.eq(&role.org_id))
+                                    .and(pike_allowed_orgs::org_id.eq(&a.org_id))
+                                    .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_allowed_orgs::end_commit_num.eq(a.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    }
                 }
 
                 insert_into(pike_allowed_orgs::table)
@@ -359,29 +465,67 @@ impl<'a> PikeStoreAddRoleOperation for PikeStoreOperations<'a, diesel::sqlite::S
                 })?;
 
             if duplicate_role.is_some() {
-                update(pike_role::table)
-                    .filter(
-                        pike_role::name
-                            .eq(&role.name)
-                            .and(pike_role::org_id.eq(&role.org_id))
-                            .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    )
-                    .set(pike_role::end_commit_num.eq(role.start_commit_num))
-                    .execute(self.conn)
-                    .map(|_| ())
-                    .map_err(PikeStoreError::from)?;
+                if let Some(service_id) = &role.service_id {
+                    update(pike_role::table)
+                        .filter(
+                            pike_role::name
+                                .eq(&role.name)
+                                .and(pike_role::org_id.eq(&role.org_id))
+                                .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM))
+                                .and(pike_role::service_id.eq(service_id)),
+                        )
+                        .set(pike_role::end_commit_num.eq(role.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
 
-                update(pike_role_state_address_assoc::table)
-                    .filter(
-                        pike_role_state_address_assoc::name
-                            .eq(&role.name)
-                            .and(pike_role_state_address_assoc::org_id.eq(&role.org_id))
-                            .and(pike_role_state_address_assoc::end_commit_num.eq(MAX_COMMIT_NUM)),
-                    )
-                    .set(pike_role_state_address_assoc::end_commit_num.eq(role.start_commit_num))
-                    .execute(self.conn)
-                    .map(|_| ())
-                    .map_err(PikeStoreError::from)?;
+                    update(pike_role_state_address_assoc::table)
+                        .filter(
+                            pike_role_state_address_assoc::name
+                                .eq(&role.name)
+                                .and(pike_role_state_address_assoc::org_id.eq(&role.org_id))
+                                .and(
+                                    pike_role_state_address_assoc::end_commit_num
+                                        .eq(MAX_COMMIT_NUM),
+                                )
+                                .and(pike_role_state_address_assoc::service_id.eq(service_id)),
+                        )
+                        .set(
+                            pike_role_state_address_assoc::end_commit_num.eq(role.start_commit_num),
+                        )
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
+                } else {
+                    update(pike_role::table)
+                        .filter(
+                            pike_role::name
+                                .eq(&role.name)
+                                .and(pike_role::org_id.eq(&role.org_id))
+                                .and(pike_role::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(pike_role::end_commit_num.eq(role.start_commit_num))
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
+
+                    update(pike_role_state_address_assoc::table)
+                        .filter(
+                            pike_role_state_address_assoc::name
+                                .eq(&role.name)
+                                .and(pike_role_state_address_assoc::org_id.eq(&role.org_id))
+                                .and(
+                                    pike_role_state_address_assoc::end_commit_num
+                                        .eq(MAX_COMMIT_NUM),
+                                ),
+                        )
+                        .set(
+                            pike_role_state_address_assoc::end_commit_num.eq(role.start_commit_num),
+                        )
+                        .execute(self.conn)
+                        .map(|_| ())
+                        .map_err(PikeStoreError::from)?;
+                }
             }
 
             insert_into(pike_role::table)
@@ -429,19 +573,36 @@ impl<'a> PikeStoreAddRoleOperation for PikeStoreOperations<'a, diesel::sqlite::S
                     })?;
 
                 if duplicate.is_some() {
-                    update(pike_inherit_from::table)
-                        .filter(
-                            pike_inherit_from::role_name
-                                .eq(&role.name)
-                                .and(pike_inherit_from::role_name.eq(&i.role_name))
-                                .and(pike_inherit_from::org_id.eq(&role.org_id))
-                                .and(pike_inherit_from::org_id.eq(&i.org_id))
-                                .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
-                        )
-                        .set(pike_inherit_from::end_commit_num.eq(i.start_commit_num))
-                        .execute(self.conn)
-                        .map(|_| ())
-                        .map_err(PikeStoreError::from)?;
+                    if let Some(service_id) = &i.service_id {
+                        update(pike_inherit_from::table)
+                            .filter(
+                                pike_inherit_from::role_name
+                                    .eq(&role.name)
+                                    .and(pike_inherit_from::role_name.eq(&i.role_name))
+                                    .and(pike_inherit_from::org_id.eq(&role.org_id))
+                                    .and(pike_inherit_from::org_id.eq(&i.org_id))
+                                    .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM))
+                                    .and(pike_inherit_from::service_id.eq(service_id)),
+                            )
+                            .set(pike_inherit_from::end_commit_num.eq(i.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    } else {
+                        update(pike_inherit_from::table)
+                            .filter(
+                                pike_inherit_from::role_name
+                                    .eq(&role.name)
+                                    .and(pike_inherit_from::role_name.eq(&i.role_name))
+                                    .and(pike_inherit_from::org_id.eq(&role.org_id))
+                                    .and(pike_inherit_from::org_id.eq(&i.org_id))
+                                    .and(pike_inherit_from::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_inherit_from::end_commit_num.eq(i.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    }
                 }
 
                 insert_into(pike_inherit_from::table)
@@ -471,19 +632,36 @@ impl<'a> PikeStoreAddRoleOperation for PikeStoreOperations<'a, diesel::sqlite::S
 
             for r in removed {
                 if !permissions.iter().any(|p| p.name == r.name) {
-                    update(pike_permissions::table)
-                        .filter(
-                            pike_permissions::role_name
-                                .eq(&role.name)
-                                .and(pike_permissions::role_name.eq(&r.role_name))
-                                .and(pike_permissions::org_id.eq(&role.org_id))
-                                .and(pike_permissions::org_id.eq(&r.org_id))
-                                .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
-                        )
-                        .set(pike_permissions::end_commit_num.eq(&role.start_commit_num))
-                        .execute(self.conn)
-                        .map(|_| ())
-                        .map_err(PikeStoreError::from)?;
+                    if let Some(service_id) = &role.service_id {
+                        update(pike_permissions::table)
+                            .filter(
+                                pike_permissions::role_name
+                                    .eq(&role.name)
+                                    .and(pike_permissions::role_name.eq(&r.role_name))
+                                    .and(pike_permissions::org_id.eq(&role.org_id))
+                                    .and(pike_permissions::org_id.eq(&r.org_id))
+                                    .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM))
+                                    .and(pike_permissions::service_id.eq(service_id)),
+                            )
+                            .set(pike_permissions::end_commit_num.eq(&role.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    } else {
+                        update(pike_permissions::table)
+                            .filter(
+                                pike_permissions::role_name
+                                    .eq(&role.name)
+                                    .and(pike_permissions::role_name.eq(&r.role_name))
+                                    .and(pike_permissions::org_id.eq(&role.org_id))
+                                    .and(pike_permissions::org_id.eq(&r.org_id))
+                                    .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_permissions::end_commit_num.eq(&role.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    }
                 }
             }
 
@@ -519,19 +697,36 @@ impl<'a> PikeStoreAddRoleOperation for PikeStoreOperations<'a, diesel::sqlite::S
                     })?;
 
                 if duplicate.is_some() {
-                    update(pike_permissions::table)
-                        .filter(
-                            pike_permissions::role_name
-                                .eq(&role.name)
-                                .and(pike_permissions::name.eq(&p.name))
-                                .and(pike_permissions::org_id.eq(&role.org_id))
-                                .and(pike_permissions::org_id.eq(&p.org_id))
-                                .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
-                        )
-                        .set(pike_permissions::end_commit_num.eq(p.start_commit_num))
-                        .execute(self.conn)
-                        .map(|_| ())
-                        .map_err(PikeStoreError::from)?;
+                    if let Some(service_id) = &p.service_id {
+                        update(pike_permissions::table)
+                            .filter(
+                                pike_permissions::role_name
+                                    .eq(&role.name)
+                                    .and(pike_permissions::name.eq(&p.name))
+                                    .and(pike_permissions::org_id.eq(&role.org_id))
+                                    .and(pike_permissions::org_id.eq(&p.org_id))
+                                    .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM))
+                                    .and(pike_permissions::service_id.eq(service_id)),
+                            )
+                            .set(pike_permissions::end_commit_num.eq(p.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    } else {
+                        update(pike_permissions::table)
+                            .filter(
+                                pike_permissions::role_name
+                                    .eq(&role.name)
+                                    .and(pike_permissions::name.eq(&p.name))
+                                    .and(pike_permissions::org_id.eq(&role.org_id))
+                                    .and(pike_permissions::org_id.eq(&p.org_id))
+                                    .and(pike_permissions::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_permissions::end_commit_num.eq(p.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    }
                 }
 
                 insert_into(pike_permissions::table)
@@ -572,19 +767,36 @@ impl<'a> PikeStoreAddRoleOperation for PikeStoreOperations<'a, diesel::sqlite::S
                     })?;
 
                 if duplicate.is_some() {
-                    update(pike_allowed_orgs::table)
-                        .filter(
-                            pike_allowed_orgs::role_name
-                                .eq(&role.name)
-                                .and(pike_allowed_orgs::role_name.eq(&a.role_name))
-                                .and(pike_allowed_orgs::org_id.eq(&role.org_id))
-                                .and(pike_allowed_orgs::org_id.eq(&a.org_id))
-                                .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM)),
-                        )
-                        .set(pike_allowed_orgs::end_commit_num.eq(a.start_commit_num))
-                        .execute(self.conn)
-                        .map(|_| ())
-                        .map_err(PikeStoreError::from)?;
+                    if let Some(service_id) = &a.service_id {
+                        update(pike_allowed_orgs::table)
+                            .filter(
+                                pike_allowed_orgs::role_name
+                                    .eq(&role.name)
+                                    .and(pike_allowed_orgs::role_name.eq(&a.role_name))
+                                    .and(pike_allowed_orgs::org_id.eq(&role.org_id))
+                                    .and(pike_allowed_orgs::org_id.eq(&a.org_id))
+                                    .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM))
+                                    .and(pike_allowed_orgs::service_id.eq(service_id)),
+                            )
+                            .set(pike_allowed_orgs::end_commit_num.eq(a.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    } else {
+                        update(pike_allowed_orgs::table)
+                            .filter(
+                                pike_allowed_orgs::role_name
+                                    .eq(&role.name)
+                                    .and(pike_allowed_orgs::role_name.eq(&a.role_name))
+                                    .and(pike_allowed_orgs::org_id.eq(&role.org_id))
+                                    .and(pike_allowed_orgs::org_id.eq(&a.org_id))
+                                    .and(pike_allowed_orgs::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(pike_allowed_orgs::end_commit_num.eq(a.start_commit_num))
+                            .execute(self.conn)
+                            .map(|_| ())
+                            .map_err(PikeStoreError::from)?;
+                    }
                 }
 
                 insert_into(pike_allowed_orgs::table)


### PR DESCRIPTION
This fixes the update_* operations for the Pike module to properly set
the `end_commit_num` for the record being updated. Previously, the
`end_commit_num` was not being updated because the diesel query builder
was not properly checking for the `service_id` or lack thereof.

Signed-off-by: Davey Newhall <newhall@bitwise.io>