### PR TITLE
Add --skip flag to keygen CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -103,7 +103,8 @@ fn run() -> Result<(), CliError> {
         (@subcommand keygen =>
             (about: "Generates keys with which the user can sign transactions and batches.")
             (@arg key_name: +takes_value "Name of the key to create")
-            (@arg force: --force "Overwrite files if they exist")
+            (@arg force: --force conflicts_with[skip] "Overwrite files if they exist")
+            (@arg skip: --skip conflicts_with[force] "Check if files exist; generate if missing" )
             (@arg key_dir: -d --("key-dir") +takes_value conflicts_with[system]
                 "Specify the directory for the key files")
             (@arg system: --system "Generate system keys in /etc/grid/keys")
@@ -2055,7 +2056,15 @@ fn run() -> Result<(), CliError> {
                     .ok_or_else(|| CliError::UserError("Home directory not found".into()))?
             };
 
-            keygen::generate_keys(key_name, m.is_present("force"), key_dir)?
+            let conflict_strategy = if m.is_present("force") {
+                keygen::ConflictStrategy::Force
+            } else if m.is_present("skip") {
+                keygen::ConflictStrategy::Skip
+            } else {
+                keygen::ConflictStrategy::Error
+            };
+
+            keygen::generate_keys(key_name, conflict_strategy, key_dir)?
         }
         ("product", Some(m)) => {
             let url = m

--- a/examples/sawtooth/docker-compose.yaml
+++ b/examples/sawtooth/docker-compose.yaml
@@ -246,7 +246,7 @@ services:
     depends_on:
       - sawtooth-validator
     command: |
-        devmode-engine-rust -vv --connect tcp://sawtooth-validator:5050
+      devmode-engine-rust -vv --connect tcp://sawtooth-validator:5050
     stop_signal: SIGKILL
 
   # ---== alpha node ==---
@@ -291,8 +291,8 @@ services:
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1
         done
-        grid keygen && \
-        grid keygen --system && \
+        grid keygen --skip && \
+        grid keygen --system --skip && \
         grid -vv database migrate \
             -C postgres://grid:grid_example@db-alpha/grid &&
         gridd -vv -b 0.0.0.0:8080 -k root -C tcp://sawtooth-validator:4004 \
@@ -340,11 +340,11 @@ services:
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1
         done
-        grid keygen && \
-        grid keygen --system && \
+        grid keygen --skip && \
+        grid keygen --system --skip && \
         grid -vv database migrate \
             -C postgres://grid:grid_example@db-beta/grid &&
         gridd -vv -b 0.0.0.0:8080 -C tcp://sawtooth-validator:4004 \
             -k root \
-            --database-url postgres://grid:grid_example@db-beta/grid &&
+            --database-url postgres://grid:grid_example@db-beta/grid
       "

--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -215,7 +215,7 @@ services:
             sleep 1
         done
         grid -vv admin keygen --skip && \
-        grid -vv keygen --system && \
+        grid -vv keygen --system --skip && \
         grid -vv database migrate \
             -C postgres://grid:grid_example@db-alpha/grid &&
         gridd -vv -b 0.0.0.0:8080 -k root -C splinter:http://splinterd-alpha:8085 \
@@ -343,7 +343,7 @@ services:
             sleep 1
         done
         grid -vv admin keygen --skip && \
-        grid -vv keygen --system && \
+        grid -vv keygen --system --skip && \
         grid -vv database migrate \
             -C postgres://grid:grid_example@db-beta/grid &&
         gridd -vv -k root -b 0.0.0.0:8080 -C splinter:http://splinterd-beta:8085 \
@@ -470,7 +470,7 @@ services:
             sleep 1
         done
         grid -vv admin keygen --skip && \
-        grid -vv keygen --system && \
+        grid -vv keygen --system --skip && \
         grid -vv database migrate \
             -C postgres://grid:grid_example@db-gamma/grid &&
         gridd -vv -b 0.0.0.0:8080 -k root -C splinter:http://splinterd-gamma:8085 \


### PR DESCRIPTION
subsequent runs of docker compose up in the example projects would fail
due to keys created in previous runs. Adding a --skip flag allows us to
reuse previously-created keys. Also updated docker-compose in example
projects

Signed-off-by: Kevin Johnson <kevin_johnson@cargill.com>