### PR TITLE
Fix typo in schema contract error msg

### DIFF
--- a/contracts/schema/src/handler.rs
+++ b/contracts/schema/src/handler.rs
@@ -216,7 +216,7 @@ fn schema_update(
             .is_ok()
         {
             return Err(ApplyError::InvalidTransaction(format!(
-                "Schema already has PropertyDefination with name {}",
+                "Schema already has PropertyDefinition with name {}",
                 property.name()
             )));
         }
@@ -701,7 +701,7 @@ mod tests {
         match schema_update(&action, signer, &state, &perm_checker) {
             Ok(()) => panic!("Agent does not exist, InvalidTransaction should be returned"),
             Err(ApplyError::InvalidTransaction(err)) => {
-                assert!(err.contains("Schema already has PropertyDefination with name TEST"));
+                assert!(err.contains("Schema already has PropertyDefinition with name TEST"));
             }
             Err(err) => panic!("Should have gotten invalid error but got {}", err),
         }


### PR DESCRIPTION
This fixes a typo in an error message in the schema smart contract
caused by attempting to update a smart contract with a duplicate
property.

Signed-off-by: Davey Newhall <newhall@bitwise.io>