### PR TITLE
Stabilize sqlite features

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -54,6 +54,7 @@ default = [
     "sawtooth",
     "database",
     "postgres",
+    "sqlite",
 ]
 
 stable = [
@@ -73,7 +74,6 @@ experimental = [
     "product-gdsn",
     "purchase-order",
     "splinter",
-    "sqlite",
 ]
 
 database = ["diesel"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -92,6 +92,7 @@ stable = [
     "rest-api-resources-role",
     "rest-api-resources-schema",
     "schema",
+    "sqlite",
 ]
 
 experimental = [
@@ -116,7 +117,6 @@ experimental = [
     "rest-api-resources-submit",
     "rest-api-resources-track-and-trace",
     "sawtooth-compat",
-    "sqlite",
     "track-and-trace",
     "workflow"
 ]
@@ -176,5 +176,5 @@ sawtooth-compat = [
     "sabre-sdk",
     "sawtooth-sdk"
 ]
-sqlite = ["chrono", "diesel/sqlite", "diesel_migrations"]
+sqlite = ["chrono", "diesel/sqlite", "diesel_migrations", "log"]
 workflow = []


### PR DESCRIPTION
This stabilizes the "sqlite" sdk feature by moving it into stable. This
also moves its associated "database-sqlite" feature in other parts of
Grid into stable.

Signed-off-by: Davey Newhall <newhall@bitwise.io>