### PR TITLE
Generate man pages for cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ tests/sawtooth_sc_test/protobuf/
 **/sapling-dev-server/profile
 **/sapling-dev-server/register-login.js
 
+# Generated man pages
+/cli/packaging/man/grid*
+
 # misc
 .DS_Store
 .env.local

--- a/ci/grid-dev
+++ b/ci/grid-dev
@@ -31,6 +31,7 @@ RUN apt-get update \
     libxml2-dev \
     libzmq3-dev \
     openssl \
+    pandoc \
     pkg-config \
     unzip \
  && apt-get clean \

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -101,5 +101,6 @@ maintainer = "The Hyperledger Grid Team"
 depends = "$auto, bash-completion"
 assets = [
     ["target/release/grid", "/usr/bin/grid", "755"],
+    ["packaging/man/*", "/usr/share/man/man1", "644"],
     ["packaging/ubuntu/completions/grid", "/usr/share/bash-completion/completions/grid", "644"]
 ]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -14,11 +14,14 @@
 
 FROM hyperledger/grid-dev:v5 as grid-cli-builder
 
+ENV GRID_FORCE_PANDOC=true
+
 # Install dependencies
 RUN apt-get update \
  && apt-get install -y -q \
     libxml2-dev \
- && apt-get clean \
+    pandoc \
+   && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
 # Temporary workaround until sabre is updated to focal
@@ -66,6 +69,8 @@ COPY --from=grid-cli-builder /build/target/debian/grid-cli_*.deb /tmp
 COPY --from=grid-cli-builder /commit-hash /commit-hash
 
 RUN apt-get update \
+ && apt-get install -y -q man \
+ && mandb \
  && dpkg --unpack /tmp/grid-cli*.deb \
  && apt-get -f -y install
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,156 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::process::Command;
+
+const FORCE_PANDOC: &str = "GRID_FORCE_PANDOC";
+const PATH: &str = "PATH";
+
+/// This build script will take the markdown files in the /man directory and convert them to
+/// man pages stored in packaging/man. This build script will check if pandoc is installed locally
+/// and skip generating the manpages if it is not. If the build should fail if man pages cannot be
+/// generated set environment variable GRID_FORCE_PANDOC=true
+fn main() -> Result<(), BuildError> {
+    let paths = env::var(PATH)
+        .map_err(|_| BuildError("Unable to read PATH environment variable".into()))?;
+    let mut pandoc_exist = false;
+    for path in paths.split(':') {
+        let entries = match fs::read_dir(path) {
+            Ok(entries) => entries,
+            Err(err) => {
+                // skip a directory in the path that cannot be read.
+                println!("Unable to read path entry {}: {}", path, err);
+                continue;
+            }
+        };
+
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(err) => {
+                    // skip an entry in the path that cannot be read.
+                    println!("Unable to read entry in {}: {}", path, err);
+                    continue;
+                }
+            };
+
+            let path = entry.path();
+            if path.ends_with("pandoc") {
+                pandoc_exist = true;
+                break;
+            }
+        }
+    }
+
+    if !pandoc_exist {
+        if let Ok(var) = env::var(FORCE_PANDOC) {
+            let map_to_build_err =
+                move |_| BuildError("Unable to read GRID_FORCE_PANDOC environment variable".into());
+            if var.parse().map_err(map_to_build_err)? {
+                return Err(BuildError(
+                    "Cannot generate man pages, pandoc is not installed".into(),
+                ));
+            }
+        } else {
+            println!("Skip generating man pages");
+            return Ok(());
+        }
+    }
+
+    let entries = match fs::read_dir("man/") {
+        Ok(entries) => {
+            match entries
+                .map(|res| res.map(|e| e.path()))
+                .collect::<Result<Vec<_>, io::Error>>()
+            {
+                Ok(entries) => entries,
+                Err(err) => {
+                    return Err(BuildError(format!(
+                        "Unable to retrieve entries for man pages: {}",
+                        err
+                    )))
+                }
+            }
+        }
+        Err(err) => {
+            return Err(BuildError(format!(
+                "Unable to read man pages directory: {}",
+                err
+            )))
+        }
+    };
+
+    println!("Markdown files found {:?}", entries);
+
+    for entry in entries {
+        // This conversion would only fail if the filename is not valid UTF-8
+        let markdown = &entry
+            .to_str()
+            .ok_or_else(|| BuildError("Cannot get markdown file path".into()))?
+            .to_string();
+
+        let file = entry
+            .file_stem()
+            .ok_or_else(|| BuildError("Cannot get markdown file name".into()))?;
+        let manpage = &format!(
+            "packaging/man/{}",
+            file.to_str()
+                .ok_or_else(|| BuildError("Cannot get markdown file name".into()))?
+        );
+
+        if markdown.ends_with(".md") {
+            match Command::new("pandoc")
+                .args(&["--standalone", "--to", "man", &markdown, "-o", &manpage])
+                .status()
+            {
+                Ok(status) => {
+                    if status.success() {
+                        println!("Generated man page: {}", manpage);
+                    } else {
+                        println!("Unable to generate man page {} status {}", manpage, status);
+                    }
+                }
+                Err(err) => {
+                    return Err(BuildError(format!(
+                        "Unable to generate man page: {} {}",
+                        manpage, err
+                    )))
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub struct BuildError(String);
+
+impl Error for BuildError {}
+
+// This is the output that will be used for print errors returned from main
+impl fmt::Debug for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}

--- a/cli/packaging/man/README.md
+++ b/cli/packaging/man/README.md
@@ -1,0 +1,2 @@
+This is the directory where the generated man pages for the `grid` CLI will
+be located.

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -14,6 +14,11 @@
 
 FROM hyperledger/grid-dev:v9 as gridd-builder
 
+ENV GRID_FORCE_PANDOC=true
+
+# This is temporary until hyperledger/grid-dev updates
+RUN apt-get update && apt-get install -y -q pandoc
+
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
 COPY cli/Cargo.toml /build/cli/Cargo.toml
@@ -67,8 +72,9 @@ COPY --from=gridd-builder /commit-hash /commit-hash
 RUN apt-get update \
  && apt-get install -y -q \
     postgresql-client \
-&& apt-get install -y -q \
     libsqlite3-dev \
+    man \
+ && mandb \
  && dpkg --unpack /tmp/grid*.deb \
  && apt-get -f -y install
 


### PR DESCRIPTION
Uses pandoc to convert markdown files from cli/man to manfiles in
cli/packaging/man. This follows the same pattern found in the Splinter
project's cli.

Signed-off-by: Kevin Johnson <kevin_johnson@cargill.com>