### PR TITLE
Fix rest API URL handling in `run` methods

### DIFF
--- a/daemon/src/sawtooth/run.rs
+++ b/daemon/src/sawtooth/run.rs
@@ -39,6 +39,7 @@ use crate::rest_api;
 use super::connection::SawtoothConnection;
 
 pub fn run_sawtooth(config: GridConfig) -> Result<(), DaemonError> {
+    let sawtooth_endpoint = Endpoint::from(config.endpoint());
     let connection_uri = config
         .database_url()
         .parse()
@@ -47,7 +48,7 @@ pub fn run_sawtooth(config: GridConfig) -> Result<(), DaemonError> {
     let store_factory = create_store_factory(&connection_uri)
         .map_err(|err| DaemonError::from_source(Box::new(err)))?;
 
-    let sawtooth_connection = SawtoothConnection::new(&config.endpoint());
+    let sawtooth_connection = SawtoothConnection::new(&sawtooth_endpoint.url());
     let backend_client = SawtoothBackendClient::new(sawtooth_connection.get_sender());
     let backend_state = BackendState::new(Arc::new(backend_client));
 
@@ -113,7 +114,7 @@ pub fn run_sawtooth(config: GridConfig) -> Result<(), DaemonError> {
         backend_state,
         #[cfg(feature = "integration")]
         key_state,
-        Endpoint::from(config.endpoint()),
+        sawtooth_endpoint,
     )
     .map_err(|err| DaemonError::from_source(Box::new(err)))?;
 


### PR DESCRIPTION
This change creates an `Endpoint` object from the `GridConfig`'s
`endpoint` immediately as it is passed into the daemon's `run` methods
for Splinter and Sawtooth backends. This allows for the backend rest
API URL to be correctly formatted as it is returned by the
config object with a `splinter:` or `sawtooth:` prefix to allow the
daemon to start correctly. This fixes the issue where the `splinter:`
and `sawtooth:` prefixes are being passed in with the URL, returning
an error as this creates an invalid URL scheme.

Signed-off-by: Shannyn Telander <telander@bitwise.io>

To test: run `docker-compose -f examples/splinter/docker-compose.yaml up` and ensure that the logs start as normal 