### PR TITLE
Add grid organization `list` and `show` commands 

### DIFF
--- a/cli/man/grid-organization-create.1.md
+++ b/cli/man/grid-organization-create.1.md
@@ -83,6 +83,8 @@ SEE ALSO
 ========
 | `grid organization(1)`
 | `grid organization update(1)`
+| `grid organization list(1)`
+| `grid organization show(1)`
 | `grid agent(1)`
 | `grid role(1)`
 |

--- a/cli/man/grid-organization-list.1.md
+++ b/cli/man/grid-organization-list.1.md
@@ -1,0 +1,93 @@
+% GRID-ORGANIZATION-LIST(1) Cargill, Incorporated | Grid Commands
+
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-organization-list** — List all organizations
+
+SYNOPSIS
+========
+
+**grid organization list** \[**FLAGS**\]
+
+DESCRIPTION
+===========
+
+List all organizations in grid. If the `service_id` flag is specified, only
+organizations corresponding to that `service_id` will be shown.
+
+FLAGS
+=====
+
+`-F`, `--format`
+: Specifies the output format of the list. Possible values for formatting are `human` and `csv`. Defaults to `human`.
+
+`-h`, `--help`
+: Prints help information
+
+`--alternate-ids`
+: Displays the Alternate IDs of the organizations being listed.
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more output
+
+OPTIONS
+=======
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>.
+
+`--url`
+: URL for the REST API
+
+EXAMPLES
+========
+
+The following command will list all organizations:
+
+```
+$ grid organization list
+ORG_ID NAME    LOCATIONS
+crgl   Cargill 0123456789012
+```
+
+The next command will list all organizations, including the organizations'
+Alternate IDs using the `--alternated-ids` flag:
+
+```
+$ grid organization list --alternate-ids
+ORG_ID NAME    LOCATIONS     ALTERNATE_IDS
+crgl   Cargill 0123456789012 crgl:001
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies a default value for `--url`
+
+**`GRID_SERVICE_ID`**
+: Specifies a default value for `--service-id`
+
+SEE ALSO
+========
+| `grid organization(1)`
+| `grid organization create(1)`
+| `grid organization update(1)`
+| `grid agent(1)`
+| `grid role(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/cli/man/grid-organization-show.1.md
+++ b/cli/man/grid-organization-show.1.md
@@ -1,0 +1,110 @@
+% GRID-ORGANIZATION-SHOW(1) Cargill, Incorporated | Grid Commands
+
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-organization-show** — Show the details of the specified organization.
+
+SYNOPSIS
+========
+
+**grid organization show** \[**FLAGS**\] \[**OPTIONS**\] <org_id>
+
+DESCRIPTION
+===========
+
+Show the details of the organization specified. This command requires the
+`ORG_ID` argument to specify the unique identifier for the organization being
+retrieved.
+
+ARGS
+====
+
+`ORG_ID`
+: A unique identifier for an organization
+
+
+FLAGS
+=====
+
+`-F`, `--format`
+: Specifies the output format of the list. Possible values for formatting are `human` and `csv`. Defaults to `human`.
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more output
+
+OPTIONS
+=======
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>.
+
+`--url`
+: URL for the REST API
+
+EXAMPLES
+========
+
+The following command will show an organization with an `org_id` of `crgl`:
+
+```
+$ grid organization show crgl
+Organization ID: crgl
+Name: Cargill
+Locations: 0123456789012
+Alternate IDs:
+    crgl:001
+Metadata: -
+```
+
+If Grid is running on Splinter, the organization will be shown with its
+associated `service_id`. The following command will show an organization with an
+`org_id` of `crgl` and a `service_id` of `01234-ABCDE`.
+
+```
+$ grid organization show crgl
+Organization ID: crgl
+Name: Cargill
+Service ID: 01234-ABCDE::gsAA
+Locations: 0123456789012
+Alternate IDs:
+    crgl:001
+Metadata: -
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies a default value for `--url`
+
+**`GRID_SERVICE_ID`**
+: Specifies a default value for `--service-id`
+
+SEE ALSO
+========
+
+| `grid organization(1)`
+| `grid organization create(1)`
+| `grid organization update(1)`
+| `grid organization list(1)`
+| `grid agent(1)`
+| `grid role(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/cli/man/grid-organization-update.1.md
+++ b/cli/man/grid-organization-update.1.md
@@ -86,6 +86,8 @@ SEE ALSO
 ========
 | `grid organization(1)`
 | `grid organization create(1)`
+| `grid organization list(1)`
+| `grid organization show(1)`
 | `grid agent(1)`
 | `grid role(1)`
 |

--- a/cli/man/grid-organization.1.md
+++ b/cli/man/grid-organization.1.md
@@ -69,6 +69,8 @@ SEE ALSO
 ========
 | `grid organization create(1)`
 | `grid organization update(1)`
+| `grid organization list(1)`
+| `grid organization show(1)`
 | `grid agent(1)`
 | `grid role(1)`
 |

--- a/cli/src/actions/organizations.rs
+++ b/cli/src/actions/organizations.rs
@@ -235,3 +235,50 @@ fn print_human_readable(column_names: Vec<String>, row_values: Vec<Vec<String>>)
         println!("{}", print_row);
     }
 }
+
+impl std::fmt::Display for OrganizationSlice {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut display_string =
+            format!("Organization ID: {}\nName: {}\n", &self.org_id, &self.name);
+        if let Some(service_id) = &self.service_id {
+            display_string += &format!("Service ID: {}\n", service_id);
+        }
+        display_string += "Locations:";
+        let locations = if self.locations.is_empty() {
+            " -\n".to_string()
+        } else {
+            self.locations
+                .iter()
+                .map(|locale| format!("\n\t{}", locale))
+                .collect::<Vec<String>>()
+                .join(",")
+        };
+        display_string += &locations;
+
+        display_string += "Alternate IDs:";
+        let ids = if self.alternate_ids.is_empty() {
+            " -\n".to_string()
+        } else {
+            self.alternate_ids
+                .iter()
+                .map(|alt_id| format!("\n\t{}: {}", alt_id.id_type, alt_id.id))
+                .collect::<Vec<String>>()
+                .join(",")
+        };
+        display_string += &ids;
+
+        display_string += "Metadata:";
+        let metadata = if self.metadata.is_empty() {
+            " -\n".to_string()
+        } else {
+            self.metadata
+                .iter()
+                .map(|data| format!("\n\t{}: {}", data.key, data.value))
+                .collect::<Vec<String>>()
+                .join(",")
+        };
+        display_string += &metadata;
+
+        write!(f, "{}", display_string)
+    }
+}

--- a/cli/src/actions/organizations.rs
+++ b/cli/src/actions/organizations.rs
@@ -17,9 +17,6 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::error::CliError;
-use crate::http::submit_batches;
-use crate::transaction::pike_batch_builder;
 use cylinder::Signer;
 use grid_sdk::{
     pike::addressing::PIKE_NAMESPACE,
@@ -28,6 +25,10 @@ use grid_sdk::{
     },
     protos::IntoProto,
 };
+
+use crate::error::CliError;
+use crate::http::submit_batches;
+use crate::transaction::pike_batch_builder;
 
 pub fn do_create_organization(
     url: &str,

--- a/cli/src/actions/organizations.rs
+++ b/cli/src/actions/organizations.rs
@@ -15,6 +15,7 @@
  * -----------------------------------------------------------------------------
  */
 
+use std::cmp;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use cylinder::Signer;
@@ -25,10 +26,42 @@ use grid_sdk::{
     },
     protos::IntoProto,
 };
+use reqwest::Client;
+use serde::Deserialize;
 
+use crate::actions::Paging;
 use crate::error::CliError;
 use crate::http::submit_batches;
 use crate::transaction::pike_batch_builder;
+
+#[derive(Debug, Deserialize)]
+pub struct AlternateIdSlice {
+    pub id_type: String,
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OrganizationMetadataSlice {
+    pub key: String,
+    pub value: String,
+    pub service_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OrganizationSlice {
+    pub org_id: String,
+    pub name: String,
+    pub locations: Vec<String>,
+    pub alternate_ids: Vec<AlternateIdSlice>,
+    pub metadata: Vec<OrganizationMetadataSlice>,
+    pub service_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OrganizationListSlice {
+    pub data: Vec<OrganizationSlice>,
+    pub paging: Paging,
+}
 
 pub fn do_create_organization(
     url: &str,
@@ -86,4 +119,119 @@ pub fn do_update_organization(
         .create_batch_list();
 
     submit_batches(url, wait, &batch_list, service_id.as_deref())
+}
+
+pub fn do_list_organizations(
+    url: &str,
+    service_id: Option<String>,
+    format: &str,
+    display_alternate_ids: bool,
+) -> Result<(), CliError> {
+    let client = Client::new();
+    let mut final_url = format!("{}/organization", url);
+    if let Some(service_id) = service_id {
+        final_url = format!("{}?service_id={}", final_url, service_id);
+    }
+
+    let mut orgs = Vec::new();
+
+    loop {
+        let mut response = client.get(&final_url).send()?;
+
+        if !response.status().is_success() {
+            return Err(CliError::DaemonError(response.text()?));
+        }
+
+        let mut orgs_list = response.json::<OrganizationListSlice>()?;
+        orgs.append(&mut orgs_list.data);
+
+        if let Some(next) = orgs_list.paging.next {
+            final_url = format!("{}{}", url, next);
+        } else {
+            break;
+        }
+    }
+
+    list_organizations(orgs, format, display_alternate_ids);
+    Ok(())
+}
+
+fn list_organizations(orgs: Vec<OrganizationSlice>, format: &str, display_alternate_ids: bool) {
+    let mut headers = vec![
+        "ORG_ID".to_string(),
+        "NAME".to_string(),
+        "LOCATIONS".to_string(),
+    ];
+    if display_alternate_ids {
+        headers.push("ALTERNATE_IDS".to_string());
+    }
+    let mut rows = vec![];
+    orgs.iter().for_each(|org| {
+        let mut values = vec![
+            org.org_id.to_string(),
+            org.name.to_string(),
+            org.locations.join(", "),
+        ];
+        if display_alternate_ids {
+            values.push(
+                org.alternate_ids
+                    .iter()
+                    .map(|id| format!("{}:{}", id.id_type, id.id))
+                    .collect::<Vec<String>>()
+                    .join(", "),
+            );
+        }
+        rows.push(values);
+    });
+    if format == "csv" {
+        print_csv(headers, rows);
+    } else {
+        print_human_readable(headers, rows);
+    }
+}
+
+fn print_csv(column_names: Vec<String>, row_values: Vec<Vec<String>>) {
+    // print header row
+    let mut header_row = "".to_owned();
+    for column in &column_names {
+        header_row += &format!("\"{}\",", column);
+    }
+    header_row.pop();
+    println!("{}", header_row);
+
+    // print each row
+    for row in row_values {
+        let mut print_row = "".to_owned();
+        for cell in row.iter().take(column_names.len()) {
+            print_row += &format!("\"{}\",", cell);
+        }
+        print_row.pop();
+        println!("{}", print_row);
+    }
+}
+
+fn print_human_readable(column_names: Vec<String>, row_values: Vec<Vec<String>>) {
+    // Calculate max-widths for columns
+    let mut widths: Vec<usize> = column_names.iter().map(|name| name.len()).collect();
+    row_values.iter().for_each(|row| {
+        for i in 0..widths.len() {
+            widths[i] = cmp::max(widths[i], row[i].len())
+        }
+    });
+
+    // print header row
+    let mut header_row = "".to_owned();
+    for i in 0..column_names.len() {
+        header_row += &format!("{:width$} ", column_names[i], width = widths[i]);
+    }
+    println!("{}", header_row);
+
+    // print each row
+    for row in row_values {
+        let mut print_row = "".to_owned();
+        for i in 0..column_names.len() {
+            print_row += &format!("{:width$} ", row[i], width = widths[i]);
+        }
+        println!("{}", print_row);
+    }
 }

--- a/cli/src/actions/organizations.rs
+++ b/cli/src/actions/organizations.rs
@@ -236,6 +236,30 @@ fn print_human_readable(column_names: Vec<String>, row_values: Vec<Vec<String>>)
     }
 }
 
+pub fn do_show_organization(
+    url: &str,
+    service_id: Option<String>,
+    org_id: &str,
+) -> Result<(), CliError> {
+    let client = Client::new();
+    let mut final_url = format!("{}/organization/{}", url, org_id);
+    if let Some(service_id) = service_id {
+        final_url = format!("{}?service_id={}", final_url, service_id);
+    }
+
+    let mut response = client.get(&final_url).send()?;
+
+    if !response.status().is_success() {
+        return Err(CliError::DaemonError(response.text()?));
+    }
+
+    let org = response.json::<OrganizationSlice>()?;
+
+    println!("{}", org);
+
+    Ok(())
+}
+
 impl std::fmt::Display for OrganizationSlice {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut display_string =

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -500,6 +500,17 @@ fn run() -> Result<(), CliError> {
                     )
                     .after_help(AFTER_HELP_WITHOUT_KEY)
                 )
+                .subcommand(
+                    SubCommand::with_name("show")
+                    .about("Show an organization specified by ID")
+                    .arg(
+                        Arg::with_name("org_id")
+                            .takes_value(true)
+                            .required(true)
+                            .help("Unique ID for organization")
+                    )
+                    .after_help(AFTER_HELP_WITHOUT_KEY)
+                )
         )
         .subcommand(
             SubCommand::with_name("role")
@@ -1905,8 +1916,11 @@ fn run() -> Result<(), CliError> {
                     &url,
                     service_id,
                     m.value_of("format").unwrap(),
-                    m.is_present("alternate-ids"),
+                    m.is_present("alternate_ids"),
                 )?,
+                ("show", Some(m)) => {
+                    orgs::do_show_organization(&url, service_id, m.value_of("org_id").unwrap())?
+                }
                 _ => return Err(CliError::UserError("Subcommand not recognized".into())),
             }
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -362,7 +362,7 @@ fn run() -> Result<(), CliError> {
         )
         .subcommand(
             SubCommand::with_name("organization")
-                .about("Update or create organization")
+                .about("Update, create, list or show organizations")
                 .setting(clap::AppSettings::SubcommandRequiredElseHelp)
                 .arg(
                     Arg::with_name("service_id")
@@ -480,6 +480,25 @@ fn run() -> Result<(), CliError> {
                                 .help("How long to wait for transaction to be committed")
                         )
                         .after_help(AFTER_HELP_WITH_KEY),
+                )
+                .subcommand(
+                    SubCommand::with_name("list")
+                    .about("List organizations")
+                    .arg(
+                        Arg::with_name("alternate_ids")
+                            .long("alternate-ids")
+                            .help("List organizations with the associated Alternate IDs")
+                    )
+                    .arg(
+                        Arg::with_name("format")
+                            .short("F")
+                            .long("format")
+                            .help("Output format")
+                            .possible_values(&["human", "csv"])
+                            .default_value("human")
+                            .takes_value(true),
+                    )
+                    .after_help(AFTER_HELP_WITHOUT_KEY)
                 )
         )
         .subcommand(
@@ -1882,6 +1901,12 @@ fn run() -> Result<(), CliError> {
                     info!("Submitting request to update organization...");
                     orgs::do_update_organization(&url, signer, wait, update_org, service_id)?;
                 }
+                ("list", Some(m)) => orgs::do_list_organizations(
+                    &url,
+                    service_id,
+                    m.value_of("format").unwrap(),
+                    m.is_present("alternate-ids"),
+                )?,
                 _ => return Err(CliError::UserError("Subcommand not recognized".into())),
             }
         }


### PR DESCRIPTION
This change adds commands to list organizations and to show a specific organization based on the `org_id`. This also adds the man page entries for each of these commands.