### PR TITLE
Fix Rest API error message

### DIFF
--- a/sdk/src/rest_api/actix_web_3/service.rs
+++ b/sdk/src/rest_api/actix_web_3/service.rs
@@ -63,7 +63,7 @@ impl FromRequest for AcceptServiceIdParam {
                 )
                 .json(ErrorResponse::new(
                     400,
-                    "Circuit ID present, but grid is running in sawtooth mode",
+                    "Service ID present, but grid is running in sawtooth mode",
                 )),
             );
         } else if service_id.is_none() && !endpoint.is_sawtooth() {
@@ -73,7 +73,7 @@ impl FromRequest for AcceptServiceIdParam {
                 )
                 .json(ErrorResponse::new(
                     400,
-                    "Circuit ID is not present, but grid is running in splinter mode",
+                    "Service ID is not present, but grid is running in splinter mode",
                 )),
             );
         }


### PR DESCRIPTION
Fixes an error message produced when the Grid daemon verifies the `service_id`. The `service_id` should be present if Grid is running on Splinter and should not be present if Grid is running on Sawtooth. The error message fixed in this PR is produced if the service id is present while on sawtooth and the other instance when it is not present on splinter. In each case, the errors produced stated that the `Circuit ID` was/was not present. However, this message should state `Service ID` as this is actually the value being checked.