### PR TITLE
Add accessor methods to Pike `Agent`

### DIFF
--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -182,7 +182,7 @@ mod test {
     };
     use grid_sdk::{
         location::store::{DieselLocationStore, Location, LocationAttribute, LocationStore},
-        pike::store::{Agent, DieselPikeStore, Organization, PikeStore},
+        pike::store::{Agent, AgentBuilder, DieselPikeStore, Organization, PikeStore},
         product::store::{
             DieselProductStore, Product, ProductBuilder, ProductStore, PropertyValue,
             PropertyValueBuilder,
@@ -2879,44 +2879,50 @@ mod test {
     }
 
     fn get_agent(service_id: Option<String>) -> Vec<Agent> {
-        vec![Agent {
-            public_key: KEY1.to_string(),
-            org_id: KEY2.to_string(),
-            active: true,
-            roles: vec![],
-            metadata: vec![],
-            start_commit_num: 0,
-            end_commit_num: i64::MAX,
-            last_updated: None,
-            service_id,
-        }]
+        let mut agent = AgentBuilder::new()
+            .with_public_key(KEY1.to_string())
+            .with_org_id(KEY2.to_string())
+            .with_active(true)
+            .with_start_commit_num(0)
+            .with_end_commit_num(i64::MAX);
+
+        if let Some(service_id) = service_id {
+            agent = agent.with_service_id(service_id.to_string())
+        }
+
+        vec![agent.build().expect("Unable to build Pike Agent")]
     }
 
     #[cfg(feature = "track-and-trace")]
     fn get_agents_with_roles(service_id: Option<String>) -> Vec<Agent> {
+        let mut agent_1 = AgentBuilder::new()
+            .with_public_key(KEY1.to_string())
+            .with_org_id(KEY2.to_string())
+            .with_active(true)
+            .with_roles(vec!["OWNER".to_string()])
+            .with_start_commit_num(0)
+            .with_end_commit_num(i64::MAX);
+        if let Some(id) = &service_id {
+            agent_1 = agent_1.with_service_id(id.to_string())
+        }
+        let mut agent_2 = AgentBuilder::new()
+            .with_public_key(KEY2.to_string())
+            .with_org_id(KEY3.to_string())
+            .with_active(true)
+            .with_roles(vec!["CUSTODIAN".to_string()])
+            .with_start_commit_num(0)
+            .with_end_commit_num(i64::MAX);
+        if let Some(id) = &service_id {
+            agent_2 = agent_2.with_service_id(id.to_string())
+        }
+
         vec![
-            Agent {
-                public_key: KEY1.to_string(),
-                org_id: KEY3.to_string(),
-                active: true,
-                roles: vec!["OWNER".to_string()],
-                metadata: vec![],
-                start_commit_num: 0,
-                end_commit_num: i64::MAX,
-                service_id: service_id.clone(),
-                last_updated: None,
-            },
-            Agent {
-                public_key: KEY2.to_string(),
-                org_id: KEY3.to_string(),
-                active: true,
-                roles: vec!["CUSTODIAN".to_string()],
-                metadata: vec![],
-                start_commit_num: 0,
-                end_commit_num: i64::MAX,
-                service_id,
-                last_updated: None,
-            },
+            agent_1
+                .build()
+                .expect("Unable to build Pike Agent with roles"),
+            agent_2
+                .build()
+                .expect("Unable to build Pike Agent with roles"),
         ]
     }
 

--- a/sdk/src/pike/store/builder.rs
+++ b/sdk/src/pike/store/builder.rs
@@ -1,0 +1,182 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::InvalidArgumentError;
+
+use super::error::PikeBuilderError;
+use super::Agent;
+
+/// Builder used to create a Pike Agent
+#[derive(Clone, Debug, Default)]
+pub struct AgentBuilder {
+    public_key: Option<String>,
+    org_id: Option<String>,
+    active: Option<bool>,
+    metadata: Option<Vec<u8>>,
+    roles: Option<Vec<String>>,
+    // The indicators of the start and stop for the slowly-changing dimensions.
+    start_commit_num: Option<i64>,
+    end_commit_num: Option<i64>,
+    service_id: Option<String>,
+    last_updated: Option<i64>,
+}
+
+impl AgentBuilder {
+    /// Creates a new Agent builder
+    pub fn new() -> Self {
+        AgentBuilder::default()
+    }
+
+    /// Set the public key of the Agent
+    ///
+    /// # Arguments
+    ///
+    /// * `public_key` - The public key of the Agent being built
+    pub fn with_public_key(mut self, public_key: String) -> Self {
+        self.public_key = Some(public_key);
+        self
+    }
+
+    /// Set the organization ID of the Agent
+    ///
+    /// # Arguments
+    ///
+    /// * `org_id` - The ID of the organization the Agent being built belongs to
+    pub fn with_org_id(mut self, org_id: String) -> Self {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    /// Set the active flag for the Agent
+    ///
+    /// # Arguments
+    ///
+    /// * `active` - Boolean representing whether the Agent being built is currently active
+    pub fn with_active(mut self, active: bool) -> Self {
+        self.active = Some(active);
+        self
+    }
+
+    /// Set the metadata of the Agent
+    ///
+    /// # Arguments
+    ///
+    /// * `metadata` - Metadata represented as key-value pairs related to the Agent being built
+    pub fn with_metadata(mut self, metadata: Vec<u8>) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+
+    /// Set the roles for the Agent
+    ///
+    /// # Arguments
+    ///
+    /// * `roles` - List of roles assigned to the Agent being built
+    pub fn with_roles(mut self, roles: Vec<String>) -> Self {
+        self.roles = Some(roles);
+        self
+    }
+
+    /// Set the starting commit num for the Agent
+    ///
+    /// # Arguments
+    ///
+    /// * `start_commit_num` - The start commit num for the Agent being built
+    pub fn with_start_commit_num(mut self, start_commit_num: i64) -> Self {
+        self.start_commit_num = Some(start_commit_num);
+        self
+    }
+
+    /// Set the ending commit num for the Agent
+    ///
+    /// # Arguments
+    ///
+    /// * `end_commit_num` - The end commit num for the Agent being built
+    pub fn with_end_commit_num(mut self, end_commit_num: i64) -> Self {
+        self.end_commit_num = Some(end_commit_num);
+        self
+    }
+
+    /// Set the service ID of the Agent
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The service ID for the Agent being built
+    pub fn with_service_id(mut self, service_id: String) -> Self {
+        self.service_id = Some(service_id);
+        self
+    }
+
+    /// Set the last updated timestamp for the Agent
+    ///
+    /// # Arguments
+    ///
+    /// * `last_updated` - The timestamp the Agent being built was last updated
+    pub fn with_last_updated(mut self, last_updated: i64) -> Self {
+        self.last_updated = Some(last_updated);
+        self
+    }
+
+    pub fn build(self) -> Result<Agent, PikeBuilderError> {
+        let public_key = self
+            .public_key
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("public_key".to_string()))?;
+        let org_id = self
+            .org_id
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("org_id".to_string()))?;
+        let active = self
+            .active
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("active".to_string()))?;
+        let metadata = self.metadata.unwrap_or_default();
+        let roles = self.roles.unwrap_or_default();
+
+        let start_commit_num = self.start_commit_num.ok_or_else(|| {
+            PikeBuilderError::MissingRequiredField("start_commit_num".to_string())
+        })?;
+        let end_commit_num = self
+            .end_commit_num
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("end_commit_num".to_string()))?;
+
+        if start_commit_num >= end_commit_num {
+            return Err(PikeBuilderError::InvalidArgumentError(
+                InvalidArgumentError::new(
+                    "start_commit_num".to_string(),
+                    "argument cannot be greater than or equal to `end_commit_num`".to_string(),
+                ),
+            ));
+        }
+        if end_commit_num <= start_commit_num {
+            return Err(PikeBuilderError::InvalidArgumentError(
+                InvalidArgumentError::new(
+                    "end_commit_num".to_string(),
+                    "argument cannot be less than or equal to `start_commit_num`".to_string(),
+                ),
+            ));
+        }
+        let service_id = self.service_id;
+        let last_updated = self.last_updated;
+
+        Ok(Agent {
+            public_key,
+            org_id,
+            active,
+            metadata,
+            roles,
+            start_commit_num,
+            end_commit_num,
+            service_id,
+            last_updated,
+        })
+    }
+}

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -25,6 +25,7 @@
 //! [`DieselPikeStore`]: diesel/struct.DieselPikeStore.html
 //! [`Diesel`]: https://crates.io/crates/diesel
 
+mod builder;
 #[cfg(feature = "diesel")]
 pub(in crate) mod diesel;
 mod error;
@@ -33,6 +34,7 @@ use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
 pub use self::diesel::DieselPikeStore;
+pub use builder::AgentBuilder;
 pub use error::PikeStoreError;
 
 /// Represents a Grid Agent

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -40,18 +40,65 @@ pub use error::PikeStoreError;
 /// Represents a Grid Agent
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct Agent {
-    pub public_key: String,
-    pub org_id: String,
-    pub active: bool,
-    pub metadata: Vec<u8>,
-    pub roles: Vec<String>,
+    public_key: String,
+    org_id: String,
+    active: bool,
+    metadata: Vec<u8>,
+    roles: Vec<String>,
     // The indicators of the start and stop for the slowly-changing dimensions.
-    pub start_commit_num: i64,
-    pub end_commit_num: i64,
+    start_commit_num: i64,
+    end_commit_num: i64,
 
-    pub service_id: Option<String>,
+    service_id: Option<String>,
 
-    pub last_updated: Option<i64>,
+    last_updated: Option<i64>,
+}
+
+impl Agent {
+    /// Returns the public key of the Agent
+    pub fn public_key(&self) -> &str {
+        &self.public_key
+    }
+
+    /// Returns the organization ID of the organization the Agent belongs to
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    /// Returns the `active` status of the Agent
+    pub fn active(&self) -> bool {
+        self.active
+    }
+
+    /// Returns the metadata of the Agent
+    pub fn metadata(&self) -> &[u8] {
+        &self.metadata
+    }
+
+    /// Returns the roles of the Agent
+    pub fn roles(&self) -> &[String] {
+        &self.roles
+    }
+
+    /// Returns the `start_commit_num` for this Agent
+    pub fn start_commit_num(&self) -> &i64 {
+        &self.start_commit_num
+    }
+
+    /// Returns the `end_commit_num` for this Agent
+    pub fn end_commit_num(&self) -> &i64 {
+        &self.end_commit_num
+    }
+
+    /// Returns the service ID for this Agent
+    pub fn service_id(&self) -> Option<&str> {
+        self.service_id.as_deref()
+    }
+
+    /// Returns the last updated timestamp for the Agent
+    pub fn last_updated(&self) -> Option<&i64> {
+        self.last_updated.as_ref()
+    }
 }
 
 /// Represents a Grid Role

--- a/sdk/src/rest_api/resources/agents/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/agents/v1/payloads.rs
@@ -45,9 +45,9 @@ impl TryFrom<Agent> for AgentSlice {
     type Error = ErrorResponse;
 
     fn try_from(agent: Agent) -> Result<Self, Self::Error> {
-        let metadata = if !agent.metadata.is_empty() {
+        let metadata = if !agent.metadata().is_empty() {
             JsonValue::from_str(
-                &String::from_utf8(agent.metadata.clone())
+                &String::from_utf8(agent.metadata().to_vec())
                     .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?,
             )
             .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?
@@ -56,13 +56,13 @@ impl TryFrom<Agent> for AgentSlice {
         };
 
         Ok(Self {
-            public_key: agent.public_key.clone(),
-            org_id: agent.org_id.clone(),
-            active: agent.active,
-            roles: agent.roles.clone(),
+            public_key: agent.public_key().to_string(),
+            org_id: agent.org_id().to_string(),
+            active: agent.active(),
+            roles: agent.roles().to_vec(),
             metadata,
-            service_id: agent.service_id,
-            last_updated: agent.last_updated,
+            service_id: agent.service_id().map(ToOwned::to_owned),
+            last_updated: agent.last_updated().map(ToOwned::to_owned),
         })
     }
 }


### PR DESCRIPTION
This PR makes a few changes in order to allow the fields of the `Agent` Pike struct to be private, rather than public. Store objects should have private fields and accessor methods, hence the change. Also, this PR adds a new `builder` module within the Pike store which currently holds an `AgentBuilder` used to construct agents. This PR also implements the use of the `AgentBuilder`. 