### PR TITLE
Rename pike to grid_pike

### DIFF
--- a/cli/src/actions/agents.rs
+++ b/cli/src/actions/agents.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use grid_sdk::{
-    pike::addressing::PIKE_NAMESPACE,
+    pike::addressing::GRID_PIKE_NAMESPACE,
     protocol::pike::payload::{Action, CreateAgentAction, PikePayloadBuilder, UpdateAgentAction},
     protos::IntoProto,
 };
@@ -65,8 +65,8 @@ pub fn do_create_agent(
     let batch_list = pike_batch_builder(signer)
         .add_transaction(
             &payload.into_proto()?,
-            &[PIKE_NAMESPACE.to_string()],
-            &[PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
         )?
         .create_batch_list();
 
@@ -94,8 +94,8 @@ pub fn do_update_agent(
     let batch_list = pike_batch_builder(signer)
         .add_transaction(
             &payload.into_proto()?,
-            &[PIKE_NAMESPACE.to_string()],
-            &[PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
         )?
         .create_batch_list();
 

--- a/cli/src/actions/locations.rs
+++ b/cli/src/actions/locations.rs
@@ -21,7 +21,7 @@ use std::{
 
 use grid_sdk::{
     location::addressing::GRID_LOCATION_NAMESPACE,
-    pike::addressing::PIKE_NAMESPACE,
+    pike::addressing::GRID_PIKE_NAMESPACE,
     protocol::{
         location::payload::{
             Action, LocationCreateAction, LocationCreateActionBuilder, LocationDeleteAction,
@@ -174,7 +174,7 @@ fn submit_payloads(
             &action.into_proto()?,
             &[
                 GRID_SCHEMA_NAMESPACE.to_string(),
-                PIKE_NAMESPACE.to_string(),
+                GRID_PIKE_NAMESPACE.to_string(),
                 GRID_LOCATION_NAMESPACE.to_string(),
             ],
             &[GRID_LOCATION_NAMESPACE.to_string()],

--- a/cli/src/actions/organizations.rs
+++ b/cli/src/actions/organizations.rs
@@ -20,7 +20,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use cylinder::Signer;
 use grid_sdk::{
-    pike::addressing::PIKE_NAMESPACE,
+    pike::addressing::GRID_PIKE_NAMESPACE,
     protocol::pike::payload::{
         Action, CreateOrganizationAction, PikePayloadBuilder, UpdateOrganizationAction,
     },
@@ -84,8 +84,8 @@ pub fn do_create_organization(
     let batch_list = pike_batch_builder(signer)
         .add_transaction(
             &payload.into_proto()?,
-            &[PIKE_NAMESPACE.to_string()],
-            &[PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
         )?
         .create_batch_list();
 
@@ -113,8 +113,8 @@ pub fn do_update_organization(
     let batch_list = pike_batch_builder(signer)
         .add_transaction(
             &payload.into_proto()?,
-            &[PIKE_NAMESPACE.to_string()],
-            &[PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
         )?
         .create_batch_list();
 

--- a/cli/src/actions/products.rs
+++ b/cli/src/actions/products.rs
@@ -18,7 +18,7 @@ use crate::actions::Paging;
 use crate::http::submit_batches;
 use crate::transaction::product_batch_builder;
 use cylinder::Signer;
-use grid_sdk::pike::addressing::PIKE_NAMESPACE;
+use grid_sdk::pike::addressing::GRID_PIKE_NAMESPACE;
 use grid_sdk::product::addressing::GRID_PRODUCT_NAMESPACE;
 use grid_sdk::product::gdsn::{get_trade_items_from_xml, GDSN_3_1_PROPERTY_NAME};
 use grid_sdk::protocol::product::payload::{
@@ -702,7 +702,7 @@ fn submit_payloads(
         builder.add_transaction(
             &action.into_proto()?,
             &[
-                PIKE_NAMESPACE.to_string(),
+                GRID_PIKE_NAMESPACE.to_string(),
                 GRID_SCHEMA_NAMESPACE.to_string(),
                 GRID_PRODUCT_NAMESPACE.to_string(),
             ],

--- a/cli/src/actions/roles.rs
+++ b/cli/src/actions/roles.rs
@@ -23,7 +23,7 @@ use crate::http::submit_batches;
 use crate::transaction::pike_batch_builder;
 use cylinder::Signer;
 use grid_sdk::{
-    pike::addressing::PIKE_NAMESPACE,
+    pike::addressing::GRID_PIKE_NAMESPACE,
     protocol::pike::payload::{
         Action, CreateRoleAction, DeleteRoleAction, PikePayloadBuilder, UpdateRoleAction,
     },
@@ -152,8 +152,8 @@ pub fn do_create_role(
     let batch_list = pike_batch_builder(signer)
         .add_transaction(
             &payload.into_proto()?,
-            &[PIKE_NAMESPACE.to_string()],
-            &[PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
         )?
         .create_batch_list();
 
@@ -181,8 +181,8 @@ pub fn do_update_role(
     let batch_list = pike_batch_builder(signer)
         .add_transaction(
             &payload.into_proto()?,
-            &[PIKE_NAMESPACE.to_string()],
-            &[PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
         )?
         .create_batch_list();
 
@@ -210,8 +210,8 @@ pub fn do_delete_role(
     let batch_list = pike_batch_builder(signer)
         .add_transaction(
             &payload.into_proto()?,
-            &[PIKE_NAMESPACE.to_string()],
-            &[PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
+            &[GRID_PIKE_NAMESPACE.to_string()],
         )?
         .create_batch_list();
 

--- a/cli/src/actions/schemas.rs
+++ b/cli/src/actions/schemas.rs
@@ -21,7 +21,7 @@ use crate::yaml_parser::{
     parse_value_as_string, parse_value_as_vec_string,
 };
 use cylinder::Signer;
-use grid_sdk::pike::addressing::PIKE_NAMESPACE;
+use grid_sdk::pike::addressing::GRID_PIKE_NAMESPACE;
 use grid_sdk::protocol::schema::payload::{
     Action, SchemaCreateAction, SchemaCreateBuilder, SchemaPayload, SchemaPayloadBuilder,
     SchemaUpdateAction, SchemaUpdateBuilder,
@@ -213,7 +213,7 @@ pub fn do_create_schemas(
         batch_list_builder = batch_list_builder.add_transaction(
             &payload.into_proto()?,
             &[
-                PIKE_NAMESPACE.to_string(),
+                GRID_PIKE_NAMESPACE.to_string(),
                 GRID_SCHEMA_NAMESPACE.to_string(),
             ],
             &[GRID_SCHEMA_NAMESPACE.to_string()],
@@ -238,7 +238,7 @@ pub fn do_update_schemas(
         batch_list_builder = batch_list_builder.add_transaction(
             &payload.into_proto()?,
             &[
-                PIKE_NAMESPACE.to_string(),
+                GRID_PIKE_NAMESPACE.to_string(),
                 GRID_SCHEMA_NAMESPACE.to_string(),
             ],
             &[GRID_SCHEMA_NAMESPACE.to_string()],

--- a/cli/src/transaction.rs
+++ b/cli/src/transaction.rs
@@ -33,8 +33,8 @@ use sawtooth_sdk::messages::transaction::TransactionHeader;
 
 use crate::CliError;
 
-const PIKE_FAMILY_NAME: &str = "pike";
-const PIKE_FAMILY_VERSION: &str = "2";
+const GRID_PIKE_FAMILY_NAME: &str = "grid_pike";
+const GRID_PIKE_FAMILY_VERSION: &str = "2";
 
 const GRID_SCHEMA_FAMILY_NAME: &str = "grid_schema";
 const GRID_SCHEMA_FAMILY_VERSION: &str = "1";
@@ -53,7 +53,7 @@ pub fn schema_batch_builder(signer: Box<dyn Signer>) -> BatchBuilder {
 }
 
 pub fn pike_batch_builder(signer: Box<dyn Signer>) -> BatchBuilder {
-    BatchBuilder::new(PIKE_FAMILY_NAME, PIKE_FAMILY_VERSION, signer)
+    BatchBuilder::new(GRID_PIKE_FAMILY_NAME, GRID_PIKE_FAMILY_VERSION, signer)
 }
 
 pub fn product_batch_builder(signer: Box<dyn Signer>) -> BatchBuilder {

--- a/contracts/pike/packaging/scar/manifest.yaml
+++ b/contracts/pike/packaging/scar/manifest.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: pike
+name: grid_pike
 version: '2'
 inputs:
   - '621dee05'

--- a/contracts/pike/pike.yaml
+++ b/contracts/pike/pike.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: pike
+name: grid_pike
 version: '2'
 wasm: /tmp/grid-pike-tp.wasm
 inputs:

--- a/contracts/pike/src/handler.rs
+++ b/contracts/pike/src/handler.rs
@@ -30,7 +30,7 @@ cfg_if! {
 }
 
 use grid_sdk::{
-    pike::addressing::PIKE_NAMESPACE,
+    pike::addressing::GRID_PIKE_NAMESPACE,
     pike::permissions::PermissionChecker,
     protocol::pike::state::{AlternateIdIndexEntryBuilder, RoleBuilder},
     protos::{
@@ -46,8 +46,8 @@ use grid_sdk::{
 use crate::permissions::{permission_to_perm_string, Permission};
 use crate::state::PikeState;
 
-const PIKE_FAMILY_NAME: &str = "pike";
-const PIKE_FAMILY_VERSION: &str = "2";
+const GRID_PIKE_FAMILY_NAME: &str = "grid_pike";
+const GRID_PIKE_FAMILY_VERSION: &str = "2";
 
 pub struct PikeTransactionHandler {
     family_name: String,
@@ -59,9 +59,9 @@ impl PikeTransactionHandler {
     #[allow(clippy::new_without_default)]
     pub fn new() -> PikeTransactionHandler {
         PikeTransactionHandler {
-            family_name: PIKE_FAMILY_NAME.to_string(),
-            family_versions: vec![PIKE_FAMILY_VERSION.to_string()],
-            namespaces: vec![PIKE_NAMESPACE.to_string()],
+            family_name: GRID_PIKE_FAMILY_NAME.to_string(),
+            family_versions: vec![GRID_PIKE_FAMILY_VERSION.to_string()],
+            namespaces: vec![GRID_PIKE_NAMESPACE.to_string()],
         }
     }
 }

--- a/contracts/track_and_trace/src/handler.rs
+++ b/contracts/track_and_trace/src/handler.rs
@@ -30,7 +30,7 @@ cfg_if! {
 }
 
 use grid_sdk::{
-    pike::addressing::PIKE_NAMESPACE,
+    pike::addressing::GRID_PIKE_NAMESPACE,
     protocol::{
         errors::BuilderError,
         schema::state::{PropertyDefinition, PropertyValue},
@@ -71,7 +71,7 @@ impl TrackAndTraceTransactionHandler {
             family_versions: vec!["1".to_string()],
             namespaces: vec![
                 TRACK_AND_TRACE_NAMESPACE.to_string(),
-                PIKE_NAMESPACE.to_string(),
+                GRID_PIKE_NAMESPACE.to_string(),
                 GRID_NAMESPACE.to_string(),
             ],
         }

--- a/daemon/src/event/db_handler.rs
+++ b/daemon/src/event/db_handler.rs
@@ -42,7 +42,8 @@ use grid_sdk::{
 use grid_sdk::{
     pike::{
         addressing::{
-            PIKE_AGENT_NAMESPACE, PIKE_NAMESPACE, PIKE_ORGANIZATION_NAMESPACE, PIKE_ROLE_NAMESPACE,
+            GRID_PIKE_AGENT_NAMESPACE, GRID_PIKE_NAMESPACE, GRID_PIKE_ORGANIZATION_NAMESPACE,
+            GRID_PIKE_ROLE_NAMESPACE,
         },
         store::{
             Agent, AgentBuilder, AlternateId, DieselPikeStore, Organization, OrganizationMetadata,
@@ -513,8 +514,8 @@ fn state_change_to_db_operation(
     match state_change {
         StateChange::Set { key, value } => match &key[0..8] {
             #[cfg(feature = "pike")]
-            PIKE_NAMESPACE => match &key[0..10] {
-                PIKE_AGENT_NAMESPACE => {
+            GRID_PIKE_NAMESPACE => match &key[0..10] {
+                GRID_PIKE_AGENT_NAMESPACE => {
                     let agents: Vec<Agent> = AgentList::from_bytes(&value)
                         .map_err(|err| EventError(format!("Failed to parse agent list {}", err)))?
                         .agents()
@@ -550,7 +551,7 @@ fn state_change_to_db_operation(
 
                     Ok(Some(DbInsertOperation::Agents(agents)))
                 }
-                PIKE_ORGANIZATION_NAMESPACE => {
+                GRID_PIKE_ORGANIZATION_NAMESPACE => {
                     let orgs = OrganizationList::from_bytes(&value)
                         .map_err(|err| {
                             EventError(format!("Failed to parse organization list {}", err))
@@ -593,7 +594,7 @@ fn state_change_to_db_operation(
 
                     Ok(Some(DbInsertOperation::Organizations(orgs)))
                 }
-                PIKE_ROLE_NAMESPACE => {
+                GRID_PIKE_ROLE_NAMESPACE => {
                     let roles = RoleList::from_bytes(&value)
                         .map_err(|err| EventError(format!("Failed to parse role list {}", err)))?
                         .roles()
@@ -892,8 +893,8 @@ fn state_change_to_db_operation(
         },
         StateChange::Delete { key } => match &key[0..8] {
             #[cfg(feature = "pike")]
-            PIKE_NAMESPACE => match &key[0..10] {
-                PIKE_ROLE_NAMESPACE => Ok(Some(DbInsertOperation::RemoveRole(
+            GRID_PIKE_NAMESPACE => match &key[0..10] {
+                GRID_PIKE_ROLE_NAMESPACE => Ok(Some(DbInsertOperation::RemoveRole(
                     key.to_string(),
                     commit_num,
                 ))),

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -22,7 +22,7 @@ use std::cell::RefCell;
 use std::thread;
 
 #[cfg(feature = "pike")]
-use grid_sdk::pike::addressing::PIKE_NAMESPACE;
+use grid_sdk::pike::addressing::GRID_PIKE_NAMESPACE;
 
 cfg_if! {
     if #[cfg(feature = "schema")] {
@@ -43,7 +43,7 @@ pub use self::error::{EventError, EventIoError, EventProcessorError};
 
 const ALL_GRID_NAMESPACES: &[&str] = &[
     #[cfg(feature = "pike")]
-    PIKE_NAMESPACE,
+    GRID_PIKE_NAMESPACE,
     #[cfg(any(feature = "schema", feature = "product", feature = "location"))]
     GRID_NAMESPACE,
     #[cfg(feature = "track-and-trace")]

--- a/daemon/src/splinter/app_auth_handler/sabre.rs
+++ b/daemon/src/splinter/app_auth_handler/sabre.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 #[cfg(feature = "location")]
 use grid_sdk::location::addressing::GRID_LOCATION_NAMESPACE;
 #[cfg(feature = "pike")]
-use grid_sdk::pike::addressing::PIKE_NAMESPACE;
+use grid_sdk::pike::addressing::GRID_PIKE_NAMESPACE;
 #[cfg(feature = "product")]
 use grid_sdk::product::addressing::GRID_PRODUCT_NAMESPACE;
 #[cfg(feature = "purchase-order")]
@@ -146,16 +146,16 @@ fn make_pike_txns(
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
-    let pike_contract_txn = make_upload_contract_txn(signer, &pike_contract, PIKE_NAMESPACE)?;
+    let pike_contract_txn = make_upload_contract_txn(signer, &pike_contract, GRID_PIKE_NAMESPACE)?;
     let pike_namespace_registry_txn = CreateNamespaceRegistryActionBuilder::new()
-        .with_namespace(PIKE_NAMESPACE.into())
+        .with_namespace(GRID_PIKE_NAMESPACE.into())
         .with_owners(vec![bytes_to_hex_str(signer.public_key())])
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
 
     let pike_namespace_permissions_txn = CreateNamespaceRegistryPermissionActionBuilder::new()
-        .with_namespace(PIKE_NAMESPACE.into())
+        .with_namespace(GRID_PIKE_NAMESPACE.into())
         .with_contract_name(pike_contract.metadata.name)
         .with_read(true)
         .with_write(true)
@@ -205,7 +205,7 @@ fn make_product_txns(
         .build(signer)?;
     let product_pike_namespace_permissions_txn =
         CreateNamespaceRegistryPermissionActionBuilder::new()
-            .with_namespace(PIKE_NAMESPACE.into())
+            .with_namespace(GRID_PIKE_NAMESPACE.into())
             .with_contract_name(product_contract.metadata.name.clone())
             .with_read(true)
             .with_write(true)
@@ -266,7 +266,7 @@ fn make_location_txns(
         .build(signer)?;
     let location_pike_namespace_permissions_txn =
         CreateNamespaceRegistryPermissionActionBuilder::new()
-            .with_namespace(PIKE_NAMESPACE.into())
+            .with_namespace(GRID_PIKE_NAMESPACE.into())
             .with_contract_name(location_contract.metadata.name.clone())
             .with_read(true)
             .with_write(true)
@@ -327,7 +327,7 @@ fn make_schema_txns(
         .build(signer)?;
     let schema_pike_namespace_permissions_txn =
         CreateNamespaceRegistryPermissionActionBuilder::new()
-            .with_namespace(PIKE_NAMESPACE.into())
+            .with_namespace(GRID_PIKE_NAMESPACE.into())
             .with_contract_name(schema_contract.metadata.name)
             .with_read(true)
             .with_write(true)
@@ -385,7 +385,7 @@ fn make_purchase_order_txns(
             .build(signer)?;
     let purchase_order_pike_namespace_permissions_txn =
         CreateNamespaceRegistryPermissionActionBuilder::new()
-            .with_namespace(PIKE_NAMESPACE.into())
+            .with_namespace(GRID_PIKE_NAMESPACE.into())
             .with_contract_name(purchase_order_contract.metadata.name)
             .with_read(true)
             .with_write(true)
@@ -416,7 +416,7 @@ fn make_upload_contract_txn(
     contract: &SmartContractArchive,
     contract_prefix: &str,
 ) -> Result<Transaction, AppAuthHandlerError> {
-    let action_addresses = vec![PIKE_NAMESPACE.into(), contract_prefix.into()];
+    let action_addresses = vec![GRID_PIKE_NAMESPACE.into(), contract_prefix.into()];
     Ok(CreateContractActionBuilder::new()
         .with_name(contract.metadata.name.clone())
         .with_version(contract.metadata.version.clone())

--- a/integration/docker-compose.yaml
+++ b/integration/docker-compose.yaml
@@ -53,10 +53,10 @@ services:
     entrypoint: |
       bash -c "
         while true; do curl -s http://grid-sawtooth-rest-api:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
-        sabre cr --create pike --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre cr --create grid_pike --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
         sabre upload --filename /tmp/pike.yaml --key /grid-shared/my_key --url http://grid-sawtooth-rest-api:8008 --wait 30
         sabre ns --create 621dee05 --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://grid-sawtooth-rest-api:8008 --wait 30
-        sabre perm 621dee05 pike --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
+        sabre perm 621dee05 grid_pike --key /grid-shared/my_key --read --write --url http://grid-sawtooth-rest-api:8008 --wait 30
         echo '---------========= pike contract is loaded =========---------'
         tail -f /dev/null
       "
@@ -173,7 +173,7 @@ services:
         done
         while true; do curl -s http://grid-sawtooth-rest-api:8008/state/00ec023b83af696f65e0579200b7f066089db00fe628034c405c1a9acda1dc16a5e961 | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
         while true; do curl -s http://grid-sawtooth-rest-api:8008/state/00ec027e3e56bcd14d28d036fcfcde2cd2e3c83e83256dc986b5f27d65cc3ef1693cf3 | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
-        while true; do curl -s http://grid-sawtooth-rest-api:8008/state/00ec02bb0b4ad88592b206787ba6a3adef17774763b03ce516281dcafe538254553219 | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
+        while true; do curl -s http://grid-sawtooth-rest-api:8008/state/00ec025e503966e698583f792b5d6e6062c97640e5eb2cfc72c4c64f9d3b6a95cfac46 | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
         cp /build/target/debug/gridd /usr/sbin/gridd && \
         cp /build/target/debug/grid /usr/bin/grid && \
         grid database migrate \

--- a/sdk/src/pike/addressing.rs
+++ b/sdk/src/pike/addressing.rs
@@ -18,34 +18,35 @@ use crypto::digest::Digest;
 use crypto::sha2::Sha512;
 
 /// Namespace for Pike objects, prefixes addresses
-pub const PIKE_NAMESPACE: &str = "621dee05";
+pub const GRID_PIKE_NAMESPACE: &str = "621dee05";
 
 /// Address prefix representing Pike agents
 pub const AGENT_PREFIX: &str = "00";
 /// Namespace specific to Pike agents
-pub const PIKE_AGENT_NAMESPACE: &str = "621dee0500";
+pub const GRID_PIKE_AGENT_NAMESPACE: &str = "621dee0500";
 
 /// Address prefix representing Pike organizations
 pub const ORG_PREFIX: &str = "01";
 /// Namespace specific to Pike organizations
-pub const PIKE_ORGANIZATION_NAMESPACE: &str = "621dee0501";
+pub const GRID_PIKE_ORGANIZATION_NAMESPACE: &str = "621dee0501";
 
 /// Address prefix representing Pike roles
 pub const ROLE_PREFIX: &str = "02";
 /// Namespace specific to Pike roles
-pub const PIKE_ROLE_NAMESPACE: &str = "621dee0502";
+pub const GRID_PIKE_ROLE_NAMESPACE: &str = "621dee0502";
 
 /// Address prefix representing Pike alternate IDs
 pub const ALTERNATE_ID_INDEX_ENTRY_PREFIX: &str = "03";
 /// Namespace specific to Pike alternate IDs
-pub const PIKE_ALTERNATE_ID_INDEX_ENTRY_NAMESPACE: &str = "621dee0503";
+pub const GRID_PIKE_ALTERNATE_ID_INDEX_ENTRY_NAMESPACE: &str = "621dee0503";
 
 /// Computes the address a Pike Agent is stored at based on its public_key
 pub fn compute_agent_address(public_key: &str) -> String {
     let mut sha = Sha512::new();
     sha.input(public_key.as_bytes());
     // (pike namespace) + (agent namespace) + hash
-    let hash_str = String::from(PIKE_NAMESPACE) + &String::from(AGENT_PREFIX) + &sha.result_str();
+    let hash_str =
+        String::from(GRID_PIKE_NAMESPACE) + &String::from(AGENT_PREFIX) + &sha.result_str();
     hash_str[..70].to_string()
 }
 
@@ -54,7 +55,7 @@ pub fn compute_organization_address(org_id: &str) -> String {
     let mut sha = Sha512::new();
     sha.input(org_id.as_bytes());
     // (pike namespace) + (org namespace) + hash
-    let hash_str = String::from(PIKE_NAMESPACE) + ORG_PREFIX + &sha.result_str();
+    let hash_str = String::from(GRID_PIKE_NAMESPACE) + ORG_PREFIX + &sha.result_str();
     hash_str[..70].to_string()
 }
 
@@ -64,7 +65,7 @@ pub fn compute_role_address(name: &str, org_id: &str) -> String {
     let mut sha = Sha512::new();
     sha.input(uname.as_bytes());
     // (pike namespace) + (role namespace) + hash
-    let hash_str = String::from(PIKE_NAMESPACE) + ROLE_PREFIX + &sha.result_str();
+    let hash_str = String::from(GRID_PIKE_NAMESPACE) + ROLE_PREFIX + &sha.result_str();
     hash_str[..70].to_string()
 }
 
@@ -75,6 +76,6 @@ pub fn compute_alternate_id_index_entry_address(id_type: &str, id: &str) -> Stri
     sha.input(uname.as_bytes());
     // (pike namespace) + (alternate ID namespace) + hash
     let hash_str =
-        String::from(PIKE_NAMESPACE) + ALTERNATE_ID_INDEX_ENTRY_PREFIX + &sha.result_str();
+        String::from(GRID_PIKE_NAMESPACE) + ALTERNATE_ID_INDEX_ENTRY_PREFIX + &sha.result_str();
     hash_str[..70].to_string()
 }


### PR DESCRIPTION
The rest of the grid contracts are prefixed with grid_, this change updates
pike to match.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>