### PR TITLE
Add get_current_service_commits

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -105,6 +105,7 @@ experimental = [
     "batch-store",
     "client",
     "client-reqwest",
+    "commit-store-service-commits",
     "pike-rest-api",
     "purchase-order",
     "rest-api-resources",
@@ -126,6 +127,7 @@ backend-sawtooth = ["backend", "uuid"]
 backend-splinter = ["backend", "reqwest"]
 client = []
 client-reqwest = ["client", "reqwest"]
+commit-store-service-commits = []
 location = ["pike", "schema"]
 pike = ["cfg-if"]
 pike-rest-api = ["pike", "serde_json", "rest-api-resources"]

--- a/sdk/src/commits/store/diesel/mod.rs
+++ b/sdk/src/commits/store/diesel/mod.rs
@@ -27,6 +27,8 @@ use operations::add_commit::CommitStoreAddCommitOperation as _;
 use operations::create_db_commit_from_commit_event::CommitStoreCreateDbCommitFromCommitEventOperation as _;
 use operations::get_commit_by_commit_num::CommitStoreGetCommitByCommitNumOperation as _;
 use operations::get_current_commit_id::CommitStoreGetCurrentCommitIdOperation as _;
+#[cfg(feature = "commit-store-service-commits")]
+use operations::get_current_service_commits::CommitStoreGetCurrentSericeCommitsOperation as _;
 use operations::get_next_commit_num::CommitStoreGetNextCommitNumOperation as _;
 use operations::resolve_fork::CommitStoreResolveForkOperation as _;
 use operations::CommitStoreOperations;
@@ -70,6 +72,11 @@ impl CommitStore for DieselCommitStore<diesel::pg::PgConnection> {
         CommitStoreOperations::new(&*self.connection_pool.get()?).get_current_commit_id()
     }
 
+    #[cfg(feature = "commit-store-service-commits")]
+    fn get_current_service_commits(&self) -> Result<Vec<Commit>, CommitStoreError> {
+        CommitStoreOperations::new(&*self.connection_pool.get()?).get_current_service_commits()
+    }
+
     fn get_next_commit_num(&self) -> Result<i64, CommitStoreError> {
         CommitStoreOperations::new(&*self.connection_pool.get()?).get_next_commit_num()
     }
@@ -103,6 +110,11 @@ impl CommitStore for DieselCommitStore<diesel::sqlite::SqliteConnection> {
 
     fn get_current_commit_id(&self) -> Result<Option<String>, CommitStoreError> {
         CommitStoreOperations::new(&*self.connection_pool.get()?).get_current_commit_id()
+    }
+
+    #[cfg(feature = "commit-store-service-commits")]
+    fn get_current_service_commits(&self) -> Result<Vec<Commit>, CommitStoreError> {
+        CommitStoreOperations::new(&*self.connection_pool.get()?).get_current_service_commits()
     }
 
     fn get_next_commit_num(&self) -> Result<i64, CommitStoreError> {

--- a/sdk/src/commits/store/diesel/operations/get_current_service_commits.rs
+++ b/sdk/src/commits/store/diesel/operations/get_current_service_commits.rs
@@ -1,0 +1,188 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Nullable, Text};
+
+use crate::commits::store::diesel::{Commit, CommitStoreError};
+use crate::error::InternalError;
+
+use super::CommitStoreOperations;
+
+#[derive(QueryableByName)]
+struct CurrentCommit {
+    #[column_name = "commit_id"]
+    #[sql_type = "Text"]
+    pub commit_id: String,
+
+    #[column_name = "current_commit_number"]
+    #[sql_type = "BigInt"]
+    pub commit_num: i64,
+
+    #[column_name = "service_id"]
+    #[sql_type = "Nullable<Text>"]
+    pub service_id: Option<String>,
+}
+
+/// Performs the operation to return the current commits recorded for services. It ignores any
+/// commits that have no service id (i.e. Sawtooth commits).
+pub(in crate::commits) trait CommitStoreGetCurrentSericeCommitsOperation {
+    fn get_current_service_commits(&self) -> Result<Vec<Commit>, CommitStoreError>;
+}
+
+impl<'a> CommitStoreGetCurrentSericeCommitsOperation
+    for CommitStoreOperations<'a, SqliteConnection>
+{
+    fn get_current_service_commits(&self) -> Result<Vec<Commit>, CommitStoreError> {
+        // A raw query is required, as diesel does not support this style of query as of its 1.4.x
+        // release branch.
+        sql_query(
+            r#"
+            SELECT commit_id, MAX (commit_num) as current_commit_number, service_id
+            FROM commits
+            GROUP BY service_id
+        "#,
+        )
+        .load::<CurrentCommit>(self.conn)
+        .map(|values| {
+            values
+                .into_iter()
+                .filter_map(
+                    |CurrentCommit {
+                         commit_id,
+                         commit_num,
+                         service_id,
+                     }| {
+                        service_id.map(|service_id| Commit {
+                            commit_id,
+                            commit_num,
+                            service_id: Some(service_id),
+                        })
+                    },
+                )
+                .collect::<Vec<_>>()
+        })
+        .map_err(|err| CommitStoreError::InternalError(InternalError::from_source(Box::new(err))))
+    }
+}
+
+impl<'a> CommitStoreGetCurrentSericeCommitsOperation for CommitStoreOperations<'a, PgConnection> {
+    fn get_current_service_commits(&self) -> Result<Vec<Commit>, CommitStoreError> {
+        // A raw query is required, as diesel does not support this style of query as of its 1.4.x
+        // release branch.
+        sql_query(
+            r#"
+            WITH current_commits AS
+            (
+                SELECT service_id, max(commit_num) AS current_commit_number
+                FROM commits
+                GROUP BY service_id
+            )
+            SELECT commits.commit_id,
+                   commits.commit_num AS current_commit_number,
+                   commits.service_id
+            FROM current_commits
+            INNER JOIN commits
+            ON  commits.service_id = current_commits.service_id
+            AND commits.commit_num = current_commits.current_commit_number
+        "#,
+        )
+        .load::<CurrentCommit>(self.conn)
+        .map(|values| {
+            values
+                .into_iter()
+                .filter_map(
+                    |CurrentCommit {
+                         commit_id,
+                         commit_num,
+                         service_id,
+                     }| {
+                        service_id.map(|service_id| Commit {
+                            commit_id,
+                            commit_num,
+                            service_id: Some(service_id),
+                        })
+                    },
+                )
+                .collect::<Vec<_>>()
+        })
+        .map_err(|err| CommitStoreError::InternalError(InternalError::from_source(Box::new(err))))
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use super::*;
+
+    use diesel::insert_into;
+
+    use crate::commits::store::diesel::{models::NewCommitModel, schema::commits};
+    use crate::migrations::run_sqlite_migrations;
+
+    #[test]
+    fn test_get_current_service_commits() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_sqlite_migrations(&conn)?;
+
+        insert_into(commits::table)
+            .values(vec![
+                NewCommitModel {
+                    commit_id: "first:sawtooth".into(),
+                    commit_num: 1,
+                    service_id: None,
+                },
+                // service 1
+                NewCommitModel {
+                    commit_id: "first:service1".into(),
+                    commit_num: 1,
+                    service_id: Some("service1".into()),
+                },
+                NewCommitModel {
+                    commit_id: "second:service1".into(),
+                    commit_num: 2,
+                    service_id: Some("service1".into()),
+                },
+                // Service 2
+                NewCommitModel {
+                    commit_id: "first:service2".into(),
+                    commit_num: 1,
+                    service_id: Some("service2".into()),
+                },
+            ])
+            .execute(&conn)?;
+
+        let ops = CommitStoreOperations::new(&conn);
+        let current_service_commits = ops.get_current_service_commits()?;
+
+        assert_eq!(
+            vec![
+                Commit {
+                    commit_id: "second:service1".into(),
+                    commit_num: 2,
+                    service_id: Some("service1".into()),
+                },
+                Commit {
+                    commit_id: "first:service2".into(),
+                    commit_num: 1,
+                    service_id: Some("service2".into()),
+                },
+            ],
+            current_service_commits,
+        );
+
+        Ok(())
+    }
+}

--- a/sdk/src/commits/store/diesel/operations/mod.rs
+++ b/sdk/src/commits/store/diesel/operations/mod.rs
@@ -16,6 +16,8 @@ pub(super) mod add_commit;
 pub(super) mod create_db_commit_from_commit_event;
 pub(super) mod get_commit_by_commit_num;
 pub(super) mod get_current_commit_id;
+#[cfg(feature = "commit-store-service-commits")]
+pub(super) mod get_current_service_commits;
 pub(super) mod get_next_commit_num;
 pub(super) mod resolve_fork;
 

--- a/sdk/src/commits/store/mod.rs
+++ b/sdk/src/commits/store/mod.rs
@@ -75,6 +75,13 @@ pub trait CommitStore: Send + Sync {
     /// Gets the current commit ID from the underlying storage
     fn get_current_commit_id(&self) -> Result<Option<String>, CommitStoreError>;
 
+    #[cfg(feature = "commit-store-service-commits")]
+    /// Gets all the current commits on services.
+    ///
+    /// This returns the latest commit values for all commits where `commit.service_id` is not
+    /// `None`.
+    fn get_current_service_commits(&self) -> Result<Vec<Commit>, CommitStoreError>;
+
     /// Gets the next commit number from the underlying storage
     fn get_next_commit_num(&self) -> Result<i64, CommitStoreError>;
 
@@ -113,6 +120,11 @@ where
 
     fn get_current_commit_id(&self) -> Result<Option<String>, CommitStoreError> {
         (**self).get_current_commit_id()
+    }
+
+    #[cfg(feature = "commit-store-service-commits")]
+    fn get_current_service_commits(&self) -> Result<Vec<Commit>, CommitStoreError> {
+        (**self).get_current_service_commits()
     }
 
     fn get_next_commit_num(&self) -> Result<i64, CommitStoreError> {


### PR DESCRIPTION
This change adds a method to the `CommitStore` to provide the current commits for all services.

It also adds the implementation for the `DieselCommitStore`, supplying the query via an operation trait.  The operation implementation itself requires using a raw SQL query, as the query cannot be generated using the diesel DSL (as of diesel 1.4.x releases).

It is guarded behind the experimental feature `"commit-store-service-commits"`.
