### PR TITLE
Reconnect scabbard event processors on restart

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -88,6 +88,7 @@ experimental = [
     # The following features are experimental:
     "integration",
     "purchase-order",
+    "scabbard-event-restart",
     "track-and-trace",
 ]
 
@@ -114,6 +115,7 @@ sawtooth-support = [
     "grid-sdk/sawtooth-compat",
     "rest-api"
 ]
+scabbard-event-restart = ["grid-sdk/commit-store-service-commits"]
 schema = ["grid-sdk/rest-api-endpoint-schema", "grid-sdk/schema", "pike"]
 splinter-support = [
   "cylinder/key-load",

--- a/sdk/src/error/invalid_state.rs
+++ b/sdk/src/error/invalid_state.rs
@@ -1,0 +1,71 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module containing InvalidStateError implementation.
+
+use std::error;
+use std::fmt;
+
+/// An error returned when an operation cannot be completed because the state of the underlying
+/// struct is inconsistent.
+///
+/// This can be caused by a caller when a sequence of functions is called in a way that results in
+/// a state which is inconsistent.
+///
+/// This usually indicates a programming error on behalf of the caller.
+#[derive(Debug)]
+pub struct InvalidStateError {
+    message: String,
+}
+
+impl InvalidStateError {
+    /// Constructs a new `InvalidStateError` with a specified message string.
+    ///
+    /// The implementation of `std::fmt::Display` for this error will be the message string
+    /// provided.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grid_sdk::error::InvalidStateError;
+    ///
+    /// let invalid_state_error = InvalidStateError::with_message("oops".to_string());
+    /// assert_eq!(format!("{}", invalid_state_error), "oops");
+    /// ```
+    pub fn with_message(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl error::Error for InvalidStateError {}
+
+impl fmt::Display for InvalidStateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.message)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    /// Tests that error constructed with `InvalidStateError::with_message` return message as the
+    /// display string.
+    #[test]
+    fn test_display_with_message() {
+        let msg = "test message";
+        let err = InvalidStateError::with_message(msg.to_string());
+        assert_eq!(format!("{}", err), msg);
+    }
+}

--- a/sdk/src/error/mod.rs
+++ b/sdk/src/error/mod.rs
@@ -77,9 +77,11 @@
 mod constraint_violation;
 mod internal;
 mod invalid_argument;
+mod invalid_state;
 mod unavailable;
 
 pub use constraint_violation::{ConstraintViolationError, ConstraintViolationType};
 pub use internal::InternalError;
 pub use invalid_argument::InvalidArgumentError;
+pub use invalid_state::InvalidStateError;
 pub use unavailable::ResourceTemporarilyUnavailableError;


### PR DESCRIPTION
To Test:

Start up a network using

```
$ docker-compose -f examples/splinter/docker-compose.yaml up --build
```

Follow the guide for [creating circuits](https://grid.hyperledger.org/docs/0.2/creating_splinter_circuits.html).

`ctrl+c`  the compose run, followed by 

```
$ docker-compose -f examples/splinter/docker-compose.yaml up
```

Attempt to create a role (via the [pike guid](https://grid.hyperledger.org/docs/0.2/using_pike.html))

Before this PR, this would not receive state delta events.  After, the state delta events should still be applied.

~Depends on #801~ 