### PR TITLE
Add private fields to Pike store's Role

### DIFF
--- a/sdk/src/pike/store/builder.rs
+++ b/sdk/src/pike/store/builder.rs
@@ -15,7 +15,7 @@
 use crate::error::InvalidArgumentError;
 
 use super::error::PikeBuilderError;
-use super::Agent;
+use super::{Agent, Role};
 
 /// Builder used to create a Pike Agent
 #[derive(Clone, Debug, Default)]
@@ -173,6 +173,194 @@ impl AgentBuilder {
             active,
             metadata,
             roles,
+            start_commit_num,
+            end_commit_num,
+            service_id,
+            last_updated,
+        })
+    }
+}
+
+/// Builder used to create a Pike role
+#[derive(Clone, Debug, Default)]
+pub struct RoleBuilder {
+    name: Option<String>,
+    org_id: Option<String>,
+    description: Option<String>,
+    active: Option<bool>,
+    permissions: Option<Vec<String>>,
+    allowed_organizations: Option<Vec<String>>,
+    inherit_from: Option<Vec<String>>,
+    start_commit_num: Option<i64>,
+    end_commit_num: Option<i64>,
+    service_id: Option<String>,
+    last_updated: Option<i64>,
+}
+
+impl RoleBuilder {
+    /// Creates a new role builder
+    pub fn new() -> Self {
+        RoleBuilder::default()
+    }
+
+    /// Set the name of the role
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Name of the role being built
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    /// Set the organization ID of the role
+    ///
+    /// # Arguments
+    ///
+    /// * `org_id` - The ID of the organization the role being built belongs to
+    pub fn with_org_id(mut self, org_id: String) -> Self {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    /// Set the description of the role
+    ///
+    /// # Arguments
+    ///
+    /// * `description` - The description of the role being built
+    pub fn with_description(mut self, description: String) -> Self {
+        self.description = Some(description);
+        self
+    }
+
+    /// Set the active flag for the role
+    ///
+    /// # Arguments
+    ///
+    /// * `active` - Boolean representing whether the role being built is currently active
+    pub fn with_active(mut self, active: bool) -> Self {
+        self.active = Some(active);
+        self
+    }
+
+    /// Set the permissions of the role
+    ///
+    /// # Arguments
+    ///
+    /// * `permissions` - The list of permissions belonging to the role being built
+    pub fn with_permissions(mut self, permissions: Vec<String>) -> Self {
+        self.permissions = Some(permissions);
+        self
+    }
+
+    /// Set the allowed organizations of the role
+    ///
+    /// # Arguments
+    ///
+    /// * `allowed_organizations` - The list of allowed organization IDs of the role being built
+    pub fn with_allowed_organizations(mut self, allowed_organizations: Vec<String>) -> Self {
+        self.allowed_organizations = Some(allowed_organizations);
+        self
+    }
+
+    /// Set the list of roles the role being built is able to inherit permissions from
+    ///
+    /// # Arguments
+    ///
+    /// * `inherit_from` - List of roles the role being built inherits permissions from
+    pub fn with_inherit_from(mut self, inherit_from: Vec<String>) -> Self {
+        self.inherit_from = Some(inherit_from);
+        self
+    }
+
+    /// Set the starting commit num for the role
+    ///
+    /// # Arguments
+    ///
+    /// * `start_commit_num` - The start commit num for the role being built
+    pub fn with_start_commit_num(mut self, start_commit_num: i64) -> Self {
+        self.start_commit_num = Some(start_commit_num);
+        self
+    }
+
+    /// Set the ending commit num for the role
+    ///
+    /// # Arguments
+    ///
+    /// * `end_commit_num` - The end commit num for the role being built
+    pub fn with_end_commit_num(mut self, end_commit_num: i64) -> Self {
+        self.end_commit_num = Some(end_commit_num);
+        self
+    }
+
+    /// Set the service ID of the role
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The service ID for the role being built
+    pub fn with_service_id(mut self, service_id: String) -> Self {
+        self.service_id = Some(service_id);
+        self
+    }
+
+    /// Set the last updated timestamp for the role
+    ///
+    /// # Arguments
+    ///
+    /// * `last_updated` - The timestamp the role being built was last updated
+    pub fn with_last_updated(mut self, last_updated: i64) -> Self {
+        self.last_updated = Some(last_updated);
+        self
+    }
+
+    pub fn build(self) -> Result<Role, PikeBuilderError> {
+        let name = self
+            .name
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("name".to_string()))?;
+        let org_id = self
+            .org_id
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("org_id".to_string()))?;
+        let description = self.description.unwrap_or_default();
+        let active = self
+            .active
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("active".to_string()))?;
+        let permissions = self.permissions.unwrap_or_default();
+        let allowed_organizations = self.allowed_organizations.unwrap_or_default();
+        let inherit_from = self.inherit_from.unwrap_or_default();
+        let start_commit_num = self.start_commit_num.ok_or_else(|| {
+            PikeBuilderError::MissingRequiredField("start_commit_num".to_string())
+        })?;
+        let end_commit_num = self
+            .end_commit_num
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("end_commit_num".to_string()))?;
+
+        if start_commit_num >= end_commit_num {
+            return Err(PikeBuilderError::InvalidArgumentError(
+                InvalidArgumentError::new(
+                    "start_commit_num".to_string(),
+                    "argument cannot be greater than or equal to `end_commit_num`".to_string(),
+                ),
+            ));
+        }
+        if end_commit_num <= start_commit_num {
+            return Err(PikeBuilderError::InvalidArgumentError(
+                InvalidArgumentError::new(
+                    "end_commit_num".to_string(),
+                    "argument cannot be less than or equal to `start_commit_num`".to_string(),
+                ),
+            ));
+        }
+        let service_id = self.service_id;
+        let last_updated = self.last_updated;
+
+        Ok(Role {
+            name,
+            org_id,
+            description,
+            active,
+            permissions,
+            allowed_organizations,
+            inherit_from,
             start_commit_num,
             end_commit_num,
             service_id,

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -34,7 +34,7 @@ use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
 pub use self::diesel::DieselPikeStore;
-pub use builder::AgentBuilder;
+pub use builder::{AgentBuilder, RoleBuilder};
 pub use error::PikeStoreError;
 
 /// Represents a Grid Agent

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -104,17 +104,74 @@ impl Agent {
 /// Represents a Grid Role
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct Role {
-    pub name: String,
-    pub org_id: String,
-    pub description: String,
-    pub active: bool,
-    pub permissions: Vec<String>,
-    pub allowed_organizations: Vec<String>,
-    pub inherit_from: Vec<String>,
-    pub start_commit_num: i64,
-    pub end_commit_num: i64,
-    pub service_id: Option<String>,
-    pub last_updated: Option<i64>,
+    name: String,
+    org_id: String,
+    description: String,
+    active: bool,
+    permissions: Vec<String>,
+    allowed_organizations: Vec<String>,
+    inherit_from: Vec<String>,
+    start_commit_num: i64,
+    end_commit_num: i64,
+    service_id: Option<String>,
+    last_updated: Option<i64>,
+}
+
+impl Role {
+    /// Return the name of this role
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Return the ID of the organization that created this role
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    /// Return the description of this role
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// Return the `active` status of this role
+    pub fn active(&self) -> bool {
+        self.active
+    }
+
+    /// Return the permissions assigned to this role
+    pub fn permissions(&self) -> &[String] {
+        &self.permissions
+    }
+
+    /// Return a list of organizations that are allowed to use this role
+    pub fn allowed_organizations(&self) -> &[String] {
+        &self.allowed_organizations
+    }
+
+    /// Return a list of roles this role is able to inherit permissions from
+    pub fn inherit_from(&self) -> &[String] {
+        &self.inherit_from
+    }
+
+    /// Return the `start_commit_num` for this roole
+    pub fn start_commit_num(&self) -> &i64 {
+        &self.start_commit_num
+    }
+
+    /// Return the `end_commit_num` for this role
+    pub fn end_commit_num(&self) -> &i64 {
+        &self.end_commit_num
+    }
+
+    /// Return the service ID for this role
+    pub fn service_id(&self) -> Option<&str> {
+        self.service_id.as_deref()
+    }
+
+    /// Return the last updated timestamp for this role
+    pub fn last_updated(&self) -> Option<&i64> {
+        self.last_updated.as_ref()
+    }
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq)]

--- a/sdk/src/rest_api/resources/roles/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/roles/v1/payloads.rs
@@ -32,26 +32,26 @@ pub struct RoleSlice {
 
 impl From<Role> for RoleSlice {
     fn from(role: Role) -> Self {
-        let permissions = role.permissions.into_iter().map(String::from).collect();
+        let permissions = role.permissions().iter().map(String::from).collect();
 
         let allowed_organizations = role
-            .allowed_organizations
-            .into_iter()
+            .allowed_organizations()
+            .iter()
             .map(String::from)
             .collect();
 
-        let inherit_from = role.inherit_from.into_iter().map(String::from).collect();
+        let inherit_from = role.inherit_from().iter().map(String::from).collect();
 
         Self {
-            org_id: role.org_id.clone(),
-            name: role.name.clone(),
-            description: role.description.clone(),
-            active: role.active,
+            org_id: role.org_id().to_string(),
+            name: role.name().to_string(),
+            description: role.description().to_string(),
+            active: role.active(),
             permissions,
             allowed_organizations,
             inherit_from,
-            service_id: role.service_id,
-            last_updated: role.last_updated,
+            service_id: role.service_id().map(ToOwned::to_owned),
+            last_updated: role.last_updated().map(ToOwned::to_owned),
         }
     }
 }


### PR DESCRIPTION
This change updates the Role struct in the PikeStore to have private fields, with public accessor methods. This PR also adds a `RoleBuilder` implementation that may be used to create a `Role`. 