### PR TITLE
Remove public fields from Pike Organization, Alternate ID, and metadata

### DIFF
--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -182,7 +182,9 @@ mod test {
     };
     use grid_sdk::{
         location::store::{DieselLocationStore, Location, LocationAttribute, LocationStore},
-        pike::store::{Agent, AgentBuilder, DieselPikeStore, Organization, PikeStore},
+        pike::store::{
+            Agent, AgentBuilder, DieselPikeStore, Organization, OrganizationBuilder, PikeStore,
+        },
         product::store::{
             DieselProductStore, Product, ProductBuilder, ProductStore, PropertyValue,
             PropertyValueBuilder,
@@ -2935,44 +2937,40 @@ mod test {
     }
 
     fn get_organization(service_id: Option<String>) -> Vec<Organization> {
-        vec![Organization {
-            org_id: KEY2.to_string(),
-            name: ORG_NAME_1.to_string(),
-            locations: vec![ADDRESS_1.to_string()],
-            alternate_ids: vec![],
-            metadata: vec![],
-            start_commit_num: 1,
-            end_commit_num: i64::MAX,
-            service_id: service_id.clone(),
-            last_updated: None,
-        }]
+        let org = {
+            let mut builder = OrganizationBuilder::new()
+                .with_org_id(KEY2.to_string())
+                .with_name(ORG_NAME_1.to_string())
+                .with_locations(vec![ADDRESS_1.to_string()])
+                .with_start_commit_num(1)
+                .with_end_commit_num(i64::MAX);
+            if let Some(id) = service_id {
+                builder = builder.with_service_id(id.to_string());
+            }
+            builder.build().expect("Unable to build organization")
+        };
+
+        vec![org]
     }
 
     fn get_updated_organization() -> Vec<Organization> {
-        vec![
-            Organization {
-                org_id: KEY3.to_string(),
-                name: ORG_NAME_2.to_string(),
-                locations: vec![ADDRESS_2.to_string()],
-                alternate_ids: vec![],
-                metadata: vec![],
-                start_commit_num: 2,
-                end_commit_num: 4,
-                service_id: None,
-                last_updated: None,
-            },
-            Organization {
-                org_id: KEY3.to_string(),
-                name: ORG_NAME_2.to_string(),
-                locations: vec![UPDATED_ADDRESS_2.to_string()],
-                alternate_ids: vec![],
-                metadata: vec![],
-                start_commit_num: 4,
-                end_commit_num: i64::MAX,
-                service_id: None,
-                last_updated: None,
-            },
-        ]
+        let org_1 = OrganizationBuilder::new()
+            .with_org_id(KEY3.to_string())
+            .with_name(ORG_NAME_2.to_string())
+            .with_locations(vec![ADDRESS_2.to_string()])
+            .with_start_commit_num(2)
+            .with_end_commit_num(4)
+            .build()
+            .expect("Unable to build organization");
+        let org_2 = OrganizationBuilder::new()
+            .with_org_id(KEY3.to_string())
+            .with_name(ORG_NAME_2.to_string())
+            .with_locations(vec![UPDATED_ADDRESS_2.to_string()])
+            .with_start_commit_num(4)
+            .with_end_commit_num(i64::MAX)
+            .build()
+            .expect("Unable to build organization");
+        vec![org_1, org_2]
     }
 
     fn populate_organization_table(

--- a/sdk/src/pike/store/builder.rs
+++ b/sdk/src/pike/store/builder.rs
@@ -15,7 +15,7 @@
 use crate::error::InvalidArgumentError;
 
 use super::error::PikeBuilderError;
-use super::{Agent, Role};
+use super::{Agent, AlternateId, Organization, OrganizationMetadata, Role};
 
 /// Builder used to create a Pike Agent
 #[derive(Clone, Debug, Default)]
@@ -361,6 +361,166 @@ impl RoleBuilder {
             permissions,
             allowed_organizations,
             inherit_from,
+            start_commit_num,
+            end_commit_num,
+            service_id,
+            last_updated,
+        })
+    }
+}
+
+/// Builder used to create a Pike organization
+#[derive(Clone, Debug, Default)]
+pub struct OrganizationBuilder {
+    org_id: Option<String>,
+    name: Option<String>,
+    locations: Option<Vec<String>>,
+    alternate_ids: Option<Vec<AlternateId>>,
+    metadata: Option<Vec<OrganizationMetadata>>,
+    start_commit_num: Option<i64>,
+    end_commit_num: Option<i64>,
+    service_id: Option<String>,
+    last_updated: Option<i64>,
+}
+
+impl OrganizationBuilder {
+    /// Creates a new organization builder
+    pub fn new() -> Self {
+        OrganizationBuilder::default()
+    }
+
+    /// Set the organization's ID
+    ///
+    /// # Arguments
+    ///
+    /// * `org_id` - The unique identifier of this organization
+    pub fn with_org_id(mut self, org_id: String) -> Self {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    /// Set the name of the organization
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Name of the organization being built
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    /// Set the locations of the organization
+    ///
+    /// # Arguments
+    ///
+    /// * `locations` - The locations of the organization being built
+    pub fn with_locations(mut self, locations: Vec<String>) -> Self {
+        self.locations = Some(locations);
+        self
+    }
+
+    /// Set the alternate IDs for the organization
+    ///
+    /// # Arguments
+    ///
+    /// * `alternate_ids` - List of alternate IDs belonging to the organization being built
+    pub fn with_alternate_ids(mut self, alternate_ids: Vec<AlternateId>) -> Self {
+        self.alternate_ids = Some(alternate_ids);
+        self
+    }
+
+    /// Set the metadata of the organization
+    ///
+    /// # Arguments
+    ///
+    /// * `metadata` - The metadata belonging to the organization being built
+    pub fn with_metadata(mut self, metadata: Vec<OrganizationMetadata>) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+
+    /// Set the starting commit num for the organization
+    ///
+    /// # Arguments
+    ///
+    /// * `start_commit_num` - The start commit num for the organization being built
+    pub fn with_start_commit_num(mut self, start_commit_num: i64) -> Self {
+        self.start_commit_num = Some(start_commit_num);
+        self
+    }
+
+    /// Set the ending commit num for the organization
+    ///
+    /// # Arguments
+    ///
+    /// * `end_commit_num` - The end commit num for the organization being built
+    pub fn with_end_commit_num(mut self, end_commit_num: i64) -> Self {
+        self.end_commit_num = Some(end_commit_num);
+        self
+    }
+
+    /// Set the service ID of the organization
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The service ID for the organization being built
+    pub fn with_service_id(mut self, service_id: String) -> Self {
+        self.service_id = Some(service_id);
+        self
+    }
+
+    /// Set the last updated timestamp for the organization
+    ///
+    /// # Arguments
+    ///
+    /// * `last_updated` - The timestamp the organization being built was last updated
+    pub fn with_last_updated(mut self, last_updated: i64) -> Self {
+        self.last_updated = Some(last_updated);
+        self
+    }
+
+    pub fn build(self) -> Result<Organization, PikeBuilderError> {
+        let org_id = self
+            .org_id
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("org_id".to_string()))?;
+        let name = self
+            .name
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("name".to_string()))?;
+        let locations = self.locations.unwrap_or_default();
+        let alternate_ids = self.alternate_ids.unwrap_or_default();
+        let metadata = self.metadata.unwrap_or_default();
+        let start_commit_num = self.start_commit_num.ok_or_else(|| {
+            PikeBuilderError::MissingRequiredField("start_commit_num".to_string())
+        })?;
+        let end_commit_num = self
+            .end_commit_num
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("end_commit_num".to_string()))?;
+
+        if start_commit_num >= end_commit_num {
+            return Err(PikeBuilderError::InvalidArgumentError(
+                InvalidArgumentError::new(
+                    "start_commit_num".to_string(),
+                    "argument cannot be greater than or equal to `end_commit_num`".to_string(),
+                ),
+            ));
+        }
+        if end_commit_num <= start_commit_num {
+            return Err(PikeBuilderError::InvalidArgumentError(
+                InvalidArgumentError::new(
+                    "end_commit_num".to_string(),
+                    "argument cannot be less than or equal to `start_commit_num`".to_string(),
+                ),
+            ));
+        }
+        let service_id = self.service_id;
+        let last_updated = self.last_updated;
+
+        Ok(Organization {
+            org_id,
+            name,
+            locations,
+            alternate_ids,
+            metadata,
             start_commit_num,
             end_commit_num,
             service_id,

--- a/sdk/src/pike/store/builder.rs
+++ b/sdk/src/pike/store/builder.rs
@@ -546,11 +546,11 @@ impl AlternateIdBuilder {
         AlternateIdBuilder::default()
     }
 
-    /// Set the organization's ID
+    /// Set the unique identifier for the organization associated with the Alternate ID
     ///
     /// # Arguments
     ///
-    /// * `org_id` - The unique identifier of this organization
+    /// * `org_id` - The unique identifier of the organization the Alternate ID belongs to
     pub fn with_org_id(mut self, org_id: String) -> Self {
         self.org_id = Some(org_id);
         self
@@ -646,6 +646,115 @@ impl AlternateIdBuilder {
             org_id,
             alternate_id_type,
             alternate_id,
+            start_commit_num,
+            end_commit_num,
+            service_id,
+        })
+    }
+}
+
+/// Builder used to create organization metadata, represented as a key-value pair
+#[derive(Clone, Debug, Default)]
+pub struct OrganizationMetadataBuilder {
+    key: Option<String>,
+    value: Option<String>,
+    start_commit_num: Option<i64>,
+    end_commit_num: Option<i64>,
+    service_id: Option<String>,
+}
+
+impl OrganizationMetadataBuilder {
+    /// Creates a new organization metadata builder
+    pub fn new() -> Self {
+        OrganizationMetadataBuilder::default()
+    }
+
+    /// Set the key for the organization metadata
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key of the organization's metadata's internal key-value pair
+    pub fn with_key(mut self, key: String) -> Self {
+        self.key = Some(key);
+        self
+    }
+
+    /// Set the value for the organization metadata
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The value of the organization's metadata's internal key-value pair
+    pub fn with_value(mut self, value: String) -> Self {
+        self.value = Some(value);
+        self
+    }
+
+    /// Set the starting commit num for the organization metadata
+    ///
+    /// # Arguments
+    ///
+    /// * `start_commit_num` - The start commit num for the organization metadata being built
+    pub fn with_start_commit_num(mut self, start_commit_num: i64) -> Self {
+        self.start_commit_num = Some(start_commit_num);
+        self
+    }
+
+    /// Set the ending commit num for the organization metadata
+    ///
+    /// # Arguments
+    ///
+    /// * `end_commit_num` - The end commit num for the organization metadata being built
+    pub fn with_end_commit_num(mut self, end_commit_num: i64) -> Self {
+        self.end_commit_num = Some(end_commit_num);
+        self
+    }
+
+    /// Set the service ID of the organization metadata
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The service ID for the organization metadata being built
+    pub fn with_service_id(mut self, service_id: String) -> Self {
+        self.service_id = Some(service_id);
+        self
+    }
+
+    pub fn build(self) -> Result<OrganizationMetadata, PikeBuilderError> {
+        let key = self
+            .key
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("key".to_string()))?;
+        let value = self
+            .value
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("value".to_string()))?;
+
+        let start_commit_num = self.start_commit_num.ok_or_else(|| {
+            PikeBuilderError::MissingRequiredField("start_commit_num".to_string())
+        })?;
+        let end_commit_num = self
+            .end_commit_num
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("end_commit_num".to_string()))?;
+
+        if start_commit_num >= end_commit_num {
+            return Err(PikeBuilderError::InvalidArgumentError(
+                InvalidArgumentError::new(
+                    "start_commit_num".to_string(),
+                    "argument cannot be greater than or equal to `end_commit_num`".to_string(),
+                ),
+            ));
+        }
+        if end_commit_num <= start_commit_num {
+            return Err(PikeBuilderError::InvalidArgumentError(
+                InvalidArgumentError::new(
+                    "end_commit_num".to_string(),
+                    "argument cannot be less than or equal to `start_commit_num`".to_string(),
+                ),
+            ));
+        }
+        let service_id = self.service_id;
+
+        Ok(OrganizationMetadata {
+            key,
+            value,
             start_commit_num,
             end_commit_num,
             service_id,

--- a/sdk/src/pike/store/builder.rs
+++ b/sdk/src/pike/store/builder.rs
@@ -528,3 +528,127 @@ impl OrganizationBuilder {
         })
     }
 }
+
+/// Builder used to create an Alternate ID
+#[derive(Clone, Debug, Default)]
+pub struct AlternateIdBuilder {
+    org_id: Option<String>,
+    alternate_id_type: Option<String>,
+    alternate_id: Option<String>,
+    start_commit_num: Option<i64>,
+    end_commit_num: Option<i64>,
+    service_id: Option<String>,
+}
+
+impl AlternateIdBuilder {
+    /// Creates a new Alternate ID builder
+    pub fn new() -> Self {
+        AlternateIdBuilder::default()
+    }
+
+    /// Set the organization's ID
+    ///
+    /// # Arguments
+    ///
+    /// * `org_id` - The unique identifier of this organization
+    pub fn with_org_id(mut self, org_id: String) -> Self {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    /// Set the type of the Alternate ID
+    ///
+    /// # Arguments
+    ///
+    /// * `alternate_id_type` - Type of the Alternate ID being built
+    pub fn with_alternate_id_type(mut self, alternate_id_type: String) -> Self {
+        self.alternate_id_type = Some(alternate_id_type);
+        self
+    }
+
+    /// Set the unique identifier of the Alternate ID
+    ///
+    /// # Arguments
+    ///
+    /// * `alternate_id` - Unique identifier of the Alternate ID being built
+    pub fn with_alternate_id(mut self, alternate_id: String) -> Self {
+        self.alternate_id = Some(alternate_id);
+        self
+    }
+
+    /// Set the starting commit num for the Alternate ID
+    ///
+    /// # Arguments
+    ///
+    /// * `start_commit_num` - The start commit num for the Alternate ID being built
+    pub fn with_start_commit_num(mut self, start_commit_num: i64) -> Self {
+        self.start_commit_num = Some(start_commit_num);
+        self
+    }
+
+    /// Set the ending commit num for the Alternate ID
+    ///
+    /// # Arguments
+    ///
+    /// * `end_commit_num` - The end commit num for the Alternate ID being built
+    pub fn with_end_commit_num(mut self, end_commit_num: i64) -> Self {
+        self.end_commit_num = Some(end_commit_num);
+        self
+    }
+
+    /// Set the service ID of the Alternate ID
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The service ID for the Alternate ID being built
+    pub fn with_service_id(mut self, service_id: String) -> Self {
+        self.service_id = Some(service_id);
+        self
+    }
+
+    pub fn build(self) -> Result<AlternateId, PikeBuilderError> {
+        let org_id = self
+            .org_id
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("org_id".to_string()))?;
+        let alternate_id_type = self.alternate_id_type.ok_or_else(|| {
+            PikeBuilderError::MissingRequiredField("alternate_id_type".to_string())
+        })?;
+        let alternate_id = self
+            .alternate_id
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("alternate_id".to_string()))?;
+
+        let start_commit_num = self.start_commit_num.ok_or_else(|| {
+            PikeBuilderError::MissingRequiredField("start_commit_num".to_string())
+        })?;
+        let end_commit_num = self
+            .end_commit_num
+            .ok_or_else(|| PikeBuilderError::MissingRequiredField("end_commit_num".to_string()))?;
+
+        if start_commit_num >= end_commit_num {
+            return Err(PikeBuilderError::InvalidArgumentError(
+                InvalidArgumentError::new(
+                    "start_commit_num".to_string(),
+                    "argument cannot be greater than or equal to `end_commit_num`".to_string(),
+                ),
+            ));
+        }
+        if end_commit_num <= start_commit_num {
+            return Err(PikeBuilderError::InvalidArgumentError(
+                InvalidArgumentError::new(
+                    "end_commit_num".to_string(),
+                    "argument cannot be less than or equal to `start_commit_num`".to_string(),
+                ),
+            ));
+        }
+        let service_id = self.service_id;
+
+        Ok(AlternateId {
+            org_id,
+            alternate_id_type,
+            alternate_id,
+            start_commit_num,
+            end_commit_num,
+            service_id,
+        })
+    }
+}

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -191,15 +191,62 @@ impl RoleList {
 /// Represents a Grid Organization
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct Organization {
-    pub org_id: String,
-    pub name: String,
-    pub locations: Vec<String>,
-    pub alternate_ids: Vec<AlternateId>,
-    pub metadata: Vec<OrganizationMetadata>,
-    pub start_commit_num: i64,
-    pub end_commit_num: i64,
-    pub service_id: Option<String>,
-    pub last_updated: Option<i64>,
+    org_id: String,
+    name: String,
+    locations: Vec<String>,
+    alternate_ids: Vec<AlternateId>,
+    metadata: Vec<OrganizationMetadata>,
+    start_commit_num: i64,
+    end_commit_num: i64,
+    service_id: Option<String>,
+    last_updated: Option<i64>,
+}
+
+impl Organization {
+    /// Return the unique identifier of the organization
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    /// Return the name of the organization
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Return the locations of the organization
+    pub fn locations(&self) -> &[String] {
+        &self.locations
+    }
+
+    /// Return the Alternate IDs of the organization
+    pub fn alternate_ids(&self) -> &[AlternateId] {
+        &self.alternate_ids
+    }
+
+    /// Return the metadata of the organization
+    pub fn metadata(&self) -> &[OrganizationMetadata] {
+        &self.metadata
+    }
+
+    /// Return the start commit num of the organization
+    pub fn start_commit_num(&self) -> &i64 {
+        &self.start_commit_num
+    }
+
+    /// Return the end commit num of the organization
+    pub fn end_commit_num(&self) -> &i64 {
+        &self.end_commit_num
+    }
+
+    /// Return the service ID of the organization
+    pub fn service_id(&self) -> Option<&str> {
+        self.service_id.as_deref()
+    }
+
+    /// Return the last updated timestamp of the organization
+    pub fn last_updated(&self) -> Option<&i64> {
+        self.last_updated.as_ref()
+    }
 }
 
 /// Represents a Grid Alternate ID

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -276,6 +276,11 @@ impl AlternateId {
         &self.alternate_id
     }
 
+    /// Return the start commit num of the Alternate ID
+    pub fn start_commit_num(&self) -> &i64 {
+        &self.start_commit_num
+    }
+
     /// Return the end commit num of the Alternate ID
     pub fn end_commit_num(&self) -> &i64 {
         &self.end_commit_num
@@ -313,11 +318,38 @@ impl AgentList {
 /// Represents a Grid Organization metadata key-value pair
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct OrganizationMetadata {
-    pub key: String,
-    pub value: String,
-    pub start_commit_num: i64,
-    pub end_commit_num: i64,
-    pub service_id: Option<String>,
+    key: String,
+    value: String,
+    start_commit_num: i64,
+    end_commit_num: i64,
+    service_id: Option<String>,
+}
+
+impl OrganizationMetadata {
+    /// Return the key of the metadata's internal key-value pair
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// Return the value of the metadata's internal key-value pair
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// Return the start commit num of the metadata
+    pub fn start_commit_num(&self) -> &i64 {
+        &self.start_commit_num
+    }
+
+    /// Return the end commit num of the metadata
+    pub fn end_commit_num(&self) -> &i64 {
+        &self.end_commit_num
+    }
+
+    /// Return the service ID associated with the metadata
+    pub fn service_id(&self) -> Option<&str> {
+        self.service_id.as_deref()
+    }
 }
 
 pub trait PikeStore: Send + Sync {

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -34,7 +34,9 @@ use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
 pub use self::diesel::DieselPikeStore;
-pub use builder::{AgentBuilder, AlternateIdBuilder, OrganizationBuilder, RoleBuilder};
+pub use builder::{
+    AgentBuilder, AlternateIdBuilder, OrganizationBuilder, OrganizationMetadataBuilder, RoleBuilder,
+};
 pub use error::PikeStoreError;
 
 /// Represents a Grid Agent

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -252,12 +252,39 @@ impl Organization {
 /// Represents a Grid Alternate ID
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct AlternateId {
-    pub org_id: String,
-    pub alternate_id_type: String,
-    pub alternate_id: String,
-    pub start_commit_num: i64,
-    pub end_commit_num: i64,
-    pub service_id: Option<String>,
+    org_id: String,
+    alternate_id_type: String,
+    alternate_id: String,
+    start_commit_num: i64,
+    end_commit_num: i64,
+    service_id: Option<String>,
+}
+
+impl AlternateId {
+    /// Return the organization ID associated with the Alternate ID
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    /// Return the type of this Alternate ID
+    pub fn alternate_id_type(&self) -> &str {
+        &self.alternate_id_type
+    }
+
+    /// Return the unique identifier of the Alternate ID
+    pub fn alternate_id(&self) -> &str {
+        &self.alternate_id
+    }
+
+    /// Return the end commit num of the Alternate ID
+    pub fn end_commit_num(&self) -> &i64 {
+        &self.end_commit_num
+    }
+
+    /// Return the service ID associated with the Alternate ID
+    pub fn service_id(&self) -> Option<&str> {
+        self.service_id.as_deref()
+    }
 }
 
 pub struct OrganizationList {

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -34,7 +34,7 @@ use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
 pub use self::diesel::DieselPikeStore;
-pub use builder::{AgentBuilder, OrganizationBuilder, RoleBuilder};
+pub use builder::{AgentBuilder, AlternateIdBuilder, OrganizationBuilder, RoleBuilder};
 pub use error::PikeStoreError;
 
 /// Represents a Grid Agent

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -34,7 +34,7 @@ use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
 pub use self::diesel::DieselPikeStore;
-pub use builder::{AgentBuilder, RoleBuilder};
+pub use builder::{AgentBuilder, OrganizationBuilder, RoleBuilder};
 pub use error::PikeStoreError;
 
 /// Represents a Grid Agent

--- a/sdk/src/rest_api/resources/organizations/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/organizations/v1/payloads.rs
@@ -23,11 +23,11 @@ pub struct AlternateIdSlice {
     pub id: String,
 }
 
-impl From<AlternateId> for AlternateIdSlice {
-    fn from(id: AlternateId) -> Self {
+impl From<&AlternateId> for AlternateIdSlice {
+    fn from(id: &AlternateId) -> Self {
         Self {
-            id_type: id.alternate_id_type,
-            id: id.alternate_id,
+            id_type: id.alternate_id_type.to_string(),
+            id: id.alternate_id.to_string(),
         }
     }
 }
@@ -64,35 +64,31 @@ pub struct OrganizationListSlice {
 impl From<Organization> for OrganizationSlice {
     fn from(organization: Organization) -> Self {
         Self {
-            org_id: organization.org_id.clone(),
-            name: organization.name.clone(),
-            locations: organization
-                .locations
-                .into_iter()
-                .map(String::from)
-                .collect(),
+            org_id: organization.org_id().to_string(),
+            name: organization.name().to_string(),
+            locations: organization.locations().iter().map(String::from).collect(),
             alternate_ids: organization
-                .alternate_ids
-                .into_iter()
+                .alternate_ids()
+                .iter()
                 .map(AlternateIdSlice::from)
                 .collect(),
             metadata: organization
-                .metadata
-                .into_iter()
+                .metadata()
+                .iter()
                 .map(OrganizationMetadataSlice::from)
                 .collect(),
-            service_id: organization.service_id,
-            last_updated: organization.last_updated,
+            service_id: organization.service_id().map(ToOwned::to_owned),
+            last_updated: organization.last_updated().map(ToOwned::to_owned),
         }
     }
 }
 
-impl From<OrganizationMetadata> for OrganizationMetadataSlice {
-    fn from(metadata: OrganizationMetadata) -> Self {
+impl From<&OrganizationMetadata> for OrganizationMetadataSlice {
+    fn from(metadata: &OrganizationMetadata) -> Self {
         Self {
             key: metadata.key.clone(),
             value: metadata.value.clone(),
-            service_id: metadata.service_id,
+            service_id: metadata.service_id.clone(),
         }
     }
 }

--- a/sdk/src/rest_api/resources/organizations/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/organizations/v1/payloads.rs
@@ -86,9 +86,9 @@ impl From<Organization> for OrganizationSlice {
 impl From<&OrganizationMetadata> for OrganizationMetadataSlice {
     fn from(metadata: &OrganizationMetadata) -> Self {
         Self {
-            key: metadata.key.clone(),
-            value: metadata.value.clone(),
-            service_id: metadata.service_id.clone(),
+            key: metadata.key().to_string(),
+            value: metadata.value().to_string(),
+            service_id: metadata.service_id().map(ToOwned::to_owned),
         }
     }
 }

--- a/sdk/src/rest_api/resources/organizations/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/organizations/v1/payloads.rs
@@ -26,8 +26,8 @@ pub struct AlternateIdSlice {
 impl From<&AlternateId> for AlternateIdSlice {
     fn from(id: &AlternateId) -> Self {
         Self {
-            id_type: id.alternate_id_type.to_string(),
-            id: id.alternate_id.to_string(),
+            id_type: id.alternate_id_type().to_string(),
+            id: id.alternate_id().to_string(),
         }
     }
 }


### PR DESCRIPTION
This PR removes public fields from the remaining Pike store structs, including Organization, AlternateId, and OrganizationMetadata. The public fields are replaced by public accessor methods. Creating these objects has been replaced by each struct's builder, which are implemented in the PikeStore's builder module. 