### PR TITLE
Add contracts volume to scabbard-cli containers

### DIFF
--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -228,6 +228,7 @@ services:
     hostname: scabbard-cli-alpha
     volumes:
       - gridd-alpha:/root/.splinter/keys
+      - contracts-shared:/usr/share/scar
     command: tail -f /dev/null
 
   splinterd-alpha:
@@ -356,6 +357,7 @@ services:
     hostname: scabbard-cli-beta
     volumes:
       - gridd-beta:/root/.splinter/keys
+      - contracts-shared:/usr/share/scar
     command: tail -f /dev/null
 
   splinterd-beta:


### PR DESCRIPTION
This adds the `contracts-shared` volume to the scabbard-cli containers
for the grid on splinter example. This is necessary for the smart
contract upgrade process to work.

Signed-off-by: Davey Newhall <newhall@bitwise.io>