### PR TITLE
Stabilize commit-store-service-commits

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -115,7 +115,7 @@ sawtooth-support = [
     "grid-sdk/sawtooth-compat",
     "rest-api"
 ]
-scabbard-event-restart = ["grid-sdk/commit-store-service-commits"]
+scabbard-event-restart = []
 schema = ["grid-sdk/rest-api-endpoint-schema", "grid-sdk/schema", "pike"]
 splinter-support = [
   "cylinder/key-load",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -105,7 +105,6 @@ experimental = [
     "batch-store",
     "client",
     "client-reqwest",
-    "commit-store-service-commits",
     "pike-rest-api",
     "purchase-order",
     "rest-api-resources",
@@ -127,7 +126,6 @@ backend-sawtooth = ["backend", "uuid"]
 backend-splinter = ["backend", "reqwest"]
 client = []
 client-reqwest = ["client", "reqwest"]
-commit-store-service-commits = []
 location = ["pike", "schema"]
 pike = ["cfg-if"]
 pike-rest-api = ["pike", "serde_json", "rest-api-resources"]

--- a/sdk/src/commits/store/diesel/mod.rs
+++ b/sdk/src/commits/store/diesel/mod.rs
@@ -27,7 +27,6 @@ use operations::add_commit::CommitStoreAddCommitOperation as _;
 use operations::create_db_commit_from_commit_event::CommitStoreCreateDbCommitFromCommitEventOperation as _;
 use operations::get_commit_by_commit_num::CommitStoreGetCommitByCommitNumOperation as _;
 use operations::get_current_commit_id::CommitStoreGetCurrentCommitIdOperation as _;
-#[cfg(feature = "commit-store-service-commits")]
 use operations::get_current_service_commits::CommitStoreGetCurrentSericeCommitsOperation as _;
 use operations::get_next_commit_num::CommitStoreGetNextCommitNumOperation as _;
 use operations::resolve_fork::CommitStoreResolveForkOperation as _;
@@ -72,7 +71,6 @@ impl CommitStore for DieselCommitStore<diesel::pg::PgConnection> {
         CommitStoreOperations::new(&*self.connection_pool.get()?).get_current_commit_id()
     }
 
-    #[cfg(feature = "commit-store-service-commits")]
     fn get_current_service_commits(&self) -> Result<Vec<Commit>, CommitStoreError> {
         CommitStoreOperations::new(&*self.connection_pool.get()?).get_current_service_commits()
     }
@@ -112,7 +110,6 @@ impl CommitStore for DieselCommitStore<diesel::sqlite::SqliteConnection> {
         CommitStoreOperations::new(&*self.connection_pool.get()?).get_current_commit_id()
     }
 
-    #[cfg(feature = "commit-store-service-commits")]
     fn get_current_service_commits(&self) -> Result<Vec<Commit>, CommitStoreError> {
         CommitStoreOperations::new(&*self.connection_pool.get()?).get_current_service_commits()
     }

--- a/sdk/src/commits/store/diesel/operations/mod.rs
+++ b/sdk/src/commits/store/diesel/operations/mod.rs
@@ -16,7 +16,6 @@ pub(super) mod add_commit;
 pub(super) mod create_db_commit_from_commit_event;
 pub(super) mod get_commit_by_commit_num;
 pub(super) mod get_current_commit_id;
-#[cfg(feature = "commit-store-service-commits")]
 pub(super) mod get_current_service_commits;
 pub(super) mod get_next_commit_num;
 pub(super) mod resolve_fork;

--- a/sdk/src/commits/store/mod.rs
+++ b/sdk/src/commits/store/mod.rs
@@ -75,7 +75,6 @@ pub trait CommitStore: Send + Sync {
     /// Gets the current commit ID from the underlying storage
     fn get_current_commit_id(&self) -> Result<Option<String>, CommitStoreError>;
 
-    #[cfg(feature = "commit-store-service-commits")]
     /// Gets all the current commits on services.
     ///
     /// This returns the latest commit values for all commits where `commit.service_id` is not
@@ -122,7 +121,6 @@ where
         (**self).get_current_commit_id()
     }
 
-    #[cfg(feature = "commit-store-service-commits")]
     fn get_current_service_commits(&self) -> Result<Vec<Commit>, CommitStoreError> {
         (**self).get_current_service_commits()
     }


### PR DESCRIPTION
This change stabilizes the feature "commit-store-service-commits" by removing the feature. The method it guards will now be part of the complete store API for commits, as a result.
