### PR TITLE
Use builder pattern for Batch store

### DIFF
--- a/sdk/src/batches/store/builder.rs
+++ b/sdk/src/batches/store/builder.rs
@@ -1,0 +1,426 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::hex;
+
+use super::error::BatchBuilderError;
+use super::{Batch, NaiveDateTime, Transaction, TransactionReceipt};
+
+/// Builder used to create a Batch
+#[derive(Clone, Debug, Default)]
+pub struct BatchBuilder {
+    header_signature: Option<String>,
+    data_change_id: Option<String>,
+    signer_public_key: Option<String>,
+    trace: Option<bool>,
+    serialized_batch: Option<String>,
+    submitted: Option<bool>,
+    submission_error: Option<String>,
+    submission_error_message: Option<String>,
+    dlt_status: Option<String>,
+    claim_expires: Option<NaiveDateTime>,
+    created: Option<NaiveDateTime>,
+    service_id: Option<String>,
+    transactions: Option<Vec<Transaction>>,
+}
+
+impl BatchBuilder {
+    ///  Creates a new Batch builder
+    pub fn new() -> Self {
+        BatchBuilder::default()
+    }
+
+    /// Set the header signature of the Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `header_signature` - The header signature of the Batch being built
+    pub fn with_header_signature(mut self, header_signature: String) -> Self {
+        self.header_signature = Some(header_signature);
+        self
+    }
+
+    /// Set the data change ID of the Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The data change ID of the Batch being built
+    pub fn data_change_id(mut self, id: String) -> Self {
+        self.data_change_id = Some(id);
+        self
+    }
+
+    /// Set the signer public key of the Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `public_key` - The signer public key of the Batch being built
+    pub fn with_signer_public_key(mut self, public_key: String) -> Self {
+        self.signer_public_key = Some(public_key);
+        self
+    }
+
+    /// Set the trace value of the Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `trace` - The trace value for the Batch being built
+    pub fn with_trace(mut self, trace: bool) -> Self {
+        self.trace = Some(trace);
+        self
+    }
+
+    /// Set the serialized batch value of the Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `serialized_batch` - The serialized batch bytes of the Batch being
+    ///    built
+    pub fn with_serialized_batch(mut self, serialized_batch: &[u8]) -> Self {
+        self.serialized_batch = Some(hex::to_hex(serialized_batch));
+        self
+    }
+
+    /// Set the submitted value of the Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `submitted` - The submitted value of the Batch being built
+    pub fn with_submitted(mut self, submitted: bool) -> Self {
+        self.submitted = Some(submitted);
+        self
+    }
+
+    /// Set the submission error type of the Batch if it fails
+    ///
+    /// # Arguments
+    ///
+    /// * `error type` - The error type of the submission error if it exists
+    pub fn with_submission_error(mut self, error_type: String) -> Self {
+        self.submission_error = Some(error_type);
+        self
+    }
+
+    /// Set the submission error message of the Batch if it fails
+    ///
+    /// # Arguments
+    ///
+    /// * `error_msg` - The error message of the submission error if it exists
+    pub fn with_submission_error_message(mut self, error_msg: String) -> Self {
+        self.submission_error_message = Some(error_msg);
+        self
+    }
+
+    /// Set the dlt status of the Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `status` - The dlt status of the Batch being built
+    pub fn with_dlt_status(mut self, status: String) -> Self {
+        self.dlt_status = Some(status);
+        self
+    }
+
+    /// Set the claim expiration of the Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `expires` - The duration of the claim expiration of the Batch being
+    ///    built
+    pub fn with_claim_expires(mut self, expires: NaiveDateTime) -> Self {
+        self.claim_expires = Some(expires);
+        self
+    }
+
+    /// Set the created time of the Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `created` - The created time of the Batch being built
+    pub fn with_created(mut self, created: NaiveDateTime) -> Self {
+        self.created = Some(created);
+        self
+    }
+
+    /// Set the service ID of the Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The service ID of the Batch being built
+    pub fn with_service_id(mut self, service_id: String) -> Self {
+        self.service_id = Some(service_id);
+        self
+    }
+
+    /// Set the transactions of the Batch
+    ///
+    /// # Arguments
+    ///
+    /// * `txns` - The list of transactions of the Batch being built
+    pub fn with_transactions(mut self, txns: Vec<Transaction>) -> Self {
+        self.transactions = Some(txns);
+        self
+    }
+
+    pub fn build(self) -> Result<Batch, BatchBuilderError> {
+        let header_signature = self.header_signature.ok_or_else(|| {
+            BatchBuilderError::MissingRequiredField("header_signature".to_string())
+        })?;
+        let signer_public_key = self.signer_public_key.ok_or_else(|| {
+            BatchBuilderError::MissingRequiredField("signer_public_key".to_string())
+        })?;
+        let trace = self
+            .trace
+            .ok_or_else(|| BatchBuilderError::MissingRequiredField("trace".to_string()))?;
+        let serialized_batch = self.serialized_batch.ok_or_else(|| {
+            BatchBuilderError::MissingRequiredField("serialized_batch".to_string())
+        })?;
+        let submitted = self
+            .submitted
+            .ok_or_else(|| BatchBuilderError::MissingRequiredField("submitted".to_string()))?;
+        let transactions = self.transactions.unwrap_or_default();
+
+        let data_change_id = self.data_change_id;
+        let submission_error = self.submission_error;
+        let submission_error_message = self.submission_error_message;
+        let dlt_status = self.dlt_status;
+        let claim_expires = self.claim_expires;
+        let created = self.created;
+        let service_id = self.service_id;
+
+        Ok(Batch {
+            header_signature,
+            data_change_id,
+            signer_public_key,
+            trace,
+            serialized_batch,
+            submitted,
+            submission_error,
+            submission_error_message,
+            dlt_status,
+            claim_expires,
+            created,
+            service_id,
+            transactions,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TransactionBuilder {
+    header_signature: Option<String>,
+    batch_id: Option<String>,
+    family_name: Option<String>,
+    family_version: Option<String>,
+    signer_public_key: Option<String>,
+}
+
+impl TransactionBuilder {
+    ///  Creates a new Transaction builder
+    pub fn new() -> Self {
+        TransactionBuilder::default()
+    }
+
+    /// Set the header signature of the Transaction
+    ///
+    /// # Arguments
+    ///
+    /// * `header_signature` - The header signature of the Transaction being built
+    pub fn with_header_signature(mut self, header_signature: String) -> Self {
+        self.header_signature = Some(header_signature);
+        self
+    }
+
+    /// Set the batch ID of the Transaction
+    ///
+    /// # Arguments
+    ///
+    /// * `batch_id` - The batch_id of the Transaction being built
+    pub fn with_batch_id(mut self, batch_id: String) -> Self {
+        self.batch_id = Some(batch_id);
+        self
+    }
+
+    /// Set the family name of the Transaction
+    ///
+    /// # Arguments
+    ///
+    /// * `family_name` - The family name of the Transaction being built
+    pub fn with_family_name(mut self, family_name: String) -> Self {
+        self.family_name = Some(family_name);
+        self
+    }
+
+    /// Set the family version of the Transaction
+    ///
+    /// # Arguments
+    ///
+    /// * `family_version` - The family version of the Transaction being built
+    pub fn with_family_version(mut self, family_version: String) -> Self {
+        self.family_version = Some(family_version);
+        self
+    }
+
+    /// Set the signer public key of the Transaction
+    ///
+    /// # Arguments
+    ///
+    /// * `public_key` - The signer public key of the Transaction being built
+    pub fn with_signer_public_key(mut self, public_key: String) -> Self {
+        self.signer_public_key = Some(public_key);
+        self
+    }
+
+    pub fn build(self) -> Result<Transaction, BatchBuilderError> {
+        let header_signature = self.header_signature.ok_or_else(|| {
+            BatchBuilderError::MissingRequiredField("header_signature".to_string())
+        })?;
+        let batch_id = self
+            .batch_id
+            .ok_or_else(|| BatchBuilderError::MissingRequiredField("batch_id".to_string()))?;
+        let family_name = self
+            .family_name
+            .ok_or_else(|| BatchBuilderError::MissingRequiredField("family_name".to_string()))?;
+        let family_version = self
+            .family_version
+            .ok_or_else(|| BatchBuilderError::MissingRequiredField("family_version".to_string()))?;
+        let signer_public_key = self.signer_public_key.ok_or_else(|| {
+            BatchBuilderError::MissingRequiredField("signer_public_key".to_string())
+        })?;
+
+        Ok(Transaction {
+            header_signature,
+            batch_id,
+            family_name,
+            family_version,
+            signer_public_key,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TransactionReceiptBuilder {
+    transaction_id: Option<String>,
+    result_valid: Option<bool>,
+    error_message: Option<String>,
+    error_data: Option<String>,
+    serialized_receipt: Option<String>,
+    external_status: Option<String>,
+    external_error_message: Option<String>,
+}
+
+impl TransactionReceiptBuilder {
+    ///  Creates a new TransactionReceipt builder
+    pub fn new() -> Self {
+        TransactionReceiptBuilder::default()
+    }
+
+    /// Set the transaction ID of the TransactionReceipt
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The transaction ID of the TransactionReceipt
+    pub fn with_transaction_id(mut self, id: String) -> Self {
+        self.transaction_id = Some(id);
+        self
+    }
+
+    /// Set the result valid value of the TransactionReceipt
+    ///
+    /// # Arguments
+    ///
+    /// * `valid` - The header signature of the TransactionReceipt being built
+    pub fn with_result_valid(mut self, valid: bool) -> Self {
+        self.result_valid = Some(valid);
+        self
+    }
+
+    /// Set the error message of the TransactionReceipt
+    ///
+    /// # Arguments
+    ///
+    /// * `msg` - The error message of the TransactionReceipt being built
+    pub fn with_error_message(mut self, msg: String) -> Self {
+        self.error_message = Some(msg);
+        self
+    }
+
+    /// Set the error data of the TransactionReceipt
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The error data of the TransactionReceipt being built
+    pub fn with_error_data(mut self, data: String) -> Self {
+        self.error_data = Some(data);
+        self
+    }
+
+    /// Set the serialized receipt for the TransactionReceipt
+    ///
+    /// # Arguments
+    ///
+    /// * `receipt` - The serialized receipt of the
+    ///   TransactionReceipt being built
+    pub fn with_serialized_receipt(mut self, receipt: String) -> Self {
+        self.serialized_receipt = Some(receipt);
+        self
+    }
+
+    /// Set the external status of the TransactionReceipt
+    ///
+    /// # Arguments
+    ///
+    /// * `status` - The external status of the TransactionReceipt being built
+    pub fn with_external_status(mut self, status: String) -> Self {
+        self.external_status = Some(status);
+        self
+    }
+
+    /// Set the external error message of the TransactionReceipt
+    ///
+    /// # Arguments
+    ///
+    /// * `msg` - The external error message of the TransactionReceipt being
+    ///   built
+    pub fn with_external_error_message(mut self, msg: String) -> Self {
+        self.external_error_message = Some(msg);
+        self
+    }
+
+    pub fn build(self) -> Result<TransactionReceipt, BatchBuilderError> {
+        let transaction_id = self
+            .transaction_id
+            .ok_or_else(|| BatchBuilderError::MissingRequiredField("transaction_id".to_string()))?;
+        let result_valid = self
+            .result_valid
+            .ok_or_else(|| BatchBuilderError::MissingRequiredField("result_valid".to_string()))?;
+        let serialized_receipt = self.serialized_receipt.ok_or_else(|| {
+            BatchBuilderError::MissingRequiredField("serialized_receipt".to_string())
+        })?;
+        let error_message = self.error_message;
+        let error_data = self.error_data;
+        let external_status = self.external_status;
+        let external_error_message = self.external_error_message;
+
+        Ok(TransactionReceipt {
+            transaction_id,
+            result_valid,
+            error_message,
+            error_data,
+            serialized_receipt,
+            external_status,
+            external_error_message,
+        })
+    }
+}

--- a/sdk/src/batches/store/error.rs
+++ b/sdk/src/batches/store/error.rs
@@ -21,7 +21,10 @@ use std::fmt;
 
 #[cfg(feature = "diesel")]
 use crate::error::ConstraintViolationType;
-use crate::error::{ConstraintViolationError, InternalError, ResourceTemporarilyUnavailableError};
+use crate::error::{
+    ConstraintViolationError, InternalError, InvalidArgumentError,
+    ResourceTemporarilyUnavailableError,
+};
 
 /// Represents BatchStore errors
 #[derive(Debug)]
@@ -85,5 +88,39 @@ impl From<PoolError> for BatchStoreError {
         BatchStoreError::ResourceTemporarilyUnavailableError(
             ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
         )
+    }
+}
+
+#[derive(Debug)]
+pub enum BatchBuilderError {
+    /// Returned when a required field was not set
+    MissingRequiredField(String),
+    /// Returned when an error occurs building Pike objects
+    BuildError(Box<dyn Error>),
+    /// Returned when an invalid argument is detected in the builder
+    InvalidArgumentError(InvalidArgumentError),
+}
+
+impl Error for BatchBuilderError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            BatchBuilderError::MissingRequiredField(_) => None,
+            BatchBuilderError::BuildError(err) => Some(&**err),
+            BatchBuilderError::InvalidArgumentError(err) => Some(err),
+        }
+    }
+}
+
+impl fmt::Display for BatchBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BatchBuilderError::MissingRequiredField(ref s) => {
+                write!(f, "missing required field `{}`", s)
+            }
+            BatchBuilderError::BuildError(ref s) => {
+                write!(f, "failed to build Batch object: {}", s)
+            }
+            BatchBuilderError::InvalidArgumentError(ref s) => f.write_str(&s.to_string()),
+        }
     }
 }

--- a/sdk/src/batches/store/mod.rs
+++ b/sdk/src/batches/store/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod builder;
 #[cfg(feature = "diesel")]
 pub(in crate) mod diesel;
 mod error;
@@ -23,6 +24,7 @@ use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
 pub use self::diesel::DieselBatchStore;
+pub use builder::{BatchBuilder, TransactionBuilder, TransactionReceiptBuilder};
 pub use error::BatchStoreError;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/sdk/src/batches/store/mod.rs
+++ b/sdk/src/batches/store/mod.rs
@@ -19,7 +19,6 @@ mod error;
 
 use chrono::NaiveDateTime;
 
-use crate::hex;
 use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
@@ -29,46 +28,22 @@ pub use error::BatchStoreError;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Batch {
-    pub header_signature: String,
-    pub data_change_id: Option<String>,
-    pub signer_public_key: String,
-    pub trace: bool,
-    pub serialized_batch: String,
-    pub submitted: bool,
-    pub submission_error: Option<String>,
-    pub submission_error_message: Option<String>,
-    pub dlt_status: Option<String>,
-    pub claim_expires: Option<NaiveDateTime>,
-    pub created: Option<NaiveDateTime>,
-    pub service_id: Option<String>,
-    pub transactions: Vec<Transaction>,
+    header_signature: String,
+    data_change_id: Option<String>,
+    signer_public_key: String,
+    trace: bool,
+    serialized_batch: String,
+    submitted: bool,
+    submission_error: Option<String>,
+    submission_error_message: Option<String>,
+    dlt_status: Option<String>,
+    claim_expires: Option<NaiveDateTime>,
+    created: Option<NaiveDateTime>,
+    service_id: Option<String>,
+    transactions: Vec<Transaction>,
 }
 
 impl Batch {
-    pub fn new(
-        header_signature: String,
-        signer_public_key: String,
-        trace: bool,
-        serialized_batch: &[u8],
-        service_id: Option<String>,
-    ) -> Self {
-        Self {
-            header_signature,
-            data_change_id: None,
-            signer_public_key,
-            trace,
-            serialized_batch: hex::to_hex(serialized_batch),
-            submitted: false,
-            submission_error: None,
-            submission_error_message: None,
-            dlt_status: None,
-            claim_expires: None,
-            created: None,
-            service_id,
-            transactions: vec![],
-        }
-    }
-
     pub fn add_transaction(
         &mut self,
         header_signature: &str,
@@ -83,6 +58,71 @@ impl Batch {
             signer_public_key: self.signer_public_key.clone(),
         });
     }
+
+    /// Returns the header signature of the batch
+    pub fn header_signature(&self) -> &str {
+        &self.header_signature
+    }
+
+    /// Returns the data change ID of the batch
+    pub fn data_change_id(&self) -> Option<&str> {
+        self.data_change_id.as_deref()
+    }
+
+    /// Returns the public key of the signer of the batch
+    pub fn signer_public_key(&self) -> &str {
+        &self.signer_public_key
+    }
+
+    /// Returns the trace value of the batch
+    pub fn trace(&self) -> bool {
+        self.trace
+    }
+
+    /// Returns the serialized batch data
+    pub fn serialized_batch(&self) -> &str {
+        &self.serialized_batch
+    }
+
+    /// Returns the submission status of the batch
+    pub fn submitted(&self) -> bool {
+        self.submitted
+    }
+
+    /// Returns the error status of the batch
+    pub fn submission_error(&self) -> Option<&str> {
+        self.submission_error.as_deref()
+    }
+
+    /// Returns the message of an error in submission of the batch
+    pub fn submission_error_message(&self) -> Option<&str> {
+        self.submission_error_message.as_deref()
+    }
+
+    /// Returns the dlt status of the batch
+    pub fn dlt_status(&self) -> Option<&str> {
+        self.dlt_status.as_deref()
+    }
+
+    /// Returns the expiration time remaining on the batch
+    pub fn claim_expires(&self) -> Option<&NaiveDateTime> {
+        self.claim_expires.as_ref()
+    }
+
+    /// Returns the created date/time of the batch
+    pub fn created(&self) -> Option<&NaiveDateTime> {
+        self.created.as_ref()
+    }
+
+    /// Returns the Splinter service ID of the batch
+    pub fn service_id(&self) -> Option<&str> {
+        self.service_id.as_deref()
+    }
+
+    /// Returns the transactions in the batch
+    pub fn transactions(&self) -> &[Transaction] {
+        &self.transactions
+    }
 }
 
 /// Data needed to submit a batch
@@ -93,24 +133,105 @@ pub struct BatchSubmitInfo {
     pub service_id: Option<String>,
 }
 
+impl BatchSubmitInfo {
+    /// Returns the header signature of the batch info
+    pub fn header_signature(&self) -> &str {
+        &self.header_signature
+    }
+
+    /// Returns the serialized batch data
+    pub fn serialized_batch(&self) -> &str {
+        &self.serialized_batch
+    }
+
+    /// Returns the Splinter service ID of the batch
+    pub fn service_id(&self) -> Option<&str> {
+        self.service_id.as_deref()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Transaction {
-    pub header_signature: String,
-    pub batch_id: String,
-    pub family_name: String,
-    pub family_version: String,
-    pub signer_public_key: String,
+    header_signature: String,
+    batch_id: String,
+    family_name: String,
+    family_version: String,
+    signer_public_key: String,
+}
+
+impl Transaction {
+    /// Returns the header signature of the transaction
+    pub fn header_signature(&self) -> &str {
+        &self.header_signature
+    }
+
+    /// Returns the ID of the batch the transaction is in
+    pub fn batch_id(&self) -> &str {
+        &self.batch_id
+    }
+
+    /// Returns the family name of the transaction
+    pub fn family_name(&self) -> &str {
+        &self.family_name
+    }
+
+    // Returns the family version of the transaction
+    pub fn family_version(&self) -> &str {
+        &self.family_version
+    }
+
+    /// Returns the public key of the signer of the  transaction
+    pub fn signer_public_key(&self) -> &str {
+        &self.signer_public_key
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TransactionReceipt {
-    pub transaction_id: String,
-    pub result_valid: bool,
-    pub error_message: Option<String>,
-    pub error_data: Option<String>,
-    pub serialized_receipt: String,
-    pub external_status: Option<String>,
-    pub external_error_message: Option<String>,
+    transaction_id: String,
+    result_valid: bool,
+    error_message: Option<String>,
+    error_data: Option<String>,
+    serialized_receipt: String,
+    external_status: Option<String>,
+    external_error_message: Option<String>,
+}
+
+impl TransactionReceipt {
+    /// Returns the ID of the transaction
+    pub fn transaction_id(&self) -> &str {
+        &self.transaction_id
+    }
+
+    /// Returns the result validity of the transaction submission
+    pub fn result_valid(&self) -> bool {
+        self.result_valid
+    }
+
+    /// Returns the error message for the transaction
+    pub fn error_message(&self) -> Option<&str> {
+        self.error_message.as_deref()
+    }
+
+    /// Returns the error data for the transaction
+    pub fn error_data(&self) -> Option<&str> {
+        self.error_data.as_deref()
+    }
+
+    /// Returns the serialized receipt for the transaction
+    pub fn serialized_receipt(&self) -> &str {
+        &self.serialized_receipt
+    }
+
+    /// Returns the external status of the transaction
+    pub fn external_status(&self) -> Option<&str> {
+        self.external_status.as_deref()
+    }
+
+    /// Returns the external error message of the transaction
+    pub fn external_error_message(&self) -> Option<&str> {
+        self.external_error_message.as_deref()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/sdk/src/rest_api/resources/submit/v1/handler.rs
+++ b/sdk/src/rest_api/resources/submit/v1/handler.rs
@@ -25,7 +25,10 @@ use sabre_sdk::{
 };
 use sawtooth_sdk::messages::{batch, transaction};
 
-use crate::batches::store::{Batch as DbBatch, BatchStore, BatchStoreError};
+use crate::batches::store::{
+    Batch as DbBatch, BatchBuilder as DbBatchBuilder, BatchStore, BatchStoreError,
+    Transaction as DbTransaction, TransactionBuilder,
+};
 use crate::protos::IntoBytes;
 use crate::rest_api::resources::error::ErrorResponse;
 
@@ -57,22 +60,24 @@ pub async fn submit_batches(
     let mut ids = Vec::new();
 
     for db_batch in db_batches {
-        let id = db_batch.header_signature.clone();
+        let id = db_batch.header_signature();
 
-        batch_store.add_batch(db_batch).map_err(|err| match err {
-            BatchStoreError::ConstraintViolationError(err) => {
-                ErrorResponse::new(400, &format!("{}", err))
-            }
-            BatchStoreError::ResourceTemporarilyUnavailableError(_) => {
-                ErrorResponse::new(503, "Service unavailable")
-            }
-            err => {
-                error!("{}", err);
-                ErrorResponse::internal_error(Box::new(err))
-            }
-        })?;
+        batch_store
+            .add_batch(db_batch.clone())
+            .map_err(|err| match err {
+                BatchStoreError::ConstraintViolationError(err) => {
+                    ErrorResponse::new(400, &format!("{}", err))
+                }
+                BatchStoreError::ResourceTemporarilyUnavailableError(_) => {
+                    ErrorResponse::new(503, "Service unavailable")
+                }
+                err => {
+                    error!("{}", err);
+                    ErrorResponse::internal_error(Box::new(err))
+                }
+            })?;
 
-        ids.push(id);
+        ids.push(id.to_string());
     }
 
     Ok(SubmitBatchResponse::new(ids))
@@ -243,19 +248,47 @@ fn batches_into_bytes(
             ErrorResponse::internal_error(Box::new(err))
         })?;
 
-        let mut db_batch = DbBatch::new(header_signature, public_key, trace, &bytes, service_id);
+        let mut txns = Vec::new();
+
         transactions.iter().for_each(|t| {
-            db_batch.add_transaction(
-                t.get_header_signature(),
-                SABRE_FAMILY_NAME,
-                SABRE_FAMILY_VERSION,
-            );
+            let txn = build_transaction(t);
+
+            txns.push(txn);
         });
+
+        let mut db_batch_builder = DbBatchBuilder::new()
+            .with_header_signature(header_signature)
+            .with_signer_public_key(public_key)
+            .with_trace(trace)
+            .with_serialized_batch(&*bytes);
+
+        if let Some(service_id) = service_id {
+            db_batch_builder = db_batch_builder.with_service_id(service_id.to_string());
+        }
+
+        let db_batch = db_batch_builder.build().map_err(|err| {
+            error!("{}", err);
+            ErrorResponse::internal_error(Box::new(err))
+        })?;
 
         batches.push(db_batch);
     }
 
     Ok(batches)
+}
+
+fn build_transaction(txn: &transaction::Transaction) -> Result<DbTransaction, ErrorResponse> {
+    let db_txn = TransactionBuilder::new()
+        .with_header_signature(txn.get_header_signature().to_string())
+        .with_family_name(SABRE_FAMILY_NAME.to_string())
+        .with_family_version(SABRE_FAMILY_VERSION.to_string())
+        .build()
+        .map_err(|err| {
+            error!("{}", err);
+            ErrorResponse::internal_error(Box::new(err))
+        })?;
+
+    Ok(db_txn)
 }
 
 /// Creates a nonce appropriate for a TransactionHeader


### PR DESCRIPTION
This updates the Batches store to use the builder pattern established in
other stores. This updates the structs with builders and accessor
methods to help stabilize the feature.

Signed-off-by: Davey Newhall <newhall@bitwise.io>