### PR TITLE
Move Grid features to default in CLI and gridd

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,6 +55,7 @@ default = [
     "database",
     "pike",
     "postgres",
+    "product",
     "schema",
     "sqlite",
 ]
@@ -64,7 +65,6 @@ stable = [
     "default",
     # The following features are stable:
     "location",
-    "product",
 ]
 
 experimental = [

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,6 +55,7 @@ default = [
     "database",
     "pike",
     "postgres",
+    "schema",
     "sqlite",
 ]
 
@@ -64,7 +65,6 @@ stable = [
     # The following features are stable:
     "location",
     "product",
-    "schema",
 ]
 
 experimental = [

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -53,6 +53,7 @@ whoami = "1"
 default = [
     "sawtooth",
     "database",
+    "location",
     "pike",
     "postgres",
     "product",
@@ -64,7 +65,6 @@ stable = [
     # The stable feature extends default:
     "default",
     # The following features are stable:
-    "location",
 ]
 
 experimental = [

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -53,6 +53,7 @@ whoami = "1"
 default = [
     "sawtooth",
     "database",
+    "pike",
     "postgres",
     "sqlite",
 ]
@@ -62,7 +63,6 @@ stable = [
     "default",
     # The following features are stable:
     "location",
-    "pike",
     "product",
     "schema",
 ]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -68,6 +68,7 @@ default = [
     "database-sqlite",
     "event",
     "pike",
+    "product",
     "rest-api",
     "sawtooth-support",
     "schema",
@@ -79,7 +80,6 @@ stable = [
     "default",
     # The following features are stable:
     "location",
-    "product",
 ]
 
 experimental = [

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -70,6 +70,7 @@ default = [
     "pike",
     "rest-api",
     "sawtooth-support",
+    "schema",
     "splinter-support",
 ]
 
@@ -79,7 +80,6 @@ stable = [
     # The following features are stable:
     "location",
     "product",
-    "schema",
 ]
 
 experimental = [

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -67,6 +67,7 @@ default = [
     "database-postgres",
     "database-sqlite",
     "event",
+    "location",
     "pike",
     "product",
     "rest-api",
@@ -79,7 +80,6 @@ stable = [
     # The stable feature extends default:
     "default",
     # The following features are stable:
-    "location",
 ]
 
 experimental = [

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -67,6 +67,7 @@ default = [
     "database-postgres",
     "database-sqlite",
     "event",
+    "pike",
     "rest-api",
     "sawtooth-support",
     "splinter-support",
@@ -77,7 +78,6 @@ stable = [
     "default",
     # The following features are stable:
     "location",
-    "pike",
     "product",
     "schema",
 ]


### PR DESCRIPTION
In the CLI and gridd we want the default experience to include all Grid business functionality. This set of commits moves pike, product, schema, and location to default for these two components.