### PR TITLE
BACKPORT: Update Sawtooth dockerfile for grid_pike

### DIFF
--- a/examples/sawtooth/docker-compose.yaml
+++ b/examples/sawtooth/docker-compose.yaml
@@ -88,10 +88,10 @@ services:
     entrypoint: |
       bash -c "
         while true; do curl -s http://sawtooth-rest-api:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done;
-        sabre cr --create pike --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://sawtooth-rest-api:8008 --wait 30
+        sabre cr --create grid_pike --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://sawtooth-rest-api:8008 --wait 30
         sabre upload --filename /tmp/pike.yaml --key /grid-shared/my_key --url http://sawtooth-rest-api:8008 --wait 30
         sabre ns --create 621dee05 --key /grid-shared/my_key --owner $$(cat /grid-shared/my_key.pub) --url http://sawtooth-rest-api:8008 --wait 30
-        sabre perm 621dee05 pike --key /grid-shared/my_key --read --write --url http://sawtooth-rest-api:8008 --wait 30
+        sabre perm 621dee05 grid_pike --key /grid-shared/my_key --read --write --url http://sawtooth-rest-api:8008 --wait 30
         echo '---------========= pike contract is loaded =========---------'
       "
 


### PR DESCRIPTION
backport to 0.2

This updates the `pike-contract-builder` for the Sawtooth example
Docker-compose file to account for the name change from `pike` to
`grid-pike`.