### PR TITLE
Add Product table loading indicator

### DIFF
--- a/ui/saplings/product/src/components/ProductsTable.js
+++ b/ui/saplings/product/src/components/ProductsTable.js
@@ -28,6 +28,7 @@ import './ProductsTable.scss';
 
 function ProductsTable() {
   const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(false);
   const { selectedService, selectedCircuit } = useServiceState();
   const [filterInputState, setFilterInputState] = useState({
     type: 'product name',
@@ -64,12 +65,14 @@ function ProductsTable() {
     const getProducts = async () => {
       if (selectedService !== 'none') {
         try {
+          setLoading(true);
           const productList = await listProducts(selectedService);
           productList.map(p => productXMLToJSON(p))
           setProducts(productList.map(p => ({
             product: p,
             data: productXMLToJSON(p)
           })));
+          setLoading(false);
         } catch (e) {
           console.error(`Error listing products: ${e}`);
         }
@@ -267,7 +270,7 @@ function ProductsTable() {
         </div>
       </div>
       <div className="table">
-        <Table columns={columns} data={data} filterTypes={filterTypes} filters={filters} actions={[{action: downloadXMLGDSN3_1, icon: 'code'}]} />
+        <Table columns={columns} data={data} filterTypes={filterTypes} filters={filters} actions={[{action: downloadXMLGDSN3_1, icon: 'code'}]} loading={loading} />
       </div>
     </div>
   );

--- a/ui/saplings/product/src/components/Table.js
+++ b/ui/saplings/product/src/components/Table.js
@@ -16,11 +16,12 @@
 import React, {useEffect} from 'react'
 import PropTypes from 'prop-types';
 import Icon from '@material-ui/core/Icon';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import { useTable, useFilters, usePagination } from 'react-table';
 import { Input } from './Input';
 import './Table.scss';
 
-export function Table({ columns, data, filterTypes, filters, actions }) {
+export function Table({ columns, data, filterTypes, filters, actions, loading }) {
   const {
     getTableProps,
     getTableBodyProps,
@@ -80,7 +81,7 @@ export function Table({ columns, data, filterTypes, filters, actions }) {
 
   return (
     <>
-      <Pagination />
+      {loading ? <CircularProgress className="loading" size="1.5rem" color="inherit" /> : <Pagination />}
       <div className="table-wrapper">
         <table {...getTableProps()}>
           <thead>
@@ -136,7 +137,7 @@ export function Table({ columns, data, filterTypes, filters, actions }) {
           </tbody>
         </table>
       </div>
-      <Pagination />
+      {!loading && <Pagination />}
     </>
   )
 }
@@ -151,11 +152,13 @@ Table.propTypes = {
       action: PropTypes.func,
       icon: PropTypes.string,
     })
-  )
+  ),
+  loading: PropTypes.bool
 }
 
 Table.defaultProps = {
   filterTypes: {},
   filters: [],
-  actions: []
+  actions: [],
+  loading: false
 }

--- a/ui/saplings/product/src/components/Table.scss
+++ b/ui/saplings/product/src/components/Table.scss
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+.loading {
+  margin-bottom: 0.5rem;
+}
+
 .pagination {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Add a loading indicator on the products table. This load can take a few seconds since we are brute force searching for Org names. This should be optimized eventually, but either way we should add an indicator when we are loading data.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>