### PR TITLE
Update CLAP definitions to align with man pages.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -301,7 +301,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file")
+                                .help("Base name or path for private signing key file")
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -362,7 +362,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file")
+                                .help("Base name or path for private signing key file")
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -462,7 +462,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file")
+                                .help("Base name or path for private signing key file")
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -517,7 +517,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file")
+                                .help("Base name or path for private signing key file")
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -643,7 +643,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file")
+                                .help("Base name or path for private signing key file")
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -718,7 +718,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file")
+                                .help("Base name or path for private signing key file")
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -748,7 +748,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file")
+                                .help("Base name or path for private signing key file")
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -829,7 +829,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file"),
+                                .help("Base name or path for private signing key file"),
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -853,7 +853,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file"),
+                                .help("Base name or path for private signing key file"),
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -957,7 +957,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file"),
+                                .help("Base name or path for private signing key file"),
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -1010,7 +1010,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file"),
+                                .help("Base name or path for private signing key file"),
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -1040,7 +1040,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file"),
+                                .help("Base name or path for private signing key file"),
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -1144,7 +1144,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file"),
+                                .help("Base name or path for private signing key file"),
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -1195,7 +1195,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file"),
+                                .help("Base name or path for private signing key file"),
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -1225,7 +1225,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file"),
+                                .help("Base name or path for private signing key file"),
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -1329,7 +1329,7 @@ fn run() -> Result<(), CliError> {
                             .long("key")
                             .short("k")
                             .takes_value(true)
-                            .help("Base name for private signing key file"),
+                            .help("Base name or path for private signing key file"),
                     )
                     .arg(
                         Arg::with_name("wait")
@@ -1380,7 +1380,7 @@ fn run() -> Result<(), CliError> {
                             .long("key")
                             .short("k")
                             .takes_value(true)
-                            .help("Base name for private signing key file"),
+                            .help("Base name or path for private signing key file"),
                     )
                     .arg(
                         Arg::with_name("wait")
@@ -1494,7 +1494,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file"),
+                                .help("Base name or path for private signing key file"),
                         )
                         .arg(
                             Arg::with_name("wait")
@@ -1615,7 +1615,7 @@ fn run() -> Result<(), CliError> {
                                 .long("key")
                                 .short("k")
                                 .takes_value(true)
-                                .help("Base name for private signing key file"),
+                                .help("Base name or path for private signing key file"),
                         )
                         .arg(
                             Arg::with_name("wait")


### PR DESCRIPTION
Work done involved verifying that the CLAP definitions align with man
pages. The CLAP definitions were already aligned, but the `--key` option
required updating throughout all of main.rs