### PR TITLE
Add experimental support for Cylinder JWTs

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -86,11 +86,13 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "cylinder-jwt-support",
     "integration",
     "purchase-order",
     "track-and-trace",
 ]
 
+cylinder-jwt-support = ["cylinder/jwt", "grid-sdk/cylinder-jwt-support"]
 event = ["database"]
 database = []
 database-postgres = ["grid-sdk/postgres"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -105,6 +105,7 @@ experimental = [
     "batch-store",
     "client",
     "client-reqwest",
+    "cylinder-jwt-support",
     "pike-rest-api",
     "purchase-order",
     "rest-api-resources",
@@ -126,6 +127,7 @@ backend-sawtooth = ["backend", "uuid"]
 backend-splinter = ["backend", "reqwest"]
 client = []
 client-reqwest = ["client", "reqwest"]
+cylinder-jwt-support = ["cylinder/jwt"]
 location = ["pike", "schema"]
 pike = ["cfg-if"]
 pike-rest-api = ["pike", "serde_json", "rest-api-resources"]


### PR DESCRIPTION
This adds support for using Cylinder JWTs as an Auth header in requests
to submit batches. This new functionality is guarded behind the
experimental `cylinder-jwt-support` feature. This creates the Signer in
the the `run_splinter` function which is then passed through to the
REST API when that is set up.

Signed-off-by: Davey Newhall <newhall@bitwise.io>