### PR TITLE
Fix some incorrect migration data

### DIFF
--- a/sdk/src/migrations/diesel/postgres/migrations/2021-03-30-164015_update_batch_tables/down.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-03-30-164015_update_batch_tables/down.sql
@@ -13,9 +13,9 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-DROP transaction_receipts;
-DROP transactions;
-DROP batches;
+DROP TABLE transaction_receipts;
+DROP TABLE transactions;
+DROP TABLE batches;
 
 CREATE TABLE batches (
     id TEXT PRIMARY KEY,

--- a/sdk/src/migrations/diesel/postgres/migrations/2021-07-22-161800_drop_unused_tables/down.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-07-22-161800_drop_unused_tables/down.sql
@@ -1,0 +1,14 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------

--- a/sdk/src/migrations/diesel/postgres/migrations/2021-07-22-161800_drop_unused_tables/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-07-22-161800_drop_unused_tables/up.sql
@@ -1,0 +1,19 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE grid_circuit;
+DROP TABLE grid_circuit_proposal;
+DROP TABLE grid_circuit_member;
+DROP TABLE grid_circuit_proposal_vote_record;

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-03-30-164015_update_batch_tables/down.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-03-30-164015_update_batch_tables/down.sql
@@ -13,9 +13,9 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-DROP transaction_receipts;
-DROP transactions;
-DROP batches;
+DROP TABLE transaction_receipts;
+DROP TABLE transactions;
+DROP TABLE batches;
 
 CREATE TABLE batches (
     id TEXT PRIMARY KEY,

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-07-22-161800_drop_unused_tables/down.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-07-22-161800_drop_unused_tables/down.sql
@@ -1,0 +1,14 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-07-22-161800_drop_unused_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-07-22-161800_drop_unused_tables/up.sql
@@ -1,0 +1,19 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE grid_circuit;
+DROP TABLE grid_circuit_proposal;
+DROP TABLE grid_circuit_member;
+DROP TABLE grid_circuit_proposal_vote_record;


### PR DESCRIPTION
This PR adds a migration folder to both the sqlite and postgres migration modules to correct a few migration data inconsistencies. Mainly, this addresses two issues: 

- Down unused tables in the newly added `up.sql` file
   (This includes tables meant to store circuit data that are currently not being used to store any data)
- Correctly down some tables that are incorrectly downed in their respective migration modules 
    (The tables are downed in the original migration file using the command `DROP` rather than `DROP TABLE`)  