### PR TITLE
BACKPORT: Update CLI Format syntax in Man Pages

### DIFF
--- a/cli/man/grid-agent-create.1.md
+++ b/cli/man/grid-agent-create.1.md
@@ -59,7 +59,7 @@ OPTIONS
 : base name or path to a private signing key file
 
 `--metadata`
-: Key-value pairs (format: <key>=<value>) in a comma-separated list
+: Key-value pairs (format: `<key>=<value>`) in a comma-separated list
 
 `--role`
 : Roles assigned to the agent. Multiple roles can be assigned in a 
@@ -67,7 +67,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-agent-list.1.md
+++ b/cli/man/grid-agent-list.1.md
@@ -51,7 +51,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-agent-show.1.md
+++ b/cli/man/grid-agent-show.1.md
@@ -50,7 +50,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-agent-update.1.md
+++ b/cli/man/grid-agent-update.1.md
@@ -58,7 +58,7 @@ OPTIONS
 : base name or path to a private signing key file
 
 `--metadata`
-: Key-value pairs (format: <key>=<value>) in a comma-separated list
+: Key-value pairs (format: `<key>=<value>`) in a comma-separated list
 
 `--role`
 : Roles assigned to the agent. Multiple roles can be assigned in a 
@@ -66,7 +66,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-location-create.1.md
+++ b/cli/man/grid-location-create.1.md
@@ -70,7 +70,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-location-delete.1.md
+++ b/cli/man/grid-location-delete.1.md
@@ -57,7 +57,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-location-list.1.md
+++ b/cli/man/grid-location-list.1.md
@@ -42,7 +42,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-location-show.1.md
+++ b/cli/man/grid-location-show.1.md
@@ -49,7 +49,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-location-update.1.md
+++ b/cli/man/grid-location-update.1.md
@@ -67,7 +67,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter; Format <circuit-id>::<service-id>
+  Splinter; Format: `<circuit-id>::<service-id>`
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-organization-create.1.md
+++ b/cli/man/grid-organization-create.1.md
@@ -44,18 +44,18 @@ OPTIONS
 
 `--alternate-ids`
 : Alternate IDs for organization in a comma-separated list. 
-  Format: <id_type>:<id>.
+  Format: `<id_type>:<id>`.
 
 `-k`, `--key`
 : Base name or path to a private signing key file.
 
 `--metadata`
 : Key-value pairs in a comma-separated list.
-  Format: <key>=<value>.
+  Format: `<key>=<value>`.
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-organization-list.1.md
+++ b/cli/man/grid-organization-list.1.md
@@ -50,7 +50,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-organization-show.1.md
+++ b/cli/man/grid-organization-show.1.md
@@ -55,7 +55,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-organization-update.1.md
+++ b/cli/man/grid-organization-update.1.md
@@ -44,7 +44,7 @@ OPTIONS
 
 `--alternate-ids`
 : Alternate IDs for organization in a comma-separated list. 
-  Format: <id_type>:<id>.
+  Format: `<id_type>:<id>`.
 
 `-k`, `--key`
 : Base name or path to a private signing key file.
@@ -54,11 +54,11 @@ OPTIONS
 
 `--metadata`
 : Key-value pairs in a comma-separated list.
-  Format: <key>=<value>.
+  Format: `<key>=<value>`.
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-po-create.1.md
+++ b/cli/man/grid-po-create.1.md
@@ -53,7 +53,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-po-list.1.md
+++ b/cli/man/grid-po-list.1.md
@@ -64,7 +64,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
   `--url`
 : URL for the REST API.

--- a/cli/man/grid-po-show.1.md
+++ b/cli/man/grid-po-show.1.md
@@ -59,7 +59,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-po-update.1.md
+++ b/cli/man/grid-po-update.1.md
@@ -71,7 +71,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-po-version-create.1.md
+++ b/cli/man/grid-po-version-create.1.md
@@ -69,7 +69,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-po-version-list.1.md
+++ b/cli/man/grid-po-version-list.1.md
@@ -71,8 +71,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>. This location could 
-  instead be set with the environment variable GRID_SERVICE_ID.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-po-version-update.1.md
+++ b/cli/man/grid-po-version-update.1.md
@@ -64,7 +64,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-po-version.1.md
+++ b/cli/man/grid-po-version.1.md
@@ -48,7 +48,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--wait`
 : How long to wait for transaction to be committed.

--- a/cli/man/grid-po.1.md
+++ b/cli/man/grid-po.1.md
@@ -45,7 +45,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API

--- a/cli/man/grid-product-create.1.md
+++ b/cli/man/grid-product-create.1.md
@@ -65,7 +65,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-product-delete.1.md
+++ b/cli/man/grid-product-delete.1.md
@@ -57,7 +57,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-product-list.1.md
+++ b/cli/man/grid-product-list.1.md
@@ -42,7 +42,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-product-show.1.md
+++ b/cli/man/grid-product-show.1.md
@@ -49,7 +49,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-product-update.1.md
+++ b/cli/man/grid-product-update.1.md
@@ -63,7 +63,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-product.1.md
+++ b/cli/man/grid-product.1.md
@@ -45,7 +45,7 @@ OPTIONS
   
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-role-create.1.md
+++ b/cli/man/grid-role-create.1.md
@@ -66,7 +66,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-role-update.1.md
+++ b/cli/man/grid-role-update.1.md
@@ -66,7 +66,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-schema-create.1.md
+++ b/cli/man/grid-schema-create.1.md
@@ -50,7 +50,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-schema-list.1.md
+++ b/cli/man/grid-schema-list.1.md
@@ -41,7 +41,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-schema-show.1.md
+++ b/cli/man/grid-schema-show.1.md
@@ -47,7 +47,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-schema-update.1.md
+++ b/cli/man/grid-schema-update.1.md
@@ -50,7 +50,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid-schema.1.md
+++ b/cli/man/grid-schema.1.md
@@ -42,7 +42,7 @@ Many subcommands utilize the following options:
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.

--- a/cli/man/grid.1.md
+++ b/cli/man/grid.1.md
@@ -85,7 +85,7 @@ OPTIONS
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format <circuit-id>::<service-id>.
+  Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API.


### PR DESCRIPTION
Noticed that the grid-docs didn't correctly format some values in tags.
These changes remedy the problem.

Signed-off-by: Kevin Johnson <kevin_johnson@cargill.com>