### PR TITLE
Add Cylinder JWT/Splinter 0.5 support to app auth handler

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -47,19 +47,19 @@ grid-sdk = { path = "../sdk"}
 log = "0.4"
 protobuf = "2.19"
 reqwest = { version = "0.10.1", optional = true, features = ["json", "blocking"] }
-sabre-sdk = { version = "0.5", optional = true }
+sabre-sdk = { version = "0.7", optional = true }
 sawtooth-sdk = { version = "0.4", features = ["transact-compat"] }
-scabbard = { version = "0.4", optional = true, features = ["client", "events"] }
+scabbard = { version = "0.5", optional = true, features = ["client", "events", "reqwest"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-transact = { version = "0.2", optional = true }
+transact = { version = "0.3", optional = true }
 url = "2.1"
 uuid = { version = "0.8", features = ["v4"] }
 
 [dependencies.splinter]
-version = "0.4"
+version = "0.5"
 optional = true
-features = [ "events" ]
+features = [ "events", "admin-service" ]
 
 [features]
 default = [

--- a/daemon/src/splinter/app_auth_handler/error.rs
+++ b/daemon/src/splinter/app_auth_handler/error.rs
@@ -15,8 +15,8 @@
  * -----------------------------------------------------------------------------
  */
 
+use cylinder::{KeyParseError, SigningError};
 use sabre_sdk::protocol::payload::{ActionBuildError, SabrePayloadBuildError};
-use sawtooth_sdk::signing::Error as SigningError;
 use scabbard::client::ScabbardClientError;
 use splinter::events;
 use std::error::Error;
@@ -136,6 +136,12 @@ impl From<BatchBuildError> for AppAuthHandlerError {
 
 impl From<TransactionBuildError> for AppAuthHandlerError {
     fn from(err: TransactionBuildError) -> Self {
+        AppAuthHandlerError::from_source(Box::new(err))
+    }
+}
+
+impl From<KeyParseError> for AppAuthHandlerError {
+    fn from(err: KeyParseError) -> Self {
         AppAuthHandlerError::from_source(Box::new(err))
     }
 }

--- a/daemon/src/splinter/app_auth_handler/node.rs
+++ b/daemon/src/splinter/app_auth_handler/node.rs
@@ -35,10 +35,17 @@ impl fmt::Display for GetNodeError {
     }
 }
 
-pub fn get_node_id(splinterd_url: String) -> Result<String, GetNodeError> {
+pub fn get_node_id(
+    splinterd_url: String,
+    #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
+) -> Result<String, GetNodeError> {
     let uri = format!("{}/status", splinterd_url);
 
+    #[cfg(not(feature = "cylinder-jwt-support"))]
     let body = wait_for_status(&uri)?;
+
+    #[cfg(feature = "cylinder-jwt-support")]
+    let body = wait_for_status(&uri, authorization)?;
 
     let node_id_val = body
         .get("node_id")
@@ -51,10 +58,22 @@ pub fn get_node_id(splinterd_url: String) -> Result<String, GetNodeError> {
     Ok(node_id.to_string())
 }
 
-fn wait_for_status(uri: &str) -> Result<Value, GetNodeError> {
+fn wait_for_status(
+    uri: &str,
+    #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
+) -> Result<Value, GetNodeError> {
     let mut wait_time = 1;
+    let client = reqwest::blocking::Client::new();
     loop {
-        match reqwest::blocking::get(uri) {
+        #[allow(unused_mut)]
+        let mut request = client.get(uri);
+
+        #[cfg(feature = "cylinder-jwt-support")]
+        {
+            request = request.header("Authorization", authorization.to_string());
+        }
+
+        match request.send() {
             Ok(res) => {
                 return res.json().map_err(|err| {
                     GetNodeError(format!("Failed to parse response body: {}", err))

--- a/daemon/src/splinter/app_auth_handler/sabre.rs
+++ b/daemon/src/splinter/app_auth_handler/sabre.rs
@@ -15,7 +15,6 @@
  * -----------------------------------------------------------------------------
  */
 
-use std::convert::TryInto;
 use std::time::Duration;
 
 #[cfg(feature = "location")]
@@ -29,6 +28,8 @@ use grid_sdk::purchase_order::addressing::GRID_PURCHASE_ORDER_NAMESPACE;
 #[cfg(feature = "schema")]
 use grid_sdk::schema::addressing::GRID_SCHEMA_NAMESPACE;
 
+use cylinder::{secp256k1::Secp256k1Context, Context, PrivateKey, Signer};
+
 #[cfg(any(
     feature = "location",
     feature = "pike",
@@ -40,11 +41,7 @@ use sabre_sdk::protocol::payload::{
     CreateContractActionBuilder, CreateContractRegistryActionBuilder,
     CreateNamespaceRegistryActionBuilder, CreateNamespaceRegistryPermissionActionBuilder,
 };
-use sawtooth_sdk::signing::{
-    create_context, secp256k1::Secp256k1PrivateKey, transact::TransactSigner,
-    Signer as SawtoothSigner,
-};
-use scabbard::client::{ScabbardClient, ServiceId};
+use scabbard::client::{ReqwestScabbardClientBuilder, ScabbardClient, ServiceId};
 #[cfg(any(
     feature = "location",
     feature = "pike",
@@ -53,6 +50,7 @@ use scabbard::client::{ScabbardClient, ServiceId};
     feature = "schema"
 ))]
 use transact::contract::archive::default_scar_path;
+use transact::protocol::batch::BatchBuilder;
 #[cfg(any(
     feature = "location",
     feature = "pike",
@@ -61,7 +59,6 @@ use transact::contract::archive::default_scar_path;
     feature = "schema"
 ))]
 use transact::{contract::archive::SmartContractArchive, protocol::transaction::Transaction};
-use transact::{protocol::batch::BatchBuilder, signing::Signer};
 
 use crate::splinter::app_auth_handler::error::AppAuthHandlerError;
 
@@ -73,6 +70,7 @@ pub fn setup_grid(
     splinterd_url: &str,
     service_id: &str,
     circuit_id: &str,
+    #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
 ) -> Result<(), AppAuthHandlerError> {
     #[cfg(any(
         feature = "location",
@@ -84,9 +82,8 @@ pub fn setup_grid(
     let version = env!("CARGO_PKG_VERSION");
 
     let signer = new_signer(scabbard_admin_key)?;
+    let public_key = signer.public_key()?.as_hex();
 
-    // The node with the first key in the list of scabbard admins is responsible for setting up xo
-    let public_key = bytes_to_hex_str(signer.public_key());
     let is_submitter = match proposed_admin_pubkeys.get(0) {
         Some(submitting_key) => &public_key == submitting_key,
         None => false,
@@ -101,27 +98,39 @@ pub fn setup_grid(
 
     // Make Pike transactions
     #[cfg(feature = "pike")]
-    make_pike_txns(&mut txns, version, &signer)?;
+    make_pike_txns(&mut txns, version, &*signer)?;
 
     // Make schema transactions
     #[cfg(feature = "schema")]
-    make_schema_txns(&mut txns, version, &signer)?;
+    make_schema_txns(&mut txns, version, &*signer)?;
 
     // Make Product transactions
     #[cfg(feature = "product")]
-    make_product_txns(&mut txns, version, &signer)?;
+    make_product_txns(&mut txns, version, &*signer)?;
 
     // Make Location transactions
     #[cfg(feature = "location")]
-    make_location_txns(&mut txns, version, &signer)?;
+    make_location_txns(&mut txns, version, &*signer)?;
 
     // Make Purchase Order transactions
     #[cfg(feature = "purchase-order")]
-    make_purchase_order_txns(&mut txns, version, &signer)?;
+    make_purchase_order_txns(&mut txns, version, &*signer)?;
 
-    let batch = BatchBuilder::new().with_transactions(txns).build(&signer)?;
+    let batch = BatchBuilder::new()
+        .with_transactions(txns)
+        .build(&*signer)?;
 
-    ScabbardClient::new(splinterd_url)
+    #[allow(unused_mut)]
+    let mut client_builder = ReqwestScabbardClientBuilder::new().with_url(splinterd_url);
+
+    #[cfg(feature = "cylinder-jwt-support")]
+    {
+        client_builder = client_builder.with_auth(authorization);
+    }
+
+    client_builder
+        .build()
+        .map_err(|err| AppAuthHandlerError::from_source(Box::new(err)))?
         .submit(
             &ServiceId::new(circuit_id, service_id),
             vec![batch],
@@ -136,20 +145,20 @@ pub fn setup_grid(
 fn make_pike_txns(
     txns: &mut Vec<Transaction>,
     version: &str,
-    signer: &TransactSigner,
+    signer: &dyn Signer,
 ) -> Result<(), AppAuthHandlerError> {
     let pike_contract =
         SmartContractArchive::from_scar_file("grid-pike", version, &default_scar_path())?;
     let pike_contract_registry_txn = CreateContractRegistryActionBuilder::new()
         .with_name(String::from(&pike_contract.metadata.name))
-        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .with_owners(vec![bytes_to_hex_str(signer.public_key()?.as_slice())])
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
     let pike_contract_txn = make_upload_contract_txn(signer, &pike_contract, GRID_PIKE_NAMESPACE)?;
     let pike_namespace_registry_txn = CreateNamespaceRegistryActionBuilder::new()
         .with_namespace(GRID_PIKE_NAMESPACE.into())
-        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .with_owners(vec![bytes_to_hex_str(signer.public_key()?.as_slice())])
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
@@ -177,13 +186,13 @@ fn make_pike_txns(
 fn make_product_txns(
     txns: &mut Vec<Transaction>,
     version: &str,
-    signer: &TransactSigner,
+    signer: &dyn Signer,
 ) -> Result<(), AppAuthHandlerError> {
     let product_contract =
         SmartContractArchive::from_scar_file("grid-product", version, &default_scar_path())?;
     let product_contract_registry_txn = CreateContractRegistryActionBuilder::new()
         .with_name(String::from(&product_contract.metadata.name))
-        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .with_owners(vec![bytes_to_hex_str(signer.public_key()?.as_slice())])
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
@@ -191,7 +200,7 @@ fn make_product_txns(
         make_upload_contract_txn(signer, &product_contract, GRID_PRODUCT_NAMESPACE)?;
     let product_namespace_registry_txn = CreateNamespaceRegistryActionBuilder::new()
         .with_namespace(GRID_PRODUCT_NAMESPACE.into())
-        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .with_owners(vec![bytes_to_hex_str(signer.public_key()?.as_slice())])
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
@@ -238,13 +247,13 @@ fn make_product_txns(
 fn make_location_txns(
     txns: &mut Vec<Transaction>,
     version: &str,
-    signer: &TransactSigner,
+    signer: &dyn Signer,
 ) -> Result<(), AppAuthHandlerError> {
     let location_contract =
         SmartContractArchive::from_scar_file("grid-location", version, &default_scar_path())?;
     let location_contract_registry_txn = CreateContractRegistryActionBuilder::new()
         .with_name(String::from(&location_contract.metadata.name))
-        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .with_owners(vec![bytes_to_hex_str(signer.public_key()?.as_slice())])
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
@@ -252,7 +261,7 @@ fn make_location_txns(
         make_upload_contract_txn(signer, &location_contract, GRID_LOCATION_NAMESPACE)?;
     let location_namespace_registry_txn = CreateNamespaceRegistryActionBuilder::new()
         .with_namespace(GRID_LOCATION_NAMESPACE.into())
-        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .with_owners(vec![bytes_to_hex_str(signer.public_key()?.as_slice())])
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
@@ -299,13 +308,13 @@ fn make_location_txns(
 fn make_schema_txns(
     txns: &mut Vec<Transaction>,
     version: &str,
-    signer: &TransactSigner,
+    signer: &dyn Signer,
 ) -> Result<(), AppAuthHandlerError> {
     let schema_contract =
         SmartContractArchive::from_scar_file("grid-schema", version, &default_scar_path())?;
     let schema_contract_registry_txn = CreateContractRegistryActionBuilder::new()
         .with_name(String::from(&schema_contract.metadata.name))
-        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .with_owners(vec![bytes_to_hex_str(signer.public_key()?.as_slice())])
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
@@ -313,7 +322,7 @@ fn make_schema_txns(
         make_upload_contract_txn(signer, &schema_contract, GRID_SCHEMA_NAMESPACE)?;
     let schema_namespace_registry_txn = CreateNamespaceRegistryActionBuilder::new()
         .with_namespace(GRID_SCHEMA_NAMESPACE.into())
-        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .with_owners(vec![bytes_to_hex_str(signer.public_key()?.as_slice())])
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
@@ -350,13 +359,13 @@ fn make_schema_txns(
 fn make_purchase_order_txns(
     txns: &mut Vec<Transaction>,
     version: &str,
-    signer: &TransactSigner,
+    signer: &dyn Signer,
 ) -> Result<(), AppAuthHandlerError> {
     let purchase_order_contract =
         SmartContractArchive::from_scar_file("grid-purchase-order", version, &default_scar_path())?;
     let purchase_order_contract_registry_txn = CreateContractRegistryActionBuilder::new()
         .with_name(String::from(&purchase_order_contract.metadata.name))
-        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .with_owners(vec![bytes_to_hex_str(signer.public_key()?.as_slice())])
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
@@ -367,7 +376,7 @@ fn make_purchase_order_txns(
     )?;
     let purchase_order_namespace_registry_txn = CreateNamespaceRegistryActionBuilder::new()
         .with_namespace(GRID_PURCHASE_ORDER_NAMESPACE.into())
-        .with_owners(vec![bytes_to_hex_str(signer.public_key())])
+        .with_owners(vec![bytes_to_hex_str(signer.public_key()?.as_slice())])
         .into_payload_builder()?
         .into_transaction_builder(signer)?
         .build(signer)?;
@@ -401,10 +410,10 @@ fn make_purchase_order_txns(
     Ok(())
 }
 
-fn new_signer(private_key: &str) -> Result<TransactSigner, AppAuthHandlerError> {
-    let context = create_context("secp256k1")?;
-    let private_key = Box::new(Secp256k1PrivateKey::from_hex(private_key)?);
-    Ok(SawtoothSigner::new_boxed(context, private_key).try_into()?)
+fn new_signer(private_key: &str) -> Result<Box<dyn Signer>, AppAuthHandlerError> {
+    let context = Secp256k1Context::new();
+    let private_key = PrivateKey::new_from_hex(private_key)?;
+    Ok(context.new_signer(private_key))
 }
 
 #[cfg(feature = "pike")]

--- a/daemon/src/splinter/event/processors.rs
+++ b/daemon/src/splinter/event/processors.rs
@@ -47,6 +47,7 @@ impl EventProcessors {
         circuit_id: &str,
         service_id: &str,
         last_seen_id: Option<&str>,
+        #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
         handlers_factory_fn: F,
     ) -> Result<(), InternalError>
     where
@@ -55,7 +56,17 @@ impl EventProcessors {
         let mut inner = self.inner.lock().map_err(|_| {
             InternalError::with_message("EventProcessors inner mutex was poisoned".into())
         })?;
-        inner.add_once(circuit_id, service_id, last_seen_id, handlers_factory_fn)
+        #[cfg(not(feature = "cylinder-jwt-support"))]
+        return inner.add_once(circuit_id, service_id, last_seen_id, handlers_factory_fn);
+
+        #[cfg(feature = "cylinder-jwt-support")]
+        inner.add_once(
+            circuit_id,
+            service_id,
+            last_seen_id,
+            authorization,
+            handlers_factory_fn,
+        )
     }
 }
 
@@ -77,6 +88,7 @@ impl Inner {
         circuit_id: &str,
         service_id: &str,
         last_seen_id: Option<&str>,
+        #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
         factory_fn: F,
     ) -> Result<(), InternalError>
     where
@@ -84,9 +96,16 @@ impl Inner {
     {
         let key = format!("{}::{}", circuit_id, service_id);
         if let Entry::Vacant(entry) = self.processors.entry(key) {
+            #[cfg(not(feature = "cylinder-jwt-support"))]
             let event_connection = self
                 .event_connection_factory
                 .create_connection(circuit_id, service_id)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+            #[cfg(feature = "cylinder-jwt-support")]
+            let event_connection = self
+                .event_connection_factory
+                .create_connection(circuit_id, service_id, authorization)
                 .map_err(|err| InternalError::from_source(Box::new(err)))?;
 
             let evt_processor = EventProcessor::start(event_connection, last_seen_id, factory_fn())

--- a/examples/splinter/docker-compose.yaml
+++ b/examples/splinter/docker-compose.yaml
@@ -116,9 +116,16 @@ services:
       "
 
   generate-registry:
-    image: splintercommunity/splinter-cli:0.4
+    image: splintercommunity/splinter-cli:0.5
     volumes:
       - registry:/registry
+      - gridd-alpha:/gridd_alpha/keys
+      - gridd-beta:/gridd_beta/keys
+      - gridd-gamma:/gridd_gamma/keys
+    depends_on:
+      - gridd-alpha
+      - gridd-beta
+      - gridd-gamma
     command: |
       bash -c "
         if [ ! -f /registry/registry.yaml ]
@@ -128,17 +135,17 @@ services:
           splinter admin keygen beta -d /registry
           splinter admin keygen gamma -d /registry
           # check if splinterd-alpha is available
-          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-alpha:8085/status) -ne 200 ]] ; do
+          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-alpha:8085/status) -ne 401 ]] ; do
              >&2 echo \"splinterd is unavailable - sleeping\"
              sleep 1
           done
           # check if splinterd-beta is available
-          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-beta:8085/status) -ne 200 ]] ; do
+          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-beta:8085/status) -ne 401 ]] ; do
              >&2 echo \"splinterd is unavailable - sleeping\"
              sleep 1
           done
           # check if splinterd-gamma is available
-          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-gamma:8085/status) -ne 200 ]] ; do
+          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-gamma:8085/status) -ne 401 ]] ; do
              >&2 echo \"splinterd is unavailable - sleeping\"
              sleep 1
           done
@@ -146,16 +153,19 @@ services:
           splinter registry build \
             http://splinterd-alpha:8085 \
             --file /registry/registry.yaml \
+            --key /gridd_alpha/keys/gridd.priv \
             --key-file /registry/alpha.pub \
             --metadata organization='Alpha'
           splinter registry build \
             http://splinterd-beta:8085 \
             --file /registry/registry.yaml \
+            --key /gridd_beta/keys/gridd.priv \
             --key-file /registry/beta.pub \
             --metadata organization='Beta'
           splinter registry build \
             http://splinterd-gamma:8085 \
             --file /registry/registry.yaml \
+            --key /gridd_gamma/keys/gridd.priv \
             --key-file /registry/gamma.pub \
             --metadata organization='Gamma'
         fi
@@ -222,7 +232,7 @@ services:
       "
 
   scabbard-cli-alpha:
-    image: splintercommunity/scabbard-cli:0.4
+    image: splintercommunity/scabbard-cli:0.5
     container_name: scabbard-cli-alpha
     hostname: scabbard-cli-alpha
     volumes:
@@ -231,7 +241,7 @@ services:
     command: tail -f /dev/null
 
   splinterd-alpha:
-    image: splintercommunity/splinterd:0.4
+    image: splintercommunity/splinterd:0.5
     container_name: splinterd-alpha
     hostname: splinterd-alpha
     expose:
@@ -244,8 +254,19 @@ services:
       - contracts-shared:/usr/share/scar
       - registry:/registry
       - templates-shared:/usr/share/splinter/circuit-templates
+      - gridd-alpha:/etc/grid/keys
+    depends_on:
+      - gridd-alpha
     entrypoint: |
       bash -c "
+        while [ ! -f /etc/grid/keys/gridd.pub ] ; do
+          >&2 echo \"Grid key file is unavailable - sleeping\"
+          sleep 1
+        done && \
+        if [ ! -s /etc/splinter/allow_keys ]
+        then
+          echo $$(cat /etc/grid/keys/gridd.pub) >> /etc/splinter/allow_keys
+        fi && \
         until PGPASSWORD=admin psql -h splinter-db-alpha -U admin -d splinter -c '\q'; do
           >&2 echo \"Database is unavailable - sleeping\"
           sleep 1
@@ -257,17 +278,15 @@ services:
         splinter database migrate -C postgres://admin:admin@splinter-db-alpha:5432/splinter && \
         splinterd -vv \
         --registries http://registry-server:80/registry.yaml \
-        --rest-api-endpoint 0.0.0.0:8085 \
+        --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
         --advertised-endpoint tcps://splinterd-alpha:8044 \
         --node-id alpha-node-000 \
-        --service-endpoint tcp://0.0.0.0:8043 \
-        --storage yaml \
         --tls-client-cert /etc/splinter/certs/client.crt \
         --tls-client-key /etc/splinter/certs/private/client.key \
         --tls-server-cert /etc/splinter/certs/server.crt \
         --tls-server-key /etc/splinter/certs/private/server.key \
-        --enable-biome \
+        --enable-biome-credentials \
         --database postgres://admin:admin@splinter-db-alpha:5432/splinter \
         --tls-insecure
       "
@@ -350,7 +369,7 @@ services:
       "
 
   scabbard-cli-beta:
-    image: splintercommunity/scabbard-cli:0.4
+    image: splintercommunity/scabbard-cli:0.5
     container_name: scabbard-cli-beta
     hostname: scabbard-cli-beta
     volumes:
@@ -359,7 +378,7 @@ services:
     command: tail -f /dev/null
 
   splinterd-beta:
-    image: splintercommunity/splinterd:0.4
+    image: splintercommunity/splinterd:0.5
     container_name: splinterd-beta
     hostname: splinterd-beta
     expose:
@@ -371,8 +390,19 @@ services:
       - contracts-shared:/usr/share/scar
       - registry:/registry
       - templates-shared:/usr/share/splinter/circuit-templates
+      - gridd-beta:/etc/grid/keys
+    depends_on:
+      - gridd-beta
     entrypoint: |
       bash -c "
+        while [ ! -f /etc/grid/keys/gridd.pub ] ; do
+          >&2 echo \"Grid key file is unavailable - sleeping\"
+          sleep 1
+        done && \
+        if [ ! -s /etc/splinter/allow_keys ]
+        then
+          echo $$(cat /etc/grid/keys/gridd.pub) >> /etc/splinter/allow_keys
+        fi && \
         until PGPASSWORD=admin psql -h splinter-db-beta -U admin -d splinter -c '\q'; do
           >&2 echo \"Database is unavailable - sleeping\"
           sleep 1
@@ -384,17 +414,15 @@ services:
         splinter database migrate -C postgres://admin:admin@splinter-db-beta:5432/splinter && \
         splinterd -vv \
         --registries http://registry-server:80/registry.yaml \
-        --rest-api-endpoint 0.0.0.0:8085 \
+        --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
         --advertised-endpoint tcps://splinterd-beta:8044 \
         --node-id beta-node-000 \
-        --service-endpoint tcp://0.0.0.0:8043 \
-        --storage yaml \
         --tls-client-cert /etc/splinter/certs/client.crt \
         --tls-client-key /etc/splinter/certs/private/client.key \
         --tls-server-cert /etc/splinter/certs/server.crt \
         --tls-server-key /etc/splinter/certs/private/server.key \
-        --enable-biome \
+        --enable-biome-credentials \
         --database postgres://admin:admin@splinter-db-beta:5432/splinter \
         --tls-insecure
       "
@@ -477,7 +505,7 @@ services:
       "
 
   splinterd-gamma:
-    image: splintercommunity/splinterd:0.4
+    image: splintercommunity/splinterd:0.5
     container_name: splinterd-gamma
     hostname: splinterd-gamma
     expose:
@@ -489,8 +517,19 @@ services:
       - contracts-shared:/usr/share/scar
       - registry:/registry
       - templates-shared:/usr/share/splinter/circuit-templates
+      - gridd-gamma:/etc/grid/keys
+    depends_on:
+      - gridd-gamma
     entrypoint: |
       bash -c "
+        while [ ! -f /etc/grid/keys/gridd.pub ] ; do
+          >&2 echo \"Grid key file is unavailable - sleeping\"
+          sleep 1
+        done && \
+        if [ ! -s /etc/splinter/allow_keys ]
+        then
+          echo $$(cat /etc/grid/keys/gridd.pub) >> /etc/splinter/allow_keys
+        fi && \
         until PGPASSWORD=admin psql -h splinter-db-gamma -U admin -d splinter -c '\q'; do
           >&2 echo \"Database is unavailable - sleeping\"
           sleep 1
@@ -502,17 +541,15 @@ services:
         splinter database migrate -C postgres://admin:admin@splinter-db-gamma:5432/splinter && \
         splinterd -vv \
         --registries http://registry-server:80/registry.yaml \
-        --rest-api-endpoint 0.0.0.0:8085 \
+        --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
         --advertised-endpoint tcps://splinterd-gamma:8044 \
         --node-id gamma-node-000 \
-        --service-endpoint tcp://0.0.0.0:8043 \
-        --storage yaml \
         --tls-client-cert /etc/splinter/certs/client.crt \
         --tls-client-key /etc/splinter/certs/private/client.key \
         --tls-server-cert /etc/splinter/certs/server.crt \
         --tls-server-key /etc/splinter/certs/private/server.key \
-        --enable-biome \
+        --enable-biome-credentials \
         --database postgres://admin:admin@splinter-db-gamma:5432/splinter \
         --tls-insecure
       "


### PR DESCRIPTION
This PR makes various updates to support the authorization requirements in Splinter 0.5. This updates the Splinter dep, and various others in support of this update, to 0.5 within the Grid daemon. Authorization, in the form of Cylinder JWTs, has been added to all requests sent to the Splinter backend. This also updates the Signer used by the app auth handler to a Cylinder signer, allowing the JWT to be formed from this signer and added to rest requests. 

This functionality is behind the experimental `cylinder-jwt-support` feature. 

**To test:** 
There are a few workarounds needed when using Splinter 0.5 with Grid when setting up the Splinter circuit. Make sure to clear out leftover containers before running the Splinter examples docker-compose file: 

```$ docker-compose -f examples/splinter/docker-compose.yaml up```  

Once you are able to access the splinter containers:

```$ docker-compose -f examples/splinter/docker-compose.yaml exec splinterd-alpha bash``` 

First, in order to make requests to the splinter CLI, we need to set up authorization for this node. 
You will need to add the alpha node client's public key, generated by the registry, to the Splinter's allow_keys file:

```root@splinterd-alpha:/# echo $(cat /registry/alpha.pub) >> /etc/splinter/allow_keys```

Once this is done, the alpha container is able to make authorized requests to Splinter. 
Running the command:
```root@splinterd-alpha:/# splinter circuit proposals -k /registry/alpha.priv -U http://splinterd-alpha:8085```
should return the empty proposal rows as we have not proposed a circuit yet. 

Once the Splinter client is authorized, you may propose a circuit. If using the Grid walkthrough, as Splinter 0.5 does not send the circuit's service `admin_keys` argument as a JSON string, you may see an error like this: 
```
splinterd-beta                     | [2021-08-06 20:34:24.462] T["consensus-admin::beta-node-000"] ERROR [splinter::consensus::two_phase] failed to accept proposal 35323037653039663537306561303533633537386637626466636632616135376136396330656433326236323137386134373262646365653939393237666563 due to error: failed to commit proposal: Unable to start service gsBB on circuit aSMq7-kqdED: failed to initialize service: invalid arguments specified: failed to parse admin_keys list: invalid number at line 1 column 2
```

Do not fret, this bug is recorded. In order to workaround this error, the admin keys must be formatted as a JSON string when proposing a circuit:

```
root@splinterd-alpha:/# splinter circuit propose --key /registry/alpha.priv --url http://splinterd-alpha:8085 --node alpha-node-000::tcps://splinterd-alpha:8044 --node beta-node-000::tcps://splinterd-beta:8044 --service gsAA::alpha-node-000 --service gsBB::beta-node-000 --service-type *::scabbard --management grid --service-arg *::admin_keys="[\"{Grid Daemon public key}\"]" --service-peer-group gsAA,gsBB
```

Once this is submitted, you should be able to see this proposal by running: 

```root@splinterd-alpha:/# splinter circuit proposals -k /registry/alpha.priv -U http://splinterd-alpha:8085```

Now, to create a circuit from this proposal similar steps must be taken in the Splinterd-beta container (or the peer container you are attempting to create a circuit with)
```$ docker-compose -f examples/splinter/docker-compose.yaml exec splinterd-beta bash``` 

Now, repeat the first step when connecting to the alpha node, and copy over the Beta node's public key to the allow_keys file:
```root@splinterd-beta:/# echo $(cat /registry/beta.pub) >> /etc/splinter/allow_keys```

Now, running:
```root@splinterd-beta:/# splinter circuit proposals -k /registry/beta.priv -U http://splinterd-beta:8085```
you should be able to see the circuit proposed by the alpha node.

At this point, you may vote to accept the circuit:
```root@splinterd-beta:/# splinter circuit vote {circuit ID} --accept -k /registry/beta.priv -U http://splinterd-beta:8085```

Once this is done, you should be able to see the circuit from either alpha or beta node, running:
```splinter circuit list -k /registry/{Node}.priv -U http://{Node host}:8085``` after replacing the relevant information.

At this point, you may continue with the Grid walkthrough as documented. 