### PR TITLE
Avoid duplicate events

### DIFF
--- a/daemon/src/event/db_handler.rs
+++ b/daemon/src/event/db_handler.rs
@@ -202,6 +202,7 @@ impl EventHandler for DatabaseEventHandler<diesel::pg::PgConnection> {
                         "Commit {} at height {} is duplicate no action taken",
                         &commit.commit_id, commit.commit_num
                     );
+                    return Ok(());
                 }
                 Ok(None) => {
                     info!("Received new commit {}", commit.commit_id);

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -164,6 +164,12 @@ pub trait EventHandler: Send {
     fn cloned_box(&self) -> Box<dyn EventHandler>;
 }
 
+impl Clone for Box<dyn EventHandler> {
+    fn clone(&self) -> Self {
+        self.cloned_box()
+    }
+}
+
 #[macro_export]
 macro_rules! event_handlers {
     [$($handler:expr),*] => {

--- a/daemon/src/splinter/event/mod.rs
+++ b/daemon/src/splinter/event/mod.rs
@@ -16,6 +16,7 @@
  */
 
 mod error;
+pub(in crate::splinter) mod processors;
 
 use std::cell::RefCell;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};

--- a/daemon/src/splinter/event/processors.rs
+++ b/daemon/src/splinter/event/processors.rs
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::collections::{hash_map::Entry, HashMap};
+use std::sync::{Arc, Mutex};
+
+use grid_sdk::error::InternalError;
+
+use crate::event::{EventHandler, EventProcessor};
+
+use super::{ScabbardEventConnection, ScabbardEventConnectionFactory};
+
+/// A collection of event processors.
+#[derive(Clone)]
+pub struct EventProcessors {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl EventProcessors {
+    pub fn new(event_connection_factory: ScabbardEventConnectionFactory) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner::new(event_connection_factory))),
+        }
+    }
+
+    /// Add the event processor for a given circuit_id::service_id, if it is not in the collection.
+    ///
+    /// The provided factory function will create the handlers if there is an event processor miss.
+    ///
+    /// This method is idempotent.
+    pub fn add_once<F>(
+        &self,
+        circuit_id: &str,
+        service_id: &str,
+        last_seen_id: Option<&str>,
+        handlers_factory_fn: F,
+    ) -> Result<(), InternalError>
+    where
+        F: Fn() -> Vec<Box<dyn EventHandler>>,
+    {
+        let mut inner = self.inner.lock().map_err(|_| {
+            InternalError::with_message("EventProcessors inner mutex was poisoned".into())
+        })?;
+        inner.add_once(circuit_id, service_id, last_seen_id, handlers_factory_fn)
+    }
+}
+
+struct Inner {
+    event_connection_factory: ScabbardEventConnectionFactory,
+    processors: HashMap<String, EventProcessor<ScabbardEventConnection>>,
+}
+
+impl Inner {
+    pub fn new(event_connection_factory: ScabbardEventConnectionFactory) -> Self {
+        Self {
+            event_connection_factory,
+            processors: HashMap::new(),
+        }
+    }
+
+    pub fn add_once<F>(
+        &mut self,
+        circuit_id: &str,
+        service_id: &str,
+        last_seen_id: Option<&str>,
+        factory_fn: F,
+    ) -> Result<(), InternalError>
+    where
+        F: Fn() -> Vec<Box<dyn EventHandler>>,
+    {
+        let key = format!("{}::{}", circuit_id, service_id);
+        if let Entry::Vacant(entry) = self.processors.entry(key) {
+            let event_connection = self
+                .event_connection_factory
+                .create_connection(circuit_id, service_id)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+            let evt_processor = EventProcessor::start(event_connection, last_seen_id, factory_fn())
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+            entry.insert(evt_processor);
+        }
+
+        Ok(())
+    }
+}

--- a/daemon/src/splinter/run.rs
+++ b/daemon/src/splinter/run.rs
@@ -45,12 +45,35 @@ use splinter::events::Reactor;
 use crate::config::GridConfig;
 use crate::database::ConnectionPool;
 use crate::error::DaemonError;
-use crate::event::{db_handler::DatabaseEventHandler, EventHandler};
+use crate::event::{db_handler::DatabaseEventHandler, CommitEvent, EventError, EventHandler};
 use crate::rest_api;
 
 use super::{
     app_auth_handler, event::processors::EventProcessors, event::ScabbardEventConnectionFactory,
 };
+
+enum EventCmd {
+    Event(CommitEvent),
+    Exit,
+}
+
+struct ChannelEventHandler {
+    sender: std::sync::mpsc::Sender<EventCmd>,
+}
+
+impl EventHandler for ChannelEventHandler {
+    fn handle_event(&self, event: &CommitEvent) -> Result<(), EventError> {
+        self.sender
+            .send(EventCmd::Event(event.clone()))
+            .map_err(|_| EventError("Unable to send event due to closed channel".into()))
+    }
+
+    fn cloned_box(&self) -> Box<dyn EventHandler> {
+        Box::new(ChannelEventHandler {
+            sender: self.sender.clone(),
+        })
+    }
+}
 
 pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
     let splinter_endpoint = Endpoint::from(config.endpoint());
@@ -73,11 +96,7 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
     ));
 
     #[cfg(any(feature = "database-postgres", feature = "database-sqlite"))]
-    let (store_state, db_handler, previous_commits): (
-        _,
-        Box<dyn EventHandler + Sync + 'static>,
-        Vec<Commit>,
-    ) = {
+    let (store_state, db_handler, previous_commits): (_, Box<dyn EventHandler>, Vec<Commit>) = {
         let connection_uri = config
             .database_url()
             .parse()
@@ -121,6 +140,26 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
         }
     };
 
+    let (event_tx, event_rx) = std::sync::mpsc::channel();
+    let chan_event_handler: Box<dyn EventHandler> = Box::new(ChannelEventHandler {
+        sender: event_tx.clone(),
+    });
+
+    let db_event_handler_join_handler = std::thread::Builder::new()
+        .name("db-event-handler-splinter".into())
+        .spawn(move || loop {
+            match event_rx.recv() {
+                Ok(EventCmd::Event(evt)) => {
+                    if let Err(err) = db_handler.handle_event(&evt) {
+                        error!("{}", err.to_string());
+                    }
+                }
+                Ok(EventCmd::Exit) => break,
+                Err(_) => break,
+            }
+        })
+        .map_err(|_| DaemonError::with_message("Unable to spawn db handler thread"))?;
+
     for commit in previous_commits {
         if let Some(service_id) = commit.service_id {
             let service_id = match ServiceId::try_from(service_id.deref()) {
@@ -144,7 +183,7 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
                     service_id.circuit_id,
                     service_id.service_id,
                     Some(&commit.commit_id),
-                    || vec![db_handler.cloned_box()],
+                    || vec![chan_event_handler.cloned_box()],
                 )
                 .map_err(|err| DaemonError::from_source(Box::new(err)))?;
         }
@@ -153,7 +192,7 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
     app_auth_handler::run(
         splinter_endpoint.url(),
         event_processors,
-        db_handler,
+        chan_event_handler,
         reactor.igniter(),
         scabbard_admin_key.to_string(),
     )
@@ -203,6 +242,12 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
 
         #[cfg(feature = "rest-api")]
         rest_api_shutdown_handle.shutdown();
+        if let Err(err) = event_tx.send(EventCmd::Exit) {
+            error!(
+                "Unable to signal shutdown to the DB event handler thread: {}",
+                err
+            );
+        }
     })
     .map_err(|err| DaemonError::from_source(Box::new(err)))?;
 
@@ -211,6 +256,10 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
         .join()
         .map_err(|_| DaemonError::with_message("Unable to cleanly join the REST API thread"))
         .and_then(|res| res.map_err(|err| DaemonError::from_source(Box::new(err))))?;
+
+    if db_event_handler_join_handler.join().is_err() {
+        error!("Unable to cleanly join the DB event handler thread");
+    }
 
     if let Err(err) = reactor.wait_for_shutdown() {
         error!("Unable to shutdown splinter event reactor: {}", err);


### PR DESCRIPTION
This PR introduces an EventProcessors struct to manages that event processors are only created once per circuit/service instance.

It also introduces a work-around for an issue with database transaction creation while handling commit events. It serializes the events received from event processors into a channel and handle the events serially.  This fix ensures that duplicate events won't result in duplicate entries in the DB.  This second commit may be rolled back when a proper fix for transactions is introduced.