### PR TITLE
Refactor SDE transaction handling

### DIFF
--- a/daemon/src/database/mod.rs
+++ b/daemon/src/database/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Cargill Incorporated
+ * Copyright 2019-2021 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,15 +50,6 @@ impl<C: diesel::Connection> ConnectionPool<C> {
                 }
             })?,
         })
-    }
-
-    pub fn get(&self) -> Result<PooledConnection<ConnectionManager<C>>, DatabaseError> {
-        self.pool
-            .get()
-            .map_err(|err| DatabaseError::ConnectionError {
-                context: "Failed to get Connection from connection pool".to_string(),
-                source: Box::new(err),
-            })
     }
 }
 

--- a/daemon/src/event/error.rs
+++ b/daemon/src/event/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Cargill Incorporated
+ * Copyright 2019-2021 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 
 use std::error::Error;
 use std::fmt;
+
+use grid_sdk::error::InternalError;
 
 use grid_sdk::commits::store::CommitStoreError;
 #[cfg(feature = "location")]
@@ -49,6 +51,12 @@ impl Error for EventError {}
 impl fmt::Display for EventError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Event Error: {}", self.0)
+    }
+}
+
+impl From<InternalError> for EventError {
+    fn from(err: InternalError) -> Self {
+        EventError(format!("{}", err))
     }
 }
 

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2019 Bitwise IO, Inc.
+// Copyright 2020-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/daemon/src/sawtooth/run.rs
+++ b/daemon/src/sawtooth/run.rs
@@ -70,10 +70,13 @@ pub fn run_sawtooth(config: GridConfig) -> Result<(), DaemonError> {
                 let connection_pool: ConnectionPool<diesel::pg::PgConnection> =
                     ConnectionPool::new(config.database_url())
                         .map_err(|err| DaemonError::from_source(Box::new(err)))?;
+                let store_factory = create_store_factory(&connection_uri)
+                    .map_err(|err| DaemonError::from_source(Box::new(err)))?;
+                let event_handler = DatabaseEventHandler::new(store_factory);
                 let evt_processor = EventProcessor::start(
                     sawtooth_connection,
                     current_commit.as_deref(),
-                    event_handlers![DatabaseEventHandler::from_pg_pool(connection_pool.clone())],
+                    event_handlers![event_handler],
                 )
                 .map_err(|err| DaemonError::from_source(Box::new(err)))?;
 
@@ -87,12 +90,13 @@ pub fn run_sawtooth(config: GridConfig) -> Result<(), DaemonError> {
                 let connection_pool: ConnectionPool<diesel::sqlite::SqliteConnection> =
                     ConnectionPool::new(config.database_url())
                         .map_err(|err| DaemonError::from_source(Box::new(err)))?;
+                let store_factory = create_store_factory(&connection_uri)
+                    .map_err(|err| DaemonError::from_source(Box::new(err)))?;
+                let event_handler = DatabaseEventHandler::new(store_factory);
                 let evt_processor = EventProcessor::start(
                     sawtooth_connection,
                     current_commit.as_deref(),
-                    event_handlers![DatabaseEventHandler::from_sqlite_pool(
-                        connection_pool.clone()
-                    )],
+                    event_handlers![event_handler],
                 )
                 .map_err(|err| DaemonError::from_source(Box::new(err)))?;
 

--- a/griddle/src/main.rs
+++ b/griddle/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -193,7 +193,7 @@ async fn run() -> Result<(), Error> {
 
     let batch_submitter = batch_submitter(Endpoint::from(connect.as_ref()));
     let batch_processor =
-        BatchProcessorBuilder::new(store_state.batch_store.clone(), batch_submitter);
+        BatchProcessorBuilder::new(store_state.store_factory.clone_box(), batch_submitter);
 
     batch_processor
         .start()

--- a/sdk/src/batches/store/mod.rs
+++ b/sdk/src/batches/store/mod.rs
@@ -22,7 +22,7 @@ use crate::hex;
 use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
-pub use self::diesel::DieselBatchStore;
+pub use self::diesel::{DieselBatchStore, DieselConnectionBatchStore};
 pub use error::BatchStoreError;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -123,7 +123,7 @@ impl BatchList {
     }
 }
 
-pub trait BatchStore: Send + Sync {
+pub trait BatchStore {
     /// Adds a batch to the underlying storage
     ///
     /// # Arguments

--- a/sdk/src/batches/store/mod.rs
+++ b/sdk/src/batches/store/mod.rs
@@ -191,3 +191,45 @@ pub trait BatchStore: Send + Sync {
     ///  * `id` - The id of the batch to update
     fn relinquish_claim(&self, id: &str) -> Result<(), BatchStoreError>;
 }
+
+impl<BS> BatchStore for Box<BS>
+where
+    BS: BatchStore + ?Sized,
+{
+    fn add_batch(&self, batch: Batch) -> Result<(), BatchStoreError> {
+        (**self).add_batch(batch)
+    }
+
+    fn get_batch(&self, id: &str) -> Result<Option<Batch>, BatchStoreError> {
+        (**self).get_batch(id)
+    }
+
+    fn list_batches(&self, offset: i64, limit: i64) -> Result<BatchList, BatchStoreError> {
+        (**self).list_batches(offset, limit)
+    }
+
+    fn get_unclaimed_batches(
+        &self,
+        limit: i64,
+        secs_claim_is_valid: i64,
+    ) -> Result<Vec<BatchSubmitInfo>, BatchStoreError> {
+        (**self).get_unclaimed_batches(limit, secs_claim_is_valid)
+    }
+
+    fn change_batch_to_submitted(&self, id: &str) -> Result<(), BatchStoreError> {
+        (**self).change_batch_to_submitted(id)
+    }
+
+    fn update_submission_error_info(
+        &self,
+        id: &str,
+        error: &str,
+        error_message: &str,
+    ) -> Result<(), BatchStoreError> {
+        (**self).update_submission_error_info(id, error, error_message)
+    }
+
+    fn relinquish_claim(&self, id: &str) -> Result<(), BatchStoreError> {
+        (**self).relinquish_claim(id)
+    }
+}

--- a/sdk/src/commits/store/mod.rs
+++ b/sdk/src/commits/store/mod.rs
@@ -17,7 +17,7 @@ pub(in crate) mod diesel;
 mod error;
 
 #[cfg(feature = "diesel")]
-pub use self::diesel::DieselCommitStore;
+pub use self::diesel::{DieselCommitStore, DieselConnectionCommitStore};
 pub use error::CommitStoreError;
 
 /// Represents a Grid commit
@@ -56,7 +56,7 @@ pub struct CommitEvent {
     pub state_changes: Vec<StateChange>,
 }
 
-pub trait CommitStore: Send + Sync {
+pub trait CommitStore {
     /// Adds an commit to the underlying storage
     ///
     /// # Arguments

--- a/sdk/src/location/store/mod.rs
+++ b/sdk/src/location/store/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ mod error;
 use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
-pub use self::diesel::DieselLocationStore;
+pub use self::diesel::{DieselConnectionLocationStore, DieselLocationStore};
 pub use error::LocationStoreError;
 
 /// Represents a Grid Location
@@ -75,7 +75,7 @@ pub struct LatLong;
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct LatLongValue(pub i64, pub i64);
 
-pub trait LocationStore: Send + Sync {
+pub trait LocationStore {
     /// Adds a location to the underlying storage
     ///
     /// # Arguments

--- a/sdk/src/pike/store/mod.rs
+++ b/sdk/src/pike/store/mod.rs
@@ -33,7 +33,7 @@ mod error;
 use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
-pub use self::diesel::DieselPikeStore;
+pub use self::diesel::{DieselConnectionPikeStore, DieselPikeStore};
 pub use builder::{
     AgentBuilder, AlternateIdBuilder, OrganizationBuilder, OrganizationMetadataBuilder, RoleBuilder,
 };
@@ -352,7 +352,7 @@ impl OrganizationMetadata {
     }
 }
 
-pub trait PikeStore: Send + Sync {
+pub trait PikeStore {
     /// Adds an agent to the underlying storage
     ///
     /// # Arguments

--- a/sdk/src/product/store/mod.rs
+++ b/sdk/src/product/store/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ pub mod error;
 use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
-pub use self::diesel::DieselProductStore;
+pub use self::diesel::{DieselConnectionProductStore, DieselProductStore};
 pub use error::{ProductBuilderError, ProductStoreError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -509,7 +509,7 @@ pub struct LatLongValue {
     pub longitude: i64,
 }
 
-pub trait ProductStore: Send + Sync {
+pub trait ProductStore {
     /// Adds a product to the underlying storage
     ///
     /// # Arguments

--- a/sdk/src/product/store/mod.rs
+++ b/sdk/src/product/store/mod.rs
@@ -569,3 +569,46 @@ pub trait ProductStore: Send + Sync {
         current_commit_num: i64,
     ) -> Result<(), ProductStoreError>;
 }
+
+impl<PS> ProductStore for Box<PS>
+where
+    PS: ProductStore + ?Sized,
+{
+    fn add_product(&self, product: Product) -> Result<(), ProductStoreError> {
+        (**self).add_product(product)
+    }
+
+    fn get_product(
+        &self,
+        product_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<Product>, ProductStoreError> {
+        (**self).get_product(product_id, service_id)
+    }
+
+    fn list_products(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<ProductList, ProductStoreError> {
+        (**self).list_products(service_id, offset, limit)
+    }
+
+    fn update_product(
+        &self,
+        product_id: &str,
+        service_id: Option<&str>,
+        current_commit_num: i64,
+    ) -> Result<(), ProductStoreError> {
+        (**self).update_product(product_id, service_id, current_commit_num)
+    }
+
+    fn delete_product(
+        &self,
+        address: &str,
+        current_commit_num: i64,
+    ) -> Result<(), ProductStoreError> {
+        (**self).delete_product(address, current_commit_num)
+    }
+}

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -19,7 +19,7 @@ mod error;
 use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
-pub use self::diesel::DieselPurchaseOrderStore;
+pub use self::diesel::{DieselConnectionPurchaseOrderStore, DieselPurchaseOrderStore};
 pub use error::PurchaseOrderStoreError;
 
 /// Represents a list of Grid Purchase Orders
@@ -92,7 +92,7 @@ pub struct PurchaseOrderAlternateId {
     pub service_id: Option<String>,
 }
 
-pub trait PurchaseOrderStore: Send + Sync {
+pub trait PurchaseOrderStore {
     /// Adds a purchase order to the underlying storage
     ///
     /// # Arguments

--- a/sdk/src/rest_api/actix_web_3/routes/agents.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/agents.rs
@@ -24,21 +24,20 @@ use super::DEFAULT_GRID_PROTOCOL_VERSION;
 
 #[get("/agent/{public_key}")]
 pub async fn get_agent(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     public_key: web::Path<String>,
     query: web::Query<QueryServiceId>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_pike_store();
     match version {
         ProtocolVersion::V1 => {
             match v1::get_agent(
-                state.pike_store.clone(),
+                store,
                 public_key.into_inner(),
                 query.into_inner().service_id.as_deref(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -52,24 +51,23 @@ pub async fn get_agent(
 
 #[get("/agent")]
 pub async fn list_agents(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_pike_store();
     match version {
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
             match v1::list_agents(
-                state.pike_store.clone(),
+                store,
                 service_id.as_deref(),
                 paging.offset(),
                 paging.limit(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/locations.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/locations.rs
@@ -24,21 +24,20 @@ use super::DEFAULT_GRID_PROTOCOL_VERSION;
 
 #[get("/location/{id}")]
 pub async fn get_location(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     location_id: web::Path<String>,
     query: web::Query<QueryServiceId>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_location_store();
     match version {
         ProtocolVersion::V1 => {
             match v1::get_location(
-                state.location_store.clone(),
+                store,
                 location_id.into_inner(),
                 query.into_inner().service_id.as_deref(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -52,24 +51,23 @@ pub async fn get_location(
 
 #[get("/location")]
 pub async fn list_locations(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_location_store();
     match version {
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
             match v1::list_locations(
-                state.location_store.clone(),
+                store,
                 service_id.as_deref(),
                 paging.offset(),
                 paging.limit(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/organizations.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/organizations.rs
@@ -28,21 +28,20 @@ pub enum ProtocolVersion {
 
 #[get("/organization/{id}")]
 pub async fn get_organization(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     id: web::Path<String>,
     query: web::Query<QueryServiceId>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_pike_store();
     match version {
         ProtocolVersion::V1 => {
             match v1::get_organization(
-                state.pike_store.clone(),
+                store,
                 id.into_inner(),
                 query.into_inner().service_id.as_deref(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -56,24 +55,23 @@ pub async fn get_organization(
 
 #[get("/organization")]
 pub async fn list_organizations(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
     _: AcceptServiceIdParam,
     version: ProtocolVersion,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_pike_store();
     match version {
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
             match v1::list_organizations(
-                state.pike_store.clone(),
+                store,
                 service_id.as_deref(),
                 paging.offset(),
                 paging.limit(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/products.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/products.rs
@@ -24,21 +24,20 @@ use super::DEFAULT_GRID_PROTOCOL_VERSION;
 
 #[get("/product/{id}")]
 pub async fn get_product(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     product_id: web::Path<String>,
     query: web::Query<QueryServiceId>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_product_store();
     match version {
         ProtocolVersion::V1 => {
             match v1::get_product(
-                state.product_store.clone(),
+                store,
                 product_id.into_inner(),
                 query.into_inner().service_id.as_deref(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -52,24 +51,23 @@ pub async fn get_product(
 
 #[get("/product")]
 pub async fn list_products(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_product_store();
     match version {
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
             match v1::list_products(
-                state.product_store.clone(),
+                store,
                 service_id.as_deref(),
                 paging.offset(),
                 paging.limit(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
@@ -29,27 +29,26 @@ pub struct QueryOrgId {
 
 #[get("/purchase-order")]
 pub async fn list_purchase_orders(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     query_org_id: web::Query<QueryOrgId>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_purchase_order_store();
     match version {
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let org_id = query_org_id.into_inner().org_id;
             let service_id = query_service_id.into_inner().service_id;
             match v1::list_purchase_orders(
-                state.purchase_order_store.clone(),
-                org_id.clone(),
+                store,
+                org_id,
                 service_id.as_deref(),
                 paging.offset(),
                 paging.limit(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -63,21 +62,20 @@ pub async fn list_purchase_orders(
 
 #[get("/purchase-order/{uuid}")]
 pub async fn get_purchase_order(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     uuid: web::Path<String>,
     query_service_id: web::Query<QueryServiceId>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_purchase_order_store();
     match version {
         ProtocolVersion::V1 => {
             match v1::get_purchase_order(
-                state.purchase_order_store.clone(),
+                store,
                 uuid.into_inner(),
                 query_service_id.into_inner().service_id.as_deref(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -91,7 +89,7 @@ pub async fn get_purchase_order(
 
 #[get("/purchase-order/{uuid}/versions")]
 pub async fn list_purchase_order_versions(
-    _state: web::Data<StoreState>,
+    _store_state: web::Data<StoreState>,
     _uuid: web::Path<String>,
     _query: web::Query<QueryServiceId>,
     version: ProtocolVersion,
@@ -104,7 +102,7 @@ pub async fn list_purchase_order_versions(
 
 #[get("/purchase-order/{uuid}/versions/{version_id}")]
 pub async fn get_purchase_order_version(
-    _state: web::Data<StoreState>,
+    _store_state: web::Data<StoreState>,
     _uuid: web::Path<String>,
     _version_id: web::Path<String>,
     _query: web::Query<QueryServiceId>,
@@ -118,7 +116,7 @@ pub async fn get_purchase_order_version(
 
 #[get("/purchase-order/{uuid}/versions/{version_id}/revisions")]
 pub async fn list_purchase_order_version_revisions(
-    _state: web::Data<StoreState>,
+    _store_state: web::Data<StoreState>,
     _uuid: web::Path<String>,
     _version_id: web::Path<String>,
     _query: web::Query<QueryServiceId>,
@@ -132,7 +130,7 @@ pub async fn list_purchase_order_version_revisions(
 
 #[get("/purchase-order/{uuid}/versions/{version_id}/revisions/{revision_number}")]
 pub async fn get_purchase_order_version_revision(
-    _state: web::Data<StoreState>,
+    _store_state: web::Data<StoreState>,
     _uuid: web::Path<String>,
     _version_id: web::Path<String>,
     _revision_number: web::Path<u64>,

--- a/sdk/src/rest_api/actix_web_3/routes/records.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/records.rs
@@ -24,21 +24,20 @@ use super::DEFAULT_GRID_PROTOCOL_VERSION;
 
 #[get("/record/{record_id}")]
 pub async fn get_record(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     record_id: web::Path<String>,
     query: web::Query<QueryServiceId>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_track_and_trace_store();
     match version {
         ProtocolVersion::V1 => {
             match v1::get_record(
-                state.tnt_store.clone(),
+                store,
                 record_id.into_inner(),
                 query.into_inner().service_id.as_deref(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -52,24 +51,23 @@ pub async fn get_record(
 
 #[get("/record")]
 pub async fn list_records(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_track_and_trace_store();
     match version {
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
             match v1::list_records(
-                state.tnt_store.clone(),
+                store,
                 service_id.as_deref(),
                 paging.offset(),
                 paging.limit(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -83,23 +81,22 @@ pub async fn list_records(
 
 #[get("/record/{record_id}/property/{property_name}")]
 pub async fn get_record_property_name(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     path_variables: web::Path<(String, String)>,
     query: web::Query<QueryServiceId>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_track_and_trace_store();
     match version {
         ProtocolVersion::V1 => {
             let (record_id, property_name) = path_variables.into_inner();
             match v1::get_record_property(
-                state.tnt_store.clone(),
+                store,
                 record_id,
                 property_name,
                 query.into_inner().service_id.as_deref(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/roles.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/roles.rs
@@ -23,24 +23,23 @@ use crate::rest_api::{
 use super::DEFAULT_GRID_PROTOCOL_VERSION;
 
 #[get("/role/{org_id}/{name}")]
-pub async fn get_role(
-    state: web::Data<StoreState>,
+pub fn get_role(
+    store_state: web::Data<StoreState>,
     path_variables: web::Path<(String, String)>,
     query: web::Query<QueryServiceId>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_pike_store();
     match version {
         ProtocolVersion::V1 => {
             let (org_id, name) = path_variables.into_inner();
             match v1::get_role(
-                state.pike_store.clone(),
+                store,
                 org_id,
                 name,
                 query.into_inner().service_id.as_deref(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -54,27 +53,26 @@ pub async fn get_role(
 
 #[get("/role/{org_id}")]
 pub async fn list_roles_for_organization(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     org_id: web::Path<String>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_pike_store();
     match version {
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
             let org_id = org_id.into_inner();
             match v1::list_roles_for_organization(
-                state.pike_store.clone(),
+                store,
                 org_id,
                 service_id.as_deref(),
                 paging.offset(),
                 paging.limit(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/schemas.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/schemas.rs
@@ -24,21 +24,20 @@ use super::DEFAULT_GRID_PROTOCOL_VERSION;
 
 #[get("/schema/{name}")]
 pub async fn get_schema(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     name: web::Path<String>,
     query: web::Query<QueryServiceId>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_schema_store();
     match version {
         ProtocolVersion::V1 => {
             match v1::get_schema(
-                state.schema_store.clone(),
+                store,
                 name.into_inner(),
                 query.into_inner().service_id.as_deref(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -52,24 +51,23 @@ pub async fn get_schema(
 
 #[get("/schema")]
 pub async fn list_schemas(
-    state: web::Data<StoreState>,
+    store_state: web::Data<StoreState>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_schema_store();
     match version {
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
             match v1::list_schemas(
-                state.schema_store.clone(),
+                store,
                 service_id.as_deref(),
                 paging.offset(),
                 paging.limit(),
-            )
-            .await
-            {
+            ) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/submit.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/submit.rs
@@ -29,15 +29,10 @@ async fn submit(
     key_state: web::Data<KeyState>,
     version: ProtocolVersion,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_batch_store();
     match version {
         ProtocolVersion::V1(payload) => {
-            match submit_batches(
-                &key_state.key_file_name,
-                store_state.batch_store.clone(),
-                payload,
-            )
-            .await
-            {
+            match submit_batches(&key_state.key_file_name, store, payload) {
                 Ok(res) => HttpResponse::Accepted().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/store_state.rs
+++ b/sdk/src/rest_api/actix_web_3/store_state.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::store::TransactionalStoreFactory;
 #[cfg(any(
     feature = "batch-store",
     feature = "location",
@@ -26,51 +27,14 @@ use std::sync::Arc;
 #[cfg(feature = "diesel")]
 use diesel::r2d2::{ConnectionManager, Pool};
 
-#[cfg(feature = "batch-store")]
-use crate::batches::store::BatchStore;
-#[cfg(all(feature = "diesel", feature = "batch-store"))]
-use crate::batches::store::DieselBatchStore;
-#[cfg(all(feature = "diesel", feature = "location"))]
-use crate::location::store::DieselLocationStore;
-#[cfg(feature = "location")]
-use crate::location::store::LocationStore;
-#[cfg(all(feature = "diesel", feature = "pike"))]
-use crate::pike::store::DieselPikeStore;
-#[cfg(feature = "pike")]
-use crate::pike::store::PikeStore;
-#[cfg(all(feature = "diesel", feature = "product"))]
-use crate::product::store::DieselProductStore;
-#[cfg(feature = "product")]
-use crate::product::store::ProductStore;
-#[cfg(all(feature = "diesel", feature = "purchase-order"))]
-use crate::purchase_order::store::DieselPurchaseOrderStore;
-#[cfg(feature = "purchase-order")]
-use crate::purchase_order::store::PurchaseOrderStore;
-#[cfg(all(feature = "diesel", feature = "schema"))]
-use crate::schema::store::DieselSchemaStore;
-#[cfg(feature = "schema")]
-use crate::schema::store::SchemaStore;
-#[cfg(all(feature = "diesel", feature = "track-and-trace"))]
-use crate::track_and_trace::store::DieselTrackAndTraceStore;
-#[cfg(feature = "track-and-trace")]
-use crate::track_and_trace::store::TrackAndTraceStore;
+#[cfg(feature = "postgres")]
+use crate::store::postgres::PgStoreFactory;
+#[cfg(feature = "sqlite")]
+use crate::store::sqlite::SqliteStoreFactory;
 
 #[derive(Clone)]
 pub struct StoreState {
-    #[cfg(feature = "batch-store")]
-    pub batch_store: Arc<dyn BatchStore>,
-    #[cfg(feature = "location")]
-    pub location_store: Arc<dyn LocationStore>,
-    #[cfg(feature = "pike")]
-    pub pike_store: Arc<dyn PikeStore>,
-    #[cfg(feature = "product")]
-    pub product_store: Arc<dyn ProductStore>,
-    #[cfg(feature = "purchase-order")]
-    pub purchase_order_store: Arc<dyn PurchaseOrderStore>,
-    #[cfg(feature = "schema")]
-    pub schema_store: Arc<dyn SchemaStore>,
-    #[cfg(feature = "track-and-trace")]
-    pub tnt_store: Arc<dyn TrackAndTraceStore>,
+    pub store_factory: Arc<dyn TransactionalStoreFactory>,
 }
 
 #[allow(clippy::redundant_clone)]
@@ -80,36 +44,8 @@ impl StoreState {
     pub fn with_pg_pool(
         connection_pool: Pool<ConnectionManager<diesel::pg::PgConnection>>,
     ) -> Self {
-        #[cfg(feature = "batch-store")]
-        let batch_store = Arc::new(DieselBatchStore::new(connection_pool.clone()));
-        #[cfg(feature = "location")]
-        let location_store = Arc::new(DieselLocationStore::new(connection_pool.clone()));
-        #[cfg(feature = "pike")]
-        let pike_store = Arc::new(DieselPikeStore::new(connection_pool.clone()));
-        #[cfg(feature = "product")]
-        let product_store = Arc::new(DieselProductStore::new(connection_pool.clone()));
-        #[cfg(feature = "purchase-order")]
-        let purchase_order_store = Arc::new(DieselPurchaseOrderStore::new(connection_pool.clone()));
-        #[cfg(feature = "schema")]
-        let schema_store = Arc::new(DieselSchemaStore::new(connection_pool.clone()));
-        #[cfg(feature = "track-and-trace")]
-        let tnt_store = Arc::new(DieselTrackAndTraceStore::new(connection_pool));
-
         Self {
-            #[cfg(feature = "batch-store")]
-            batch_store,
-            #[cfg(feature = "location")]
-            location_store,
-            #[cfg(feature = "pike")]
-            pike_store,
-            #[cfg(feature = "product")]
-            product_store,
-            #[cfg(feature = "purchase-order")]
-            purchase_order_store,
-            #[cfg(feature = "schema")]
-            schema_store,
-            #[cfg(feature = "track-and-trace")]
-            tnt_store,
+            store_factory: Arc::new(PgStoreFactory::new(connection_pool)),
         }
     }
 
@@ -117,36 +53,8 @@ impl StoreState {
     pub fn with_sqlite_pool(
         connection_pool: Pool<ConnectionManager<diesel::sqlite::SqliteConnection>>,
     ) -> Self {
-        #[cfg(feature = "batch-store")]
-        let batch_store = Arc::new(DieselBatchStore::new(connection_pool.clone()));
-        #[cfg(feature = "location")]
-        let location_store = Arc::new(DieselLocationStore::new(connection_pool.clone()));
-        #[cfg(feature = "pike")]
-        let pike_store = Arc::new(DieselPikeStore::new(connection_pool.clone()));
-        #[cfg(feature = "product")]
-        let product_store = Arc::new(DieselProductStore::new(connection_pool.clone()));
-        #[cfg(feature = "purchase-order")]
-        let purchase_order_store = Arc::new(DieselPurchaseOrderStore::new(connection_pool.clone()));
-        #[cfg(feature = "schema")]
-        let schema_store = Arc::new(DieselSchemaStore::new(connection_pool.clone()));
-        #[cfg(feature = "track-and-trace")]
-        let tnt_store = Arc::new(DieselTrackAndTraceStore::new(connection_pool));
-
         Self {
-            #[cfg(feature = "batch-store")]
-            batch_store,
-            #[cfg(feature = "location")]
-            location_store,
-            #[cfg(feature = "pike")]
-            pike_store,
-            #[cfg(feature = "product")]
-            product_store,
-            #[cfg(feature = "purchase-order")]
-            purchase_order_store,
-            #[cfg(feature = "schema")]
-            schema_store,
-            #[cfg(feature = "track-and-trace")]
-            tnt_store,
+            store_factory: Arc::new(SqliteStoreFactory::new(connection_pool)),
         }
     }
 }

--- a/sdk/src/rest_api/resources/agents/v1/handler.rs
+++ b/sdk/src/rest_api/resources/agents/v1/handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 use crate::{
     pike::store::{PikeStore, PikeStoreError},
@@ -22,8 +21,8 @@ use crate::{
 
 use super::payloads::{AgentListSlice, AgentSlice};
 
-pub async fn list_agents(
-    store: Arc<dyn PikeStore>,
+pub fn list_agents<'a>(
+    store: Box<dyn PikeStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
     limit: u16,
@@ -56,8 +55,8 @@ pub async fn list_agents(
     Ok(AgentListSlice { data, paging })
 }
 
-pub async fn get_agent(
-    store: Arc<dyn PikeStore>,
+pub fn get_agent<'a>(
+    store: Box<dyn PikeStore + 'a>,
     public_key: String,
     service_id: Option<&str>,
 ) -> Result<AgentSlice, ErrorResponse> {

--- a/sdk/src/rest_api/resources/locations/v1/handler.rs
+++ b/sdk/src/rest_api/resources/locations/v1/handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 use crate::{
     location::store::{LocationStore, LocationStoreError},
@@ -22,8 +21,8 @@ use crate::{
 
 use super::payloads::{LocationListSlice, LocationSlice};
 
-pub async fn list_locations(
-    store: Arc<dyn LocationStore>,
+pub fn list_locations<'a>(
+    store: Box<dyn LocationStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
     limit: u16,
@@ -61,8 +60,8 @@ pub async fn list_locations(
     Ok(LocationListSlice { data, paging })
 }
 
-pub async fn get_location(
-    store: Arc<dyn LocationStore>,
+pub fn get_location<'a>(
+    store: Box<dyn LocationStore + 'a>,
     location_id: String,
     service_id: Option<&str>,
 ) -> Result<LocationSlice, ErrorResponse> {

--- a/sdk/src/rest_api/resources/organizations/v1/handler.rs
+++ b/sdk/src/rest_api/resources/organizations/v1/handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 use crate::{
     pike::store::{PikeStore, PikeStoreError},
@@ -22,8 +21,8 @@ use crate::{
 
 use super::payloads::{OrganizationListSlice, OrganizationSlice};
 
-pub async fn list_organizations(
-    store: Arc<dyn PikeStore>,
+pub fn list_organizations<'a>(
+    store: Box<dyn PikeStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
     limit: u16,
@@ -56,8 +55,8 @@ pub async fn list_organizations(
     Ok(OrganizationListSlice { data, paging })
 }
 
-pub async fn get_organization(
-    store: Arc<dyn PikeStore>,
+pub fn get_organization<'a>(
+    store: Box<dyn PikeStore + 'a>,
     org_id: String,
     service_id: Option<&str>,
 ) -> Result<OrganizationSlice, ErrorResponse> {

--- a/sdk/src/rest_api/resources/products/v1/handler.rs
+++ b/sdk/src/rest_api/resources/products/v1/handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 use crate::{
     product::store::{ProductStore, ProductStoreError},
@@ -22,8 +21,8 @@ use crate::{
 
 use super::payloads::{ProductListSlice, ProductSlice};
 
-pub async fn list_products(
-    store: Arc<dyn ProductStore>,
+pub fn list_products<'a>(
+    store: Box<dyn ProductStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
     limit: u16,
@@ -56,8 +55,8 @@ pub async fn list_products(
     Ok(ProductListSlice { data, paging })
 }
 
-pub async fn get_product(
-    store: Arc<dyn ProductStore>,
+pub fn get_product<'a>(
+    store: Box<dyn ProductStore + 'a>,
     product_id: String,
     service_id: Option<&str>,
 ) -> Result<ProductSlice, ErrorResponse> {

--- a/sdk/src/rest_api/resources/purchase_order/v1/handler.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 use crate::{
     purchase_order::store::{PurchaseOrderStore, PurchaseOrderStoreError},
@@ -22,8 +21,8 @@ use crate::{
 
 use super::payloads::{PurchaseOrderListSlice, PurchaseOrderSlice};
 
-pub async fn list_purchase_orders(
-    store: Arc<dyn PurchaseOrderStore>,
+pub fn list_purchase_orders<'a>(
+    store: Box<dyn PurchaseOrderStore + 'a>,
     org_id: Option<String>,
     service_id: Option<&str>,
     offset: u64,
@@ -61,8 +60,8 @@ pub async fn list_purchase_orders(
     Ok(PurchaseOrderListSlice { data, paging })
 }
 
-pub async fn get_purchase_order(
-    store: Arc<dyn PurchaseOrderStore>,
+pub fn get_purchase_order<'a>(
+    store: Box<dyn PurchaseOrderStore + 'a>,
     uuid: String,
     service_id: Option<&str>,
 ) -> Result<PurchaseOrderSlice, ErrorResponse> {

--- a/sdk/src/rest_api/resources/roles/v1/handler.rs
+++ b/sdk/src/rest_api/resources/roles/v1/handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 use crate::{
     pike::store::{PikeStore, PikeStoreError},
@@ -22,8 +21,8 @@ use crate::{
 
 use super::payloads::{RoleListSlice, RoleSlice};
 
-pub async fn list_roles_for_organization(
-    store: Arc<dyn PikeStore>,
+pub fn list_roles_for_organization<'a>(
+    store: Box<dyn PikeStore + 'a>,
     org_id: String,
     service_id: Option<&str>,
     offset: u64,
@@ -53,8 +52,8 @@ pub async fn list_roles_for_organization(
     Ok(RoleListSlice { data, paging })
 }
 
-pub async fn get_role(
-    store: Arc<dyn PikeStore>,
+pub fn get_role<'a>(
+    store: Box<dyn PikeStore + 'a>,
     org_id: String,
     name: String,
     service_id: Option<&str>,

--- a/sdk/src/rest_api/resources/schemas/v1/handler.rs
+++ b/sdk/src/rest_api/resources/schemas/v1/handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 use crate::{
     rest_api::resources::{error::ErrorResponse, paging::v1::Paging},
@@ -22,8 +21,8 @@ use crate::{
 
 use super::payloads::{SchemaListSlice, SchemaSlice};
 
-pub async fn list_schemas(
-    store: Arc<dyn SchemaStore>,
+pub fn list_schemas<'a>(
+    store: Box<dyn SchemaStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
     limit: u16,
@@ -56,8 +55,8 @@ pub async fn list_schemas(
     Ok(SchemaListSlice { data, paging })
 }
 
-pub async fn get_schema(
-    store: Arc<dyn SchemaStore>,
+pub fn get_schema<'a>(
+    store: Box<dyn SchemaStore + 'a>,
     name: String,
     service_id: Option<&str>,
 ) -> Result<SchemaSlice, ErrorResponse> {

--- a/sdk/src/rest_api/resources/submit/v1/handler.rs
+++ b/sdk/src/rest_api/resources/submit/v1/handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Instant;
 
 use crypto::digest::Digest;
@@ -37,9 +36,9 @@ const SABRE_NAMESPACE_REGISTRY_PREFIX: &str = "00ec00";
 const SABRE_CONTRACT_REGISTRY_PREFIX: &str = "00ec01";
 const SABRE_CONTRACT_PREFIX: &str = "00ec02";
 
-pub async fn submit_batches(
+pub fn submit_batches<'a>(
     key_file_name: &str,
-    batch_store: Arc<dyn BatchStore>,
+    store: Box<dyn BatchStore + 'a>,
     request: SubmitBatchRequest,
 ) -> Result<SubmitBatchResponse, ErrorResponse> {
     let private_key = load_key(key_file_name, &[PathBuf::from("/etc/grid/keys")])
@@ -59,7 +58,7 @@ pub async fn submit_batches(
     for db_batch in db_batches {
         let id = db_batch.header_signature.clone();
 
-        batch_store.add_batch(db_batch).map_err(|err| match err {
+        store.add_batch(db_batch).map_err(|err| match err {
             BatchStoreError::ConstraintViolationError(err) => {
                 ErrorResponse::new(400, &format!("{}", err))
             }

--- a/sdk/src/rest_api/resources/track_and_trace/v1/handler.rs
+++ b/sdk/src/rest_api/resources/track_and_trace/v1/handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 use crate::{
     rest_api::resources::{error::ErrorResponse, paging::v1::Paging},
@@ -27,8 +26,8 @@ use super::payloads::{
     PropertySlice, PropertyValueSlice, RecordListSlice, RecordSlice, StructPropertyValue,
 };
 
-pub async fn list_records(
-    store: Arc<dyn TrackAndTraceStore>,
+pub fn list_records<'a>(
+    store: Box<dyn TrackAndTraceStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
     limit: u16,
@@ -144,8 +143,8 @@ pub async fn list_records(
     Ok(RecordListSlice { data, paging })
 }
 
-pub async fn get_record(
-    store: Arc<dyn TrackAndTraceStore>,
+pub fn get_record<'a>(
+    store: Box<dyn TrackAndTraceStore + 'a>,
     record_id: String,
     service_id: Option<&str>,
 ) -> Result<RecordSlice, ErrorResponse> {
@@ -230,8 +229,8 @@ pub async fn get_record(
     ))
 }
 
-pub async fn get_record_property(
-    store: Arc<dyn TrackAndTraceStore>,
+pub fn get_record_property<'a>(
+    store: Box<dyn TrackAndTraceStore + 'a>,
     record_id: String,
     property_name: String,
     service_id: Option<&str>,
@@ -257,8 +256,9 @@ pub async fn get_record_property(
     parse_property_slice(&store, &property, &data_type, service_id)
 }
 
-fn parse_property_slice(
-    store: &Arc<dyn TrackAndTraceStore>,
+#[allow(clippy::borrowed_box)]
+fn parse_property_slice<'a>(
+    store: &Box<dyn TrackAndTraceStore + 'a>,
     property: &Property,
     data_type: &Option<String>,
     service_id: Option<&str>,

--- a/sdk/src/schema/store/mod.rs
+++ b/sdk/src/schema/store/mod.rs
@@ -136,3 +136,53 @@ pub trait SchemaStore: Send + Sync {
         service_id: Option<&str>,
     ) -> Result<Option<PropertyDefinition>, SchemaStoreError>;
 }
+
+impl<SS> SchemaStore for Box<SS>
+where
+    SS: SchemaStore + ?Sized,
+{
+    fn add_schema(&self, schema: Schema) -> Result<(), SchemaStoreError> {
+        (**self).add_schema(schema)
+    }
+
+    fn get_schema(
+        &self,
+        name: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<Schema>, SchemaStoreError> {
+        (**self).get_schema(name, service_id)
+    }
+
+    fn list_schemas(
+        &self,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<SchemaList, SchemaStoreError> {
+        (**self).list_schemas(service_id, offset, limit)
+    }
+
+    fn list_property_definitions(
+        &self,
+        service_id: Option<&str>,
+    ) -> Result<Vec<PropertyDefinition>, SchemaStoreError> {
+        (**self).list_property_definitions(service_id)
+    }
+
+    fn list_property_definitions_with_schema_name(
+        &self,
+        schema_name: &str,
+        service_id: Option<&str>,
+    ) -> Result<Vec<PropertyDefinition>, SchemaStoreError> {
+        (**self).list_property_definitions_with_schema_name(schema_name, service_id)
+    }
+
+    fn get_property_definition_by_name(
+        &self,
+        schema_name: &str,
+        definition_name: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PropertyDefinition>, SchemaStoreError> {
+        (**self).get_property_definition_by_name(schema_name, definition_name, service_id)
+    }
+}

--- a/sdk/src/schema/store/mod.rs
+++ b/sdk/src/schema/store/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ mod error;
 use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
-pub use self::diesel::DieselSchemaStore;
+pub use self::diesel::{DieselConnectionSchemaStore, DieselSchemaStore};
 pub use error::SchemaStoreError;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -65,7 +65,7 @@ impl SchemaList {
     }
 }
 
-pub trait SchemaStore: Send + Sync {
+pub trait SchemaStore {
     /// Adds a new schema to underlying storage
     ///
     /// # Arguments

--- a/sdk/src/store/postgres.rs
+++ b/sdk/src/store/postgres.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,27 +13,37 @@
 // limitations under the License.
 
 use diesel::{
+    connection::TransactionManager,
     pg::PgConnection,
-    r2d2::{ConnectionManager, Pool},
+    r2d2::{ConnectionManager, Pool, PooledConnection},
+    Connection,
 };
 
 #[cfg(feature = "batch-store")]
-use crate::batches::store::{BatchStore, DieselBatchStore};
-use crate::commits::store::{CommitStore, DieselCommitStore};
+use crate::batches::store::{BatchStore, DieselBatchStore, DieselConnectionBatchStore};
+use crate::commits::store::{CommitStore, DieselCommitStore, DieselConnectionCommitStore};
+use crate::error::InternalError;
 #[cfg(feature = "location")]
-use crate::location::store::{DieselLocationStore, LocationStore};
+use crate::location::store::{DieselConnectionLocationStore, DieselLocationStore, LocationStore};
 #[cfg(feature = "pike")]
-use crate::pike::store::{DieselPikeStore, PikeStore};
+use crate::pike::store::{DieselConnectionPikeStore, DieselPikeStore, PikeStore};
 #[cfg(feature = "product")]
-use crate::product::store::{DieselProductStore, ProductStore};
+use crate::product::store::{DieselConnectionProductStore, DieselProductStore, ProductStore};
+#[cfg(feature = "purchase-order")]
+use crate::purchase_order::store::{
+    DieselConnectionPurchaseOrderStore, DieselPurchaseOrderStore, PurchaseOrderStore,
+};
 #[cfg(feature = "schema")]
-use crate::schema::store::{DieselSchemaStore, SchemaStore};
+use crate::schema::store::{DieselConnectionSchemaStore, DieselSchemaStore, SchemaStore};
 #[cfg(feature = "track-and-trace")]
-use crate::track_and_trace::store::{DieselTrackAndTraceStore, TrackAndTraceStore};
+use crate::track_and_trace::store::{
+    DieselConnectionTrackAndTraceStore, DieselTrackAndTraceStore, TrackAndTraceStore,
+};
 
-use super::StoreFactory;
+use super::{InContextStoreFactory, StoreFactory, TransactionalStoreFactory};
 
 /// A `StoryFactory` backed by a PostgreSQL database.
+#[derive(Clone)]
 pub struct PgStoreFactory {
     pool: Pool<ConnectionManager<PgConnection>>,
 }
@@ -45,37 +55,134 @@ impl PgStoreFactory {
 }
 
 impl StoreFactory for PgStoreFactory {
-    fn get_grid_commit_store(&self) -> Box<dyn CommitStore> {
+    fn get_grid_commit_store<'a>(&'a self) -> Box<dyn CommitStore + 'a> {
         Box::new(DieselCommitStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "pike")]
-    fn get_grid_pike_store(&self) -> Box<dyn PikeStore> {
+    fn get_grid_pike_store<'a>(&'a self) -> Box<dyn PikeStore + 'a> {
         Box::new(DieselPikeStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "location")]
-    fn get_grid_location_store(&self) -> Box<dyn LocationStore> {
+    fn get_grid_location_store<'a>(&'a self) -> Box<dyn LocationStore + 'a> {
         Box::new(DieselLocationStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "product")]
-    fn get_grid_product_store(&self) -> Box<dyn ProductStore> {
+    fn get_grid_product_store<'a>(&'a self) -> Box<dyn ProductStore + 'a> {
         Box::new(DieselProductStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "schema")]
-    fn get_grid_schema_store(&self) -> Box<dyn SchemaStore> {
+    fn get_grid_schema_store<'a>(&'a self) -> Box<dyn SchemaStore + 'a> {
         Box::new(DieselSchemaStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "track-and-trace")]
-    fn get_grid_track_and_trace_store(&self) -> Box<dyn TrackAndTraceStore> {
+    fn get_grid_track_and_trace_store<'a>(&'a self) -> Box<dyn TrackAndTraceStore + 'a> {
         Box::new(DieselTrackAndTraceStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "batch-store")]
-    fn get_batch_store(&self) -> Box<dyn BatchStore> {
+    fn get_batch_store<'a>(&'a self) -> Box<dyn BatchStore + 'a> {
         Box::new(DieselBatchStore::new(self.pool.clone()))
+    }
+
+    #[cfg(feature = "purchase-order")]
+    fn get_grid_purchase_order_store<'a>(&'a self) -> Box<dyn PurchaseOrderStore + 'a> {
+        Box::new(DieselPurchaseOrderStore::new(self.pool.clone()))
+    }
+}
+
+impl TransactionalStoreFactory for PgStoreFactory {
+    fn begin_transaction<'a>(&self) -> Result<Box<dyn InContextStoreFactory<'a>>, InternalError> {
+        let conn = self
+            .pool
+            .get()
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        let store_factory = InContextPgStoreFactory::new(conn);
+        store_factory
+            .conn
+            .transaction_manager()
+            .begin_transaction(&store_factory.conn)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+        Ok(Box::new(store_factory))
+    }
+
+    fn clone_box(&self) -> Box<dyn TransactionalStoreFactory> {
+        Box::new(self.clone())
+    }
+}
+
+pub struct InContextPgStoreFactory {
+    conn: PooledConnection<ConnectionManager<PgConnection>>,
+}
+
+impl InContextPgStoreFactory {
+    fn new(conn: PooledConnection<ConnectionManager<PgConnection>>) -> Self {
+        Self { conn }
+    }
+}
+
+impl StoreFactory for InContextPgStoreFactory {
+    fn get_grid_commit_store<'a>(&'a self) -> Box<dyn CommitStore + 'a> {
+        Box::new(DieselConnectionCommitStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "pike")]
+    fn get_grid_pike_store<'a>(&'a self) -> Box<dyn PikeStore + 'a> {
+        Box::new(DieselConnectionPikeStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "location")]
+    fn get_grid_location_store<'a>(&'a self) -> Box<dyn LocationStore + 'a> {
+        Box::new(DieselConnectionLocationStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "product")]
+    fn get_grid_product_store<'a>(&'a self) -> Box<dyn ProductStore + 'a> {
+        Box::new(DieselConnectionProductStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "schema")]
+    fn get_grid_schema_store<'a>(&'a self) -> Box<dyn SchemaStore + 'a> {
+        Box::new(DieselConnectionSchemaStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "track-and-trace")]
+    fn get_grid_track_and_trace_store<'a>(&'a self) -> Box<dyn TrackAndTraceStore + 'a> {
+        Box::new(DieselConnectionTrackAndTraceStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "batch-store")]
+    fn get_batch_store<'a>(&'a self) -> Box<dyn BatchStore + 'a> {
+        Box::new(DieselConnectionBatchStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "purchase-order")]
+    fn get_grid_purchase_order_store<'a>(&'a self) -> Box<dyn PurchaseOrderStore + 'a> {
+        Box::new(DieselConnectionPurchaseOrderStore::new(&*self.conn))
+    }
+}
+
+impl<'a> InContextStoreFactory<'a> for InContextPgStoreFactory {
+    fn commit(&self) -> Result<(), InternalError> {
+        let transaction_manager = self.conn.transaction_manager();
+        transaction_manager
+            .commit_transaction(&self.conn)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        Ok(())
+    }
+
+    fn rollback(&self) -> Result<(), InternalError> {
+        let transaction_manager = self.conn.transaction_manager();
+        transaction_manager
+            .rollback_transaction(&self.conn)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        Ok(())
     }
 }

--- a/sdk/src/store/sqlite.rs
+++ b/sdk/src/store/sqlite.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,69 +13,176 @@
 // limitations under the License.
 
 use diesel::{
-    r2d2::{ConnectionManager, Pool},
+    connection::TransactionManager,
+    r2d2::{ConnectionManager, Pool, PooledConnection},
     sqlite::SqliteConnection,
+    Connection,
 };
 
 #[cfg(feature = "batch-store")]
-use crate::batches::store::{BatchStore, DieselBatchStore};
-use crate::commits::store::{CommitStore, DieselCommitStore};
+use crate::batches::store::{BatchStore, DieselBatchStore, DieselConnectionBatchStore};
+use crate::commits::store::{CommitStore, DieselCommitStore, DieselConnectionCommitStore};
+use crate::error::InternalError;
 #[cfg(feature = "location")]
-use crate::location::store::{DieselLocationStore, LocationStore};
+use crate::location::store::{DieselConnectionLocationStore, DieselLocationStore, LocationStore};
 #[cfg(feature = "pike")]
-use crate::pike::store::{DieselPikeStore, PikeStore};
+use crate::pike::store::{DieselConnectionPikeStore, DieselPikeStore, PikeStore};
 #[cfg(feature = "product")]
-use crate::product::store::{DieselProductStore, ProductStore};
+use crate::product::store::{DieselConnectionProductStore, DieselProductStore, ProductStore};
+#[cfg(feature = "purchase-order")]
+use crate::purchase_order::store::{
+    DieselConnectionPurchaseOrderStore, DieselPurchaseOrderStore, PurchaseOrderStore,
+};
 #[cfg(feature = "schema")]
-use crate::schema::store::{DieselSchemaStore, SchemaStore};
+use crate::schema::store::{DieselConnectionSchemaStore, DieselSchemaStore, SchemaStore};
 #[cfg(feature = "track-and-trace")]
-use crate::track_and_trace::store::{DieselTrackAndTraceStore, TrackAndTraceStore};
+use crate::track_and_trace::store::{
+    DieselConnectionTrackAndTraceStore, DieselTrackAndTraceStore, TrackAndTraceStore,
+};
 
-use super::StoreFactory;
+use super::{InContextStoreFactory, StoreFactory, TransactionalStoreFactory};
 
 /// A `StoryFactory` backed by a SQLite database.
+#[derive(Clone)]
 pub struct SqliteStoreFactory {
     pool: Pool<ConnectionManager<SqliteConnection>>,
 }
 
-impl SqliteStoreFactory {
+impl<'a> SqliteStoreFactory {
     pub fn new(pool: Pool<ConnectionManager<SqliteConnection>>) -> Self {
         Self { pool }
     }
 }
 
 impl StoreFactory for SqliteStoreFactory {
-    fn get_grid_commit_store(&self) -> Box<dyn CommitStore> {
+    fn get_grid_commit_store<'a>(&'a self) -> Box<dyn CommitStore + 'a> {
         Box::new(DieselCommitStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "pike")]
-    fn get_grid_pike_store(&self) -> Box<dyn PikeStore> {
+    fn get_grid_pike_store<'a>(&'a self) -> Box<dyn PikeStore + 'a> {
         Box::new(DieselPikeStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "location")]
-    fn get_grid_location_store(&self) -> Box<dyn LocationStore> {
+    fn get_grid_location_store<'a>(&'a self) -> Box<dyn LocationStore + 'a> {
         Box::new(DieselLocationStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "product")]
-    fn get_grid_product_store(&self) -> Box<dyn ProductStore> {
+    fn get_grid_product_store<'a>(&'a self) -> Box<dyn ProductStore + 'a> {
         Box::new(DieselProductStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "schema")]
-    fn get_grid_schema_store(&self) -> Box<dyn SchemaStore> {
+    fn get_grid_schema_store<'a>(&'a self) -> Box<dyn SchemaStore + 'a> {
         Box::new(DieselSchemaStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "track-and-trace")]
-    fn get_grid_track_and_trace_store(&self) -> Box<dyn TrackAndTraceStore> {
+    fn get_grid_track_and_trace_store<'a>(&'a self) -> Box<dyn TrackAndTraceStore + 'a> {
         Box::new(DieselTrackAndTraceStore::new(self.pool.clone()))
     }
 
     #[cfg(feature = "batch-store")]
-    fn get_batch_store(&self) -> Box<dyn BatchStore> {
+    fn get_batch_store<'a>(&'a self) -> Box<dyn BatchStore + 'a> {
         Box::new(DieselBatchStore::new(self.pool.clone()))
+    }
+
+    #[cfg(feature = "purchase-order")]
+    fn get_grid_purchase_order_store<'a>(&'a self) -> Box<dyn PurchaseOrderStore + 'a> {
+        Box::new(DieselPurchaseOrderStore::new(self.pool.clone()))
+    }
+}
+
+impl TransactionalStoreFactory for SqliteStoreFactory {
+    fn begin_transaction<'a>(&self) -> Result<Box<dyn InContextStoreFactory<'a>>, InternalError> {
+        let conn = self
+            .pool
+            .get()
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        let store_factory = InContextSqliteStoreFactory::new(conn);
+        store_factory
+            .conn
+            .transaction_manager()
+            .begin_transaction(&store_factory.conn)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+        Ok(Box::new(store_factory))
+    }
+
+    fn clone_box(&self) -> Box<dyn TransactionalStoreFactory> {
+        Box::new(self.clone())
+    }
+}
+
+pub struct InContextSqliteStoreFactory {
+    conn: PooledConnection<ConnectionManager<SqliteConnection>>,
+}
+
+impl InContextSqliteStoreFactory {
+    fn new(conn: PooledConnection<ConnectionManager<SqliteConnection>>) -> Self {
+        Self { conn }
+    }
+}
+
+impl StoreFactory for InContextSqliteStoreFactory {
+    fn get_grid_commit_store<'a>(&'a self) -> Box<dyn CommitStore + 'a> {
+        Box::new(DieselConnectionCommitStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "pike")]
+    fn get_grid_pike_store<'a>(&'a self) -> Box<dyn PikeStore + 'a> {
+        Box::new(DieselConnectionPikeStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "location")]
+    fn get_grid_location_store<'a>(&'a self) -> Box<dyn LocationStore + 'a> {
+        Box::new(DieselConnectionLocationStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "product")]
+    fn get_grid_product_store<'a>(&'a self) -> Box<dyn ProductStore + 'a> {
+        Box::new(DieselConnectionProductStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "schema")]
+    fn get_grid_schema_store<'a>(&'a self) -> Box<dyn SchemaStore + 'a> {
+        Box::new(DieselConnectionSchemaStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "track-and-trace")]
+    fn get_grid_track_and_trace_store<'a>(&'a self) -> Box<dyn TrackAndTraceStore + 'a> {
+        Box::new(DieselConnectionTrackAndTraceStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "batch-store")]
+    fn get_batch_store<'a>(&'a self) -> Box<dyn BatchStore + 'a> {
+        Box::new(DieselConnectionBatchStore::new(&*self.conn))
+    }
+
+    #[cfg(feature = "purchase-order")]
+    fn get_grid_purchase_order_store<'a>(&'a self) -> Box<dyn PurchaseOrderStore + 'a> {
+        Box::new(DieselConnectionPurchaseOrderStore::new(&*self.conn))
+    }
+}
+
+impl<'a> InContextStoreFactory<'a> for InContextSqliteStoreFactory {
+    fn commit(&self) -> Result<(), InternalError> {
+        let transaction_manager = self.conn.transaction_manager();
+        transaction_manager
+            .commit_transaction(&*self.conn)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        Ok(())
+    }
+
+    fn rollback(&self) -> Result<(), InternalError> {
+        let transaction_manager = self.conn.transaction_manager();
+        transaction_manager
+            .rollback_transaction(&*self.conn)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        Ok(())
     }
 }

--- a/sdk/src/track_and_trace/store/mod.rs
+++ b/sdk/src/track_and_trace/store/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018-2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ mod error;
 use crate::paging::Paging;
 
 #[cfg(feature = "diesel")]
-pub use self::diesel::DieselTrackAndTraceStore;
+pub use self::diesel::{DieselConnectionTrackAndTraceStore, DieselTrackAndTraceStore};
 pub use error::TrackAndTraceStoreError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -150,7 +150,7 @@ pub struct LatLong;
 #[derive(Default, Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct LatLongValue(pub i64, pub i64);
 
-pub trait TrackAndTraceStore: Send + Sync {
+pub trait TrackAndTraceStore {
     /// Adds an associated agent to the underlying storage
     ///
     /// # Arguments


### PR DESCRIPTION
This PR updates the SDE to properly run database operations in a transaction. To facilitate this, two new `StoreFactory` traits were introduced, `TransactionalStoreFactory` and `InContextStoreFactory`, that expose this functionality in the daemon. These traits allow for the creation of a `StoreFactory` that can be used to initialize a transaction, get various Grid stores, and then run DB operations all within a transaction on a single Connection. Previously, there was no guarantee that operations were run within the same transaction as each operation got a Connection from a ConnectionPool individually.