### PR TITLE
Add initial implementation of the "create purchase order" action

### DIFF
--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -155,3 +155,22 @@ fn update_version(
 ) -> Result<(), ApplyError> {
     unimplemented!();
 }
+
+fn check_permission(
+    perm_checker: &PermissionChecker,
+    signer: &str,
+    permission: &str,
+    po_owner: &str,
+) -> Result<(), ApplyError> {
+    match perm_checker.has_permission(signer, permission, po_owner) {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(ApplyError::InvalidTransaction(format!(
+            "The signer \"{}\" does not have the \"{}\" permission for org \"{}\"",
+            signer, permission, po_owner
+        ))),
+        Err(e) => Err(ApplyError::InvalidTransaction(format!(
+            "Permission check failed: {}",
+            e
+        ))),
+    }
+}

--- a/contracts/purchase_order/src/main.rs
+++ b/contracts/purchase_order/src/main.rs
@@ -35,6 +35,7 @@ cfg_if! {
 }
 
 pub mod handler;
+pub mod permissions;
 mod state;
 mod workflow;
 

--- a/contracts/purchase_order/src/permissions.rs
+++ b/contracts/purchase_order/src/permissions.rs
@@ -1,0 +1,29 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub enum Permission {
+    CanCreatePo,
+    CanUpdatePo,
+    CanCreateVersion,
+    CanUpdateVersion,
+}
+
+pub fn permission_to_perm_string(permission: Permission) -> String {
+    match permission {
+        Permission::CanCreatePo => String::from("po::can-create-po"),
+        Permission::CanUpdatePo => String::from("po::can-update-po"),
+        Permission::CanCreateVersion => String::from("po::can-create-version"),
+        Permission::CanUpdateVersion => String::from("po::can-update-version"),
+    }
+}

--- a/contracts/purchase_order/src/state.rs
+++ b/contracts/purchase_order/src/state.rs
@@ -14,11 +14,18 @@
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
+        use sabre_sdk::ApplyError;
         use sabre_sdk::TransactionContext;
     } else {
         use sawtooth_sdk::processor::handler::TransactionContext;
+        use sawtooth_sdk::processor::handler::ApplyError;
     }
 }
+
+use grid_sdk::protocol::{
+    pike::state::{Agent, Organization},
+    purchase_order::state::PurchaseOrder,
+};
 
 pub struct PurchaseOrderState<'a> {
     _context: &'a dyn TransactionContext,
@@ -27,5 +34,25 @@ pub struct PurchaseOrderState<'a> {
 impl<'a> PurchaseOrderState<'a> {
     pub fn new(context: &'a dyn TransactionContext) -> Self {
         Self { _context: context }
+    }
+
+    pub fn get_purchase_order(&self, _po_uuid: &str) -> Result<Option<PurchaseOrder>, ApplyError> {
+        unimplemented!();
+    }
+
+    pub fn set_purchase_order(
+        &self,
+        _po_uuid: &str,
+        _purchase_order: PurchaseOrder,
+    ) -> Result<(), ApplyError> {
+        unimplemented!();
+    }
+
+    pub fn get_agent(&self, _public_key: &str) -> Result<Option<Agent>, ApplyError> {
+        unimplemented!();
+    }
+
+    pub fn get_organization(&self, _id: &str) -> Result<Option<Organization>, ApplyError> {
+        unimplemented!();
     }
 }

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -24,31 +24,34 @@ message PurchaseOrderPayload {
     UPDATE_VERSION = 4;
   }
   Action action = 1;
-  string org_id = 2;
-  string public_key = 3;
-  uint64 timestamp = 4;
+  string public_key = 2;
+  uint64 timestamp = 3;
 
-  CreatePurchaseOrderPayload create_po_payload = 5;
-  UpdatePurchaseOrderPayload update_po_payload = 6;
-  CreateVersionPayload create_version_payload = 7;
-  UpdateVersionPayload update_version_payload = 8;
+  CreatePurchaseOrderPayload create_po_payload = 4;
+  UpdatePurchaseOrderPayload update_po_payload = 5;
+  CreateVersionPayload create_version_payload = 6;
+  UpdateVersionPayload update_version_payload = 7;
 }
 
 message CreatePurchaseOrderPayload {
-  string uuid = 1;
-  uint64 created_at = 2;
+  string org_id = 1;
+  string uuid = 2;
+  uint64 created_at = 3;
+  CreateVersionPayload create_version_payload = 4;
 }
 
 message UpdatePurchaseOrderPayload {
   string workflow_status = 1;
   bool is_closed = 2;
   string accepted_version_number = 3;
+  string po_uuid = 4;
 }
 
 message CreateVersionPayload {
   string version_id = 1;
   bool is_draft = 2;
   PayloadRevision revision = 3;
+  string po_uuid = 4;
 }
 
 message UpdateVersionPayload {

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -43,7 +43,7 @@ message CreatePurchaseOrderPayload {
 message UpdatePurchaseOrderPayload {
   string workflow_status = 1;
   bool is_closed = 2;
-  string accepted_version_number = 3;
+  string accepted_version_id = 3;
   string po_uuid = 4;
 }
 

--- a/sdk/protos/purchase_order_state.proto
+++ b/sdk/protos/purchase_order_state.proto
@@ -16,12 +16,13 @@
 syntax = "proto3";
 
 message PurchaseOrder {
-  string uuid = 1;
-  string workflow_status = 2;
-  repeated PurchaseOrderVersion versions = 3;
-  string accepted_version_number = 4;
-  uint64 created_at = 5;
-  bool is_closed = 6;
+  string org_id = 1;
+  string uuid = 2;
+  string workflow_status = 3;
+  repeated PurchaseOrderVersion versions = 4;
+  string accepted_version_number = 5;
+  uint64 created_at = 6;
+  bool is_closed = 7;
 }
 
 message PurchaseOrderList {
@@ -34,6 +35,7 @@ message PurchaseOrderVersion {
   bool is_draft = 3;
   string current_revision_id = 4;
   PurchaseOrderRevision revisions = 5;
+  string po_uuid = 6;
 }
 
 message PurchaseOrderRevision {

--- a/sdk/protos/purchase_order_state.proto
+++ b/sdk/protos/purchase_order_state.proto
@@ -20,7 +20,7 @@ message PurchaseOrder {
   string uuid = 2;
   string workflow_status = 3;
   repeated PurchaseOrderVersion versions = 4;
-  string accepted_version_number = 5;
+  string accepted_version_id = 5;
   uint64 created_at = 6;
   bool is_closed = 7;
 }

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -342,7 +342,7 @@ impl CreatePurchaseOrderPayloadBuilder {
 pub struct UpdatePurchaseOrderPayload {
     workflow_status: String,
     is_closed: bool,
-    accepted_version_number: String,
+    accepted_version_id: String,
     po_uuid: String,
 }
 
@@ -355,8 +355,8 @@ impl UpdatePurchaseOrderPayload {
         self.is_closed
     }
 
-    pub fn accepted_version_number(&self) -> &str {
-        &self.accepted_version_number
+    pub fn accepted_version_id(&self) -> &str {
+        &self.accepted_version_id
     }
 
     pub fn po_uuid(&self) -> &str {
@@ -371,7 +371,7 @@ impl FromProto<purchase_order_payload::UpdatePurchaseOrderPayload> for UpdatePur
         Ok(UpdatePurchaseOrderPayload {
             workflow_status: proto.take_workflow_status(),
             is_closed: proto.get_is_closed(),
-            accepted_version_number: proto.take_accepted_version_number(),
+            accepted_version_id: proto.take_accepted_version_id(),
             po_uuid: proto.take_po_uuid(),
         })
     }
@@ -382,7 +382,7 @@ impl FromNative<UpdatePurchaseOrderPayload> for purchase_order_payload::UpdatePu
         let mut proto = purchase_order_payload::UpdatePurchaseOrderPayload::new();
         proto.set_workflow_status(native.workflow_status().to_string());
         proto.set_is_closed(native.is_closed());
-        proto.set_accepted_version_number(native.accepted_version_number().to_string());
+        proto.set_accepted_version_id(native.accepted_version_id().to_string());
         proto.set_po_uuid(native.po_uuid().to_string());
 
         Ok(proto)
@@ -421,7 +421,7 @@ impl IntoNative<UpdatePurchaseOrderPayload> for purchase_order_payload::UpdatePu
 pub struct UpdatePurchaseOrderPayloadBuilder {
     workflow_status: Option<String>,
     is_closed: Option<bool>,
-    accepted_version_number: Option<String>,
+    accepted_version_id: Option<String>,
     po_uuid: Option<String>,
 }
 
@@ -440,8 +440,8 @@ impl UpdatePurchaseOrderPayloadBuilder {
         self
     }
 
-    pub fn with_accepted_version_number(mut self, value: String) -> Self {
-        self.accepted_version_number = Some(value);
+    pub fn with_accepted_version_id(mut self, value: String) -> Self {
+        self.accepted_version_id = Some(value);
         self
     }
 
@@ -459,8 +459,8 @@ impl UpdatePurchaseOrderPayloadBuilder {
             BuilderError::MissingField("'is_closed' field is required".to_string())
         })?;
 
-        let accepted_version_number = self.accepted_version_number.ok_or_else(|| {
-            BuilderError::MissingField("'accepted_version_number' field is required".to_string())
+        let accepted_version_id = self.accepted_version_id.ok_or_else(|| {
+            BuilderError::MissingField("'accepted_version_id' field is required".to_string())
         })?;
 
         let po_uuid = self
@@ -470,7 +470,7 @@ impl UpdatePurchaseOrderPayloadBuilder {
         Ok(UpdatePurchaseOrderPayload {
             workflow_status,
             is_closed,
-            accepted_version_number,
+            accepted_version_id,
             po_uuid,
         })
     }

--- a/sdk/src/protocol/purchase_order/state.rs
+++ b/sdk/src/protocol/purchase_order/state.rs
@@ -414,7 +414,7 @@ pub struct PurchaseOrder {
     uuid: String,
     workflow_status: String,
     versions: Vec<PurchaseOrderVersion>,
-    accepted_version_number: String,
+    accepted_version_id: String,
     created_at: u64,
     is_closed: bool,
 }
@@ -436,8 +436,8 @@ impl PurchaseOrder {
         &self.versions
     }
 
-    pub fn accepted_version_number(&self) -> &str {
-        &self.accepted_version_number
+    pub fn accepted_version_id(&self) -> &str {
+        &self.accepted_version_id
     }
 
     pub fn created_at(&self) -> u64 {
@@ -454,7 +454,7 @@ impl PurchaseOrder {
             .with_uuid(self.uuid)
             .with_workflow_status(self.workflow_status)
             .with_versions(self.versions)
-            .with_accepted_version_number(self.accepted_version_number)
+            .with_accepted_version_id(self.accepted_version_id)
             .with_created_at(self.created_at)
             .with_is_closed(self.is_closed)
     }
@@ -473,7 +473,7 @@ impl FromProto<purchase_order_state::PurchaseOrder> for PurchaseOrder {
                 .into_iter()
                 .map(PurchaseOrderVersion::from_proto)
                 .collect::<Result<_, _>>()?,
-            accepted_version_number: order.take_accepted_version_number(),
+            accepted_version_id: order.take_accepted_version_id(),
             created_at: order.get_created_at(),
             is_closed: order.get_is_closed(),
         })
@@ -494,7 +494,7 @@ impl FromNative<PurchaseOrder> for purchase_order_state::PurchaseOrder {
                 .map(|version| version.into_proto())
                 .collect::<Result<_, _>>()?,
         ));
-        proto.set_accepted_version_number(order.accepted_version_number().to_string());
+        proto.set_accepted_version_id(order.accepted_version_id().to_string());
         proto.set_created_at(order.created_at());
         proto.set_is_closed(order.is_closed());
 
@@ -551,7 +551,7 @@ pub struct PurchaseOrderBuilder {
     uuid: Option<String>,
     workflow_status: Option<String>,
     versions: Option<Vec<PurchaseOrderVersion>>,
-    accepted_version_number: Option<String>,
+    accepted_version_id: Option<String>,
     created_at: Option<u64>,
     is_closed: Option<bool>,
 }
@@ -581,8 +581,8 @@ impl PurchaseOrderBuilder {
         self
     }
 
-    pub fn with_accepted_version_number(mut self, accepted_version_number: String) -> Self {
-        self.accepted_version_number = Some(accepted_version_number);
+    pub fn with_accepted_version_id(mut self, accepted_version_id: String) -> Self {
+        self.accepted_version_id = Some(accepted_version_id);
         self
     }
 
@@ -613,9 +613,9 @@ impl PurchaseOrderBuilder {
             PurchaseOrderBuildError::EmptyVec("'versions' field is required".to_string())
         })?;
 
-        let accepted_version_number = self.accepted_version_number.ok_or_else(|| {
+        let accepted_version_id = self.accepted_version_id.ok_or_else(|| {
             PurchaseOrderBuildError::MissingField(
-                "'accepted_version_number' field is required".to_string(),
+                "'accepted_version_id' field is required".to_string(),
             )
         })?;
 
@@ -632,7 +632,7 @@ impl PurchaseOrderBuilder {
             uuid,
             workflow_status,
             versions,
-            accepted_version_number,
+            accepted_version_id,
             created_at,
             is_closed,
         })


### PR DESCRIPTION
This PR makes a few updates to the purchase order protos and corresponding protocol code. This also adds an initial implementation of the "create purchase order" action for the Purchase Order smart contract's transaction handler.