### PR TITLE
Implement some methods for Purchase Order state

### DIFF
--- a/contracts/purchase_order/src/state.rs
+++ b/contracts/purchase_order/src/state.rs
@@ -14,11 +14,18 @@
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
+        use sabre_sdk::ApplyError;
         use sabre_sdk::TransactionContext;
     } else {
         use sawtooth_sdk::processor::handler::TransactionContext;
+        use sawtooth_sdk::processor::handler::ApplyError;
     }
 }
+
+use grid_sdk::protocol::{
+    pike::state::{Agent, Organization},
+    purchase_order::state::PurchaseOrder,
+};
 
 pub struct PurchaseOrderState<'a> {
     _context: &'a dyn TransactionContext,
@@ -27,5 +34,25 @@ pub struct PurchaseOrderState<'a> {
 impl<'a> PurchaseOrderState<'a> {
     pub fn new(context: &'a dyn TransactionContext) -> Self {
         Self { _context: context }
+    }
+
+    pub fn _get_purchase_order(&self, _po_uuid: &str) -> Result<Option<PurchaseOrder>, ApplyError> {
+        unimplemented!();
+    }
+
+    pub fn _set_purchase_order(
+        &self,
+        _po_uuid: &str,
+        _purchase_order: PurchaseOrder,
+    ) -> Result<(), ApplyError> {
+        unimplemented!();
+    }
+
+    pub fn _get_agent(&self, _public_key: &str) -> Result<Option<Agent>, ApplyError> {
+        unimplemented!();
+    }
+
+    pub fn _get_organization(&self, _id: &str) -> Result<Option<Organization>, ApplyError> {
+        unimplemented!();
     }
 }


### PR DESCRIPTION
This PR adds implementations for a few methods on the Purchase Order state that are used by the smart contract actions. This pr adds implementations for the methods `get_purchase_order`, `set_purchase_order`, `get_agent`, and `get_organization`.