### PR TITLE
Update purchase order protos

### DIFF
--- a/contracts/purchase_order/src/state.rs
+++ b/contracts/purchase_order/src/state.rs
@@ -41,8 +41,8 @@ impl<'a> PurchaseOrderState<'a> {
         Self { _context: context }
     }
 
-    pub fn _get_purchase_order(&self, po_uuid: &str) -> Result<Option<PurchaseOrder>, ApplyError> {
-        let address = compute_purchase_order_address(po_uuid);
+    pub fn _get_purchase_order(&self, po_uid: &str) -> Result<Option<PurchaseOrder>, ApplyError> {
+        let address = compute_purchase_order_address(po_uid);
         if let Some(packed) = self._context.get_state_entry(&address)? {
             let purchase_orders =
                 PurchaseOrderList::from_bytes(packed.as_slice()).map_err(|_| {
@@ -51,7 +51,7 @@ impl<'a> PurchaseOrderState<'a> {
             Ok(purchase_orders
                 .purchase_orders()
                 .iter()
-                .find(|p| p.uuid() == po_uuid)
+                .find(|p| p.uid() == po_uid)
                 .cloned())
         } else {
             Ok(None)
@@ -60,10 +60,10 @@ impl<'a> PurchaseOrderState<'a> {
 
     pub fn _set_purchase_order(
         &self,
-        po_uuid: &str,
+        po_uid: &str,
         purchase_order: PurchaseOrder,
     ) -> Result<(), ApplyError> {
-        let address = compute_purchase_order_address(po_uuid);
+        let address = compute_purchase_order_address(po_uid);
         let mut purchase_orders: Vec<PurchaseOrder> =
             match self._context.get_state_entry(&address)? {
                 Some(packed) => PurchaseOrderList::from_bytes(packed.as_slice())
@@ -80,7 +80,7 @@ impl<'a> PurchaseOrderState<'a> {
 
         let mut index = None;
         for (i, po) in purchase_orders.iter().enumerate() {
-            if po.uuid() == po_uuid {
+            if po.uid() == po_uid {
                 index = Some(i);
                 break;
             }
@@ -90,7 +90,7 @@ impl<'a> PurchaseOrderState<'a> {
             purchase_orders.remove(i);
         }
         purchase_orders.push(purchase_order);
-        purchase_orders.sort_by_key(|r| r.uuid().to_string());
+        purchase_orders.sort_by_key(|r| r.uid().to_string());
         let po_list = PurchaseOrderListBuilder::new()
             .with_purchase_orders(purchase_orders)
             .build()

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -25,13 +25,12 @@ message PurchaseOrderPayload {
   }
   Action action = 1;
   string org_id = 2;
-  string public_key = 3;
-  uint64 timestamp = 4;
+  uint64 timestamp = 3;
 
-  CreatePurchaseOrderPayload create_po_payload = 5;
-  UpdatePurchaseOrderPayload update_po_payload = 6;
-  CreateVersionPayload create_version_payload = 7;
-  UpdateVersionPayload update_version_payload = 8;
+  CreatePurchaseOrderPayload create_po_payload = 4;
+  UpdatePurchaseOrderPayload update_po_payload = 5;
+  CreateVersionPayload create_version_payload = 6;
+  UpdateVersionPayload update_version_payload = 7;
 }
 
 message CreatePurchaseOrderPayload {

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -34,7 +34,7 @@ message PurchaseOrderPayload {
 }
 
 message CreatePurchaseOrderPayload {
-  string uuid = 1;
+  string uid = 1;
   uint64 created_at = 2;
   CreateVersionPayload create_version_payload = 3;
 }

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -40,23 +40,26 @@ message CreatePurchaseOrderPayload {
 }
 
 message UpdatePurchaseOrderPayload {
-  string workflow_status = 1;
-  bool is_closed = 2;
-  string accepted_version_number = 3;
+  string po_uid = 1;
+  string workflow_status = 2;
+  bool is_closed = 3;
+  string accepted_version_number = 4;
 }
 
 message CreateVersionPayload {
   string version_id = 1;
-  bool is_draft = 2;
-  PayloadRevision revision = 3;
+  string po_uid = 2;
+  bool is_draft = 3;
+  PayloadRevision revision = 4;
 }
 
 message UpdateVersionPayload {
   string version_id = 1;
-  string workflow_status = 2;
-  bool is_draft = 3;
-  string current_revision_id = 4;
-  PayloadRevision revision = 5;
+  string po_uid = 2;
+  string workflow_status = 3;
+  bool is_draft = 4;
+  string current_revision_id = 5;
+  PayloadRevision revision = 6;
 }
 
 message PayloadRevision {

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -36,6 +36,7 @@ message PurchaseOrderPayload {
 message CreatePurchaseOrderPayload {
   string uuid = 1;
   uint64 created_at = 2;
+  CreateVersionPayload create_version_payload = 3;
 }
 
 message UpdatePurchaseOrderPayload {

--- a/sdk/protos/purchase_order_state.proto
+++ b/sdk/protos/purchase_order_state.proto
@@ -16,7 +16,7 @@
 syntax = "proto3";
 
 message PurchaseOrder {
-  string uuid = 1;
+  string uid = 1;
   string workflow_status = 2;
   repeated PurchaseOrderVersion versions = 3;
   string accepted_version_number = 4;

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -201,14 +201,14 @@ impl PurchaseOrderPayloadBuilder {
 /// Native representation of the "create purchase order" payload
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct CreatePurchaseOrderPayload {
-    uuid: String,
+    uid: String,
     created_at: u64,
     create_version_payload: Option<CreateVersionPayload>,
 }
 
 impl CreatePurchaseOrderPayload {
-    pub fn uuid(&self) -> &str {
-        &self.uuid
+    pub fn uid(&self) -> &str {
+        &self.uid
     }
 
     pub fn created_at(&self) -> u64 {
@@ -227,7 +227,7 @@ impl FromProto<purchase_order_payload::CreatePurchaseOrderPayload> for CreatePur
         let create_version_payload =
             CreateVersionPayload::from_proto(proto.take_create_version_payload()).ok();
         Ok(CreatePurchaseOrderPayload {
-            uuid: proto.take_uuid(),
+            uid: proto.take_uid(),
             created_at: proto.get_created_at(),
             create_version_payload,
         })
@@ -237,7 +237,7 @@ impl FromProto<purchase_order_payload::CreatePurchaseOrderPayload> for CreatePur
 impl FromNative<CreatePurchaseOrderPayload> for purchase_order_payload::CreatePurchaseOrderPayload {
     fn from_native(native: CreatePurchaseOrderPayload) -> Result<Self, ProtoConversionError> {
         let mut proto = purchase_order_payload::CreatePurchaseOrderPayload::new();
-        proto.set_uuid(native.uuid().to_string());
+        proto.set_uid(native.uid().to_string());
         proto.set_created_at(native.created_at());
 
         if let Some(payload) = native.create_version_payload() {
@@ -280,7 +280,7 @@ impl IntoNative<CreatePurchaseOrderPayload> for purchase_order_payload::CreatePu
 /// Builder used to create the "create agent" payload
 #[derive(Default, Debug)]
 pub struct CreatePurchaseOrderPayloadBuilder {
-    uuid: Option<String>,
+    uid: Option<String>,
     created_at: Option<u64>,
     create_version_payload: Option<CreateVersionPayload>,
 }
@@ -290,8 +290,8 @@ impl CreatePurchaseOrderPayloadBuilder {
         CreatePurchaseOrderPayloadBuilder::default()
     }
 
-    pub fn with_uuid(mut self, value: String) -> Self {
-        self.uuid = Some(value);
+    pub fn with_uid(mut self, value: String) -> Self {
+        self.uid = Some(value);
         self
     }
 
@@ -306,9 +306,9 @@ impl CreatePurchaseOrderPayloadBuilder {
     }
 
     pub fn build(self) -> Result<CreatePurchaseOrderPayload, BuilderError> {
-        let uuid = self
-            .uuid
-            .ok_or_else(|| BuilderError::MissingField("'uuid' field is required".to_string()))?;
+        let uid = self
+            .uid
+            .ok_or_else(|| BuilderError::MissingField("'uid' field is required".to_string()))?;
 
         let created_at = self.created_at.ok_or_else(|| {
             BuilderError::MissingField("'created_at' field is required".to_string())
@@ -317,7 +317,7 @@ impl CreatePurchaseOrderPayloadBuilder {
         let create_version_payload = self.create_version_payload;
 
         Ok(CreatePurchaseOrderPayload {
-            uuid,
+            uid,
             created_at,
             create_version_payload,
         })

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -588,6 +588,7 @@ impl PayloadRevisionBuilder {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct CreateVersionPayload {
     version_id: String,
+    po_uid: String,
     is_draft: bool,
     revision: PayloadRevision,
 }
@@ -595,6 +596,10 @@ pub struct CreateVersionPayload {
 impl CreateVersionPayload {
     pub fn version_id(&self) -> &str {
         &self.version_id
+    }
+
+    pub fn po_uid(&self) -> &str {
+        &self.po_uid
     }
 
     pub fn is_draft(&self) -> bool {
@@ -612,6 +617,7 @@ impl FromProto<purchase_order_payload::CreateVersionPayload> for CreateVersionPa
     ) -> Result<Self, ProtoConversionError> {
         Ok(CreateVersionPayload {
             version_id: proto.take_version_id(),
+            po_uid: proto.take_po_uid(),
             is_draft: proto.get_is_draft(),
             revision: PayloadRevision::from_proto(proto.take_revision())?,
         })
@@ -622,6 +628,7 @@ impl FromNative<CreateVersionPayload> for purchase_order_payload::CreateVersionP
     fn from_native(native: CreateVersionPayload) -> Result<Self, ProtoConversionError> {
         let mut proto = purchase_order_payload::CreateVersionPayload::new();
         proto.set_version_id(native.version_id().to_string());
+        proto.set_po_uid(native.po_uid().to_string());
         proto.set_is_draft(native.is_draft());
         proto.set_revision(native.revision().clone().into_proto()?);
 
@@ -660,6 +667,7 @@ impl IntoNative<CreateVersionPayload> for purchase_order_payload::CreateVersionP
 #[derive(Default, Debug)]
 pub struct CreateVersionPayloadBuilder {
     version_id: Option<String>,
+    po_uid: Option<String>,
     is_draft: Option<bool>,
     revision: Option<PayloadRevision>,
 }
@@ -671,6 +679,11 @@ impl CreateVersionPayloadBuilder {
 
     pub fn with_version_id(mut self, value: String) -> Self {
         self.version_id = Some(value);
+        self
+    }
+
+    pub fn with_po_uid(mut self, value: String) -> Self {
+        self.po_uid = Some(value);
         self
     }
 
@@ -689,6 +702,10 @@ impl CreateVersionPayloadBuilder {
             BuilderError::MissingField("'version_id' field is required".to_string())
         })?;
 
+        let po_uid = self
+            .po_uid
+            .ok_or_else(|| BuilderError::MissingField("'po_uid' field is required".to_string()))?;
+
         let is_draft = self.is_draft.ok_or_else(|| {
             BuilderError::MissingField("'is_draft' field is required".to_string())
         })?;
@@ -699,6 +716,7 @@ impl CreateVersionPayloadBuilder {
 
         Ok(CreateVersionPayload {
             version_id,
+            po_uid,
             is_draft,
             revision,
         })
@@ -709,6 +727,7 @@ impl CreateVersionPayloadBuilder {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct UpdateVersionPayload {
     version_id: String,
+    po_uid: String,
     workflow_status: String,
     is_draft: bool,
     current_revision_id: String,
@@ -718,6 +737,10 @@ pub struct UpdateVersionPayload {
 impl UpdateVersionPayload {
     pub fn version_id(&self) -> &str {
         &self.version_id
+    }
+
+    pub fn po_uid(&self) -> &str {
+        &self.po_uid
     }
 
     pub fn workflow_status(&self) -> &str {
@@ -743,6 +766,7 @@ impl FromProto<purchase_order_payload::UpdateVersionPayload> for UpdateVersionPa
     ) -> Result<Self, ProtoConversionError> {
         Ok(UpdateVersionPayload {
             version_id: proto.take_version_id(),
+            po_uid: proto.take_po_uid(),
             workflow_status: proto.take_workflow_status(),
             is_draft: proto.get_is_draft(),
             current_revision_id: proto.take_current_revision_id(),
@@ -755,6 +779,7 @@ impl FromNative<UpdateVersionPayload> for purchase_order_payload::UpdateVersionP
     fn from_native(native: UpdateVersionPayload) -> Result<Self, ProtoConversionError> {
         let mut proto = purchase_order_payload::UpdateVersionPayload::new();
         proto.set_version_id(native.version_id().to_string());
+        proto.set_po_uid(native.po_uid().to_string());
         proto.set_workflow_status(native.workflow_status().to_string());
         proto.set_is_draft(native.is_draft());
         proto.set_current_revision_id(native.current_revision_id().to_string());
@@ -795,6 +820,7 @@ impl IntoNative<UpdateVersionPayload> for purchase_order_payload::UpdateVersionP
 #[derive(Default, Debug)]
 pub struct UpdateVersionPayloadBuilder {
     version_id: Option<String>,
+    po_uid: Option<String>,
     workflow_status: Option<String>,
     is_draft: Option<bool>,
     current_revision_id: Option<String>,
@@ -808,6 +834,11 @@ impl UpdateVersionPayloadBuilder {
 
     pub fn with_version_id(mut self, value: String) -> Self {
         self.version_id = Some(value);
+        self
+    }
+
+    pub fn with_po_uid(mut self, value: String) -> Self {
+        self.po_uid = Some(value);
         self
     }
 
@@ -836,6 +867,10 @@ impl UpdateVersionPayloadBuilder {
             BuilderError::MissingField("'version_id' field is required".to_string())
         })?;
 
+        let po_uid = self
+            .po_uid
+            .ok_or_else(|| BuilderError::MissingField("'po_uid' field is required".to_string()))?;
+
         let workflow_status = self.workflow_status.ok_or_else(|| {
             BuilderError::MissingField("'workflow_status' field is required".to_string())
         })?;
@@ -854,6 +889,7 @@ impl UpdateVersionPayloadBuilder {
 
         Ok(UpdateVersionPayload {
             version_id,
+            po_uid,
             workflow_status,
             is_draft,
             current_revision_id,

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -36,7 +36,6 @@ pub enum Action {
 pub struct PurchaseOrderPayload {
     action: Action,
     org_id: String,
-    public_key: String,
     timestamp: u64,
 }
 
@@ -47,10 +46,6 @@ impl PurchaseOrderPayload {
 
     pub fn org_id(&self) -> &str {
         &self.org_id
-    }
-
-    pub fn public_key(&self) -> &str {
-        &self.public_key
     }
 
     pub fn timestamp(&self) -> u64 {
@@ -88,7 +83,6 @@ impl FromProto<purchase_order_payload::PurchaseOrderPayload> for PurchaseOrderPa
         Ok(PurchaseOrderPayload {
             action,
             org_id: payload.take_org_id(),
-            public_key: payload.take_public_key(),
             timestamp: payload.get_timestamp(),
         })
     }
@@ -100,7 +94,6 @@ impl FromNative<PurchaseOrderPayload> for purchase_order_payload::PurchaseOrderP
 
         proto.set_timestamp(native.timestamp());
         proto.set_org_id(native.org_id().to_string());
-        proto.set_public_key(native.public_key().to_string());
 
         match native.action() {
             Action::CreatePo(payload) => {
@@ -161,7 +154,6 @@ impl IntoNative<PurchaseOrderPayload> for purchase_order_payload::PurchaseOrderP
 pub struct PurchaseOrderPayloadBuilder {
     action: Option<Action>,
     org_id: Option<String>,
-    public_key: Option<String>,
     timestamp: Option<u64>,
 }
 
@@ -180,11 +172,6 @@ impl PurchaseOrderPayloadBuilder {
         self
     }
 
-    pub fn with_public_key(mut self, public_key: String) -> Self {
-        self.public_key = Some(public_key);
-        self
-    }
-
     pub fn with_timestamp(mut self, value: u64) -> Self {
         self.timestamp = Some(value);
         self
@@ -199,10 +186,6 @@ impl PurchaseOrderPayloadBuilder {
             .org_id
             .ok_or_else(|| BuilderError::MissingField("'org_id' field is required".into()))?;
 
-        let public_key = self
-            .public_key
-            .ok_or_else(|| BuilderError::MissingField("'public_key' field is required".into()))?;
-
         let timestamp = self
             .timestamp
             .ok_or_else(|| BuilderError::MissingField("'timestamp' field is required".into()))?;
@@ -210,7 +193,6 @@ impl PurchaseOrderPayloadBuilder {
         Ok(PurchaseOrderPayload {
             action,
             org_id,
-            public_key,
             timestamp,
         })
     }

--- a/sdk/src/protocol/purchase_order/state.rs
+++ b/sdk/src/protocol/purchase_order/state.rs
@@ -391,7 +391,7 @@ impl PurchaseOrderVersionBuilder {
 /// Purchase orders in real-life trade scenarios are represented by `PurchaseOrder`
 #[derive(Debug, Clone, PartialEq)]
 pub struct PurchaseOrder {
-    uuid: String,
+    uid: String,
     workflow_status: String,
     versions: Vec<PurchaseOrderVersion>,
     accepted_version_number: String,
@@ -400,8 +400,8 @@ pub struct PurchaseOrder {
 }
 
 impl PurchaseOrder {
-    pub fn uuid(&self) -> &str {
-        &self.uuid
+    pub fn uid(&self) -> &str {
+        &self.uid
     }
 
     pub fn workflow_status(&self) -> &str {
@@ -426,7 +426,7 @@ impl PurchaseOrder {
 
     pub fn into_builder(self) -> PurchaseOrderBuilder {
         PurchaseOrderBuilder::new()
-            .with_uuid(self.uuid)
+            .with_uid(self.uid)
             .with_workflow_status(self.workflow_status)
             .with_versions(self.versions)
             .with_accepted_version_number(self.accepted_version_number)
@@ -440,7 +440,7 @@ impl FromProto<purchase_order_state::PurchaseOrder> for PurchaseOrder {
         mut order: purchase_order_state::PurchaseOrder,
     ) -> Result<Self, ProtoConversionError> {
         Ok(PurchaseOrder {
-            uuid: order.take_uuid(),
+            uid: order.take_uid(),
             workflow_status: order.take_workflow_status(),
             versions: order
                 .take_versions()
@@ -457,7 +457,7 @@ impl FromProto<purchase_order_state::PurchaseOrder> for PurchaseOrder {
 impl FromNative<PurchaseOrder> for purchase_order_state::PurchaseOrder {
     fn from_native(order: PurchaseOrder) -> Result<Self, ProtoConversionError> {
         let mut proto = purchase_order_state::PurchaseOrder::new();
-        proto.set_uuid(order.uuid().to_string());
+        proto.set_uid(order.uid().to_string());
         proto.set_workflow_status(order.workflow_status().to_string());
         proto.set_versions(RepeatedField::from_vec(
             order
@@ -520,7 +520,7 @@ impl std::fmt::Display for PurchaseOrderBuildError {
 /// Builder used to create a `PurchaseOrder`
 #[derive(Default, Clone, PartialEq)]
 pub struct PurchaseOrderBuilder {
-    uuid: Option<String>,
+    uid: Option<String>,
     workflow_status: Option<String>,
     versions: Option<Vec<PurchaseOrderVersion>>,
     accepted_version_number: Option<String>,
@@ -533,8 +533,8 @@ impl PurchaseOrderBuilder {
         PurchaseOrderBuilder::default()
     }
 
-    pub fn with_uuid(mut self, uuid: String) -> Self {
-        self.uuid = Some(uuid);
+    pub fn with_uid(mut self, uid: String) -> Self {
+        self.uid = Some(uid);
         self
     }
 
@@ -564,8 +564,8 @@ impl PurchaseOrderBuilder {
     }
 
     pub fn build(self) -> Result<PurchaseOrder, PurchaseOrderBuildError> {
-        let uuid = self.uuid.ok_or_else(|| {
-            PurchaseOrderBuildError::MissingField("'uuid' field is required".to_string())
+        let uid = self.uid.ok_or_else(|| {
+            PurchaseOrderBuildError::MissingField("'uid' field is required".to_string())
         })?;
 
         let workflow_status = self.workflow_status.ok_or_else(|| {
@@ -591,7 +591,7 @@ impl PurchaseOrderBuilder {
         })?;
 
         Ok(PurchaseOrder {
-            uuid,
+            uid,
             workflow_status,
             versions,
             accepted_version_number,


### PR DESCRIPTION
This change makes various updates to the Purchase Order smart contract's
state and payload protobuf messages, as several necessary attributes
were left out of these messages.

Signed-off-by: Shannyn Telander <telander@bitwise.io>