### PR TITLE
Add workflow-aware "Create PO" action

### DIFF
--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -135,19 +135,19 @@ fn create_purchase_order(
     let buyer_org_id = payload.buyer_org_id().to_string();
     let seller_org_id = payload.seller_org_id().to_string();
     // Check that the organizations owning the purchase order exist
-    state._get_organization(&buyer_org_id)?.ok_or_else(|| {
+    state.get_organization(&buyer_org_id)?.ok_or_else(|| {
         ApplyError::InvalidTransaction(format!("Organization {} does not exist", &buyer_org_id))
     })?;
-    state._get_organization(&seller_org_id)?.ok_or_else(|| {
+    state.get_organization(&seller_org_id)?.ok_or_else(|| {
         ApplyError::InvalidTransaction(format!("Organization {} does not exist", &seller_org_id))
     })?;
     // Validate the signer exists
-    let agent = state._get_agent(signer)?.ok_or_else(|| {
+    let agent = state.get_agent(signer)?.ok_or_else(|| {
         ApplyError::InvalidTransaction(format!("The signer is not an Agent: {}", signer))
     })?;
     // Validate the purchase order does not already exist
     let po_uid = payload.uid();
-    if state._get_purchase_order(po_uid)?.is_some() {
+    if state.get_purchase_order(po_uid)?.is_some() {
         return Err(ApplyError::InvalidTransaction(format!(
             "Purchase Order already exists: {}",
             po_uid,
@@ -306,7 +306,7 @@ fn create_purchase_order(
             ApplyError::InvalidTransaction(format!("Cannot build purchase order: {}", err))
         })?;
 
-    state._set_purchase_order(po_uid, purchase_order)?;
+    state.set_purchase_order(po_uid, purchase_order)?;
 
     Ok(())
 }

--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -27,16 +27,22 @@ cfg_if! {
     }
 }
 
-use crate::state::PurchaseOrderState;
 use grid_sdk::protos::FromBytes;
 use grid_sdk::{
     pike::permissions::PermissionChecker,
-    protocol::purchase_order::payload::{
-        Action, CreatePurchaseOrderPayload, CreateVersionPayload, PurchaseOrderPayload,
-        UpdatePurchaseOrderPayload, UpdateVersionPayload,
+    protocol::purchase_order::{
+        payload::{
+            Action, CreatePurchaseOrderPayload, CreateVersionPayload, PurchaseOrderPayload,
+            UpdatePurchaseOrderPayload, UpdateVersionPayload,
+        },
+        state::{PurchaseOrderBuilder, PurchaseOrderRevisionBuilder, PurchaseOrderVersionBuilder},
     },
     purchase_order::addressing::GRID_PURCHASE_ORDER_NAMESPACE,
 };
+
+use crate::permissions::Permission;
+use crate::state::PurchaseOrderState;
+use crate::workflow::{get_workflow, POWorkflow};
 
 #[cfg(target_arch = "wasm32")]
 fn apply(
@@ -121,12 +127,188 @@ impl TransactionHandler for PurchaseOrderTransactionHandler {
 }
 
 fn create_purchase_order(
-    _payload: &CreatePurchaseOrderPayload,
-    _signer: &str,
-    _state: &mut PurchaseOrderState,
-    _perm_checker: &PermissionChecker,
+    payload: &CreatePurchaseOrderPayload,
+    signer: &str,
+    state: &mut PurchaseOrderState,
+    perm_checker: &PermissionChecker,
 ) -> Result<(), ApplyError> {
-    unimplemented!();
+    let buyer_org_id = payload.buyer_org_id().to_string();
+    let seller_org_id = payload.seller_org_id().to_string();
+    // Check that the organizations owning the purchase order exist
+    state._get_organization(&buyer_org_id)?.ok_or_else(|| {
+        ApplyError::InvalidTransaction(format!("Organization {} does not exist", &buyer_org_id))
+    })?;
+    state._get_organization(&seller_org_id)?.ok_or_else(|| {
+        ApplyError::InvalidTransaction(format!("Organization {} does not exist", &seller_org_id))
+    })?;
+    // Validate the signer exists
+    let agent = state._get_agent(signer)?.ok_or_else(|| {
+        ApplyError::InvalidTransaction(format!("The signer is not an Agent: {}", signer))
+    })?;
+    // Validate the purchase order does not already exist
+    let po_uid = payload.uid();
+    if state._get_purchase_order(po_uid)?.is_some() {
+        return Err(ApplyError::InvalidTransaction(format!(
+            "Purchase Order already exists: {}",
+            po_uid,
+        )));
+    }
+    // Check if the payload contains a `PurchaseOrderVersion`
+    let mut workflow = POWorkflow::SystemOfRecord;
+    let versions = match payload.create_version_payload() {
+        Some(payload) => {
+            let payload_revision = payload.revision();
+            let revision = PurchaseOrderRevisionBuilder::new()
+                .with_revision_id(payload_revision.revision_id().to_string())
+                .with_submitter(signer.to_string())
+                .with_created_at(payload_revision.created_at())
+                .with_order_xml_v3_4(payload_revision.order_xml_v3_4().to_string())
+                .build()
+                .map_err(|err| {
+                    ApplyError::InvalidTransaction(format!(
+                        "Cannot build purchase order revision: {}",
+                        err
+                    ))
+                })?;
+            let mut version_builder = PurchaseOrderVersionBuilder::new()
+                .with_version_id(payload.version_id().to_string())
+                .with_is_draft(payload.is_draft())
+                .with_current_revision_id(revision.revision_id().to_string())
+                .with_revisions(vec![revision]);
+            let perm_string = Permission::CanCreatePoVersion.to_string();
+            if payload.is_draft() {
+                let beginning_workflow = get_workflow(&workflow).ok_or_else(|| {
+                    ApplyError::InternalError("Cannot build PO Workflow".to_string())
+                })?;
+                let version_subworkflow =
+                    beginning_workflow.subworkflow("version").ok_or_else(|| {
+                        ApplyError::InternalError("Unable to get `version` subworkflow".to_string())
+                    })?;
+                let start_state = version_subworkflow.state("editable").ok_or_else(|| {
+                    ApplyError::InternalError(
+                        "Unable to get create state from subworkflow".to_string(),
+                    )
+                })?;
+                let perm_result = perm_checker
+                    ._check_permission_with_workflow(
+                        &perm_string,
+                        signer,
+                        agent.org_id(),
+                        start_state,
+                        "editable",
+                    )
+                    .map_err(|err| {
+                        ApplyError::InternalError(format!(
+                            "Unable to check agent's permission: {}",
+                            err
+                        ))
+                    })?;
+                if !perm_result {
+                    return Err(ApplyError::InvalidTransaction(format!(
+                        "Agent {} does not have permission {} for organization {}",
+                        signer,
+                        &perm_string,
+                        agent.org_id(),
+                    )));
+                }
+                version_builder = version_builder.with_workflow_status("editable".to_string());
+            } else {
+                let beginning_workflow = get_workflow(&workflow).ok_or_else(|| {
+                    ApplyError::InternalError("Cannot build PO Workflow".to_string())
+                })?;
+                let version_subworkflow =
+                    beginning_workflow.subworkflow("version").ok_or_else(|| {
+                        ApplyError::InternalError("Unable to get `version` subworkflow".to_string())
+                    })?;
+                let start_state = version_subworkflow.state("create").ok_or_else(|| {
+                    ApplyError::InternalError(
+                        "Unable to get create state from subworkflow".to_string(),
+                    )
+                })?;
+                let perm_result = perm_checker
+                    ._check_permission_with_workflow(
+                        &perm_string,
+                        signer,
+                        agent.org_id(),
+                        start_state,
+                        "proposed",
+                    )
+                    .map_err(|err| {
+                        ApplyError::InternalError(format!(
+                            "Unable to check agent's permission: {}",
+                            err
+                        ))
+                    })?;
+                if !perm_result {
+                    return Err(ApplyError::InvalidTransaction(format!(
+                        "Agent {} does not have permission {} for organization {}",
+                        signer,
+                        &perm_string,
+                        agent.org_id(),
+                    )));
+                }
+                version_builder = version_builder.with_workflow_status("proposed".to_string());
+            }
+
+            vec![version_builder.build().map_err(|err| {
+                ApplyError::InvalidTransaction(format!(
+                    "Cannot build purchase order version: {}",
+                    err
+                ))
+            })?]
+        }
+        None => {
+            workflow = POWorkflow::Collaborative;
+            vec![]
+        }
+    };
+    let beginning_workflow = get_workflow(&workflow).ok_or_else(|| {
+        ApplyError::InternalError("Cannot build System Of Record PO workflow".to_string())
+    })?;
+    let po_subworkflow = beginning_workflow
+        .subworkflow("po")
+        .ok_or_else(|| ApplyError::InternalError("Unable to get po subworkflow".to_string()))?;
+    let start_state = po_subworkflow.state("create").ok_or_else(|| {
+        ApplyError::InternalError("Unable to get create state from subworkflow".to_string())
+    })?;
+    let perm_string = Permission::CanCreatePo.to_string();
+    let perm_result = perm_checker
+        ._check_permission_with_workflow(
+            &perm_string,
+            signer,
+            agent.org_id(),
+            start_state,
+            "issued",
+        )
+        .map_err(|err| {
+            ApplyError::InternalError(format!("Unable to check agent's permission: {}", err))
+        })?;
+    if !perm_result {
+        return Err(ApplyError::InvalidTransaction(format!(
+            "Agent {} does not have permission {} for organization {}",
+            signer,
+            &perm_string,
+            agent.org_id()
+        )));
+    }
+
+    let purchase_order = PurchaseOrderBuilder::new()
+        .with_uid(po_uid.to_string())
+        .with_versions(versions)
+        .with_workflow_status("issued".to_string())
+        .with_created_at(payload.created_at())
+        .with_is_closed(false)
+        .with_accepted_version_number("".to_string())
+        .with_buyer_org_id(buyer_org_id)
+        .with_seller_org_id(seller_org_id)
+        .build()
+        .map_err(|err| {
+            ApplyError::InvalidTransaction(format!("Cannot build purchase order: {}", err))
+        })?;
+
+    state._set_purchase_order(po_uid, purchase_order)?;
+
+    Ok(())
 }
 
 fn update_purchase_order(
@@ -154,4 +336,365 @@ fn update_version(
     _perm_checker: &PermissionChecker,
 ) -> Result<(), ApplyError> {
     unimplemented!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    use grid_sdk::{
+        pike::addressing::{
+            compute_agent_address, compute_organization_address, compute_role_address,
+        },
+        protocol::pike::state::{
+            AgentBuilder, AgentListBuilder, OrganizationBuilder, OrganizationListBuilder,
+            RoleBuilder, RoleListBuilder,
+        },
+        protocol::purchase_order::{
+            payload::CreatePurchaseOrderPayloadBuilder,
+            state::{
+                PurchaseOrder, PurchaseOrderBuilder, PurchaseOrderListBuilder,
+                PurchaseOrderRevision, PurchaseOrderRevisionBuilder, PurchaseOrderVersion,
+                PurchaseOrderVersionBuilder,
+            },
+        },
+        protos::IntoBytes,
+        purchase_order::addressing::compute_purchase_order_address,
+    };
+
+    use sawtooth_sdk::processor::handler::{ContextError, TransactionContext};
+
+    const BUYER_PUB_KEY: &str = "buyer_agent_pub_key";
+    const SELLER_PUB_KEY: &str = "seller_agent_pub_key";
+
+    const PO_UID: &str = "test_po_1";
+    const PO_VERSION_ID_1: &str = "01";
+
+    const ROLE_BUYER: &str = "buyer";
+    const PERM_ALIAS_BUYER: &str = "po::buyer";
+
+    const ROLE_SELLER: &str = "seller";
+    const PERM_ALIAS_SELLER: &str = "po::seller";
+
+    const ORG_ID_1: &str = "test_org_1";
+    const ORG_ID_2: &str = "test_org_2";
+
+    #[derive(Default, Debug)]
+    /// A MockTransactionContext that can be used to test ProductState
+    struct MockTransactionContext {
+        state: RefCell<HashMap<String, Vec<u8>>>,
+    }
+
+    impl TransactionContext for MockTransactionContext {
+        fn get_state_entries(
+            &self,
+            addresses: &[String],
+        ) -> Result<Vec<(String, Vec<u8>)>, ContextError> {
+            let mut results = Vec::new();
+            for addr in addresses {
+                let data = match self.state.borrow().get(addr) {
+                    Some(data) => data.clone(),
+                    None => Vec::new(),
+                };
+                results.push((addr.to_string(), data));
+            }
+            Ok(results)
+        }
+
+        fn set_state_entries(&self, entries: Vec<(String, Vec<u8>)>) -> Result<(), ContextError> {
+            for (addr, data) in entries {
+                self.state.borrow_mut().insert(addr, data);
+            }
+            Ok(())
+        }
+
+        /// this is not needed for these tests
+        fn delete_state_entries(&self, _addresses: &[String]) -> Result<Vec<String>, ContextError> {
+            unimplemented!()
+        }
+
+        /// this is not needed for these tests
+        fn add_receipt_data(&self, _data: &[u8]) -> Result<(), ContextError> {
+            unimplemented!()
+        }
+
+        /// this is not needed for these tests
+        fn add_event(
+            &self,
+            _event_type: String,
+            _attributes: Vec<(String, String)>,
+            _data: &[u8],
+        ) -> Result<(), ContextError> {
+            unimplemented!()
+        }
+    }
+
+    impl MockTransactionContext {
+        fn add_buyer_role(&self) {
+            let buyer_role = RoleBuilder::new()
+                .with_org_id(ORG_ID_1.to_string())
+                .with_name(ROLE_BUYER.to_string())
+                .with_description("Purchase Order buyer role".to_string())
+                .with_permissions(vec![PERM_ALIAS_BUYER.to_string()])
+                .build()
+                .expect("Unable to build role");
+            let role_list = RoleListBuilder::new()
+                .with_roles(vec![buyer_role])
+                .build()
+                .expect("Unable to build role list");
+            let role_bytes = role_list
+                .into_bytes()
+                .expect("Unable to convert role list to bytes");
+            let role_address = compute_role_address(ROLE_BUYER, ORG_ID_1);
+            self.set_state_entry(role_address, role_bytes)
+                .expect("Unable to set role in state");
+        }
+
+        fn add_buyer_agent(&self) {
+            let agent = AgentBuilder::new()
+                .with_org_id(ORG_ID_1.to_string())
+                .with_public_key(BUYER_PUB_KEY.to_string())
+                .with_active(true)
+                .with_roles(vec![ROLE_BUYER.to_string()])
+                .build()
+                .expect("Unable to build agent");
+
+            let agent_list = AgentListBuilder::new()
+                .with_agents(vec![agent])
+                .build()
+                .expect("Unable to build agent list");
+            let agent_bytes = agent_list
+                .into_bytes()
+                .expect("Unable to convert agent list to bytes");
+            let agent_address = compute_agent_address(BUYER_PUB_KEY);
+            self.set_state_entry(agent_address, agent_bytes)
+                .expect("Unable to add agent to state");
+        }
+
+        fn add_seller_role(&self) {
+            let role = RoleBuilder::new()
+                .with_org_id(ORG_ID_2.to_string())
+                .with_name(ROLE_SELLER.to_string())
+                .with_description("Purchase Order seller role".to_string())
+                .with_permissions(vec![PERM_ALIAS_SELLER.to_string()])
+                .build()
+                .expect("Unable to build role");
+
+            let role_list = RoleListBuilder::new()
+                .with_roles(vec![role])
+                .build()
+                .expect("Unable to build role list");
+            let role_bytes = role_list.into_bytes().unwrap();
+            let role_address = compute_role_address(ROLE_SELLER, ORG_ID_2);
+            self.set_state_entry(role_address, role_bytes)
+                .expect("Unable to add role to state");
+        }
+
+        fn add_seller_agent(&self) {
+            let agent = AgentBuilder::new()
+                .with_org_id(ORG_ID_2.to_string())
+                .with_public_key(SELLER_PUB_KEY.to_string())
+                .with_active(true)
+                .with_roles(vec![ROLE_SELLER.to_string()])
+                .build()
+                .expect("Unable to build agent");
+            let agent_list = AgentListBuilder::new()
+                .with_agents(vec![agent])
+                .build()
+                .expect("Unable to build agent list");
+            let agent_bytes = agent_list
+                .into_bytes()
+                .expect("Unable to convert agent list toy bytes");
+            let agent_address = compute_agent_address(SELLER_PUB_KEY);
+            self.set_state_entry(agent_address, agent_bytes)
+                .expect("Unable to set agent in state");
+        }
+
+        fn add_org(&self, org_id: &str) {
+            let org = OrganizationBuilder::new()
+                .with_org_id(org_id.to_string())
+                .with_name(format!("Organization {}", org_id))
+                .build()
+                .expect("Unable to build organization");
+            let list = OrganizationListBuilder::new()
+                .with_organizations(vec![org])
+                .build()
+                .expect("Unable to build organization list");
+            let org_bytes = list
+                .into_bytes()
+                .expect("Unable to convert organization list to bytes");
+            let org_address = compute_organization_address(org_id);
+            self.set_state_entry(org_address, org_bytes)
+                .expect("Unable to add organization to state");
+        }
+
+        fn add_purchase_order(&self) {
+            let po = purchase_order();
+            let list = PurchaseOrderListBuilder::new()
+                .with_purchase_orders(vec![po])
+                .build()
+                .expect("Unable to build purchase order list");
+            let po_bytes = list
+                .into_bytes()
+                .expect("Unable to convert purchase order list to bytes");
+            let po_address = compute_purchase_order_address(PO_UID);
+            self.set_state_entry(po_address, po_bytes)
+                .expect("Unable to add purchase order to state");
+        }
+    }
+
+    #[test]
+    fn test_create_po_already_exists() {
+        let ctx = MockTransactionContext::default();
+        let mut state = PurchaseOrderState::new(&ctx);
+        let perm_checker = PermissionChecker::new(&ctx);
+        ctx.add_purchase_order();
+        let create_po_payload = CreatePurchaseOrderPayloadBuilder::new()
+            .with_uid(PO_UID.to_string())
+            .with_created_at(1)
+            .with_buyer_org_id(ORG_ID_1.to_string())
+            .with_seller_org_id(ORG_ID_2.to_string())
+            .build()
+            .expect("Unable to build CreatePurchaseOrderPayload");
+
+        if let Ok(()) =
+            create_purchase_order(&create_po_payload, BUYER_PUB_KEY, &mut state, &perm_checker)
+        {
+            panic!(
+                "New purchase order should be invalid because one with the same ID already exists"
+            )
+        }
+    }
+
+    #[test]
+    fn test_create_po_org_does_not_exist() {
+        let ctx = MockTransactionContext::default();
+        let mut state = PurchaseOrderState::new(&ctx);
+        let perm_checker = PermissionChecker::new(&ctx);
+        ctx.add_org(ORG_ID_1);
+        ctx.add_buyer_agent();
+        let create_po_payload = CreatePurchaseOrderPayloadBuilder::new()
+            .with_uid(PO_UID.to_string())
+            .with_created_at(1)
+            .with_buyer_org_id(ORG_ID_1.to_string())
+            .with_seller_org_id(ORG_ID_2.to_string())
+            .build()
+            .expect("Unable to build CreatePurchaseOrderPayload");
+
+        if let Ok(()) =
+            create_purchase_order(&create_po_payload, BUYER_PUB_KEY, &mut state, &perm_checker)
+        {
+            panic!("New purchase order should be invalid because an organization does not exist")
+        }
+    }
+
+    #[test]
+    fn test_create_po_agent_does_not_exist() {
+        let ctx = MockTransactionContext::default();
+        let mut state = PurchaseOrderState::new(&ctx);
+        let perm_checker = PermissionChecker::new(&ctx);
+        ctx.add_org(ORG_ID_1);
+        ctx.add_org(ORG_ID_2);
+        let create_po_payload = CreatePurchaseOrderPayloadBuilder::new()
+            .with_uid(PO_UID.to_string())
+            .with_created_at(1)
+            .with_buyer_org_id(ORG_ID_1.to_string())
+            .with_seller_org_id(ORG_ID_2.to_string())
+            .build()
+            .expect("Unable to build CreatePurchaseOrderPayload");
+
+        if let Ok(()) =
+            create_purchase_order(&create_po_payload, BUYER_PUB_KEY, &mut state, &perm_checker)
+        {
+            panic!("New purchase order should be invalid because submitter agent does not exist")
+        }
+    }
+
+    #[test]
+    fn test_create_po_invalid_agent_role() {
+        let ctx = MockTransactionContext::default();
+        let mut state = PurchaseOrderState::new(&ctx);
+        let perm_checker = PermissionChecker::new(&ctx);
+        ctx.add_org(ORG_ID_1);
+        ctx.add_org(ORG_ID_2);
+        ctx.add_seller_role();
+        ctx.add_seller_agent();
+        let create_po_payload = CreatePurchaseOrderPayloadBuilder::new()
+            .with_uid(PO_UID.to_string())
+            .with_created_at(1)
+            .with_buyer_org_id(ORG_ID_1.to_string())
+            .with_seller_org_id(ORG_ID_2.to_string())
+            .build()
+            .expect("Unable to build CreatePurchaseOrderPayload");
+
+        if let Ok(()) = create_purchase_order(
+            &create_po_payload,
+            SELLER_PUB_KEY,
+            &mut state,
+            &perm_checker,
+        ) {
+            panic!("Should be invalid because agent does not have permission to create po")
+        }
+    }
+
+    #[test]
+    fn test_create_po_valid() {
+        let ctx = MockTransactionContext::default();
+        let mut state = PurchaseOrderState::new(&ctx);
+        let perm_checker = PermissionChecker::new(&ctx);
+        ctx.add_org(ORG_ID_1);
+        ctx.add_org(ORG_ID_2);
+        ctx.add_buyer_role();
+        ctx.add_buyer_agent();
+        let create_po_payload = CreatePurchaseOrderPayloadBuilder::new()
+            .with_uid(PO_UID.to_string())
+            .with_created_at(1)
+            .with_buyer_org_id(ORG_ID_1.to_string())
+            .with_seller_org_id(ORG_ID_2.to_string())
+            .build()
+            .expect("Unable to build CreatePurchaseOrderPayload");
+        if let Err(err) =
+            create_purchase_order(&create_po_payload, BUYER_PUB_KEY, &mut state, &perm_checker)
+        {
+            panic!("Should be valid: {}", err)
+        }
+    }
+
+    fn purchase_order() -> PurchaseOrder {
+        PurchaseOrderBuilder::new()
+            .with_uid(PO_UID.to_string())
+            .with_workflow_status("Issued".to_string())
+            .with_created_at(1)
+            .with_accepted_version_number("".to_string())
+            .with_versions(vec![purchase_order_version(PO_VERSION_ID_1)])
+            .with_is_closed(false)
+            .with_buyer_org_id(ORG_ID_1.to_string())
+            .with_seller_org_id(ORG_ID_2.to_string())
+            .build()
+            .expect("Unable to build purchase order")
+    }
+
+    fn purchase_order_version(version_id: &str) -> PurchaseOrderVersion {
+        PurchaseOrderVersionBuilder::new()
+            .with_version_id(version_id.to_string())
+            .with_workflow_status("Editable".to_string())
+            .with_is_draft(true)
+            .with_current_revision_id("1".to_string())
+            .with_revisions(purchase_order_revisions())
+            .build()
+            .expect("Unable to build first purchase order version")
+    }
+
+    fn purchase_order_revisions() -> Vec<PurchaseOrderRevision> {
+        vec![PurchaseOrderRevisionBuilder::new()
+            .with_revision_id("1".to_string())
+            .with_submitter(BUYER_PUB_KEY.to_string())
+            .with_created_at(1)
+            .with_order_xml_v3_4("xml_purchase_order".to_string())
+            .build()
+            .expect("Unable to build purchase order revision")]
+    }
 }

--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -190,7 +190,7 @@ fn create_purchase_order(
                     )
                 })?;
                 let perm_result = perm_checker
-                    ._check_permission_with_workflow(
+                    .check_permission_with_workflow(
                         &perm_string,
                         signer,
                         agent.org_id(),
@@ -226,7 +226,7 @@ fn create_purchase_order(
                     )
                 })?;
                 let perm_result = perm_checker
-                    ._check_permission_with_workflow(
+                    .check_permission_with_workflow(
                         &perm_string,
                         signer,
                         agent.org_id(),
@@ -273,13 +273,7 @@ fn create_purchase_order(
     })?;
     let perm_string = Permission::CanCreatePo.to_string();
     let perm_result = perm_checker
-        ._check_permission_with_workflow(
-            &perm_string,
-            signer,
-            agent.org_id(),
-            start_state,
-            "issued",
-        )
+        .check_permission_with_workflow(&perm_string, signer, agent.org_id(), start_state, "issued")
         .map_err(|err| {
             ApplyError::InternalError(format!("Unable to check agent's permission: {}", err))
         })?;

--- a/contracts/purchase_order/src/main.rs
+++ b/contracts/purchase_order/src/main.rs
@@ -35,6 +35,7 @@ cfg_if! {
 }
 
 pub mod handler;
+pub mod permissions;
 mod state;
 pub(in crate) mod workflow;
 

--- a/contracts/purchase_order/src/permissions.rs
+++ b/contracts/purchase_order/src/permissions.rs
@@ -1,0 +1,63 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+pub enum Permission {
+    CanCreatePo,
+    CanUpdatePo,
+    CanCreatePoVersion,
+    CanUpdatePoVersion,
+    CanUpdatePoVersionResponse,
+    CanTransitionIssued,
+    CanTransitionClosed,
+    CanTransitionConfirmed,
+    CanTransitionComposed,
+    CanTransitionProposed,
+    CanTransitionObsolete,
+    CanTransitionRejected,
+    CanTransitionAccepted,
+    CanTransitionDeclined,
+    CanTransitionModified,
+    CanTransitionEditable,
+    CanTransitionReview,
+    CanTransitionCancelled,
+}
+
+impl fmt::Display for Permission {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Permission::CanCreatePo => write!(f, "can-create-po"),
+            Permission::CanUpdatePo => write!(f, "can-update-po"),
+            Permission::CanCreatePoVersion => write!(f, "can-create-po-version"),
+            Permission::CanUpdatePoVersion => write!(f, "can-update-po-version"),
+            Permission::CanUpdatePoVersionResponse => {
+                write!(f, "can-update-po-version-response")
+            }
+            Permission::CanTransitionIssued => write!(f, "can-transition-issued"),
+            Permission::CanTransitionClosed => write!(f, "can-transition-closed"),
+            Permission::CanTransitionConfirmed => write!(f, "can-transition-confirmed"),
+            Permission::CanTransitionComposed => write!(f, "can-transition-composed"),
+            Permission::CanTransitionProposed => write!(f, "can-transition-proposed"),
+            Permission::CanTransitionObsolete => write!(f, "can-transition-obsolete"),
+            Permission::CanTransitionRejected => write!(f, "can-transition-rejected"),
+            Permission::CanTransitionAccepted => write!(f, "can-transition-accepted"),
+            Permission::CanTransitionDeclined => write!(f, "can-transition-declined"),
+            Permission::CanTransitionModified => write!(f, "can-transition-modified"),
+            Permission::CanTransitionEditable => write!(f, "can-transition-editable"),
+            Permission::CanTransitionReview => write!(f, "can-transition-review"),
+            Permission::CanTransitionCancelled => write!(f, "can-transition-cancelled"),
+        }
+    }
+}

--- a/contracts/purchase_order/src/workflow.rs
+++ b/contracts/purchase_order/src/workflow.rs
@@ -18,13 +18,11 @@ use grid_sdk::workflow::{
 
 use crate::permissions::Permission;
 
-#[allow(dead_code)]
 pub enum POWorkflow {
     SystemOfRecord,
     Collaborative,
 }
 
-#[allow(dead_code)]
 pub fn get_workflow(name: &POWorkflow) -> Option<Workflow> {
     match *name {
         POWorkflow::SystemOfRecord => Some(system_of_record_workflow()),

--- a/contracts/purchase_order/src/workflow.rs
+++ b/contracts/purchase_order/src/workflow.rs
@@ -25,8 +25,8 @@ pub enum POWorkflow {
 }
 
 #[allow(dead_code)]
-pub fn get_workflow(name: POWorkflow) -> Option<Workflow> {
-    match name {
+pub fn get_workflow(name: &POWorkflow) -> Option<Workflow> {
+    match *name {
         POWorkflow::SystemOfRecord => Some(system_of_record_workflow()),
         POWorkflow::Collaborative => Some(collaborative_workflow()),
     }

--- a/contracts/purchase_order/src/workflow.rs
+++ b/contracts/purchase_order/src/workflow.rs
@@ -16,6 +16,8 @@ use grid_sdk::workflow::{
     PermissionAlias, SubWorkflow, SubWorkflowBuilder, Workflow, WorkflowStateBuilder,
 };
 
+use crate::permissions::Permission;
+
 #[allow(dead_code)]
 pub enum POWorkflow {
     SystemOfRecord,
@@ -44,14 +46,14 @@ fn collaborative_workflow() -> Workflow {
 fn default_sub_workflow() -> SubWorkflow {
     let create = {
         let mut buyer = PermissionAlias::new("po::buyer");
-        buyer.add_permission("can-create-po");
-        buyer.add_permission("can-create-po-version");
-        buyer.add_permission("can-transition-issued");
+        buyer.add_permission(&Permission::CanCreatePo.to_string());
+        buyer.add_permission(&Permission::CanCreatePoVersion.to_string());
+        buyer.add_permission(&Permission::CanTransitionIssued.to_string());
         buyer.add_transition("issued");
 
         let mut seller = PermissionAlias::new("po::seller");
-        seller.add_permission("can-create-po-version");
-        buyer.add_permission("can-transition-issued");
+        seller.add_permission(&Permission::CanCreatePoVersion.to_string());
+        buyer.add_permission(&Permission::CanTransitionIssued.to_string());
         buyer.add_transition("issued");
 
         WorkflowStateBuilder::new("create")
@@ -63,15 +65,15 @@ fn default_sub_workflow() -> SubWorkflow {
 
     let issued = {
         let mut buyer = PermissionAlias::new("po::buyer");
-        buyer.add_permission("can-create-po-version");
-        buyer.add_permission("can-update-po-version");
-        buyer.add_permission("can-transition-closed");
+        buyer.add_permission(&Permission::CanCreatePoVersion.to_string());
+        buyer.add_permission(&Permission::CanUpdatePoVersion.to_string());
+        buyer.add_permission(&Permission::CanTransitionClosed.to_string());
         buyer.add_transition("closed");
 
         let mut seller = PermissionAlias::new("po::seller");
-        seller.add_permission("can-create-po-version");
-        seller.add_permission("can-update-po-version");
-        seller.add_permission("can-transition-confirmed");
+        seller.add_permission(&Permission::CanCreatePoVersion.to_string());
+        seller.add_permission(&Permission::CanUpdatePoVersion.to_string());
+        seller.add_permission(&Permission::CanTransitionConfirmed.to_string());
         seller.add_transition("confirmed");
 
         WorkflowStateBuilder::new("issued")
@@ -84,13 +86,13 @@ fn default_sub_workflow() -> SubWorkflow {
 
     let confirmed = {
         let mut buyer = PermissionAlias::new("po::buyer");
-        buyer.add_permission("can-create-po-version");
-        buyer.add_permission("can-transition-issued");
+        buyer.add_permission(&Permission::CanCreatePoVersion.to_string());
+        buyer.add_permission(&Permission::CanTransitionIssued.to_string());
         buyer.add_transition("issued");
 
         let mut seller = PermissionAlias::new("po::seller");
-        seller.add_permission("can-create-po-version");
-        seller.add_permission("can-transition-closed");
+        seller.add_permission(&Permission::CanCreatePoVersion.to_string());
+        seller.add_permission(&Permission::CanTransitionClosed.to_string());
         seller.add_transition("confirmed");
 
         WorkflowStateBuilder::new("confirmed")
@@ -123,8 +125,8 @@ fn default_sub_workflow() -> SubWorkflow {
 fn system_of_record_sub_workflow() -> SubWorkflow {
     let create = {
         let mut buyer = PermissionAlias::new("po::buyer");
-        buyer.add_permission("can-create-po-version");
-        buyer.add_permission("can-transition-proposed");
+        buyer.add_permission(&Permission::CanCreatePoVersion.to_string());
+        buyer.add_permission(&Permission::CanTransitionProposed.to_string());
         buyer.add_transition("proposed");
 
         let seller = PermissionAlias::new("po::seller");
@@ -138,21 +140,21 @@ fn system_of_record_sub_workflow() -> SubWorkflow {
 
     let proposed = {
         let mut buyer = PermissionAlias::new("po::buyer");
-        buyer.add_permission("can-update-po-version");
-        buyer.add_permission("can-transition-obsolete");
+        buyer.add_permission(&Permission::CanUpdatePoVersion.to_string());
+        buyer.add_permission(&Permission::CanTransitionObsolete.to_string());
         buyer.add_transition("obsolete");
 
         let mut seller_confirm = PermissionAlias::new("po::seller");
-        seller_confirm.add_permission("can-update-po-version");
-        seller_confirm.add_permission("can-transition-rejected");
-        seller_confirm.add_permission("can-transition-accepted");
+        seller_confirm.add_permission(&Permission::CanUpdatePoVersion.to_string());
+        seller_confirm.add_permission(&Permission::CanTransitionRejected.to_string());
+        seller_confirm.add_permission(&Permission::CanTransitionAccepted.to_string());
         seller_confirm.add_transition("rejected");
         seller_confirm.add_transition("accepted");
 
         let mut seller_modify = PermissionAlias::new("po::seller");
-        seller_modify.add_permission("can-update-po-version");
-        seller_modify.add_permission("can-update-po");
-        seller_modify.add_permission("can-transition-modified");
+        seller_modify.add_permission(&Permission::CanUpdatePoVersion.to_string());
+        seller_modify.add_permission(&Permission::CanUpdatePo.to_string());
+        seller_modify.add_permission(&Permission::CanTransitionModified.to_string());
         seller_modify.add_transition("modified");
 
         WorkflowStateBuilder::new("proposed")
@@ -188,18 +190,18 @@ fn system_of_record_sub_workflow() -> SubWorkflow {
 
     let modified = {
         let mut buyer = PermissionAlias::new("po::buyer");
-        buyer.add_permission("can-transition-obsolete");
+        buyer.add_permission(&Permission::CanTransitionObsolete.to_string());
         buyer.add_transition("obsolete");
 
         let mut seller_modify = PermissionAlias::new("po::seller");
-        seller_modify.add_permission("can-update-po-version");
-        seller_modify.add_permission("can-update-po");
-        seller_modify.add_permission("can-transition-modified");
-        seller_modify.add_permission("can-update-po-version-response");
+        seller_modify.add_permission(&Permission::CanUpdatePoVersion.to_string());
+        seller_modify.add_permission(&Permission::CanUpdatePo.to_string());
+        seller_modify.add_permission(&Permission::CanTransitionModified.to_string());
+        seller_modify.add_permission(&Permission::CanUpdatePoVersionResponse.to_string());
 
         let mut editor = PermissionAlias::new("po::editor");
-        editor.add_permission("can-transition-editable");
-        editor.add_permission("can-transition-review");
+        editor.add_permission(&Permission::CanTransitionEditable.to_string());
+        editor.add_permission(&Permission::CanTransitionReview.to_string());
         editor.add_transition("review");
         editor.add_transition("editable");
 
@@ -215,7 +217,7 @@ fn system_of_record_sub_workflow() -> SubWorkflow {
 
     let accepted = {
         let mut buyer = PermissionAlias::new("po::buyer");
-        buyer.add_permission("can-transition-obsolete");
+        buyer.add_permission(&Permission::CanTransitionObsolete.to_string());
         buyer.add_transition("obsolete");
 
         let seller = PermissionAlias::new("po::seller");
@@ -229,9 +231,9 @@ fn system_of_record_sub_workflow() -> SubWorkflow {
 
     let editable = {
         let mut draft = PermissionAlias::new("po::draft");
-        draft.add_permission("can-update-po-version");
-        draft.add_permission("can-transition-cancelled");
-        draft.add_permission("can-transition-review");
+        draft.add_permission(&Permission::CanUpdatePoVersion.to_string());
+        draft.add_permission(&Permission::CanTransitionCancelled.to_string());
+        draft.add_permission(&Permission::CanTransitionReview.to_string());
         draft.add_transition("cancelled");
         draft.add_transition("review");
 
@@ -244,10 +246,10 @@ fn system_of_record_sub_workflow() -> SubWorkflow {
 
     let review = {
         let mut draft = PermissionAlias::new("po::draft");
-        draft.add_permission("can-update-po-version");
-        draft.add_permission("can-transition-editable");
-        draft.add_permission("can-transition-composed");
-        draft.add_permission("can-transition-declined");
+        draft.add_permission(&Permission::CanUpdatePoVersion.to_string());
+        draft.add_permission(&Permission::CanTransitionEditable.to_string());
+        draft.add_permission(&Permission::CanTransitionComposed.to_string());
+        draft.add_permission(&Permission::CanTransitionDeclined.to_string());
         draft.add_transition("editable");
         draft.add_transition("composed");
         draft.add_transition("declined");
@@ -262,8 +264,8 @@ fn system_of_record_sub_workflow() -> SubWorkflow {
 
     let declined = {
         let mut draft = PermissionAlias::new("po::draft");
-        draft.add_permission("can-transition-editable");
-        draft.add_permission("can-transition-cancelled");
+        draft.add_permission(&Permission::CanTransitionEditable.to_string());
+        draft.add_permission(&Permission::CanTransitionCancelled.to_string());
         draft.add_transition("editable");
         draft.add_transition("cancelled");
 
@@ -310,8 +312,8 @@ fn system_of_record_sub_workflow() -> SubWorkflow {
 fn collaborative_sub_workflow() -> SubWorkflow {
     let create = {
         let mut partner = PermissionAlias::new("po::partner");
-        partner.add_permission("can-create-po-version");
-        partner.add_permission("can-transition-proposed");
+        partner.add_permission(&Permission::CanCreatePoVersion.to_string());
+        partner.add_permission(&Permission::CanTransitionProposed.to_string());
         partner.add_transition("proposed");
 
         WorkflowStateBuilder::new("create")
@@ -322,11 +324,11 @@ fn collaborative_sub_workflow() -> SubWorkflow {
 
     let proposed = {
         let mut partner = PermissionAlias::new("po::partner");
-        partner.add_permission("can-update-po-version");
-        partner.add_permission("can-transition-rejected");
-        partner.add_permission("can-transition-accepted");
-        partner.add_permission("can-transition-modified");
-        partner.add_permission("can-transition-obsolete");
+        partner.add_permission(&Permission::CanUpdatePoVersion.to_string());
+        partner.add_permission(&Permission::CanTransitionRejected.to_string());
+        partner.add_permission(&Permission::CanTransitionAccepted.to_string());
+        partner.add_permission(&Permission::CanTransitionModified.to_string());
+        partner.add_permission(&Permission::CanTransitionObsolete.to_string());
         partner.add_transition("rejected");
         partner.add_transition("accepted");
         partner.add_transition("modified");
@@ -351,7 +353,7 @@ fn collaborative_sub_workflow() -> SubWorkflow {
 
     let accepted = {
         let mut partner = PermissionAlias::new("po::partner");
-        partner.add_permission("can-transition-obsolete");
+        partner.add_permission(&Permission::CanTransitionObsolete.to_string());
         partner.add_transition("obsolete");
 
         WorkflowStateBuilder::new("proposed")
@@ -362,12 +364,12 @@ fn collaborative_sub_workflow() -> SubWorkflow {
 
     let modified = {
         let mut partner = PermissionAlias::new("po::partner");
-        partner.add_permission("can-update-po-version");
-        partner.add_permission("can-update-po");
-        partner.add_permission("can-update-po-version-response");
-        partner.add_permission("can-transition-proposed");
-        partner.add_permission("can-transition-accepted");
-        partner.add_permission("can-transition-obsolete");
+        partner.add_permission(&Permission::CanUpdatePoVersion.to_string());
+        partner.add_permission(&Permission::CanUpdatePo.to_string());
+        partner.add_permission(&Permission::CanUpdatePoVersionResponse.to_string());
+        partner.add_permission(&Permission::CanTransitionProposed.to_string());
+        partner.add_permission(&Permission::CanTransitionAccepted.to_string());
+        partner.add_permission(&Permission::CanTransitionObsolete.to_string());
         partner.add_transition("proposed");
         partner.add_transition("accepted");
         partner.add_transition("obsolete");

--- a/sdk/src/pike/permissions/mod.rs
+++ b/sdk/src/pike/permissions/mod.rs
@@ -196,7 +196,7 @@ impl<'a> PermissionChecker<'a> {
         }
     }
 
-    pub fn _check_permission_with_workflow(
+    pub fn check_permission_with_workflow(
         &self,
         permission: &str,
         signer: &str,
@@ -670,7 +670,7 @@ mod tests {
             .expect("Unable to get create state from subworkflow");
         // Validate that the Agent has the correct permission
         let result = perm_checker
-            ._check_permission_with_workflow(
+            .check_permission_with_workflow(
                 PERM_CAN_CREATE_PO,
                 PUBLIC_KEY_ALPHA,
                 ORG_ID_ALPHA,
@@ -745,7 +745,7 @@ mod tests {
             .expect("Unable to get create state from subworkflow");
         // Validate the Agent does not have the correct permission.
         let result = perm_checker
-            ._check_permission_with_workflow(
+            .check_permission_with_workflow(
                 PERM_CAN_CREATE_PO,
                 PUBLIC_KEY_ALPHA,
                 ORG_ID_ALPHA,
@@ -809,7 +809,7 @@ mod tests {
             .expect("Unable to get issued state from subworkflow");
 
         let result = perm_checker
-            ._check_permission_with_workflow(
+            .check_permission_with_workflow(
                 PERM_CAN_UPDATE_PO_VERSION,
                 PUBLIC_KEY_ALPHA,
                 ORG_ID_ALPHA,
@@ -890,7 +890,7 @@ mod tests {
         // Check that the agent is able to transition the state to "issued" and has the
         // "can-create-po" permission for the Alpha organization
         let result = perm_checker
-            ._check_permission_with_workflow(
+            .check_permission_with_workflow(
                 PERM_CAN_CREATE_PO,
                 PUBLIC_KEY_BETA,
                 ORG_ID_ALPHA,
@@ -966,7 +966,7 @@ mod tests {
             .expect("Unable to get create state from subworkflow");
 
         let result = perm_checker
-            ._check_permission_with_workflow(
+            .check_permission_with_workflow(
                 PERM_CAN_CREATE_PO,
                 PUBLIC_KEY_BETA,
                 ORG_ID_ALPHA,


### PR DESCRIPTION
This change adds an implementation to the purchase order smart contract's "create po" action. This action is implemented using the workflow-aware permission check.