### PR TITLE
Fix clippy error in CLI build file

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -116,7 +116,7 @@ fn main() -> Result<(), BuildError> {
 
         if markdown.ends_with(".md") {
             match Command::new("pandoc")
-                .args(&["--standalone", "--to", "man", &markdown, "-o", &manpage])
+                .args(&["--standalone", "--to", "man", markdown, "-o", manpage])
                 .status()
             {
                 Ok(status) => {


### PR DESCRIPTION
This change removes unneeded references from the CLI's `build.rs` file.
These references caused errors when running `just lint`.

Signed-off-by: Shannyn Telander <telander@bitwise.io>