### PR TITLE
Add purchase order list and show functionality

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,6 +30,7 @@ path = "src/main.rs"
 
 [dependencies]
 assert_cmd = "1.0"
+chrono = "0.4.19"
 clap = "2"
 diesel = { version = "1.0", features = ["postgres"], optional = true }
 cylinder = { version = "0.2.2", features = ["key-load"] }
@@ -38,12 +39,13 @@ log = "0.4"
 flexi_logger = "0.17"
 sawtooth-sdk = "0.4"
 sabre-sdk = "0.5"
-grid-sdk = { path = "../sdk", features = ["postgres", "sqlite", "pike", "schema", "product", "product-gdsn", "location", "client", "client-reqwest", "data-validation"] }
+grid-sdk = { path = "../sdk", features = ["postgres", "sqlite", "pike", "schema", "product", "product-gdsn", "purchase-order", "location", "client", "client-reqwest", "data-validation"] }
 rust-crypto = "0.2"
 protobuf = "2.19"
 users = "0.11"
 dirs = "3"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
 serde_yaml = "0.8"
 diesel_migrations = "1.4"
 whoami = "1"

--- a/cli/man/grid-po-list.1.md
+++ b/cli/man/grid-po-list.1.md
@@ -1,4 +1,5 @@
 % GRID-PO-LIST(1) Cargill, Incorporated | Grid
+
 <!--
   Copyright 2021 Cargill Incorporated
   Licensed under Creative Commons Attribution 4.0 International License
@@ -20,7 +21,6 @@ DESCRIPTION
 
 List all purchase orders in grid.
 
-
 FLAGS
 =====
 
@@ -35,7 +35,7 @@ FLAGS
 
 `--accepted`
 : Filter on whether the purchase order has an accepted version. Conflicts with
-  `--not-accepted`.
+`--not-accepted`.
 
 `--not-accepted`
 : Filter on whether the purchase order does not have an accepted version.
@@ -56,17 +56,19 @@ OPTIONS
 
 `-F`, `--format=FORMAT`
 : Specifies the output format of the list. Possible values for formatting are
-  `human`, `csv`, `yaml`, and `json`. Defaults to `human`.
-  
-`--org`
-: Optionally, filter the purchase orders for the organization specified by
-  `ORG_ID`. 
+`human`, `csv`, `yaml`, and `json`. Defaults to `human`.
+
+`--buyer-org`
+: Optionally, filter the purchase orders by the buyer's organization ID.
+
+`--seller-org`
+: Optionally, filter the purchase orders by the seller's organization ID.
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
   Splinter. Format: `<circuit-id>::<service-id>`.
 
-  `--url`
+`--url`
 : URL for the REST API.
 
 EXAMPLES
@@ -75,14 +77,14 @@ EXAMPLES
 The command
 
 ```
-$ grid po list --org=crgl
+$ grid po list --buyer-org=crgl
 ```
 
 will list all purchase orders for the org `crgl` in human-readable format:
 
 ```
-ORG   UUID                STATUS    ACCEPTED CLOSED
-crgl  82urioz098aui3871uc Confirmed v3       False
+BUYER SELLER   UID                 STATUS    ACCEPTED CLOSED
+crgl  tst      PO-1234-56789       Confirmed v3       False
 ```
 
 The command
@@ -95,11 +97,12 @@ will list all the purchase orders that have an accepted version in
 human-readable format:
 
 ```
-ORG    UUID                STATUS    ACCEPTED CLOSED
-crgl   82urioz098aui3871uc Confirmed v3       False
-tst    2389f7987d9s09df98f Issued    v1       False
-tst    f808u23hjiof09ufs0d Closed    v1       True
+BUYER SELLER   UID                 STATUS    ACCEPTED CLOSED
+crgl  tst      PO-1234-56789       Confirmed v3       False
+tst   crgl     PO-2345-67890       Issued    v1       False
+crgl  tst      PO-3456-78901       Closed    v1       True
 ```
+
 The command
 
 ```
@@ -110,12 +113,12 @@ The command
 ```
 
 will display all of the purchase orders that have an accepted version and are
-open.  The output is formatted in csv:
+open. The output is formatted in csv:
 
 ```
-ORG,UUID,STATUS,ACCEPTED,CLOSED
-crgl,82urioz098aui3871uc,Confirmed,v3,False
-tst,2389f7987d9s09df98f,Issued,v1,False
+BUYER,SELLER,UID,STATUS,ACCEPTED,CLOSED
+crgl,tst,PO-1234-56789,Confirmed,v3,False
+tst,crgl,PO-2345-67890,Issued,v1,False
 ```
 
 ENVIRONMENT VARIABLES
@@ -129,6 +132,7 @@ ENVIRONMENT VARIABLES
 
 SEE ALSO
 ========
+
 | `grid-po-show(1)`
 | `grid-po-list(1)`
 |

--- a/cli/man/grid-po-show.1.md
+++ b/cli/man/grid-po-show.1.md
@@ -1,4 +1,5 @@
 % GRID-PO-SHOW(1) Cargill, Incorporated | Grid
+
 <!--
   Copyright 2021 Cargill Incorporated
   Licensed under Creative Commons Attribution 4.0 International License
@@ -18,14 +19,14 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-Show the details of a specific purchase order.  This command displays the
+Show the details of a specific purchase order. This command displays the
 specified revision of a specified version of the purchase order.
 
 ARGS
 ====
 
 `IDENTIFIER`
-: Either a UUID or an alternate ID of a purchase order.
+: Either a UID or an alternate ID of a purchase order.
 
 FLAGS
 =====
@@ -41,32 +42,32 @@ FLAGS
 
 `-v`
 : Increases verbosity (the opposite of `-q`). Specify multiple times for more
-  output.
+output.
 
 OPTIONS
 =======
 
 `-F`, `--format=FORMAT`
 : Specifies the output format of the list. Possible values for formatting are
-  `human`, `csv`, `yaml`, and `json`. Defaults to `human`.
+`human`, `csv`, `yaml`, and `json`. Defaults to `human`.
 
 `--org`
 : Specify the organization that owns the purchase order.
 
 `--revision`
 : Specify the revision number for the specified version. Defaults to the latest
-  revision.
+revision.
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format: `<circuit-id>::<service-id>`.
+Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API
 
 `--version`
 : Specify the version ID of the purchase order to display. Defaults to the
-  accepted version.
+accepted version.
 
 EXAMPLES
 ========
@@ -74,25 +75,23 @@ EXAMPLES
 The command
 
 ```
-$ grid po show --org=crgl 82urioz098aui3871uc
+$ grid po show --org=crgl 809832081
 ```
 
 will display the current revision of the accepted version of the purchase order
-with UUID `82urioz098aui3871uc` in human-readable format. It will display
+with UID `809832081` in human-readable format. It will display
 output like the following:
 
 ```
-Purchase Order:
-    organization     crgl (Cargill Incorporated)
-    uuid             82urioz098aui3871uc
-    purchase_order   809832081
-    workflow status  Confirmed
-    is closed        False
-    created          <datetime string>
+Purchase Order 809832081:
+    Organization     crgl (Cargill Incorporated)
+    Workflow status  Confirmed
+    Created At       <datetime string>
+    Closed           false
 
 Accepted Version (v3):
     workflow_status  Editable
-    draft            False
+    draft            false
     latest revision  4
 
 Revision 4:
@@ -110,10 +109,9 @@ with the alternate ID of `purchase_order:809832081` in human-readable format.
 It will display output like the following:
 
 ```
-Purchase Order:
-    organization     crgl (Cargill Incorporated)
-    uuid             82urioz098aui3871uc
-    purchase_order   809832081
+Purchase Order 809832081:
+    buyer org        crgl (Cargill Incorporated)
+    seller org       crgl2 (Cargill 2) 
     workflow status  Confirmed
     is closed        False
     created          <datetime string>
@@ -166,6 +164,7 @@ ENVIRONMENT VARIABLES
 
 SEE ALSO
 ========
+
 | `grid-po-create(1)`
 | `grid-po-list(1)`
 | `grid-po-show(1)`

--- a/cli/src/actions/purchase_orders.rs
+++ b/cli/src/actions/purchase_orders.rs
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp;
 use std::convert::TryInto;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use grid_sdk::{
-    client::purchase_order::{PurchaseOrderClient, PurchaseOrderRevision},
+    client::purchase_order::{
+        PurchaseOrder, PurchaseOrderClient, PurchaseOrderFilter, PurchaseOrderRevision,
+        PurchaseOrderVersion,
+    },
     protocol::purchase_order::payload::{
         Action, CreatePurchaseOrderPayload, CreateVersionPayload, PurchaseOrderPayloadBuilder,
     },
@@ -24,8 +28,10 @@ use grid_sdk::{
     purchase_order::addressing::GRID_PURCHASE_ORDER_NAMESPACE,
 };
 
+use chrono::{DateTime, Utc};
 use cylinder::Signer;
 use rand::{distributions::Alphanumeric, Rng};
+use serde::Serialize;
 
 use crate::error::CliError;
 use crate::transaction::purchase_order_batch_builder;
@@ -138,4 +144,251 @@ fn generate_random_base62_string(len: usize) -> String {
         .sample_iter(Alphanumeric)
         .take(len)
         .collect()
+}
+
+pub fn do_show_purchase_order(
+    client: Box<dyn PurchaseOrderClient>,
+    purchase_order_id: String,
+    service_id: Option<String>,
+    format: Option<&str>,
+) -> Result<(), CliError> {
+    let res = client.get_purchase_order(purchase_order_id, service_id.as_deref())?;
+    match res {
+        Some(purchase_order) => {
+            print_formattable(PurchaseOrderCli::from(&purchase_order), format)?;
+        }
+        None => {
+            println!("Purchase Order Not Found.");
+        }
+    }
+    Ok(())
+}
+
+pub fn do_list_purchase_orders(
+    client: Box<dyn PurchaseOrderClient>,
+    filter: Option<PurchaseOrderFilter>,
+    service_id: Option<String>,
+    format: Option<&str>,
+) -> Result<(), CliError> {
+    let res = client.list_purchase_orders(filter, service_id.as_deref())?;
+    let po_list = res
+        .iter()
+        .map(PurchaseOrderCli::from)
+        .collect::<Vec<PurchaseOrderCli>>();
+    print_formattable_list(PurchaseOrderCliVec(po_list), format)?;
+
+    Ok(())
+}
+#[derive(Debug, Serialize)]
+struct PurchaseOrderCli {
+    buyer_org_id: String,
+    seller_org_id: String,
+    purchase_order_uid: String,
+    workflow_status: String,
+    is_closed: bool,
+    accepted_version_id: Option<String>,
+    versions: Vec<String>,
+    created_at: SystemTime,
+}
+
+impl From<&PurchaseOrder> for PurchaseOrderCli {
+    fn from(d: &PurchaseOrder) -> Self {
+        Self {
+            buyer_org_id: d.buyer_org_id.to_string(),
+            seller_org_id: d.seller_org_id.to_string(),
+            purchase_order_uid: d.purchase_order_uid.to_string(),
+            workflow_status: d.workflow_status.to_string(),
+            is_closed: d.is_closed,
+            accepted_version_id: d.accepted_version_id.as_ref().map(String::from),
+            versions: d.versions.iter().map(String::from).collect(),
+            created_at: d.created_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct PurchaseOrderVersionCli {
+    version_id: String,
+    workflow_status: String,
+    is_draft: bool,
+    current_revision_id: u64,
+    revisions: Vec<PurchaseOrderRevisionCli>,
+}
+
+impl From<&PurchaseOrderVersion> for PurchaseOrderVersionCli {
+    fn from(d: &PurchaseOrderVersion) -> Self {
+        Self {
+            version_id: d.version_id.to_string(),
+            workflow_status: d.workflow_status.to_string(),
+            is_draft: d.is_draft,
+            current_revision_id: d.current_revision_id,
+            revisions: d
+                .revisions
+                .iter()
+                .map(PurchaseOrderRevisionCli::from)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct PurchaseOrderRevisionCli {
+    revision_id: u64,
+    order_xml_v3_4: String,
+    submitter: String,
+    created_at: u64,
+}
+
+impl From<&PurchaseOrderRevision> for PurchaseOrderRevisionCli {
+    fn from(d: &PurchaseOrderRevision) -> Self {
+        Self {
+            revision_id: d.revision_id,
+            order_xml_v3_4: d.order_xml_v3_4.to_string(),
+            submitter: d.submitter.to_string(),
+            created_at: d.created_at,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct PurchaseOrderCliVec(Vec<PurchaseOrderCli>);
+
+impl std::fmt::Display for PurchaseOrderCliVec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for purchase_order in &self.0 {
+            write!(f, "\n\n{}", purchase_order)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for PurchaseOrderCli {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Purchase Order {}:", &self.purchase_order_uid)?;
+        write!(f, "\n\t{:18}{}", "Buyer Org", &self.buyer_org_id)?;
+        write!(f, "\n\t{:18}{}", "Seller Org", &self.buyer_org_id)?;
+        write!(f, "\n\t{:18}{}", "Workflow Status", &self.workflow_status)?;
+        // Note: SystemTime format has not been agreed upon. This uses ISO 8601
+        write!(
+            f,
+            "\n\t{:18}{:?}",
+            "Created At",
+            DateTime::<Utc>::from(self.created_at)
+        )?;
+        write!(f, "\n\t{:18}{}", "Closed", &self.is_closed)?;
+
+        Ok(())
+    }
+}
+
+trait ListDisplay {
+    fn header() -> Vec<&'static str>;
+    fn details(&self) -> Vec<Vec<String>>;
+}
+
+impl ListDisplay for PurchaseOrderCliVec {
+    fn header() -> Vec<&'static str> {
+        vec!["BUYER", "SELLER", "UID", "STATUS", "ACCEPTED", "CLOSED"]
+    }
+
+    fn details(&self) -> Vec<Vec<String>> {
+        self.0
+            .iter()
+            .map(|po| {
+                vec![
+                    po.buyer_org_id.to_string(),
+                    po.seller_org_id.to_string(),
+                    po.purchase_order_uid.to_string(),
+                    po.workflow_status.to_string(),
+                    match &po.accepted_version_id {
+                        Some(s) => s.to_string(),
+                        None => String::new(),
+                    },
+                    po.is_closed.to_string(),
+                ]
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+fn print_formattable<T: std::fmt::Display + Serialize>(
+    object: T,
+    format: Option<&str>,
+) -> Result<(), CliError> {
+    match format {
+        Some("json") => {
+            let formatted = serde_json::to_string(&object)
+                .map_err(|_| CliError::ActionError("Cannot Format Purchase Order".to_string()))?;
+            println!("{}", formatted);
+        }
+        Some("yaml") => {
+            let formatted = serde_yaml::to_string(&object)
+                .map_err(|_| CliError::ActionError("Cannot Format Purchase Order".to_string()))?;
+            println!("{}", formatted);
+        }
+        _ => println!("{}", object),
+    }
+    Ok(())
+}
+
+fn print_formattable_list<T: std::fmt::Display + Serialize + ListDisplay>(
+    object: T,
+    format: Option<&str>,
+) -> Result<(), CliError> {
+    match format {
+        Some("json") => {
+            print_formattable(object, format)?;
+        }
+        Some("yaml") => {
+            print_formattable(object, format)?;
+        }
+        Some("csv") => {
+            let details = object
+                .details()
+                .iter()
+                .map(|detail| str_join(detail.to_vec(), ","))
+                .collect::<Vec<String>>()
+                .join("\n");
+
+            println!("{}\n{}", str_join(T::header(), ","), details);
+        }
+        _ => {
+            print_human_readable(T::header(), object.details());
+        }
+    };
+    Ok(())
+}
+
+fn str_join<T: ToString>(array: Vec<T>, delimiter: &str) -> String {
+    array
+        .iter()
+        .map(|x| x.to_string())
+        .collect::<Vec<String>>()
+        .join(delimiter)
+}
+
+fn print_human_readable(column_names: Vec<&str>, row_values: Vec<Vec<String>>) {
+    // Calculate max-widths for columns
+    let mut widths: Vec<usize> = column_names.iter().map(|name| name.len()).collect();
+    row_values.iter().for_each(|row| {
+        for i in 0..widths.len() {
+            widths[i] = cmp::max(widths[i], row[i].len())
+        }
+    });
+
+    // print header row
+    let mut header_row = "".to_owned();
+    for i in 0..column_names.len() {
+        header_row += &format!("{:width$} ", column_names[i], width = widths[i]);
+    }
+    println!("{}", header_row);
+
+    // print each row
+    for row in row_values {
+        let mut print_row = "".to_owned();
+        for i in 0..column_names.len() {
+            print_row += &format!("{:width$} ", row[i], width = widths[i]);
+        }
+        println!("{}", print_row);
+    }
 }

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -25,6 +25,7 @@ pub enum CliError {
         feature = "location",
         feature = "pike",
         feature = "product",
+        feature = "purchase-order",
         feature = "schema",
         feature = "database",
     ))]
@@ -35,6 +36,7 @@ pub enum CliError {
         feature = "location",
         feature = "pike",
         feature = "product",
+        feature = "purchase-order",
         feature = "schema",
     ))]
     PayloadError(String),
@@ -48,6 +50,7 @@ pub enum CliError {
         feature = "location",
         feature = "pike",
         feature = "product",
+        feature = "purchase-order",
         feature = "schema",
     ))]
     DaemonError(String),
@@ -60,6 +63,7 @@ impl StdError for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
                 feature = "database",
             ))]
@@ -70,6 +74,7 @@ impl StdError for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
             ))]
             CliError::PayloadError(_) => None,
@@ -83,6 +88,7 @@ impl StdError for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
             ))]
             CliError::DaemonError(_) => None,
@@ -97,6 +103,7 @@ impl std::fmt::Display for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
                 feature = "database",
             ))]
@@ -107,6 +114,7 @@ impl std::fmt::Display for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
             ))]
             CliError::PayloadError(ref err) => write!(f, "PayloadError: {}", err),
@@ -122,6 +130,7 @@ impl std::fmt::Display for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
             ))]
             CliError::DaemonError(ref err) => write!(f, "{}", err.replace("\"", "")),
@@ -180,6 +189,7 @@ impl From<grid_sdk::product::gdsn::ProductGdsnError> for CliError {
     feature = "location",
     feature = "pike",
     feature = "product",
+    feature = "purchase-order",
     feature = "schema",
 ))]
 impl From<grid_sdk::error::ClientError> for CliError {

--- a/sdk/src/client/location/reqwest.rs
+++ b/sdk/src/client/location/reqwest.rs
@@ -151,8 +151,12 @@ impl LocationClient for ReqwestLocationClient {
     ///
     /// * `service_id` - optional - the service id to fetch locations from
     fn list_locations(&self, service_id: Option<&str>) -> Result<Vec<Location>, ClientError> {
-        let dto_vec =
-            fetch_entities_list::<LocationDto>(&self.url, LOCATION_ROUTE.to_string(), service_id)?;
+        let dto_vec = fetch_entities_list::<LocationDto>(
+            &self.url,
+            LOCATION_ROUTE.to_string(),
+            service_id,
+            None,
+        )?;
         Ok(dto_vec.iter().map(Location::from).collect())
     }
 }

--- a/sdk/src/client/pike/reqwest.rs
+++ b/sdk/src/client/pike/reqwest.rs
@@ -198,8 +198,12 @@ impl PikeClient for ReqwestPikeClient {
     ///
     /// * `service_id` - optional - the service id to fetch the agents from
     fn list_agents(&self, service_id: Option<&str>) -> Result<Vec<PikeAgent>, ClientError> {
-        let dto_vec =
-            fetch_entities_list::<PikeAgentDto>(&self.url, AGENT_ROUTE.to_string(), service_id)?;
+        let dto_vec = fetch_entities_list::<PikeAgentDto>(
+            &self.url,
+            AGENT_ROUTE.to_string(),
+            service_id,
+            None,
+        )?;
         Ok(dto_vec.iter().map(PikeAgent::from).collect())
     }
 
@@ -235,6 +239,7 @@ impl PikeClient for ReqwestPikeClient {
             &self.url,
             ORGANIZATION_ROUTE.to_string(),
             service_id,
+            None,
         )?;
         Ok(dto_vec.iter().map(PikeOrganization::from).collect())
     }
@@ -275,6 +280,7 @@ impl PikeClient for ReqwestPikeClient {
             &self.url,
             format!("{}/{}", ROLE_ROUTE, org_id),
             service_id,
+            None,
         )?;
         Ok(dto_vec.iter().map(PikeRole::from).collect())
     }

--- a/sdk/src/client/product/reqwest.rs
+++ b/sdk/src/client/product/reqwest.rs
@@ -134,8 +134,12 @@ impl ProductClient for ReqwestProductClient {
     ///
     /// * `service_id`: the service id to fetch the products from
     fn list_products(&self, service_id: Option<&str>) -> Result<Vec<Product>, ClientError> {
-        let dto_vec =
-            fetch_entities_list::<ProductDto>(&self.url, PRODUCT_ROUTE.to_string(), service_id)?;
+        let dto_vec = fetch_entities_list::<ProductDto>(
+            &self.url,
+            PRODUCT_ROUTE.to_string(),
+            service_id,
+            None,
+        )?;
         Ok(dto_vec.iter().map(Product::from).collect())
     }
 }

--- a/sdk/src/client/purchase_order/mod.rs
+++ b/sdk/src/client/purchase_order/mod.rs
@@ -22,13 +22,17 @@ use super::Client;
 pub mod reqwest;
 
 pub struct PurchaseOrder {
-    pub org_id: String,
-    pub uuid: String,
+    pub buyer_org_id: String,
+    pub seller_org_id: String,
+    pub purchase_order_uid: String,
     pub workflow_status: String,
     pub is_closed: bool,
     pub accepted_version_id: Option<String>,
-    pub versions: Vec<PurchaseOrderVersion>,
+    pub versions: Vec<String>,
     pub created_at: SystemTime,
+    pub workflow_type: String,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
 }
 
 pub struct PurchaseOrderVersion {
@@ -37,6 +41,8 @@ pub struct PurchaseOrderVersion {
     pub is_draft: bool,
     pub current_revision_id: u64,
     pub revisions: Vec<PurchaseOrderRevision>,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
 }
 
 pub struct PurchaseOrderRevision {
@@ -46,25 +52,38 @@ pub struct PurchaseOrderRevision {
     pub created_at: u64,
 }
 
+pub struct PurchaseOrderFilter {
+    pub org_id: Option<String>,
+    pub is_closed: Option<bool>,
+    pub is_accepted: Option<bool>,
+}
+
 pub trait PurchaseOrderClient: Client {
     /// Retrieves the purchase order with the specified `id`.
     ///
     /// # Arguments
     ///
-    /// * `id` - The uuid of the `PurchaseOrder` to be retrieved
-    fn get_purchase_order(&self, id: String) -> Result<Option<PurchaseOrder>, ClientError>;
+    /// * `id` - The id of the `PurchaseOrder` to be retrieved
+    /// * `service_id` - optional service id if running splinter
+    fn get_purchase_order(
+        &self,
+        id: String,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrder>, ClientError>;
 
     /// Retrieves the purchase order version with the given `version_id` of the purchase
     /// order with the given `id`
     ///
     /// # Arguments
     ///
-    /// * `id` - The uuid of the `PurchaseOrder` containing the `PurchaseOrderVersion` to be retrieved
+    /// * `id` - The id of the `PurchaseOrder` containing the `PurchaseOrderVersion` to be retrieved
     /// * `version_id` - The version id of the `PurchaseOrderVersion` to be retrieved
+    /// * `service_id` - optional service id if running splinter
     fn get_purchase_order_version(
         &self,
         id: String,
         version_id: String,
+        service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrderVersion>, ClientError>;
 
     /// Retrieves the purchase order revision with the given `revision_id` of
@@ -72,15 +91,17 @@ pub trait PurchaseOrderClient: Client {
     ///
     /// # Arguments
     ///
-    /// * `id` - The uuid of the `PurchaseOrder` containing the `PurchaseOrderRevision` to be retrieved
+    /// * `id` - The id of the `PurchaseOrder` containing the `PurchaseOrderRevision` to be retrieved
     /// * `version_id` - The version id of the `PurchaseOrderVersion` containing the
     ///   `PurchaseOrderRevision` to be retrieved
     /// * `revision_id` - The revision number of the `PurchaseOrderRevision` to be retrieved
+    /// * `service_id` - optional service id if running splinter
     fn get_purchase_order_revision(
         &self,
         id: String,
         version_id: String,
-        revision_id: u64,
+        revision_id: String,
+        service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrderRevision>, ClientError>;
 
     /// lists purchase orders.
@@ -88,32 +109,38 @@ pub trait PurchaseOrderClient: Client {
     /// # Arguments
     ///
     /// * `filter` - Filter to apply to the list of `PurchaseOrder`s
-    fn list_purchase_orders(&self, filter: Option<&str>)
-        -> Result<Vec<PurchaseOrder>, ClientError>;
+    /// * `service_id` - optional service id if running splinter
+    fn list_purchase_orders(
+        &self,
+        filter: Option<PurchaseOrderFilter>,
+        service_id: Option<&str>,
+    ) -> Result<Vec<PurchaseOrder>, ClientError>;
 
     /// lists the purchase order versions of a specific purchase order.
     ///
     /// # Arguments
     ///
-    /// * `id` - The uuid of the `PurchaseOrder` containing the `PurchaseOrderVersion`s to be listed
+    /// * `id` - The id of the `PurchaseOrder` containing the `PurchaseOrderVersion`s to be listed
     /// * `filter` - Filter to apply to the list of purchase orders
+    /// * `service_id` - optional service id if running splinter
     fn list_purchase_order_versions(
         &self,
         id: String,
-        filter: Option<&str>,
+        service_id: Option<&str>,
     ) -> Result<Vec<PurchaseOrderVersion>, ClientError>;
 
     /// lists the purchase order revisions of a specific purchase order version.
     ///
     /// # Arguments
     ///
-    /// * `id` - The uuid of the `PurchaseOrder` containing the `PurchaseOrderRevision`s to be listed
+    /// * `id` - The id of the `PurchaseOrder` containing the `PurchaseOrderRevision`s to be listed
     /// * `version_id` - The version id of the `PurchaseOrderVersion` containing
     ///   the `PurchaseOrderRevision`s to be listed
+    /// * `service_id` - optional service id if running splinter
     fn list_purchase_order_revisions(
         &self,
         id: String,
         version_id: String,
-        filter: Option<&str>,
+        service_id: Option<&str>,
     ) -> Result<Vec<PurchaseOrderRevision>, ClientError>;
 }

--- a/sdk/src/client/purchase_order/reqwest.rs
+++ b/sdk/src/client/purchase_order/reqwest.rs
@@ -26,7 +26,7 @@ use super::{
 
 use sawtooth_sdk::messages::batch::BatchList;
 
-const PURCHASE_ORDER_ROUTE: &str = "purchase-order";
+const PURCHASE_ORDER_ROUTE: &str = "purchase_order";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct PurchaseOrderDto {

--- a/sdk/src/client/schema/reqwest.rs
+++ b/sdk/src/client/schema/reqwest.rs
@@ -144,8 +144,12 @@ impl SchemaClient for ReqwestSchemaClient {
     ///
     /// * `service_id` - optional - the service id to fetch the schemas from
     fn list_schemas(&self, service_id: Option<&str>) -> Result<Vec<Schema>, ClientError> {
-        let dto_vec =
-            fetch_entities_list::<SchemaDto>(&self.url, SCHEMA_ROUTE.to_string(), service_id)?;
+        let dto_vec = fetch_entities_list::<SchemaDto>(
+            &self.url,
+            SCHEMA_ROUTE.to_string(),
+            service_id,
+            None,
+        )?;
         Ok(dto_vec.iter().map(Schema::from).collect())
     }
 }

--- a/sdk/src/rest_api/resources/purchase_order/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/payloads.rs
@@ -21,6 +21,8 @@ use crate::{
 pub struct PurchaseOrderSlice {
     pub purchase_order_uid: String,
     pub workflow_status: String,
+    pub buyer_org_id: String,
+    pub seller_org_id: String,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accepted_version_id: Option<String>,
@@ -29,6 +31,9 @@ pub struct PurchaseOrderSlice {
     pub version_numbers: Option<Vec<String>>,
     pub is_closed: bool,
     pub workflow_type: String,
+    pub created_at: i64,
+    pub start_commit_num: i64,
+    pub end_commit_num: i64,
 }
 
 impl From<PurchaseOrder> for PurchaseOrderSlice {
@@ -36,6 +41,8 @@ impl From<PurchaseOrder> for PurchaseOrderSlice {
         Self {
             purchase_order_uid: purchase_order.purchase_order_uid().to_string(),
             workflow_status: purchase_order.workflow_status().to_string(),
+            buyer_org_id: purchase_order.buyer_org_id().to_string(),
+            seller_org_id: purchase_order.seller_org_id().to_string(),
             accepted_version_id: purchase_order.accepted_version_id().map(ToOwned::to_owned),
             version_numbers: Some(
                 purchase_order
@@ -46,6 +53,9 @@ impl From<PurchaseOrder> for PurchaseOrderSlice {
             ),
             is_closed: purchase_order.is_closed(),
             workflow_type: purchase_order.workflow_type().to_string(),
+            created_at: *purchase_order.created_at(),
+            start_commit_num: *purchase_order.start_commit_num(),
+            end_commit_num: *purchase_order.end_commit_num(),
         }
     }
 }
@@ -62,6 +72,8 @@ pub struct PurchaseOrderVersionSlice {
     is_draft: bool,
     current_revision_id: String,
     revisions: Vec<String>,
+    start_commit_num: i64,
+    end_commit_num: i64,
     service_id: Option<String>,
 }
 
@@ -76,6 +88,8 @@ impl From<PurchaseOrderVersion> for PurchaseOrderVersionSlice {
                 .into_iter()
                 .map(|version| version.revision_id().to_string())
                 .collect(),
+            start_commit_num: *purchase_order_version.start_commit_num(),
+            end_commit_num: *purchase_order_version.end_commit_num(),
             service_id: purchase_order_version.service_id().map(str::to_owned),
         }
     }


### PR DESCRIPTION
Added purchase order list and show functionality in the CLI. This 
included updating the SDK client's fetch_entities_list to support 
multiple query string parameters via a hashmap, implementing list and 
show for purchase orders within ReqwestPurchaseOrderClient, and 
implementing the list and show functionality for the CLI.