### PR TITLE
Update `add_purchase_order` operation

### DIFF
--- a/sdk/src/purchase_order/store/diesel/models.rs
+++ b/sdk/src/purchase_order/store/diesel/models.rs
@@ -222,6 +222,26 @@ impl
     }
 }
 
+impl From<(PurchaseOrderVersionModel, &String, &i64)> for NewPurchaseOrderVersionModel {
+    fn from(
+        (version, current_revision_id, start_commit_num): (
+            PurchaseOrderVersionModel,
+            &String,
+            &i64,
+        ),
+    ) -> Self {
+        Self {
+            purchase_order_uid: version.purchase_order_uid,
+            version_id: version.version_id,
+            is_draft: version.is_draft,
+            current_revision_id: current_revision_id.to_string(),
+            start_commit_num: *start_commit_num,
+            end_commit_num: MAX_COMMIT_NUM,
+            service_id: version.service_id,
+        }
+    }
+}
+
 impl From<&PurchaseOrderVersionRevisionModel> for PurchaseOrderVersionRevision {
     fn from(revision: &PurchaseOrderVersionRevisionModel) -> Self {
         Self {

--- a/sdk/src/purchase_order/store/diesel/operations/add_purchase_order_version.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/add_purchase_order_version.rs
@@ -1,0 +1,169 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::purchase_order::store::diesel::{
+    models::{NewPurchaseOrderVersionModel, PurchaseOrderVersionModel},
+    schema::purchase_order_version,
+    PurchaseOrderStoreError,
+};
+
+use crate::commits::MAX_COMMIT_NUM;
+use crate::error::InternalError;
+
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+};
+
+#[cfg(feature = "postgres")]
+pub(in crate) mod pg {
+    use super::*;
+
+    pub fn add_purchase_order_version(
+        conn: &diesel::pg::PgConnection,
+        version: &NewPurchaseOrderVersionModel,
+    ) -> Result<(), PurchaseOrderStoreError> {
+        conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version::table.into_boxed().filter(
+                purchase_order_version::purchase_order_uid
+                    .eq(&version.purchase_order_uid)
+                    .and(purchase_order_version::version_id.eq(&version.version_id))
+                    .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+            if let Some(service_id) = &version.service_id {
+                query = query.filter(purchase_order_version::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version::service_id.is_null());
+            }
+
+            let duplicate = query
+                .first::<PurchaseOrderVersionModel>(conn)
+                .optional()
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            if duplicate.is_some() {
+                if let Some(service_id) = &version.service_id {
+                    update(purchase_order_version::table)
+                        .filter(
+                            purchase_order_version::purchase_order_uid
+                                .eq(&version.purchase_order_uid)
+                                .and(purchase_order_version::version_id.eq(&version.version_id))
+                                .and(purchase_order_version::service_id.eq(service_id))
+                                .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(purchase_order_version::end_commit_num.eq(&version.start_commit_num))
+                        .execute(conn)
+                        .map(|_| ())
+                        .map_err(PurchaseOrderStoreError::from)?;
+                } else {
+                    update(purchase_order_version::table)
+                        .filter(
+                            purchase_order_version::purchase_order_uid
+                                .eq(&version.purchase_order_uid)
+                                .and(purchase_order_version::version_id.eq(&version.version_id))
+                                .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(purchase_order_version::end_commit_num.eq(&version.start_commit_num))
+                        .execute(conn)
+                        .map(|_| ())
+                        .map_err(PurchaseOrderStoreError::from)?;
+                }
+            }
+
+            insert_into(purchase_order_version::table)
+                .values(version)
+                .execute(conn)
+                .map(|_| ())
+                .map_err(PurchaseOrderStoreError::from)?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+pub(in crate) mod sqlite {
+    use super::*;
+
+    pub fn add_purchase_order_version(
+        conn: &diesel::sqlite::SqliteConnection,
+        version: &NewPurchaseOrderVersionModel,
+    ) -> Result<(), PurchaseOrderStoreError> {
+        conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version::table.into_boxed().filter(
+                purchase_order_version::purchase_order_uid
+                    .eq(&version.purchase_order_uid)
+                    .and(purchase_order_version::version_id.eq(&version.version_id))
+                    .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+            if let Some(service_id) = &version.service_id {
+                query = query.filter(purchase_order_version::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version::service_id.is_null());
+            }
+
+            let duplicate = query
+                .first::<PurchaseOrderVersionModel>(conn)
+                .optional()
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            if duplicate.is_some() {
+                if let Some(service_id) = &version.service_id {
+                    update(purchase_order_version::table)
+                        .filter(
+                            purchase_order_version::purchase_order_uid
+                                .eq(&version.purchase_order_uid)
+                                .and(purchase_order_version::version_id.eq(&version.version_id))
+                                .and(purchase_order_version::service_id.eq(service_id))
+                                .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(purchase_order_version::end_commit_num.eq(&version.start_commit_num))
+                        .execute(conn)
+                        .map(|_| ())
+                        .map_err(PurchaseOrderStoreError::from)?;
+                } else {
+                    update(purchase_order_version::table)
+                        .filter(
+                            purchase_order_version::purchase_order_uid
+                                .eq(&version.purchase_order_uid)
+                                .and(purchase_order_version::version_id.eq(&version.version_id))
+                                .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                        )
+                        .set(purchase_order_version::end_commit_num.eq(&version.start_commit_num))
+                        .execute(conn)
+                        .map(|_| ())
+                        .map_err(PurchaseOrderStoreError::from)?;
+                }
+            }
+
+            insert_into(purchase_order_version::table)
+                .values(version)
+                .execute(conn)
+                .map(|_| ())
+                .map_err(PurchaseOrderStoreError::from)?;
+
+            Ok(())
+        })
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/add_purchase_order_version_revision.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/add_purchase_order_version_revision.rs
@@ -1,0 +1,285 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::purchase_order::store::diesel::{
+    models::{
+        NewPurchaseOrderVersionModel, NewPurchaseOrderVersionRevisionModel,
+        PurchaseOrderVersionModel, PurchaseOrderVersionRevisionModel,
+    },
+    schema::{purchase_order_version, purchase_order_version_revision},
+    PurchaseOrderStoreError,
+};
+
+use crate::commits::MAX_COMMIT_NUM;
+use crate::error::InternalError;
+
+use diesel::{
+    dsl::{insert_into, update},
+    prelude::*,
+    result::Error as dsl_error,
+};
+
+#[cfg(feature = "postgres")]
+pub(in crate) mod pg {
+    use super::*;
+
+    pub fn add_purchase_order_version_revision(
+        conn: &diesel::pg::PgConnection,
+        revision: &NewPurchaseOrderVersionRevisionModel,
+        po_id: &str,
+    ) -> Result<(), PurchaseOrderStoreError> {
+        conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version_revision::table.into_boxed().filter(
+                purchase_order_version_revision::version_id
+                    .eq(&revision.version_id)
+                    .and(purchase_order_version_revision::revision_id.eq(&revision.revision_id))
+                    .and(purchase_order_version_revision::created_at.eq(&revision.created_at))
+                    .and(purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+            if let Some(service_id) = &revision.service_id {
+                query = query.filter(purchase_order_version_revision::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version_revision::service_id.is_null());
+            }
+
+            let duplicate = query
+                .first::<PurchaseOrderVersionRevisionModel>(conn)
+                .optional()
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            if duplicate.is_none() {
+                insert_into(purchase_order_version_revision::table)
+                    .values(revision)
+                    .execute(conn)
+                    .map(|_| ())
+                    .map_err(PurchaseOrderStoreError::from)?;
+
+                let mut version_query = purchase_order_version::table.into_boxed().filter(
+                    purchase_order_version::purchase_order_uid
+                        .eq(po_id)
+                        .and(purchase_order_version::version_id.eq(&revision.version_id))
+                        .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+                if let Some(service_id) = &revision.service_id {
+                    version_query =
+                        version_query.filter(purchase_order_version::service_id.eq(service_id));
+                } else {
+                    version_query =
+                        version_query.filter(purchase_order_version::service_id.is_null());
+                }
+
+                let version = version_query
+                    .first::<PurchaseOrderVersionModel>(conn)
+                    .map(Some)
+                    .map_err(|err| {
+                        if err == dsl_error::NotFound {
+                            PurchaseOrderStoreError::NotFoundError(
+                                "Cannot fetch PO version to update current revision".to_string(),
+                            )
+                        } else {
+                            PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                                Box::new(err),
+                            ))
+                        }
+                    })?;
+
+                if let Some(version) = version {
+                    if let Some(service_id) = &revision.service_id {
+                        update(purchase_order_version::table)
+                            .filter(
+                                purchase_order_version::purchase_order_uid
+                                    .eq(po_id)
+                                    .and(
+                                        purchase_order_version::version_id.eq(&revision.version_id),
+                                    )
+                                    .and(purchase_order_version::service_id.eq(service_id))
+                                    .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(
+                                purchase_order_version::end_commit_num
+                                    .eq(&revision.start_commit_num),
+                            )
+                            .execute(conn)
+                            .map(|_| ())
+                            .map_err(PurchaseOrderStoreError::from)?;
+                    } else {
+                        update(purchase_order_version::table)
+                            .filter(
+                                purchase_order_version::purchase_order_uid
+                                    .eq(po_id)
+                                    .and(
+                                        purchase_order_version::version_id.eq(&revision.version_id),
+                                    )
+                                    .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(
+                                purchase_order_version::end_commit_num
+                                    .eq(&revision.start_commit_num),
+                            )
+                            .execute(conn)
+                            .map(|_| ())
+                            .map_err(PurchaseOrderStoreError::from)?;
+                    }
+
+                    let updated_version = NewPurchaseOrderVersionModel::from((
+                        version,
+                        &revision.revision_id,
+                        &revision.start_commit_num,
+                    ));
+
+                    insert_into(purchase_order_version::table)
+                        .values(&updated_version)
+                        .execute(conn)
+                        .map(|_| ())
+                        .map_err(PurchaseOrderStoreError::from)?;
+                }
+            }
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+pub(in crate) mod sqlite {
+    use super::*;
+
+    pub fn add_purchase_order_version_revision(
+        conn: &diesel::sqlite::SqliteConnection,
+        revision: &NewPurchaseOrderVersionRevisionModel,
+        po_id: &str,
+    ) -> Result<(), PurchaseOrderStoreError> {
+        conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version_revision::table.into_boxed().filter(
+                purchase_order_version_revision::version_id
+                    .eq(&revision.version_id)
+                    .and(purchase_order_version_revision::revision_id.eq(&revision.revision_id))
+                    .and(purchase_order_version_revision::created_at.eq(&revision.created_at))
+                    .and(purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM)),
+            );
+
+            if let Some(service_id) = &revision.service_id {
+                query = query.filter(purchase_order_version_revision::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version_revision::service_id.is_null());
+            }
+
+            let duplicate = query
+                .first::<PurchaseOrderVersionRevisionModel>(conn)
+                .optional()
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            if duplicate.is_none() {
+                insert_into(purchase_order_version_revision::table)
+                    .values(revision)
+                    .execute(conn)
+                    .map(|_| ())
+                    .map_err(PurchaseOrderStoreError::from)?;
+
+                let mut version_query = purchase_order_version::table.into_boxed().filter(
+                    purchase_order_version::purchase_order_uid
+                        .eq(po_id)
+                        .and(purchase_order_version::version_id.eq(&revision.version_id))
+                        .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+                if let Some(service_id) = &revision.service_id {
+                    version_query =
+                        version_query.filter(purchase_order_version::service_id.eq(service_id));
+                } else {
+                    version_query =
+                        version_query.filter(purchase_order_version::service_id.is_null());
+                }
+
+                let version = version_query
+                    .first::<PurchaseOrderVersionModel>(conn)
+                    .map(Some)
+                    .map_err(|err| {
+                        if err == dsl_error::NotFound {
+                            PurchaseOrderStoreError::NotFoundError(
+                                "Cannot fetch PO version to update current revision".to_string(),
+                            )
+                        } else {
+                            PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                                Box::new(err),
+                            ))
+                        }
+                    })?;
+
+                if let Some(version) = version {
+                    if let Some(service_id) = &revision.service_id {
+                        update(purchase_order_version::table)
+                            .filter(
+                                purchase_order_version::purchase_order_uid
+                                    .eq(po_id)
+                                    .and(
+                                        purchase_order_version::version_id.eq(&revision.version_id),
+                                    )
+                                    .and(purchase_order_version::service_id.eq(service_id))
+                                    .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(
+                                purchase_order_version::end_commit_num
+                                    .eq(&revision.start_commit_num),
+                            )
+                            .execute(conn)
+                            .map(|_| ())
+                            .map_err(PurchaseOrderStoreError::from)?;
+                    } else {
+                        update(purchase_order_version::table)
+                            .filter(
+                                purchase_order_version::purchase_order_uid
+                                    .eq(po_id)
+                                    .and(
+                                        purchase_order_version::version_id.eq(&revision.version_id),
+                                    )
+                                    .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                            )
+                            .set(
+                                purchase_order_version::end_commit_num
+                                    .eq(&revision.start_commit_num),
+                            )
+                            .execute(conn)
+                            .map(|_| ())
+                            .map_err(PurchaseOrderStoreError::from)?;
+                    }
+
+                    let updated_version = NewPurchaseOrderVersionModel::from((
+                        version,
+                        &revision.revision_id,
+                        &revision.start_commit_num,
+                    ));
+
+                    insert_into(purchase_order_version::table)
+                        .values(&updated_version)
+                        .execute(conn)
+                        .map(|_| ())
+                        .map_err(PurchaseOrderStoreError::from)?;
+                }
+            }
+
+            Ok(())
+        })
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/mod.rs
@@ -14,6 +14,7 @@
 
 pub(super) mod add_alternate_id;
 pub(super) mod add_purchase_order;
+mod add_purchase_order_version_revision;
 pub(super) mod get_purchase_order;
 pub(super) mod get_purchase_order_version;
 pub(super) mod list_alternate_ids_for_purchase_order;

--- a/sdk/src/purchase_order/store/diesel/operations/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/mod.rs
@@ -14,6 +14,7 @@
 
 pub(super) mod add_alternate_id;
 pub(super) mod add_purchase_order;
+mod add_purchase_order_version;
 mod add_purchase_order_version_revision;
 pub(super) mod get_purchase_order;
 pub(super) mod get_purchase_order_version;


### PR DESCRIPTION
This updates the `add_purchase_order` operation to properly add/update POs, versions, and revisions while avoiding unnecessary db updates.