### PR TITLE
Add `get_purchase_order_version` operation

### DIFF
--- a/sdk/src/purchase_order/store/diesel/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/mod.rs
@@ -32,6 +32,7 @@ use crate::error::ResourceTemporarilyUnavailableError;
 use operations::add_alternate_id::PurchaseOrderStoreAddAlternateIdOperation as _;
 use operations::add_purchase_order::PurchaseOrderStoreAddPurchaseOrderOperation as _;
 use operations::get_purchase_order::PurchaseOrderStoreGetPurchaseOrderOperation as _;
+use operations::get_purchase_order_version::PurchaseOrderStoreGetPurchaseOrderVersionOperation as _;
 use operations::list_alternate_ids_for_purchase_order::PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation as _;
 use operations::list_purchase_orders::PurchaseOrderStoreListPurchaseOrdersOperation as _;
 use operations::PurchaseOrderStoreOperations;
@@ -95,6 +96,20 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
             )
         })?)
         .get_purchase_order(purchase_order_uid, service_id)
+    }
+
+    fn get_purchase_order_version(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .get_purchase_order_version(po_uid, version_id, service_id)
     }
 
     fn add_alternate_id(
@@ -174,6 +189,20 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
             )
         })?)
         .get_purchase_order(purchase_order_uid, service_id)
+    }
+
+    fn get_purchase_order_version(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .get_purchase_order_version(po_uid, version_id, service_id)
     }
 
     fn add_alternate_id(
@@ -265,6 +294,16 @@ impl<'a> PurchaseOrderStore for DieselConnectionPurchaseOrderStore<'a, diesel::p
             .get_purchase_order(purchase_order_uid, service_id)
     }
 
+    fn get_purchase_order_version(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(self.connection)
+            .get_purchase_order_version(po_uid, version_id, service_id)
+    }
+
     fn add_alternate_id(
         &self,
         alternate_id: PurchaseOrderAlternateId,
@@ -326,6 +365,16 @@ impl<'a> PurchaseOrderStore
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
         PurchaseOrderStoreOperations::new(self.connection)
             .get_purchase_order(purchase_order_uid, service_id)
+    }
+
+    fn get_purchase_order_version(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(self.connection)
+            .get_purchase_order_version(po_uid, version_id, service_id)
     }
 
     fn add_alternate_id(

--- a/sdk/src/purchase_order/store/diesel/operations/get_purchase_order_version.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/get_purchase_order_version.rs
@@ -1,0 +1,187 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::PurchaseOrderStoreOperations;
+use crate::commits::MAX_COMMIT_NUM;
+use crate::error::InternalError;
+use crate::purchase_order::store::diesel::{
+    models::{PurchaseOrderVersionModel, PurchaseOrderVersionRevisionModel},
+    schema::{purchase_order_version, purchase_order_version_revision},
+    PurchaseOrderVersion,
+};
+
+use crate::purchase_order::store::PurchaseOrderStoreError;
+use diesel::prelude::*;
+
+pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreGetPurchaseOrderVersionOperation
+{
+    fn get_purchase_order_version(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> PurchaseOrderStoreGetPurchaseOrderVersionOperation
+    for PurchaseOrderStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn get_purchase_order_version(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version::table
+                .into_boxed()
+                .select(purchase_order_version::all_columns)
+                .filter(
+                    purchase_order_version::version_id
+                        .eq(&version_id)
+                        .and(purchase_order_version::purchase_order_uid.eq(&po_uid))
+                        .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version::service_id.is_null());
+            }
+
+            let version = query
+                .first::<PurchaseOrderVersionModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            match version {
+                Some(version) => {
+                    let mut query = purchase_order_version_revision::table
+                        .into_boxed()
+                        .select(purchase_order_version_revision::all_columns)
+                        .filter(
+                            purchase_order_version_revision::version_id
+                                .eq(&version_id)
+                                .and(
+                                    purchase_order_version_revision::end_commit_num
+                                        .eq(MAX_COMMIT_NUM),
+                                ),
+                        );
+
+                    if let Some(service_id) = service_id {
+                        query = query
+                            .filter(purchase_order_version_revision::service_id.eq(service_id));
+                    } else {
+                        query = query.filter(purchase_order_version_revision::service_id.is_null());
+                    }
+
+                    let revision_models = query
+                        .load::<PurchaseOrderVersionRevisionModel>(self.conn)
+                        .map_err(|err| {
+                            PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                                Box::new(err),
+                            ))
+                        })?;
+
+                    Ok(Some(PurchaseOrderVersion::from((
+                        &version,
+                        &revision_models,
+                    ))))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> PurchaseOrderStoreGetPurchaseOrderVersionOperation
+    for PurchaseOrderStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn get_purchase_order_version(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version::table
+                .into_boxed()
+                .select(purchase_order_version::all_columns)
+                .filter(
+                    purchase_order_version::version_id
+                        .eq(&version_id)
+                        .and(purchase_order_version::purchase_order_uid.eq(&po_uid))
+                        .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version::service_id.is_null());
+            }
+
+            let version = query
+                .first::<PurchaseOrderVersionModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            match version {
+                Some(version) => {
+                    let mut query = purchase_order_version_revision::table
+                        .into_boxed()
+                        .select(purchase_order_version_revision::all_columns)
+                        .filter(
+                            purchase_order_version_revision::version_id
+                                .eq(&version_id)
+                                .and(
+                                    purchase_order_version_revision::end_commit_num
+                                        .eq(MAX_COMMIT_NUM),
+                                ),
+                        );
+
+                    if let Some(service_id) = service_id {
+                        query = query
+                            .filter(purchase_order_version_revision::service_id.eq(service_id));
+                    } else {
+                        query = query.filter(purchase_order_version_revision::service_id.is_null());
+                    }
+
+                    let revision_models = query
+                        .load::<PurchaseOrderVersionRevisionModel>(self.conn)
+                        .map_err(|err| {
+                            PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                                Box::new(err),
+                            ))
+                        })?;
+
+                    Ok(Some(PurchaseOrderVersion::from((
+                        &version,
+                        &revision_models,
+                    ))))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/mod.rs
@@ -15,6 +15,7 @@
 pub(super) mod add_alternate_id;
 pub(super) mod add_purchase_order;
 pub(super) mod get_purchase_order;
+pub(super) mod get_purchase_order_version;
 pub(super) mod list_alternate_ids_for_purchase_order;
 pub(super) mod list_purchase_orders;
 

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -131,6 +131,20 @@ pub trait PurchaseOrderStore {
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError>;
 
+    /// Fetches a purchase order version from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `po_uid`    - The uid of the purchase order the version belongs to
+    ///  * `version_id` - The ID of the version to fetch
+    ///  * `service_id` - The service ID
+    fn get_purchase_order_version(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError>;
+
     /// Adds an alternate id to the underlying storage
     ///
     /// # Arguments
@@ -185,6 +199,15 @@ where
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
         (**self).get_purchase_order(purchase_order_uid, service_id)
+    }
+
+    fn get_purchase_order_version(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError> {
+        (**self).get_purchase_order_version(po_uid, version_id, service_id)
     }
 
     fn add_alternate_id(


### PR DESCRIPTION
This adds a `get_purchase_order_version` operation. This fetches a PO
version and its associated revisions and returns the Grid representation
of them.

Signed-off-by: Davey Newhall <newhall@bitwise.io>