### PR TITLE
Add `buyer` and `seller` org fields to Purchase Order

### DIFF
--- a/contracts/purchase_order/src/state.rs
+++ b/contracts/purchase_order/src/state.rs
@@ -274,6 +274,9 @@ mod tests {
     const PO_VERSION_ID_1: &str = "01";
     const PO_VERSION_ID_2: &str = "02";
 
+    const ORG_1: &str = "test_org_1";
+    const ORG_2: &str = "test_org_2";
+
     #[derive(Default, Debug)]
     /// A MockTransactionContext that can be used to test Purchase Order state
     struct MockTransactionContext {
@@ -435,6 +438,8 @@ mod tests {
             .with_workflow_status("Issued".to_string())
             .with_created_at(1)
             .with_accepted_version_number("".to_string())
+            .with_buyer_org_id(ORG_1.to_string())
+            .with_seller_org_id(ORG_2.to_string())
             .with_versions(vec![purchase_order_version(PO_VERSION_ID_1)])
             .with_is_closed(false)
             .build()
@@ -447,6 +452,8 @@ mod tests {
             .with_workflow_status("Issued".to_string())
             .with_created_at(2)
             .with_accepted_version_number("".to_string())
+            .with_buyer_org_id(ORG_1.to_string())
+            .with_seller_org_id(ORG_2.to_string())
             .with_versions(vec![
                 purchase_order_version(PO_VERSION_ID_1),
                 purchase_order_version(PO_VERSION_ID_2),

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -24,7 +24,6 @@ message PurchaseOrderPayload {
     UPDATE_VERSION = 4;
   }
   Action action = 1;
-  string org_id = 2;
   uint64 timestamp = 3;
 
   CreatePurchaseOrderPayload create_po_payload = 4;

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -35,7 +35,9 @@ message PurchaseOrderPayload {
 message CreatePurchaseOrderPayload {
   string uid = 1;
   uint64 created_at = 2;
-  CreateVersionPayload create_version_payload = 3;
+  string buyer_org_id = 3;
+  string seller_org_id = 4;
+  CreateVersionPayload create_version_payload = 5;
 }
 
 message UpdatePurchaseOrderPayload {

--- a/sdk/protos/purchase_order_state.proto
+++ b/sdk/protos/purchase_order_state.proto
@@ -18,10 +18,12 @@ syntax = "proto3";
 message PurchaseOrder {
   string uid = 1;
   string workflow_status = 2;
-  repeated PurchaseOrderVersion versions = 3;
-  string accepted_version_number = 4;
-  uint64 created_at = 5;
-  bool is_closed = 6;
+  string buyer_org_id = 3;
+  string seller_org_id = 4;
+  repeated PurchaseOrderVersion versions = 5;
+  string accepted_version_number = 6;
+  uint64 created_at = 7;
+  bool is_closed = 8;
 }
 
 message PurchaseOrderList {

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -35,17 +35,12 @@ pub enum Action {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PurchaseOrderPayload {
     action: Action,
-    org_id: String,
     timestamp: u64,
 }
 
 impl PurchaseOrderPayload {
     pub fn action(&self) -> &Action {
         &self.action
-    }
-
-    pub fn org_id(&self) -> &str {
-        &self.org_id
     }
 
     pub fn timestamp(&self) -> u64 {
@@ -82,7 +77,6 @@ impl FromProto<purchase_order_payload::PurchaseOrderPayload> for PurchaseOrderPa
         };
         Ok(PurchaseOrderPayload {
             action,
-            org_id: payload.take_org_id(),
             timestamp: payload.get_timestamp(),
         })
     }
@@ -91,9 +85,7 @@ impl FromProto<purchase_order_payload::PurchaseOrderPayload> for PurchaseOrderPa
 impl FromNative<PurchaseOrderPayload> for purchase_order_payload::PurchaseOrderPayload {
     fn from_native(native: PurchaseOrderPayload) -> Result<Self, ProtoConversionError> {
         let mut proto = purchase_order_payload::PurchaseOrderPayload::new();
-
         proto.set_timestamp(native.timestamp());
-        proto.set_org_id(native.org_id().to_string());
 
         match native.action() {
             Action::CreatePo(payload) => {
@@ -153,7 +145,6 @@ impl IntoNative<PurchaseOrderPayload> for purchase_order_payload::PurchaseOrderP
 #[derive(Default, Clone)]
 pub struct PurchaseOrderPayloadBuilder {
     action: Option<Action>,
-    org_id: Option<String>,
     timestamp: Option<u64>,
 }
 
@@ -167,11 +158,6 @@ impl PurchaseOrderPayloadBuilder {
         self
     }
 
-    pub fn with_org_id(mut self, org_id: String) -> Self {
-        self.org_id = Some(org_id);
-        self
-    }
-
     pub fn with_timestamp(mut self, value: u64) -> Self {
         self.timestamp = Some(value);
         self
@@ -182,19 +168,11 @@ impl PurchaseOrderPayloadBuilder {
             .action
             .ok_or_else(|| BuilderError::MissingField("'action' field is required".into()))?;
 
-        let org_id = self
-            .org_id
-            .ok_or_else(|| BuilderError::MissingField("'org_id' field is required".into()))?;
-
         let timestamp = self
             .timestamp
             .ok_or_else(|| BuilderError::MissingField("'timestamp' field is required".into()))?;
 
-        Ok(PurchaseOrderPayload {
-            action,
-            org_id,
-            timestamp,
-        })
+        Ok(PurchaseOrderPayload { action, timestamp })
     }
 }
 

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -181,6 +181,8 @@ impl PurchaseOrderPayloadBuilder {
 pub struct CreatePurchaseOrderPayload {
     uid: String,
     created_at: u64,
+    buyer_org_id: String,
+    seller_org_id: String,
     create_version_payload: Option<CreateVersionPayload>,
 }
 
@@ -191,6 +193,14 @@ impl CreatePurchaseOrderPayload {
 
     pub fn created_at(&self) -> u64 {
         self.created_at
+    }
+
+    pub fn buyer_org_id(&self) -> &str {
+        &self.buyer_org_id
+    }
+
+    pub fn seller_org_id(&self) -> &str {
+        &self.seller_org_id
     }
 
     pub fn create_version_payload(&self) -> Option<CreateVersionPayload> {
@@ -207,6 +217,8 @@ impl FromProto<purchase_order_payload::CreatePurchaseOrderPayload> for CreatePur
         Ok(CreatePurchaseOrderPayload {
             uid: proto.take_uid(),
             created_at: proto.get_created_at(),
+            buyer_org_id: proto.take_buyer_org_id(),
+            seller_org_id: proto.take_seller_org_id(),
             create_version_payload,
         })
     }
@@ -217,6 +229,8 @@ impl FromNative<CreatePurchaseOrderPayload> for purchase_order_payload::CreatePu
         let mut proto = purchase_order_payload::CreatePurchaseOrderPayload::new();
         proto.set_uid(native.uid().to_string());
         proto.set_created_at(native.created_at());
+        proto.set_buyer_org_id(native.buyer_org_id().to_string());
+        proto.set_seller_org_id(native.seller_org_id().to_string());
 
         if let Some(payload) = native.create_version_payload() {
             let proto_payload: purchase_order_payload::CreateVersionPayload =
@@ -260,6 +274,8 @@ impl IntoNative<CreatePurchaseOrderPayload> for purchase_order_payload::CreatePu
 pub struct CreatePurchaseOrderPayloadBuilder {
     uid: Option<String>,
     created_at: Option<u64>,
+    buyer_org_id: Option<String>,
+    seller_org_id: Option<String>,
     create_version_payload: Option<CreateVersionPayload>,
 }
 
@@ -278,6 +294,16 @@ impl CreatePurchaseOrderPayloadBuilder {
         self
     }
 
+    pub fn with_buyer_org_id(mut self, value: String) -> Self {
+        self.buyer_org_id = Some(value);
+        self
+    }
+
+    pub fn with_seller_org_id(mut self, value: String) -> Self {
+        self.seller_org_id = Some(value);
+        self
+    }
+
     pub fn with_create_version_payload(mut self, payload: CreateVersionPayload) -> Self {
         self.create_version_payload = Some(payload);
         self
@@ -292,11 +318,21 @@ impl CreatePurchaseOrderPayloadBuilder {
             BuilderError::MissingField("'created_at' field is required".to_string())
         })?;
 
+        let buyer_org_id = self.buyer_org_id.ok_or_else(|| {
+            BuilderError::MissingField("'buyer_org_id' field is required".to_string())
+        })?;
+
+        let seller_org_id = self.seller_org_id.ok_or_else(|| {
+            BuilderError::MissingField("'seller_org_id' field is required".to_string())
+        })?;
+
         let create_version_payload = self.create_version_payload;
 
         Ok(CreatePurchaseOrderPayload {
             uid,
             created_at,
+            buyer_org_id,
+            seller_org_id,
             create_version_payload,
         })
     }

--- a/sdk/src/protocol/purchase_order/state.rs
+++ b/sdk/src/protocol/purchase_order/state.rs
@@ -397,6 +397,8 @@ pub struct PurchaseOrder {
     accepted_version_number: String,
     created_at: u64,
     is_closed: bool,
+    buyer_org_id: String,
+    seller_org_id: String,
 }
 
 impl PurchaseOrder {
@@ -424,6 +426,14 @@ impl PurchaseOrder {
         self.is_closed
     }
 
+    pub fn buyer_org_id(&self) -> &str {
+        &self.buyer_org_id
+    }
+
+    pub fn seller_org_id(&self) -> &str {
+        &self.seller_org_id
+    }
+
     pub fn into_builder(self) -> PurchaseOrderBuilder {
         PurchaseOrderBuilder::new()
             .with_uid(self.uid)
@@ -432,6 +442,8 @@ impl PurchaseOrder {
             .with_accepted_version_number(self.accepted_version_number)
             .with_created_at(self.created_at)
             .with_is_closed(self.is_closed)
+            .with_buyer_org_id(self.buyer_org_id)
+            .with_seller_org_id(self.seller_org_id)
     }
 }
 
@@ -450,6 +462,8 @@ impl FromProto<purchase_order_state::PurchaseOrder> for PurchaseOrder {
             accepted_version_number: order.take_accepted_version_number(),
             created_at: order.get_created_at(),
             is_closed: order.get_is_closed(),
+            buyer_org_id: order.take_buyer_org_id(),
+            seller_org_id: order.take_seller_org_id(),
         })
     }
 }
@@ -470,6 +484,8 @@ impl FromNative<PurchaseOrder> for purchase_order_state::PurchaseOrder {
         proto.set_accepted_version_number(order.accepted_version_number().to_string());
         proto.set_created_at(order.created_at());
         proto.set_is_closed(order.is_closed());
+        proto.set_buyer_org_id(order.buyer_org_id().to_string());
+        proto.set_seller_org_id(order.seller_org_id().to_string());
 
         Ok(proto)
     }
@@ -526,6 +542,8 @@ pub struct PurchaseOrderBuilder {
     accepted_version_number: Option<String>,
     created_at: Option<u64>,
     is_closed: Option<bool>,
+    buyer_org_id: Option<String>,
+    seller_org_id: Option<String>,
 }
 
 impl PurchaseOrderBuilder {
@@ -563,6 +581,16 @@ impl PurchaseOrderBuilder {
         self
     }
 
+    pub fn with_buyer_org_id(mut self, buyer: String) -> Self {
+        self.buyer_org_id = Some(buyer);
+        self
+    }
+
+    pub fn with_seller_org_id(mut self, seller: String) -> Self {
+        self.seller_org_id = Some(seller);
+        self
+    }
+
     pub fn build(self) -> Result<PurchaseOrder, PurchaseOrderBuildError> {
         let uid = self.uid.ok_or_else(|| {
             PurchaseOrderBuildError::MissingField("'uid' field is required".to_string())
@@ -590,6 +618,14 @@ impl PurchaseOrderBuilder {
             PurchaseOrderBuildError::MissingField("'is_closed' field is required".to_string())
         })?;
 
+        let buyer_org_id = self.buyer_org_id.ok_or_else(|| {
+            PurchaseOrderBuildError::MissingField("'buyer_org_id' field is required".to_string())
+        })?;
+
+        let seller_org_id = self.seller_org_id.ok_or_else(|| {
+            PurchaseOrderBuildError::MissingField("'seller_org_id' field is required".to_string())
+        })?;
+
         Ok(PurchaseOrder {
             uid,
             workflow_status,
@@ -597,6 +633,8 @@ impl PurchaseOrderBuilder {
             accepted_version_number,
             created_at,
             is_closed,
+            buyer_org_id,
+            seller_org_id,
         })
     }
 }


### PR DESCRIPTION
This PR updates the `PurchaseOrderPayload` to remove the `org_id` field, as the organizations are now being recorded in the purchase order itself. This also updates the `CreatePurchaseOrderPayload` and `PurchaseOrder` struct in state to support a `buyer_org` and `seller_org` fields for the purchase order. 