### PR TITLE
Add `list_purchase_order_versions` operation

### DIFF
--- a/sdk/src/purchase_order/store/diesel/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/mod.rs
@@ -21,7 +21,7 @@ use diesel::r2d2::{ConnectionManager, Pool};
 
 use super::{
     PurchaseOrder, PurchaseOrderAlternateId, PurchaseOrderAlternateIdList, PurchaseOrderList,
-    PurchaseOrderStore, PurchaseOrderStoreError, PurchaseOrderVersion,
+    PurchaseOrderStore, PurchaseOrderStoreError, PurchaseOrderVersion, PurchaseOrderVersionList,
     PurchaseOrderVersionRevision,
 };
 
@@ -33,6 +33,7 @@ use operations::add_alternate_id::PurchaseOrderStoreAddAlternateIdOperation as _
 use operations::add_purchase_order::PurchaseOrderStoreAddPurchaseOrderOperation as _;
 use operations::get_purchase_order::PurchaseOrderStoreGetPurchaseOrderOperation as _;
 use operations::list_alternate_ids_for_purchase_order::PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation as _;
+use operations::list_purchase_order_versions::PurchaseOrderStoreListPurchaseOrderVersionsOperation as _;
 use operations::list_purchase_orders::PurchaseOrderStoreListPurchaseOrdersOperation as _;
 use operations::PurchaseOrderStoreOperations;
 
@@ -82,6 +83,21 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
             )
         })?)
         .list_purchase_orders(buyer_org_id, seller_org_id, service_id, offset, limit)
+    }
+
+    fn list_purchase_order_versions(
+        &self,
+        po_uid: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .list_purchase_order_versions(po_uid, service_id, offset, limit)
     }
 
     fn get_purchase_order(
@@ -161,6 +177,21 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
             )
         })?)
         .list_purchase_orders(buyer_org_id, seller_org_id, service_id, offset, limit)
+    }
+
+    fn list_purchase_order_versions(
+        &self,
+        po_uid: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .list_purchase_order_versions(po_uid, service_id, offset, limit)
     }
 
     fn get_purchase_order(
@@ -256,6 +287,17 @@ impl<'a> PurchaseOrderStore for DieselConnectionPurchaseOrderStore<'a, diesel::p
         )
     }
 
+    fn list_purchase_order_versions(
+        &self,
+        po_uid: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(self.connection)
+            .list_purchase_order_versions(po_uid, service_id, offset, limit)
+    }
+
     fn get_purchase_order(
         &self,
         purchase_order_uid: &str,
@@ -317,6 +359,17 @@ impl<'a> PurchaseOrderStore
             offset,
             limit,
         )
+    }
+
+    fn list_purchase_order_versions(
+        &self,
+        po_uid: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(self.connection)
+            .list_purchase_order_versions(po_uid, service_id, offset, limit)
     }
 
     fn get_purchase_order(

--- a/sdk/src/purchase_order/store/diesel/operations/list_purchase_order_versions.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_purchase_order_versions.rs
@@ -1,0 +1,213 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::PurchaseOrderStoreOperations;
+use crate::commits::MAX_COMMIT_NUM;
+use crate::error::InternalError;
+use crate::paging::Paging;
+use crate::purchase_order::store::diesel::{
+    models::{PurchaseOrderVersionModel, PurchaseOrderVersionRevisionModel},
+    schema::{purchase_order_version, purchase_order_version_revision},
+    PurchaseOrderVersion, PurchaseOrderVersionList,
+};
+
+use crate::purchase_order::store::PurchaseOrderStoreError;
+use diesel::prelude::*;
+
+pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreListPurchaseOrderVersionsOperation
+{
+    fn list_purchase_order_versions(
+        &self,
+        po_uid: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionList, PurchaseOrderStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> PurchaseOrderStoreListPurchaseOrderVersionsOperation
+    for PurchaseOrderStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_purchase_order_versions(
+        &self,
+        po_uid: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionList, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version::table
+                .into_boxed()
+                .select(purchase_order_version::all_columns)
+                .filter(
+                    purchase_order_version::purchase_order_uid
+                        .eq(&po_uid)
+                        .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version::service_id.is_null());
+            }
+
+            let version_models =
+                query
+                    .load::<PurchaseOrderVersionModel>(self.conn)
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+            let mut count_query = purchase_order_version::table
+                .into_boxed()
+                .select(purchase_order_version::all_columns);
+
+            if let Some(service_id) = service_id {
+                count_query = count_query.filter(purchase_order_version::service_id.eq(service_id));
+            } else {
+                count_query = count_query.filter(purchase_order_version::service_id.is_null());
+            }
+
+            let total = count_query.count().get_result(self.conn)?;
+
+            let mut versions = Vec::new();
+
+            for version in version_models {
+                let mut query = purchase_order_version_revision::table
+                    .into_boxed()
+                    .select(purchase_order_version_revision::all_columns)
+                    .filter(
+                        purchase_order_version_revision::version_id
+                            .eq(&version.version_id)
+                            .and(
+                                purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
+                            ),
+                    );
+
+                if let Some(service_id) = service_id {
+                    query =
+                        query.filter(purchase_order_version_revision::service_id.eq(service_id));
+                } else {
+                    query = query.filter(purchase_order_version_revision::service_id.is_null());
+                }
+
+                let revision_models = query
+                    .load::<PurchaseOrderVersionRevisionModel>(self.conn)
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+                versions.push(PurchaseOrderVersion::from((&version, &revision_models)));
+            }
+
+            Ok(PurchaseOrderVersionList::new(
+                versions,
+                Paging::new(offset, limit, total),
+            ))
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> PurchaseOrderStoreListPurchaseOrderVersionsOperation
+    for PurchaseOrderStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn list_purchase_order_versions(
+        &self,
+        po_uid: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionList, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version::table
+                .into_boxed()
+                .select(purchase_order_version::all_columns)
+                .filter(
+                    purchase_order_version::purchase_order_uid
+                        .eq(&po_uid)
+                        .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version::service_id.is_null());
+            }
+
+            let version_models =
+                query
+                    .load::<PurchaseOrderVersionModel>(self.conn)
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+            let mut count_query = purchase_order_version::table
+                .into_boxed()
+                .select(purchase_order_version::all_columns);
+
+            if let Some(service_id) = service_id {
+                count_query = count_query.filter(purchase_order_version::service_id.eq(service_id));
+            } else {
+                count_query = count_query.filter(purchase_order_version::service_id.is_null());
+            }
+
+            let total = count_query.count().get_result(self.conn)?;
+
+            let mut versions = Vec::new();
+
+            for version in version_models {
+                let mut query = purchase_order_version_revision::table
+                    .into_boxed()
+                    .select(purchase_order_version_revision::all_columns)
+                    .filter(
+                        purchase_order_version_revision::version_id
+                            .eq(&version.version_id)
+                            .and(
+                                purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
+                            ),
+                    );
+
+                if let Some(service_id) = service_id {
+                    query =
+                        query.filter(purchase_order_version_revision::service_id.eq(service_id));
+                } else {
+                    query = query.filter(purchase_order_version_revision::service_id.is_null());
+                }
+
+                let revision_models = query
+                    .load::<PurchaseOrderVersionRevisionModel>(self.conn)
+                    .map_err(|err| {
+                        PurchaseOrderStoreError::InternalError(InternalError::from_source(
+                            Box::new(err),
+                        ))
+                    })?;
+
+                versions.push(PurchaseOrderVersion::from((&version, &revision_models)));
+            }
+
+            Ok(PurchaseOrderVersionList::new(
+                versions,
+                Paging::new(offset, limit, total),
+            ))
+        })
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/mod.rs
@@ -16,6 +16,7 @@ pub(super) mod add_alternate_id;
 pub(super) mod add_purchase_order;
 pub(super) mod get_purchase_order;
 pub(super) mod list_alternate_ids_for_purchase_order;
+pub(super) mod list_purchase_order_versions;
 pub(super) mod list_purchase_orders;
 
 pub(super) struct PurchaseOrderStoreOperations<'a, C> {

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -263,6 +263,19 @@ impl PurchaseOrderBuilder {
     }
 }
 
+/// Represents a list of Grid Purchase Order Versions
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct PurchaseOrderVersionList {
+    pub data: Vec<PurchaseOrderVersion>,
+    pub paging: Paging,
+}
+
+impl PurchaseOrderVersionList {
+    pub fn new(data: Vec<PurchaseOrderVersion>, paging: Paging) -> Self {
+        Self { data, paging }
+    }
+}
+
 /// Represents a Grid Purchase Order Version
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct PurchaseOrderVersion {
@@ -756,7 +769,7 @@ pub trait PurchaseOrderStore {
     ///
     ///  * `buyer_org_id` - The buyer organization to fetch for
     ///  * `seller_org_id` - The seller organization to fetch for
-    ///  * `service_id` - The service id
+    ///  * `service_id` - The service ID
     ///  * `offset` - The index of the first in storage to retrieve
     ///  * `limit` - The number of items to retrieve from the offset
     fn list_purchase_orders(
@@ -767,6 +780,22 @@ pub trait PurchaseOrderStore {
         offset: i64,
         limit: i64,
     ) -> Result<PurchaseOrderList, PurchaseOrderStoreError>;
+
+    /// Lists purchase order versions from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `po_uid`   - The uid of the purchase order to get versions for
+    ///  * `service_id` - The service ID
+    ///  * `offset` - The index of the first in storage to retrieve
+    ///  * `limit` - The number of items to retrieve from the offset
+    fn list_purchase_order_versions(
+        &self,
+        po_uid: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionList, PurchaseOrderStoreError>;
 
     /// Fetches a purchase order from the underlying storage
     ///
@@ -826,6 +855,16 @@ where
         limit: i64,
     ) -> Result<PurchaseOrderList, PurchaseOrderStoreError> {
         (**self).list_purchase_orders(buyer_org_id, seller_org_id, service_id, offset, limit)
+    }
+
+    fn list_purchase_order_versions(
+        &self,
+        po_uid: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionList, PurchaseOrderStoreError> {
+        (**self).list_purchase_order_versions(po_uid, service_id, offset, limit)
     }
 
     fn get_purchase_order(


### PR DESCRIPTION
This adds a `list_purchase_order_versions` operation to the purchase
order store. This operation gets a list of purchase order versions for a
gived purchase order. This also includes that version's revisions.

Signed-off-by: Davey Newhall <newhall@bitwise.io>