### PR TITLE
Update PO store for updated protos

### DIFF
--- a/sdk/src/migrations/diesel/postgres/migrations/2021-09-10-131000_update_purchase_order_tables/down.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-09-10-131000_update_purchase_order_tables/down.sql
@@ -1,0 +1,26 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE purchase_order RENAME COLUMN purchase_order_uid TO uuid;
+ALTER TABLE purchase_order DROP COLUMN buyer_org_id;
+ALTER TABLE purchase_order DROP COLUMN seller_org_id;
+ALTER TABLE purchase_order ADD COLUMN org_id VARCHAR(256) NOT NULL;
+
+ALTER TABLE purchase_order_version RENAME COLUMN purchase_order_uid TO purchase_order_uuid;
+ALTER TABLE purchase_order_version ADD COLUMN org_id VARCHAR(256) NOT NULL;
+
+ALTER TABLE purchase_order_version_revision ADD COLUMN org_id VARCHAR(256) NOT NULL;
+
+ALTER TABLE purchase_order_alternate_id RENAME COLUMN purchase_order_uid TO purchase_order_uuid;

--- a/sdk/src/migrations/diesel/postgres/migrations/2021-09-10-131000_update_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-09-10-131000_update_purchase_order_tables/up.sql
@@ -1,0 +1,26 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE purchase_order RENAME COLUMN uuid TO purchase_order_uid;
+ALTER TABLE purchase_order DROP COLUMN org_id;
+ALTER TABLE purchase_order ADD COLUMN buyer_org_id VARCHAR(256) NOT NULL;
+ALTER TABLE purchase_order ADD COLUMN seller_org_id VARCHAR(256) NOT NULL;
+
+ALTER TABLE purchase_order_version RENAME COLUMN purchase_order_uuid TO purchase_order_uid;
+ALTER TABLE purchase_order_version DROP COLUMN org_id;
+
+ALTER TABLE purchase_order_version_revision DROP COLUMN org_id;
+
+ALTER TABLE purchase_order_alternate_id RENAME COLUMN purchase_order_uuid TO purchase_order_uid;

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-09-10-131000_update_purchase_order_tables/down.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-09-10-131000_update_purchase_order_tables/down.sql
@@ -1,0 +1,71 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE purchase_order_alternate_id RENAME COLUMN purchase_order_uid TO purchase_order_uuid;
+
+CREATE TABLE po_temp (
+    id INTEGER PRIMARY KEY,
+    uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    workflow_status TEXT NOT NULL,
+    is_closed BOOLEAN NOT NULL,
+    accepted_version_id TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO po_temp(id,uuid,workflow_status,is_closed,accepted_version_id,start_commit_num,end_commit_num,service_id)
+SELECT id,purchase_order_uid,workflow_status,is_closed,accepted_version_id,start_commit_num,end_commit_num,service_id
+FROM purchase_order;
+
+DROP TABLE purchase_order;
+ALTER TABLE po_temp RENAME TO purchase_order;
+
+CREATE TABLE version_temp (
+    id INTEGER PRIMARY KEY,
+    purchase_order_uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    version_id TEXT NOT NULL,
+    is_draft BOOLEAN NOT NULL,
+    current_revision_id TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO version_temp(id,purchase_order_uuid,version_id,is_draft,current_revision_id,start_commit_num,end_commit_num,service_id)
+SELECT id,purchase_order_uid,version_id,is_draft,current_revision_id,start_commit_num,end_commit_num,service_id
+FROM purchase_order_version;
+
+DROP TABLE purchase_order_version;
+ALTER TABLE version_temp RENAME TO purchase_order_version;
+
+CREATE TABLE rev_temp(
+    id INTEGER PRIMARY KEY,
+    version_id TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    revision_id TEXT NOT NULL,
+    order_xml_v3_4 TEXT NOT NULL,
+    submitter TEXT NOT NULL,
+    created_at BIGINT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO rev_temp(id,version_id,revision_id,order_xml_v3_4,submitter,created_at,start_commit_num,end_commit_num,service_id)
+SELECT id,version_id,revision_id,order_xml_v3_4,submitter,created_at,start_commit_num,end_commit_num,service_id
+FROM purchase_order_version_revision;

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-09-10-131000_update_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-09-10-131000_update_purchase_order_tables/up.sql
@@ -1,0 +1,70 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE purchase_order_alternate_id RENAME COLUMN purchase_order_uuid TO purchase_order_uid;
+
+CREATE TABLE po_temp (
+    id INTEGER PRIMARY KEY,
+    purchase_order_uid TEXT NOT NULL,
+    buyer_org_id VARCHAR(256) NOT NULL,
+    seller_org_id VARCHAR(256) NOT NULL,
+    workflow_status TEXT NOT NULL,
+    is_closed BOOLEAN NOT NULL,
+    accepted_version_id TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO po_temp(id,purchase_order_uid,workflow_status,is_closed,accepted_version_id,start_commit_num,end_commit_num,service_id)
+SELECT id,uuid,workflow_status,is_closed,accepted_version_id,start_commit_num,end_commit_num,service_id
+FROM purchase_order;
+
+DROP TABLE purchase_order;
+ALTER TABLE po_temp RENAME TO purchase_order;
+
+CREATE TABLE version_temp (
+    id INTEGER PRIMARY KEY,
+    purchase_order_uid TEXT NOT NULL,
+    version_id TEXT NOT NULL,
+    is_draft BOOLEAN NOT NULL,
+    current_revision_id TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO version_temp(id,purchase_order_uid,version_id,is_draft,current_revision_id,start_commit_num,end_commit_num,service_id)
+SELECT id,purchase_order_uuid,version_id,is_draft,current_revision_id,start_commit_num,end_commit_num,service_id
+FROM purchase_order_version;
+
+DROP TABLE purchase_order_version;
+ALTER TABLE version_temp RENAME TO purchase_order_version;
+
+CREATE TABLE rev_temp(
+    id INTEGER PRIMARY KEY,
+    version_id TEXT NOT NULL,
+    revision_id TEXT NOT NULL,
+    order_xml_v3_4 TEXT NOT NULL,
+    submitter TEXT NOT NULL,
+    created_at BIGINT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO rev_temp(id,version_id,revision_id,order_xml_v3_4,submitter,created_at,start_commit_num,end_commit_num,service_id)
+SELECT id,version_id,revision_id,order_xml_v3_4,submitter,created_at,start_commit_num,end_commit_num,service_id
+FROM purchase_order_version_revision;

--- a/sdk/src/purchase_order/store/diesel/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/mod.rs
@@ -70,7 +70,8 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
 
     fn list_purchase_orders(
         &self,
-        org_id: Option<String>,
+        buyer_org_id: Option<String>,
+        seller_org_id: Option<String>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
@@ -80,12 +81,12 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_purchase_orders(org_id, service_id, offset, limit)
+        .list_purchase_orders(buyer_org_id, seller_org_id, service_id, offset, limit)
     }
 
     fn get_purchase_order(
         &self,
-        uuid: &str,
+        purchase_order_uid: &str,
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
         PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
@@ -93,7 +94,7 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .get_purchase_order(uuid, service_id)
+        .get_purchase_order(purchase_order_uid, service_id)
     }
 
     fn add_alternate_id(
@@ -110,7 +111,7 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
 
     fn list_alternate_ids_for_purchase_order(
         &self,
-        purchase_order_uuid: &str,
+        purchase_order_uid: &str,
         org_id: &str,
         service_id: Option<&str>,
         offset: i64,
@@ -122,7 +123,7 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
             )
         })?)
         .list_alternate_ids_for_purchase_order(
-            purchase_order_uuid,
+            purchase_order_uid,
             org_id,
             service_id,
             offset,
@@ -148,7 +149,8 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
 
     fn list_purchase_orders(
         &self,
-        org_id: Option<String>,
+        buyer_org_id: Option<String>,
+        seller_org_id: Option<String>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
@@ -158,12 +160,12 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .list_purchase_orders(org_id, service_id, offset, limit)
+        .list_purchase_orders(buyer_org_id, seller_org_id, service_id, offset, limit)
     }
 
     fn get_purchase_order(
         &self,
-        uuid: &str,
+        purchase_order_uid: &str,
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
         PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
@@ -171,7 +173,7 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .get_purchase_order(uuid, service_id)
+        .get_purchase_order(purchase_order_uid, service_id)
     }
 
     fn add_alternate_id(
@@ -188,7 +190,7 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
 
     fn list_alternate_ids_for_purchase_order(
         &self,
-        purchase_order_uuid: &str,
+        purchase_order_uid: &str,
         org_id: &str,
         service_id: Option<&str>,
         offset: i64,
@@ -200,7 +202,7 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
             )
         })?)
         .list_alternate_ids_for_purchase_order(
-            purchase_order_uuid,
+            purchase_order_uid,
             org_id,
             service_id,
             offset,
@@ -239,21 +241,28 @@ impl<'a> PurchaseOrderStore for DieselConnectionPurchaseOrderStore<'a, diesel::p
 
     fn list_purchase_orders(
         &self,
-        org_id: Option<String>,
+        buyer_org_id: Option<String>,
+        seller_org_id: Option<String>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
     ) -> Result<PurchaseOrderList, PurchaseOrderStoreError> {
-        PurchaseOrderStoreOperations::new(self.connection)
-            .list_purchase_orders(org_id, service_id, offset, limit)
+        PurchaseOrderStoreOperations::new(self.connection).list_purchase_orders(
+            buyer_org_id,
+            seller_org_id,
+            service_id,
+            offset,
+            limit,
+        )
     }
 
     fn get_purchase_order(
         &self,
-        uuid: &str,
+        purchase_order_uid: &str,
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
-        PurchaseOrderStoreOperations::new(self.connection).get_purchase_order(uuid, service_id)
+        PurchaseOrderStoreOperations::new(self.connection)
+            .get_purchase_order(purchase_order_uid, service_id)
     }
 
     fn add_alternate_id(
@@ -265,14 +274,14 @@ impl<'a> PurchaseOrderStore for DieselConnectionPurchaseOrderStore<'a, diesel::p
 
     fn list_alternate_ids_for_purchase_order(
         &self,
-        purchase_order_uuid: &str,
+        purchase_order_uid: &str,
         org_id: &str,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
     ) -> Result<PurchaseOrderAlternateIdList, PurchaseOrderStoreError> {
         PurchaseOrderStoreOperations::new(self.connection).list_alternate_ids_for_purchase_order(
-            purchase_order_uuid,
+            purchase_order_uid,
             org_id,
             service_id,
             offset,
@@ -295,21 +304,28 @@ impl<'a> PurchaseOrderStore
 
     fn list_purchase_orders(
         &self,
-        org_id: Option<String>,
+        buyer_org_id: Option<String>,
+        seller_org_id: Option<String>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
     ) -> Result<PurchaseOrderList, PurchaseOrderStoreError> {
-        PurchaseOrderStoreOperations::new(self.connection)
-            .list_purchase_orders(org_id, service_id, offset, limit)
+        PurchaseOrderStoreOperations::new(self.connection).list_purchase_orders(
+            buyer_org_id,
+            seller_org_id,
+            service_id,
+            offset,
+            limit,
+        )
     }
 
     fn get_purchase_order(
         &self,
-        uuid: &str,
+        purchase_order_uid: &str,
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
-        PurchaseOrderStoreOperations::new(self.connection).get_purchase_order(uuid, service_id)
+        PurchaseOrderStoreOperations::new(self.connection)
+            .get_purchase_order(purchase_order_uid, service_id)
     }
 
     fn add_alternate_id(
@@ -321,14 +337,14 @@ impl<'a> PurchaseOrderStore
 
     fn list_alternate_ids_for_purchase_order(
         &self,
-        purchase_order_uuid: &str,
+        purchase_order_uid: &str,
         org_id: &str,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
     ) -> Result<PurchaseOrderAlternateIdList, PurchaseOrderStoreError> {
         PurchaseOrderStoreOperations::new(self.connection).list_alternate_ids_for_purchase_order(
-            purchase_order_uuid,
+            purchase_order_uid,
             org_id,
             service_id,
             offset,

--- a/sdk/src/purchase_order/store/diesel/models.rs
+++ b/sdk/src/purchase_order/store/diesel/models.rs
@@ -21,9 +21,10 @@ use crate::purchase_order::store::diesel::schema::*;
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "purchase_order"]
 pub struct NewPurchaseOrderModel {
-    pub uuid: String,
-    pub org_id: String,
+    pub purchase_order_uid: String,
     pub workflow_status: String,
+    pub buyer_org_id: String,
+    pub seller_org_id: String,
     pub is_closed: bool,
     pub accepted_version_id: String,
     pub created_at: i64,
@@ -36,9 +37,10 @@ pub struct NewPurchaseOrderModel {
 #[table_name = "purchase_order"]
 pub struct PurchaseOrderModel {
     pub id: i64,
-    pub uuid: String,
-    pub org_id: String,
+    pub purchase_order_uid: String,
     pub workflow_status: String,
+    pub buyer_org_id: String,
+    pub seller_org_id: String,
     pub is_closed: bool,
     pub accepted_version_id: String,
     pub created_at: i64,
@@ -50,8 +52,7 @@ pub struct PurchaseOrderModel {
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "purchase_order_version"]
 pub struct NewPurchaseOrderVersionModel {
-    pub purchase_order_uuid: String,
-    pub org_id: String,
+    pub purchase_order_uid: String,
     pub version_id: String,
     pub is_draft: bool,
     pub current_revision_id: String,
@@ -64,8 +65,7 @@ pub struct NewPurchaseOrderVersionModel {
 #[table_name = "purchase_order_version"]
 pub struct PurchaseOrderVersionModel {
     pub id: i64,
-    pub purchase_order_uuid: String,
-    pub org_id: String,
+    pub purchase_order_uid: String,
     pub version_id: String,
     pub is_draft: bool,
     pub current_revision_id: String,
@@ -78,7 +78,6 @@ pub struct PurchaseOrderVersionModel {
 #[table_name = "purchase_order_version_revision"]
 pub struct NewPurchaseOrderVersionRevisionModel {
     pub version_id: String,
-    pub org_id: String,
     pub revision_id: String,
     pub order_xml_v3_4: String,
     pub submitter: String,
@@ -93,7 +92,6 @@ pub struct NewPurchaseOrderVersionRevisionModel {
 pub struct PurchaseOrderVersionRevisionModel {
     pub id: i64,
     pub version_id: String,
-    pub org_id: String,
     pub revision_id: String,
     pub order_xml_v3_4: String,
     pub submitter: String,
@@ -106,7 +104,7 @@ pub struct PurchaseOrderVersionRevisionModel {
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "purchase_order_alternate_id"]
 pub struct NewPurchaseOrderAlternateIdModel {
-    pub purchase_order_uuid: String,
+    pub purchase_order_uid: String,
     pub org_id: String,
     pub alternate_id_type: String,
     pub alternate_id: String,
@@ -119,7 +117,7 @@ pub struct NewPurchaseOrderAlternateIdModel {
 #[table_name = "purchase_order_alternate_id"]
 pub struct PurchaseOrderAlternateIdModel {
     pub id: i64,
-    pub purchase_order_uuid: String,
+    pub purchase_order_uid: String,
     pub org_id: String,
     pub alternate_id_type: String,
     pub alternate_id: String,
@@ -131,8 +129,9 @@ pub struct PurchaseOrderAlternateIdModel {
 impl From<PurchaseOrder> for NewPurchaseOrderModel {
     fn from(order: PurchaseOrder) -> Self {
         Self {
-            uuid: order.uuid.to_string(),
-            org_id: order.org_id.to_string(),
+            purchase_order_uid: order.purchase_order_uid.to_string(),
+            buyer_org_id: order.buyer_org_id.to_string(),
+            seller_org_id: order.seller_org_id.to_string(),
             workflow_status: order.workflow_status.to_string(),
             is_closed: order.is_closed,
             accepted_version_id: order.accepted_version_id.to_string(),
@@ -147,8 +146,9 @@ impl From<PurchaseOrder> for NewPurchaseOrderModel {
 impl From<(PurchaseOrderModel, Vec<PurchaseOrderVersion>)> for PurchaseOrder {
     fn from((order, versions): (PurchaseOrderModel, Vec<PurchaseOrderVersion>)) -> Self {
         Self {
-            uuid: order.uuid.to_string(),
-            org_id: order.org_id.to_string(),
+            purchase_order_uid: order.purchase_order_uid.to_string(),
+            buyer_org_id: order.buyer_org_id.to_string(),
+            seller_org_id: order.seller_org_id.to_string(),
             workflow_status: order.workflow_status.to_string(),
             is_closed: order.is_closed,
             accepted_version_id: order.accepted_version_id.to_string(),
@@ -176,8 +176,9 @@ impl
         ),
     ) -> Self {
         Self {
-            uuid: order.uuid.to_string(),
-            org_id: order.org_id.to_string(),
+            purchase_order_uid: order.purchase_order_uid.to_string(),
+            buyer_org_id: order.buyer_org_id.to_string(),
+            seller_org_id: order.seller_org_id.to_string(),
             workflow_status: order.workflow_status.to_string(),
             is_closed: order.is_closed,
             accepted_version_id: order.accepted_version_id.to_string(),
@@ -238,7 +239,7 @@ impl From<&PurchaseOrderVersionRevisionModel> for PurchaseOrderVersionRevision {
 impl From<PurchaseOrderAlternateId> for NewPurchaseOrderAlternateIdModel {
     fn from(id: PurchaseOrderAlternateId) -> Self {
         Self {
-            purchase_order_uuid: id.purchase_order_uuid.to_string(),
+            purchase_order_uid: id.purchase_order_uid.to_string(),
             org_id: id.org_id.to_string(),
             alternate_id_type: id.id_type.to_string(),
             alternate_id: id.id.to_string(),
@@ -253,8 +254,7 @@ pub fn make_purchase_order_versions(order: &PurchaseOrder) -> Vec<NewPurchaseOrd
     let mut models = Vec::new();
     for version in &order.versions {
         let model = NewPurchaseOrderVersionModel {
-            purchase_order_uuid: order.uuid.to_string(),
-            org_id: order.org_id.to_string(),
+            purchase_order_uid: order.purchase_order_uid.to_string(),
             version_id: version.version_id.to_string(),
             is_draft: version.is_draft,
             current_revision_id: version.current_revision_id.to_string(),
@@ -277,7 +277,6 @@ pub fn make_purchase_order_version_revisions(
         for revision in &version.revisions {
             let model = NewPurchaseOrderVersionRevisionModel {
                 version_id: version.version_id.to_string(),
-                org_id: order.org_id.to_string(),
                 revision_id: revision.revision_id.to_string(),
                 order_xml_v3_4: revision.order_xml_v3_4.to_string(),
                 submitter: revision.submitter.to_string(),

--- a/sdk/src/purchase_order/store/diesel/operations/get_purchase_order.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/get_purchase_order.rs
@@ -27,7 +27,7 @@ use diesel::{prelude::*, result::Error::NotFound};
 pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreGetPurchaseOrderOperation {
     fn get_purchase_order(
         &self,
-        uuid: &str,
+        purchase_order_uid: &str,
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError>;
 }
@@ -38,7 +38,7 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderOperation
 {
     fn get_purchase_order(
         &self,
-        uuid: &str,
+        purchase_order_uid: &str,
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
         self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
@@ -46,8 +46,8 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderOperation
                 .into_boxed()
                 .select(purchase_order::all_columns)
                 .filter(
-                    purchase_order::uuid
-                        .eq(&uuid)
+                    purchase_order::purchase_order_uid
+                        .eq(&purchase_order_uid)
                         .and(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM)),
                 );
 
@@ -71,8 +71,8 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderOperation
                 .into_boxed()
                 .select(purchase_order_version::all_columns)
                 .filter(
-                    purchase_order_version::purchase_order_uuid
-                        .eq(&uuid)
+                    purchase_order_version::purchase_order_uid
+                        .eq(&purchase_order_uid)
                         .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
                 );
 
@@ -100,7 +100,6 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderOperation
                     .filter(
                         purchase_order_version_revision::version_id
                             .eq(&v.version_id)
-                            .and(purchase_order_version_revision::org_id.eq(&v.org_id))
                             .and(
                                 purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
                             ),
@@ -135,7 +134,7 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderOperation
 {
     fn get_purchase_order(
         &self,
-        uuid: &str,
+        purchase_order_uid: &str,
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
         self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
@@ -143,8 +142,8 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderOperation
                 .into_boxed()
                 .select(purchase_order::all_columns)
                 .filter(
-                    purchase_order::uuid
-                        .eq(&uuid)
+                    purchase_order::purchase_order_uid
+                        .eq(&purchase_order_uid)
                         .and(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM)),
                 );
 
@@ -168,8 +167,8 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderOperation
                 .into_boxed()
                 .select(purchase_order_version::all_columns)
                 .filter(
-                    purchase_order_version::purchase_order_uuid
-                        .eq(&uuid)
+                    purchase_order_version::purchase_order_uid
+                        .eq(&purchase_order_uid)
                         .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
                 );
 
@@ -197,7 +196,6 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderOperation
                     .filter(
                         purchase_order_version_revision::version_id
                             .eq(&v.version_id)
-                            .and(purchase_order_version_revision::org_id.eq(&v.org_id))
                             .and(
                                 purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
                             ),

--- a/sdk/src/purchase_order/store/diesel/operations/list_alternate_ids_for_purchase_order.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_alternate_ids_for_purchase_order.rs
@@ -19,7 +19,7 @@ pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreListAlterna
 {
     fn list_alternate_ids_for_purchase_order(
         &self,
-        purchase_order_uuid: &str,
+        purchase_order_uid: &str,
         org_id: &str,
         service_id: Option<&str>,
         offset: i64,
@@ -33,7 +33,7 @@ impl<'a> PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation
 {
     fn list_alternate_ids_for_purchase_order(
         &self,
-        _purchase_order_uuid: &str,
+        _purchase_order_uid: &str,
         _org_id: &str,
         _service_id: Option<&str>,
         _offset: i64,
@@ -49,7 +49,7 @@ impl<'a> PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation
 {
     fn list_alternate_ids_for_purchase_order(
         &self,
-        _purchase_order_uuid: &str,
+        _purchase_order_uid: &str,
         _org_id: &str,
         _service_id: Option<&str>,
         _offset: i64,

--- a/sdk/src/purchase_order/store/diesel/operations/list_purchase_orders.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_purchase_orders.rs
@@ -28,7 +28,8 @@ use diesel::prelude::*;
 pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreListPurchaseOrdersOperation {
     fn list_purchase_orders(
         &self,
-        org_id: Option<String>,
+        buyer_org_id: Option<String>,
+        seller_org_id: Option<String>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
@@ -41,7 +42,8 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
 {
     fn list_purchase_orders(
         &self,
-        org_id: Option<String>,
+        buyer_org_id: Option<String>,
+        seller_org_id: Option<String>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
@@ -54,8 +56,12 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
                 .limit(limit)
                 .filter(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM));
 
-            if let Some(org_id) = org_id {
-                query = query.filter(purchase_order::org_id.eq(org_id))
+            if let Some(buyer_org_id) = buyer_org_id {
+                query = query.filter(purchase_order::buyer_org_id.eq(buyer_org_id))
+            }
+
+            if let Some(seller_org_id) = seller_org_id {
+                query = query.filter(purchase_order::seller_org_id.eq(seller_org_id))
             }
 
             if let Some(service_id) = service_id {
@@ -90,9 +96,8 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
                     .into_boxed()
                     .select(purchase_order_version::all_columns)
                     .filter(
-                        purchase_order_version::purchase_order_uuid
-                            .eq(&o.uuid)
-                            .and(purchase_order_version::org_id.eq(&o.org_id))
+                        purchase_order_version::purchase_order_uid
+                            .eq(&o.purchase_order_uid)
                             .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
                     );
 
@@ -120,7 +125,6 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
                         .filter(
                             purchase_order_version_revision::version_id
                                 .eq(&v.version_id)
-                                .and(purchase_order_version_revision::org_id.eq(&v.org_id))
                                 .and(
                                     purchase_order_version_revision::end_commit_num
                                         .eq(MAX_COMMIT_NUM),
@@ -162,7 +166,8 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
 {
     fn list_purchase_orders(
         &self,
-        org_id: Option<String>,
+        buyer_org_id: Option<String>,
+        seller_org_id: Option<String>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
@@ -175,8 +180,12 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
                 .limit(limit)
                 .filter(purchase_order::end_commit_num.eq(MAX_COMMIT_NUM));
 
-            if let Some(org_id) = org_id {
-                query = query.filter(purchase_order::org_id.eq(org_id))
+            if let Some(buyer_org_id) = buyer_org_id {
+                query = query.filter(purchase_order::buyer_org_id.eq(buyer_org_id))
+            }
+
+            if let Some(seller_org_id) = seller_org_id {
+                query = query.filter(purchase_order::seller_org_id.eq(seller_org_id))
             }
 
             if let Some(service_id) = service_id {
@@ -211,9 +220,8 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
                     .into_boxed()
                     .select(purchase_order_version::all_columns)
                     .filter(
-                        purchase_order_version::purchase_order_uuid
-                            .eq(&o.uuid)
-                            .and(purchase_order_version::org_id.eq(&o.org_id))
+                        purchase_order_version::purchase_order_uid
+                            .eq(&o.purchase_order_uid)
                             .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
                     );
 
@@ -241,7 +249,6 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
                         .filter(
                             purchase_order_version_revision::version_id
                                 .eq(&v.version_id)
-                                .and(purchase_order_version_revision::org_id.eq(&v.org_id))
                                 .and(
                                     purchase_order_version_revision::end_commit_num
                                         .eq(MAX_COMMIT_NUM),

--- a/sdk/src/purchase_order/store/diesel/schema.rs
+++ b/sdk/src/purchase_order/store/diesel/schema.rs
@@ -15,8 +15,9 @@
 table! {
     purchase_order (id) {
         id -> Int8,
-        uuid -> Text,
-        org_id -> Varchar,
+        purchase_order_uid -> Text,
+        buyer_org_id -> Varchar,
+        seller_org_id -> Varchar,
         workflow_status -> Text,
         is_closed -> Bool,
         accepted_version_id -> Text,
@@ -30,8 +31,7 @@ table! {
 table! {
     purchase_order_version (id) {
         id -> Int8,
-        purchase_order_uuid -> Text,
-        org_id -> Varchar,
+        purchase_order_uid -> Text,
         version_id -> Text,
         is_draft -> Bool,
         current_revision_id -> Text,
@@ -45,7 +45,6 @@ table! {
     purchase_order_version_revision (id) {
         id -> Int8,
         version_id -> Text,
-        org_id -> Varchar,
         revision_id -> Text,
         order_xml_v3_4 -> Text,
         submitter -> Text,
@@ -59,7 +58,7 @@ table! {
 table! {
     purchase_order_alternate_id (id) {
         id -> Int8,
-        purchase_order_uuid -> Text,
+        purchase_order_uid -> Text,
         org_id -> Varchar,
         alternate_id_type -> Text,
         alternate_id -> Text,

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -105,13 +105,15 @@ pub trait PurchaseOrderStore {
     ///
     /// # Arguments
     ///
-    ///  * `org_id` - The organization to fetch for
+    ///  * `buyer_org_id` - The buyer organization to fetch for
+    ///  * `seller_org_id` - The seller organization to fetch for
     ///  * `service_id` - The service id
     ///  * `offset` - The index of the first in storage to retrieve
     ///  * `limit` - The number of items to retrieve from the offset
     fn list_purchase_orders(
         &self,
-        org_id: Option<String>,
+        buyer_org_id: Option<String>,
+        seller_org_id: Option<String>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
@@ -121,11 +123,11 @@ pub trait PurchaseOrderStore {
     ///
     /// # Arguments
     ///
-    ///  * `uuid`   - The uuid of the purchase order
+    ///  * `purchase_order_uid`   - The uid of the purchase order
     ///  * `service_id` - The service id
     fn get_purchase_order(
         &self,
-        uuid: &str,
+        purchase_order_uid: &str,
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError>;
 
@@ -143,14 +145,14 @@ pub trait PurchaseOrderStore {
     ///
     /// # Arguments
     ///
-    ///  * `purchase_order_uuid` - The purchase order to fetch alternate IDs for
+    ///  * `purchase_order_uid` - The purchase order to fetch alternate IDs for
     ///  * `org_id` - The organization to fetch for
     ///  * `service_id` - The service id
     ///  * `offset` - The index of the first in storage to retrieve
     ///  * `limit` - The number of items to retrieve from the offset
     fn list_alternate_ids_for_purchase_order(
         &self,
-        purchase_order_uuid: &str,
+        purchase_order_uid: &str,
         org_id: &str,
         service_id: Option<&str>,
         offset: i64,
@@ -168,20 +170,21 @@ where
 
     fn list_purchase_orders(
         &self,
-        org_id: Option<String>,
+        buyer_org_id: Option<String>,
+        seller_org_id: Option<String>,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
     ) -> Result<PurchaseOrderList, PurchaseOrderStoreError> {
-        (**self).list_purchase_orders(org_id, service_id, offset, limit)
+        (**self).list_purchase_orders(buyer_org_id, seller_org_id, service_id, offset, limit)
     }
 
     fn get_purchase_order(
         &self,
-        uuid: &str,
+        purchase_order_uid: &str,
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrder>, PurchaseOrderStoreError> {
-        (**self).get_purchase_order(uuid, service_id)
+        (**self).get_purchase_order(purchase_order_uid, service_id)
     }
 
     fn add_alternate_id(
@@ -193,14 +196,14 @@ where
 
     fn list_alternate_ids_for_purchase_order(
         &self,
-        purchase_order_uuid: &str,
+        purchase_order_uid: &str,
         org_id: &str,
         service_id: Option<&str>,
         offset: i64,
         limit: i64,
     ) -> Result<PurchaseOrderAlternateIdList, PurchaseOrderStoreError> {
         (**self).list_alternate_ids_for_purchase_order(
-            purchase_order_uuid,
+            purchase_order_uid,
             org_id,
             service_id,
             offset,

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -38,9 +38,10 @@ impl PurchaseOrderList {
 /// Represents a Grid Purchase Order
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct PurchaseOrder {
-    pub uuid: String,
-    pub org_id: String,
+    pub purchase_order_uid: String,
     pub workflow_status: String,
+    pub buyer_org_id: String,
+    pub seller_org_id: String,
     pub is_closed: bool,
     pub accepted_version_id: String,
     pub versions: Vec<PurchaseOrderVersion>,
@@ -83,7 +84,7 @@ pub struct PurchaseOrderAlternateIdList {
 /// Represents a Grid Purchase Order Alternate ID
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct PurchaseOrderAlternateId {
-    pub purchase_order_uuid: String,
+    pub purchase_order_uid: String,
     pub org_id: String,
     pub id_type: String,
     pub id: String,

--- a/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
@@ -30,7 +30,8 @@ pub struct QueryOrgId {
 #[get("/purchase-order")]
 pub async fn list_purchase_orders(
     store_state: web::Data<StoreState>,
-    query_org_id: web::Query<QueryOrgId>,
+    query_buyer_org_id: web::Query<QueryOrgId>,
+    query_seller_org_id: web::Query<QueryOrgId>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
     version: ProtocolVersion,
@@ -40,11 +41,13 @@ pub async fn list_purchase_orders(
     match version {
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
-            let org_id = query_org_id.into_inner().org_id;
+            let buyer_org_id = query_buyer_org_id.into_inner().org_id;
+            let seller_org_id = query_seller_org_id.into_inner().org_id;
             let service_id = query_service_id.into_inner().service_id;
             match v1::list_purchase_orders(
                 store,
-                org_id,
+                buyer_org_id,
+                seller_org_id,
                 service_id.as_deref(),
                 paging.offset(),
                 paging.limit(),

--- a/sdk/src/rest_api/resources/purchase_order/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/payloads.rs
@@ -16,7 +16,7 @@ use crate::{purchase_order::store::PurchaseOrder, rest_api::resources::paging::v
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PurchaseOrderSlice {
-    pub uuid: String,
+    pub purchase_order_uid: String,
     pub workflow_status: String,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -30,7 +30,7 @@ pub struct PurchaseOrderSlice {
 impl From<PurchaseOrder> for PurchaseOrderSlice {
     fn from(purchase_order: PurchaseOrder) -> Self {
         Self {
-            uuid: purchase_order.uuid,
+            purchase_order_uid: purchase_order.purchase_order_uid,
             workflow_status: purchase_order.workflow_status,
             accepted_version_id: Some(purchase_order.accepted_version_id),
             version_numbers: Some(


### PR DESCRIPTION
This updates the PO store to account for the changes to the PO protobuf messages. This updates the schemas, DB models, Grid structs, DB operations, and REST API to account for the different fields in the updated messages.