### PR TITLE
Add whitespace to conform to calc CSS standard

### DIFF
--- a/ui/saplings/product/src/components/CircuitDropdown.scss
+++ b/ui/saplings/product/src/components/CircuitDropdown.scss
@@ -30,7 +30,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    line-height: calc(2rem-2px);
+    line-height: calc(2rem - 2px);
     padding: 0 1rem;
 
     &.disabled {


### PR DESCRIPTION
To conform to the CSS standard, plus and minus characters must be
surrounded by whitespace within the calc function. The lack of
whitespace caused the docker image build to fail when creating
grid-ui-alpha. This change fixes that by adding the appropriate
whitespace.

Signed-off-by: Lee Bradley <bradley@bitwise.io>