### PR TITLE
Fix get/list role display bug

### DIFF
--- a/sdk/src/client/pike/reqwest.rs
+++ b/sdk/src/client/pike/reqwest.rs
@@ -113,7 +113,7 @@ struct PikeRoleDto {
     pub description: String,
     pub active: bool,
     pub permissions: Vec<String>,
-    pub inherit_from: Vec<InheritFromDto>,
+    pub inherit_from: Vec<String>,
     pub allowed_organizations: Vec<String>,
 }
 
@@ -125,23 +125,28 @@ impl From<&PikeRoleDto> for PikeRole {
             description: d.description.to_string(),
             active: d.active,
             permissions: d.permissions.iter().map(String::from).collect(),
-            inherit_from: d.inherit_from.iter().map(InheritFrom::from).collect(),
+            inherit_from: d
+                .inherit_from
+                .iter()
+                .map(|i| InheritFrom::from((i, &d.org_id)))
+                .collect(),
             allowed_organizations: d.allowed_organizations.iter().map(String::from).collect(),
         }
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct InheritFromDto {
-    pub role_name: String,
-    pub org_id: String,
-}
-
-impl From<&InheritFromDto> for InheritFrom {
-    fn from(d: &InheritFromDto) -> Self {
+impl From<(&String, &String)> for InheritFrom {
+    fn from((role, org): (&String, &String)) -> Self {
+        let mut ifoid = org.to_string();
+        let mut ifname = role.to_string();
+        if role.contains('.') {
+            let inherit_from: Vec<&str> = role.split('.').collect();
+            ifoid = inherit_from[0].to_string();
+            ifname = inherit_from[1].to_string();
+        }
         Self {
-            role_name: d.role_name.to_string(),
-            org_id: d.org_id.to_string(),
+            role_name: ifname,
+            org_id: ifoid,
         }
     }
 }

--- a/sdk/src/pike/store/diesel/models.rs
+++ b/sdk/src/pike/store/diesel/models.rs
@@ -408,15 +408,17 @@ pub fn make_inherit_from_models(role: &Role) -> Vec<NewInheritFromModel> {
 
     for i in &role.inherit_from {
         let mut ifoid = role.org_id.to_string();
+        let mut ifname = i.to_string();
         if i.contains('.') {
             let inherit_from: Vec<&str> = i.split('.').collect();
             ifoid = inherit_from[0].to_string();
+            ifname = inherit_from[1].to_string();
         }
 
         let model = NewInheritFromModel {
             role_name: role.name.to_string(),
             org_id: role.org_id.to_string(),
-            inherit_from_role_name: i.to_string(),
+            inherit_from_role_name: ifname,
             inherit_from_org_id: ifoid,
             start_commit_num: role.start_commit_num,
             end_commit_num: role.end_commit_num,


### PR DESCRIPTION
This fixes a bug where roles' `inherit_from` roles were not being
displayed correctly. This fixes it so roles now properly display their
inherited roles.

# Testing

## Create orgs

$ grid keygen alpha-agent
$ grid keygen beta-agent
$ export GRID_DAEMON_KEY="beta-agent" && grid organization create beta BetaOrg --alternate-ids gs1_company_prefix:0 --wait 10
$ export GRID_DAEMON_KEY="alpha-agent" && grid organization create alpha AlphaOrg --alternate-ids gs1_company_prefix:1 --wait 10

# Create a role for beta to inherit
$ grid role create alpha productowner --permissions schema::can-create-schema,product::can-create-product,product::can-delete-product,schema::can-update-schema,product::can-update-product --active --wait 10

# inherit role
$ export GRID_DAEMON_KEY="beta-agent"
$ $ grid role create beta alpha-po --permissions product::can-update-product --inherit-from alpha.productowner --active --wait 10

# try to list role
$ grid role list beta