### PR TITLE
Add keygen `--skip` option

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -49,6 +49,9 @@ serde_yaml = "0.8"
 diesel_migrations = "1.4"
 whoami = "1"
 
+[dev-dependencies]
+tempdir = "0.3"
+
 [features]
 default = [
     "sawtooth",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -103,7 +103,8 @@ fn run() -> Result<(), CliError> {
         (@subcommand keygen =>
             (about: "Generates keys with which the user can sign transactions and batches.")
             (@arg key_name: +takes_value "Name of the key to create")
-            (@arg force: --force "Overwrite files if they exist")
+            (@arg force: conflicts_with[skip] --force "Overwrite files if they exist")
+            (@arg skip: conflicts_with[force] --skip "Check if files exist; Generate if missing")
             (@arg key_dir: -d --("key-dir") +takes_value conflicts_with[system]
                 "Specify the directory for the key files")
             (@arg system: --system "Generate system keys in /etc/grid/keys")
@@ -2055,7 +2056,7 @@ fn run() -> Result<(), CliError> {
                     .ok_or_else(|| CliError::UserError("Home directory not found".into()))?
             };
 
-            keygen::generate_keys(key_name, m.is_present("force"), key_dir)?
+            keygen::generate_keys(key_name, m.is_present("force"), m.is_present("skip"), key_dir)?
         }
         ("product", Some(m)) => {
             let url = m


### PR DESCRIPTION
Add a keygen --skip option that will allow the keygen command to
continue if the private and public key already exist.

Also add tests for key generation to validate various permutations.