### PR TITLE
Test keygen

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -49,6 +49,9 @@ serde_yaml = "0.8"
 diesel_migrations = "1.4"
 whoami = "1"
 
+[dev-dependencies]
+tempdir = "0.3"
+
 [features]
 default = [
     "sawtooth",


### PR DESCRIPTION
Add tests to validate the behavior of key generation given various
permutations of the configuration values.

Signed-off-by: Lee Bradley <bradley@bitwise.io>