### PR TITLE
Add `--skip` to griddle examples

### DIFF
--- a/examples/griddle/docker-compose-dockerhub.yaml
+++ b/examples/griddle/docker-compose-dockerhub.yaml
@@ -233,7 +233,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-0
+        grid -vv keygen --skip --system griddle-alpha-0
         grid -vv database migrate \
             -C postgres://grid:grid_example@db-alpha/grid &&
         griddle -vv --connect splinter:http://splinterd-alpha:8085
@@ -260,7 +260,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-1
+        grid -vv keygen --skip --system griddle-alpha-1
         griddle -vv --connect splinter:http://splinterd-alpha:8085
       "
 
@@ -285,7 +285,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-2
+        grid -vv keygen --skip --system griddle-alpha-2
         griddle -vv --connect splinter:http://splinterd-alpha:8085
       "
 
@@ -310,7 +310,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-3
+        grid -vv keygen --skip --system griddle-alpha-3
         griddle -vv --connect splinter:http://splinterd-alpha:8085
       "
 
@@ -438,7 +438,7 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-0
+        grid -vv keygen --skip --system griddle-beta-0
         grid -vv database migrate \
             -C postgres://grid:grid_example@db-beta/grid &&
         griddle -vv --connect splinter:http://splinterd-beta:8085
@@ -465,7 +465,7 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-1
+        grid -vv keygen --skip --system griddle-beta-1
         griddle -vv --connect splinter:http://splinterd-beta:8085
       "
 
@@ -490,7 +490,7 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-2
+        grid -vv keygen --skip --system griddle-beta-2
         griddle -vv --connect splinter:http://splinterd-beta:8085
       "
 
@@ -515,6 +515,6 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-3
+        grid -vv keygen --skip --system griddle-beta-3
         griddle -vv --connect splinter:http://splinterd-beta:8085
       "

--- a/examples/griddle/docker-compose-sawtooth.yaml
+++ b/examples/griddle/docker-compose-sawtooth.yaml
@@ -324,7 +324,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-0
+        grid -vv keygen --skip --system griddle-alpha-0
         griddle -v --connect tcp://sawtooth-validator:4004
       "
 
@@ -349,7 +349,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-1
+        grid -vv keygen --skip --system griddle-alpha-1
         griddle -v --connect tcp://sawtooth-validator:4004
       "
 
@@ -374,7 +374,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-2
+        grid -vv keygen --skip --system griddle-alpha-2
         griddle -v --connect tcp://sawtooth-validator:4004
       "
 
@@ -399,7 +399,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-3
+        grid -vv keygen --skip --system griddle-alpha-3
         griddle -v --connect tcp://sawtooth-validator:4004
       "
 
@@ -476,7 +476,7 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-0
+        grid -vv keygen --skip --system griddle-beta-0
         griddle -v --connect tcp://sawtooth-validator:4004
       "
 
@@ -501,7 +501,7 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-1
+        grid -vv keygen --skip --system griddle-beta-1
         griddle -v --connect tcp://sawtooth-validator:4004
       "
 
@@ -526,7 +526,7 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-2
+        grid -vv keygen --skip --system griddle-beta-2
         griddle -v --connect tcp://sawtooth-validator:4004
       "
 
@@ -551,6 +551,6 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-3
+        grid -vv keygen --skip --system griddle-beta-3
         griddle -v --connect tcp://sawtooth-validator:4004
       "

--- a/examples/griddle/docker-compose-splinter.yaml
+++ b/examples/griddle/docker-compose-splinter.yaml
@@ -228,7 +228,7 @@ services:
             sleep 1
         done
         grid -vv admin keygen --skip && \
-        grid -vv keygen --system && \
+        grid -vv keygen --skip --system && \
         grid -vv database migrate \
             -C postgres://grid:grid_example@db-alpha/grid &&
         gridd -vv -b 0.0.0.0:8080 -k root -C splinter:http://splinterd-alpha:8085 \
@@ -319,7 +319,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-0
+        grid -vv keygen --skip --system griddle-alpha-0
         griddle -v --connect splinter:http://splinterd-alpha:8085
       "
 
@@ -344,7 +344,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-1
+        grid -vv keygen --skip --system griddle-alpha-1
         griddle -v --connect splinter:http://splinterd-alpha:8085
       "
 
@@ -369,7 +369,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-2
+        grid -vv keygen --skip --system griddle-alpha-2
         griddle -v --connect splinter:http://splinterd-alpha:8085
       "
 
@@ -394,7 +394,7 @@ services:
             >&2 echo \"Database alpha is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-alpha-3
+        grid -vv keygen --skip --system griddle-alpha-3
         griddle -v --connect splinter:http://splinterd-alpha:8085
       "
 
@@ -441,7 +441,7 @@ services:
             sleep 1
         done
         grid -vv admin keygen --skip && \
-        grid -vv keygen --system && \
+        grid -vv keygen --skip --system && \
         grid -vv database migrate \
             -C postgres://grid:grid_example@db-beta/grid &&
         gridd -vv -k root -b 0.0.0.0:8080 -C splinter:http://splinterd-beta:8085 \
@@ -531,7 +531,7 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-0
+        grid -vv keygen --skip --system griddle-beta-0
         griddle -v --connect splinter:http://splinterd-beta:8085
       "
 
@@ -556,7 +556,7 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-1
+        grid -vv keygen --skip --system griddle-beta-1
         griddle -v --connect splinter:http://splinterd-beta:8085
       "
 
@@ -581,7 +581,7 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-2
+        grid -vv keygen --skip --system griddle-beta-2
         griddle -v --connect splinter:http://splinterd-beta:8085
       "
 
@@ -606,6 +606,6 @@ services:
             >&2 echo \"Database beta is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv keygen --system griddle-beta-3
+        grid -vv keygen --skip --system griddle-beta-3
         griddle -v --connect splinter:http://splinterd-beta:8085
       "


### PR DESCRIPTION
These docker examples are likely to be rerun many times. The --skip
option will allow the entrypoint command to run without throwing an
error if the keys are already generated.

Signed-off-by: Lee Bradley <bradley@bitwise.io>