### PR TITLE
Add list/get revision operations

### DIFF
--- a/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -40,6 +40,7 @@ CREATE TABLE purchase_order_version (
 
 CREATE TABLE purchase_order_version_revision (
     id INTEGER PRIMARY KEY,
+    purchase_order_uid TEXT NOT NULL,
     version_id TEXT NOT NULL,
     revision_id TEXT NOT NULL,
     order_xml_v3_4 TEXT NOT NULL,

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -40,6 +40,7 @@ CREATE TABLE purchase_order_version (
 
 CREATE TABLE purchase_order_version_revision (
     id INTEGER PRIMARY KEY,
+    purchase_order_uid TEXT NOT NULL,
     version_id TEXT NOT NULL,
     revision_id TEXT NOT NULL,
     order_xml_v3_4 TEXT NOT NULL,

--- a/sdk/src/purchase_order/store/diesel/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/mod.rs
@@ -33,6 +33,7 @@ use operations::add_alternate_id::PurchaseOrderStoreAddAlternateIdOperation as _
 use operations::add_purchase_order::PurchaseOrderStoreAddPurchaseOrderOperation as _;
 use operations::get_purchase_order::PurchaseOrderStoreGetPurchaseOrderOperation as _;
 use operations::get_purchase_order_version::PurchaseOrderStoreGetPurchaseOrderVersionOperation as _;
+use operations::get_purchase_order_version_revision::PurchaseOrderStoreGetPurchaseOrderRevisionOperation as _;
 use operations::list_alternate_ids_for_purchase_order::PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation as _;
 use operations::list_purchase_order_versions::PurchaseOrderStoreListPurchaseOrderVersionsOperation as _;
 use operations::list_purchase_orders::PurchaseOrderStoreListPurchaseOrdersOperation as _;
@@ -126,6 +127,21 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
             )
         })?)
         .get_purchase_order_version(po_uid, version_id, service_id)
+    }
+
+    fn get_purchase_order_revision(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        revision_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersionRevision>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .get_purchase_order_revision(po_uid, version_id, revision_id, service_id)
     }
 
     fn add_alternate_id(
@@ -234,6 +250,21 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
             )
         })?)
         .get_purchase_order_version(po_uid, version_id, service_id)
+    }
+
+    fn get_purchase_order_revision(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        revision_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersionRevision>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .get_purchase_order_revision(po_uid, version_id, revision_id, service_id)
     }
 
     fn add_alternate_id(
@@ -346,6 +377,21 @@ impl<'a> PurchaseOrderStore for DieselConnectionPurchaseOrderStore<'a, diesel::p
             .get_purchase_order_version(po_uid, version_id, service_id)
     }
 
+    fn get_purchase_order_revision(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        revision_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersionRevision>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(self.connection).get_purchase_order_revision(
+            po_uid,
+            version_id,
+            revision_id,
+            service_id,
+        )
+    }
+
     fn add_alternate_id(
         &self,
         alternate_id: PurchaseOrderAlternateId,
@@ -428,6 +474,21 @@ impl<'a> PurchaseOrderStore
     ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError> {
         PurchaseOrderStoreOperations::new(self.connection)
             .get_purchase_order_version(po_uid, version_id, service_id)
+    }
+
+    fn get_purchase_order_revision(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        revision_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersionRevision>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(self.connection).get_purchase_order_revision(
+            po_uid,
+            version_id,
+            revision_id,
+            service_id,
+        )
     }
 
     fn add_alternate_id(

--- a/sdk/src/purchase_order/store/diesel/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/mod.rs
@@ -22,7 +22,7 @@ use diesel::r2d2::{ConnectionManager, Pool};
 use super::{
     PurchaseOrder, PurchaseOrderAlternateId, PurchaseOrderAlternateIdList, PurchaseOrderList,
     PurchaseOrderStore, PurchaseOrderStoreError, PurchaseOrderVersion, PurchaseOrderVersionList,
-    PurchaseOrderVersionRevision,
+    PurchaseOrderVersionRevision, PurchaseOrderVersionRevisionList,
 };
 
 use models::{make_purchase_order_version_revisions, make_purchase_order_versions};
@@ -35,6 +35,7 @@ use operations::get_purchase_order::PurchaseOrderStoreGetPurchaseOrderOperation 
 use operations::get_purchase_order_version::PurchaseOrderStoreGetPurchaseOrderVersionOperation as _;
 use operations::get_purchase_order_version_revision::PurchaseOrderStoreGetPurchaseOrderRevisionOperation as _;
 use operations::list_alternate_ids_for_purchase_order::PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation as _;
+use operations::list_purchase_order_version_revisions::PurchaseOrderStoreListPurchaseOrderRevisionsOperation as _;
 use operations::list_purchase_order_versions::PurchaseOrderStoreListPurchaseOrderVersionsOperation as _;
 use operations::list_purchase_orders::PurchaseOrderStoreListPurchaseOrdersOperation as _;
 use operations::PurchaseOrderStoreOperations;
@@ -142,6 +143,22 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
             )
         })?)
         .get_purchase_order_revision(po_uid, version_id, revision_id, service_id)
+    }
+
+    fn list_purchase_order_revisions(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionRevisionList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .list_purchase_order_revisions(po_uid, version_id, service_id, offset, limit)
     }
 
     fn add_alternate_id(
@@ -265,6 +282,22 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
             )
         })?)
         .get_purchase_order_revision(po_uid, version_id, revision_id, service_id)
+    }
+
+    fn list_purchase_order_revisions(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionRevisionList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .list_purchase_order_revisions(po_uid, version_id, service_id, offset, limit)
     }
 
     fn add_alternate_id(
@@ -392,6 +425,18 @@ impl<'a> PurchaseOrderStore for DieselConnectionPurchaseOrderStore<'a, diesel::p
         )
     }
 
+    fn list_purchase_order_revisions(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionRevisionList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(self.connection)
+            .list_purchase_order_revisions(po_uid, version_id, service_id, offset, limit)
+    }
+
     fn add_alternate_id(
         &self,
         alternate_id: PurchaseOrderAlternateId,
@@ -489,6 +534,18 @@ impl<'a> PurchaseOrderStore
             revision_id,
             service_id,
         )
+    }
+
+    fn list_purchase_order_revisions(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionRevisionList, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(self.connection)
+            .list_purchase_order_revisions(po_uid, version_id, service_id, offset, limit)
     }
 
     fn add_alternate_id(

--- a/sdk/src/purchase_order/store/diesel/models.rs
+++ b/sdk/src/purchase_order/store/diesel/models.rs
@@ -263,6 +263,20 @@ impl From<&PurchaseOrderVersionRevisionModel> for PurchaseOrderVersionRevision {
     }
 }
 
+impl From<PurchaseOrderVersionRevisionModel> for PurchaseOrderVersionRevision {
+    fn from(revision: PurchaseOrderVersionRevisionModel) -> Self {
+        Self {
+            revision_id: revision.revision_id.to_string(),
+            order_xml_v3_4: revision.order_xml_v3_4.to_string(),
+            submitter: revision.submitter.to_string(),
+            created_at: revision.created_at,
+            start_commit_num: revision.start_commit_num,
+            end_commit_num: revision.end_commit_num,
+            service_id: revision.service_id,
+        }
+    }
+}
+
 impl From<PurchaseOrderAlternateId> for NewPurchaseOrderAlternateIdModel {
     fn from(id: PurchaseOrderAlternateId) -> Self {
         Self {

--- a/sdk/src/purchase_order/store/diesel/models.rs
+++ b/sdk/src/purchase_order/store/diesel/models.rs
@@ -79,6 +79,7 @@ pub struct PurchaseOrderVersionModel {
 #[derive(Insertable, PartialEq, Queryable, Debug)]
 #[table_name = "purchase_order_version_revision"]
 pub struct NewPurchaseOrderVersionRevisionModel {
+    pub purchase_order_uid: String,
     pub version_id: String,
     pub revision_id: String,
     pub order_xml_v3_4: String,
@@ -93,6 +94,7 @@ pub struct NewPurchaseOrderVersionRevisionModel {
 #[table_name = "purchase_order_version_revision"]
 pub struct PurchaseOrderVersionRevisionModel {
     pub id: i64,
+    pub purchase_order_uid: String,
     pub version_id: String,
     pub revision_id: String,
     pub order_xml_v3_4: String,
@@ -301,6 +303,7 @@ pub fn make_purchase_order_version_revisions(
     for version in &order.versions {
         for revision in &version.revisions {
             let model = NewPurchaseOrderVersionRevisionModel {
+                purchase_order_uid: order.purchase_order_uid.to_string(),
                 version_id: version.version_id.to_string(),
                 revision_id: revision.revision_id.to_string(),
                 order_xml_v3_4: revision.order_xml_v3_4.to_string(),

--- a/sdk/src/purchase_order/store/diesel/operations/get_purchase_order_version_revision.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/get_purchase_order_version_revision.rs
@@ -1,0 +1,121 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::PurchaseOrderStoreOperations;
+use crate::commits::MAX_COMMIT_NUM;
+use crate::error::InternalError;
+use crate::purchase_order::store::diesel::{
+    models::PurchaseOrderVersionRevisionModel, schema::purchase_order_version_revision,
+    PurchaseOrderVersionRevision,
+};
+
+use crate::purchase_order::store::PurchaseOrderStoreError;
+use diesel::prelude::*;
+
+pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreGetPurchaseOrderRevisionOperation
+{
+    fn get_purchase_order_revision(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        revision_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersionRevision>, PurchaseOrderStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> PurchaseOrderStoreGetPurchaseOrderRevisionOperation
+    for PurchaseOrderStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn get_purchase_order_revision(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        revision_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersionRevision>, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version_revision::table
+                .into_boxed()
+                .select(purchase_order_version_revision::all_columns)
+                .filter(
+                    purchase_order_version_revision::purchase_order_uid
+                        .eq(&po_uid)
+                        .and(purchase_order_version_revision::version_id.eq(&version_id))
+                        .and(purchase_order_version_revision::revision_id.eq(&revision_id))
+                        .and(purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version_revision::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version_revision::service_id.is_null());
+            }
+
+            let revision = query
+                .first::<PurchaseOrderVersionRevisionModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            Ok(revision.map(PurchaseOrderVersionRevision::from))
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> PurchaseOrderStoreGetPurchaseOrderRevisionOperation
+    for PurchaseOrderStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn get_purchase_order_revision(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        revision_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersionRevision>, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version_revision::table
+                .into_boxed()
+                .select(purchase_order_version_revision::all_columns)
+                .filter(
+                    purchase_order_version_revision::purchase_order_uid
+                        .eq(&po_uid)
+                        .and(purchase_order_version_revision::version_id.eq(&version_id))
+                        .and(purchase_order_version_revision::revision_id.eq(&revision_id))
+                        .and(purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version_revision::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version_revision::service_id.is_null());
+            }
+
+            let revision = query
+                .first::<PurchaseOrderVersionRevisionModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            Ok(revision.map(PurchaseOrderVersionRevision::from))
+        })
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/list_purchase_order_version_revisions.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_purchase_order_version_revisions.rs
@@ -1,0 +1,165 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::PurchaseOrderStoreOperations;
+use crate::commits::MAX_COMMIT_NUM;
+use crate::error::InternalError;
+use crate::paging::Paging;
+use crate::purchase_order::store::diesel::{
+    models::PurchaseOrderVersionRevisionModel, schema::purchase_order_version_revision,
+    PurchaseOrderVersionRevision, PurchaseOrderVersionRevisionList,
+};
+
+use crate::purchase_order::store::PurchaseOrderStoreError;
+use diesel::prelude::*;
+
+pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreListPurchaseOrderRevisionsOperation
+{
+    fn list_purchase_order_revisions(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionRevisionList, PurchaseOrderStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> PurchaseOrderStoreListPurchaseOrderRevisionsOperation
+    for PurchaseOrderStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn list_purchase_order_revisions(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionRevisionList, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version_revision::table
+                .into_boxed()
+                .select(purchase_order_version_revision::all_columns)
+                .filter(
+                    purchase_order_version_revision::purchase_order_uid
+                        .eq(&po_uid)
+                        .and(purchase_order_version_revision::version_id.eq(&version_id))
+                        .and(purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version_revision::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version_revision::service_id.is_null());
+            }
+
+            let revision_models = query
+                .load::<PurchaseOrderVersionRevisionModel>(self.conn)
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            let mut count_query = purchase_order_version_revision::table
+                .into_boxed()
+                .select(purchase_order_version_revision::all_columns);
+
+            if let Some(service_id) = service_id {
+                count_query =
+                    count_query.filter(purchase_order_version_revision::service_id.eq(service_id));
+            } else {
+                count_query =
+                    count_query.filter(purchase_order_version_revision::service_id.is_null());
+            }
+
+            let total = count_query.count().get_result(self.conn)?;
+
+            let revs = revision_models
+                .iter()
+                .map(PurchaseOrderVersionRevision::from)
+                .collect();
+
+            Ok(PurchaseOrderVersionRevisionList::new(
+                revs,
+                Paging::new(offset, limit, total),
+            ))
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> PurchaseOrderStoreListPurchaseOrderRevisionsOperation
+    for PurchaseOrderStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn list_purchase_order_revisions(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionRevisionList, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut query = purchase_order_version_revision::table
+                .into_boxed()
+                .select(purchase_order_version_revision::all_columns)
+                .filter(
+                    purchase_order_version_revision::purchase_order_uid
+                        .eq(&po_uid)
+                        .and(purchase_order_version_revision::version_id.eq(&version_id))
+                        .and(purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version_revision::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version_revision::service_id.is_null());
+            }
+
+            let revision_models = query
+                .load::<PurchaseOrderVersionRevisionModel>(self.conn)
+                .map_err(|err| {
+                    PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            let mut count_query = purchase_order_version_revision::table
+                .into_boxed()
+                .select(purchase_order_version_revision::all_columns);
+
+            if let Some(service_id) = service_id {
+                count_query =
+                    count_query.filter(purchase_order_version_revision::service_id.eq(service_id));
+            } else {
+                count_query =
+                    count_query.filter(purchase_order_version_revision::service_id.is_null());
+            }
+
+            let total = count_query.count().get_result(self.conn)?;
+
+            let revs = revision_models
+                .iter()
+                .map(PurchaseOrderVersionRevision::from)
+                .collect();
+
+            Ok(PurchaseOrderVersionRevisionList::new(
+                revs,
+                Paging::new(offset, limit, total),
+            ))
+        })
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/mod.rs
@@ -20,6 +20,7 @@ pub(super) mod get_purchase_order;
 pub(super) mod get_purchase_order_version;
 pub(super) mod get_purchase_order_version_revision;
 pub(super) mod list_alternate_ids_for_purchase_order;
+pub(super) mod list_purchase_order_version_revisions;
 pub(super) mod list_purchase_order_versions;
 pub(super) mod list_purchase_orders;
 

--- a/sdk/src/purchase_order/store/diesel/operations/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/mod.rs
@@ -18,6 +18,7 @@ mod add_purchase_order_version;
 mod add_purchase_order_version_revision;
 pub(super) mod get_purchase_order;
 pub(super) mod get_purchase_order_version;
+pub(super) mod get_purchase_order_version_revision;
 pub(super) mod list_alternate_ids_for_purchase_order;
 pub(super) mod list_purchase_order_versions;
 pub(super) mod list_purchase_orders;

--- a/sdk/src/purchase_order/store/diesel/schema.rs
+++ b/sdk/src/purchase_order/store/diesel/schema.rs
@@ -45,6 +45,7 @@ table! {
 table! {
     purchase_order_version_revision (id) {
         id -> Int8,
+        purchase_order_uid -> Text,
         version_id -> Text,
         revision_id -> Text,
         order_xml_v3_4 -> Text,

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -838,6 +838,22 @@ pub trait PurchaseOrderStore {
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError>;
 
+    /// Fetches a purchase order revision from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `po_uid`    - The uid of the purchase order the revision belongs to
+    ///  * `version_id` - The ID of the version the revision is for
+    ///  * `revision_id` - The ID of the revision to fetch
+    ///  * `service_id` - The service ID
+    fn get_purchase_order_revision(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        revision_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersionRevision>, PurchaseOrderStoreError>;
+
     /// Adds an alternate id to the underlying storage
     ///
     /// # Arguments
@@ -911,6 +927,16 @@ where
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrderVersion>, PurchaseOrderStoreError> {
         (**self).get_purchase_order_version(po_uid, version_id, service_id)
+    }
+
+    fn get_purchase_order_revision(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        revision_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<PurchaseOrderVersionRevision>, PurchaseOrderStoreError> {
+        (**self).get_purchase_order_revision(po_uid, version_id, revision_id, service_id)
     }
 
     fn add_alternate_id(

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -447,6 +447,19 @@ impl PurchaseOrderVersionBuilder {
     }
 }
 
+/// Represents a list of Grid Purchase Order Revisions
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct PurchaseOrderVersionRevisionList {
+    pub data: Vec<PurchaseOrderVersionRevision>,
+    pub paging: Paging,
+}
+
+impl PurchaseOrderVersionRevisionList {
+    pub fn new(data: Vec<PurchaseOrderVersionRevision>, paging: Paging) -> Self {
+        Self { data, paging }
+    }
+}
+
 /// Represents a Grid Purchase Order Version Revision
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct PurchaseOrderVersionRevision {
@@ -854,6 +867,24 @@ pub trait PurchaseOrderStore {
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrderVersionRevision>, PurchaseOrderStoreError>;
 
+    /// Lists purchase order revisions from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `po_uid`    - The uid of the purchase order the revisions belongs to
+    ///  * `version_id` - The ID of the version the revisions are for
+    ///  * `service_id` - The service ID
+    ///  * `offset` - The index of the first in storage to retrieve
+    ///  * `limit` - The number of items to retrieve from the offset
+    fn list_purchase_order_revisions(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionRevisionList, PurchaseOrderStoreError>;
+
     /// Adds an alternate id to the underlying storage
     ///
     /// # Arguments
@@ -937,6 +968,17 @@ where
         service_id: Option<&str>,
     ) -> Result<Option<PurchaseOrderVersionRevision>, PurchaseOrderStoreError> {
         (**self).get_purchase_order_revision(po_uid, version_id, revision_id, service_id)
+    }
+
+    fn list_purchase_order_revisions(
+        &self,
+        po_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+        offset: i64,
+        limit: i64,
+    ) -> Result<PurchaseOrderVersionRevisionList, PurchaseOrderStoreError> {
+        (**self).list_purchase_order_revisions(po_uid, version_id, service_id, offset, limit)
     }
 
     fn add_alternate_id(


### PR DESCRIPTION
This adds database operations to the `PurchaseOrderStore` to get and list `PurchaseOrderVersionRevisions`. The list operation lists revisions filtered by `po_uid` and `version_id` and the get operation fetches a revision filtered by `po_uid`, `version_id`, and `revision_id`. This also includes migrations and updates to the revisions table to add a `purchase_order_uid` column. This is necessary to be able to properly get revisions in case of overlap in version IDs between different POs.