### PR TITLE
Add purchase order version list endpoint

### DIFF
--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -527,7 +527,7 @@ paths:
           $ref: "#/components/responses/500ServerError"
         "503":
           $ref: "#/components/responses/503ServiceUnavailable"
-  /purchase-order/{uid}/versions:
+  /purchase-order/{uid}/version:
     get:
       tags:
         - Purchase Order
@@ -560,7 +560,7 @@ paths:
           $ref: "#/components/responses/500ServerError"
         "503":
           $ref: "#/components/responses/503ServiceUnavailable"
-  /purchase-order/{uid}/versions/{version_id}:
+  /purchase-order/{uid}/version/{version_id}:
     get:
       tags:
         - Purchase Order
@@ -599,7 +599,7 @@ paths:
           $ref: "#/components/responses/500ServerError"
         "503":
           $ref: "#/components/responses/503ServiceUnavailable"
-  /purchase-order/{uuid}/versions/{version_id}/revisions:
+  /purchase-order/{uuid}/version/{version_id}/revisions:
     get:
       tags:
         - Purchase Order
@@ -638,7 +638,7 @@ paths:
           $ref: "#/components/responses/500ServerError"
         "503":
           $ref: "#/components/responses/503ServiceUnavailable"
-  /purchase-order/{uuid}/versions/{version_id}/revisions/{revision_id}:
+  /purchase-order/{uuid}/version/{version_id}/revisions/{revision_id}:
     get:
       tags:
         - Purchase Order

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -527,14 +527,14 @@ paths:
           $ref: "#/components/responses/500ServerError"
         "503":
           $ref: "#/components/responses/503ServiceUnavailable"
-  /purchase-order/{uuid}/versions:
+  /purchase-order/{uid}/versions:
     get:
       tags:
         - Purchase Order
       summary: Lists all purchase order versions for a purchase order
       operationId: list_purchase_order_versions
       parameters:
-        - name: uuid
+        - name: uid
           in: path
           description: ID of the PO to fetch versions for
           required: true

--- a/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
@@ -90,10 +90,10 @@ pub async fn get_purchase_order(
     }
 }
 
-#[get("/purchase-order/{uuid}/versions")]
+#[get("/purchase-order/{uid}/versions")]
 pub async fn list_purchase_order_versions(
     store_state: web::Data<StoreState>,
-    uuid: web::Path<String>,
+    uid: web::Path<String>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
     version: ProtocolVersion,
@@ -105,7 +105,7 @@ pub async fn list_purchase_order_versions(
             let paging = query_paging.into_inner();
             match v1::list_purchase_order_versions(
                 store,
-                uuid.into_inner(),
+                uid.into_inner(),
                 query_service_id.into_inner().service_id.as_deref(),
                 paging.offset(),
                 paging.limit(),

--- a/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
@@ -90,7 +90,7 @@ pub async fn get_purchase_order(
     }
 }
 
-#[get("/purchase-order/{uid}/versions")]
+#[get("/purchase-order/{uid}/version")]
 pub async fn list_purchase_order_versions(
     store_state: web::Data<StoreState>,
     uid: web::Path<String>,
@@ -121,7 +121,7 @@ pub async fn list_purchase_order_versions(
     }
 }
 
-#[get("/purchase-order/{uid}/versions/{version_id}")]
+#[get("/purchase-order/{uid}/version/{version_id}")]
 pub async fn get_purchase_order_version(
     store_state: web::Data<StoreState>,
     uid: web::Path<String>,
@@ -150,7 +150,7 @@ pub async fn get_purchase_order_version(
     }
 }
 
-#[get("/purchase-order/{uuid}/versions/{version_id}/revisions")]
+#[get("/purchase-order/{uuid}/version/{version_id}/revisions")]
 pub async fn list_purchase_order_version_revisions(
     _store_state: web::Data<StoreState>,
     _uuid: web::Path<String>,
@@ -164,7 +164,7 @@ pub async fn list_purchase_order_version_revisions(
     }
 }
 
-#[get("/purchase-order/{uuid}/versions/{version_id}/revisions/{revision_number}")]
+#[get("/purchase-order/{uuid}/version/{version_id}/revisions/{revision_number}")]
 pub async fn get_purchase_order_version_revision(
     _store_state: web::Data<StoreState>,
     _uuid: web::Path<String>,

--- a/sdk/src/rest_api/resources/purchase_order/v1/mod.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/mod.rs
@@ -15,7 +15,10 @@
 pub mod handler;
 pub mod payloads;
 
-pub use handler::{get_purchase_order, get_purchase_order_version, list_purchase_orders};
+pub use handler::{
+    get_purchase_order, get_purchase_order_version, list_purchase_order_versions,
+    list_purchase_orders,
+};
 pub use payloads::{
     PurchaseOrderListSlice, PurchaseOrderRevisionSlice, PurchaseOrderSlice,
     PurchaseOrderVersionSlice,

--- a/sdk/src/rest_api/resources/purchase_order/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/payloads.rs
@@ -82,6 +82,12 @@ impl From<PurchaseOrderVersion> for PurchaseOrderVersionSlice {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct PurchaseOrderVersionListSlice {
+    pub data: Vec<PurchaseOrderVersionSlice>,
+    pub paging: Paging,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct PurchaseOrderRevisionSlice {
     revision_number: u64,
     submitter: String,


### PR DESCRIPTION
Add an endpoint to obtain purchase order versions at
/purchase-order/{UUID}/versions.

Related: #866

Signed-off-by: Lee Bradley <bradley@bitwise.io>