### PR TITLE
Add purchase order version REST endpoint

### DIFF
--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -560,7 +560,7 @@ paths:
           $ref: "#/components/responses/500ServerError"
         "503":
           $ref: "#/components/responses/503ServiceUnavailable"
-  /purchase-order/{uuid}/versions/{version_id}:
+  /purchase-order/{uid}/versions/{version_id}:
     get:
       tags:
         - Purchase Order
@@ -573,7 +573,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: uuid
+        - name: uid
           in: path
           description: ID of the PO to fetch
           required: true

--- a/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
@@ -103,10 +103,10 @@ pub async fn list_purchase_order_versions(
     }
 }
 
-#[get("/purchase-order/{uuid}/versions/{version_id}")]
+#[get("/purchase-order/{uid}/versions/{version_id}")]
 pub async fn get_purchase_order_version(
     store_state: web::Data<StoreState>,
-    uuid: web::Path<String>,
+    uid: web::Path<String>,
     version_id: web::Path<String>,
     query_service_id: web::Query<QueryServiceId>,
     version: ProtocolVersion,
@@ -117,7 +117,7 @@ pub async fn get_purchase_order_version(
         ProtocolVersion::V1 => {
             match v1::get_purchase_order_version(
                 store,
-                uuid.into_inner(),
+                uid.into_inner(),
                 &version_id.into_inner(),
                 query_service_id.into_inner().service_id.as_deref(),
             ) {

--- a/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
@@ -105,15 +105,30 @@ pub async fn list_purchase_order_versions(
 
 #[get("/purchase-order/{uuid}/versions/{version_id}")]
 pub async fn get_purchase_order_version(
-    _store_state: web::Data<StoreState>,
-    _uuid: web::Path<String>,
-    _version_id: web::Path<String>,
-    _query: web::Query<QueryServiceId>,
+    store_state: web::Data<StoreState>,
+    uuid: web::Path<String>,
+    version_id: web::Path<String>,
+    query_service_id: web::Query<QueryServiceId>,
     version: ProtocolVersion,
     _: AcceptServiceIdParam,
 ) -> HttpResponse {
+    let store = store_state.store_factory.get_grid_purchase_order_store();
     match version {
-        ProtocolVersion::V1 => unimplemented!(),
+        ProtocolVersion::V1 => {
+            match v1::get_purchase_order_version(
+                store,
+                uuid.into_inner(),
+                &version_id.into_inner(),
+                query_service_id.into_inner().service_id.as_deref(),
+            ) {
+                Ok(res) => HttpResponse::Ok().json(res),
+                Err(err) => HttpResponse::build(
+                    StatusCode::from_u16(err.status_code())
+                        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                )
+                .json(err),
+            }
+        }
     }
 }
 

--- a/sdk/src/rest_api/resources/purchase_order/v1/handler.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/handler.rs
@@ -88,7 +88,7 @@ pub fn get_purchase_order<'a>(
         || {
             ErrorResponse::new(
                 404,
-                &format!("PurchaseOrder {} not found", purchase_order_uid),
+                &format!("Purchase order {} not found", purchase_order_uid),
             )
         },
     )?))

--- a/sdk/src/rest_api/resources/purchase_order/v1/handler.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/handler.rs
@@ -19,7 +19,7 @@ use crate::{
     rest_api::resources::{error::ErrorResponse, paging::v1::Paging},
 };
 
-use super::payloads::{PurchaseOrderListSlice, PurchaseOrderSlice};
+use super::payloads::{PurchaseOrderListSlice, PurchaseOrderSlice, PurchaseOrderVersionSlice};
 
 pub fn list_purchase_orders<'a>(
     store: Box<dyn PurchaseOrderStore + 'a>,
@@ -92,4 +92,38 @@ pub fn get_purchase_order<'a>(
             )
         },
     )?))
+}
+
+pub fn get_purchase_order_version<'a>(
+    store: Box<dyn PurchaseOrderStore + 'a>,
+    purchase_order_uid: String,
+    version_id: &str,
+    service_id: Option<&str>,
+) -> Result<PurchaseOrderVersionSlice, ErrorResponse> {
+    let purchase_order_version = store
+        .get_purchase_order_version(&purchase_order_uid, version_id, service_id)
+        .map_err(|err| match err {
+            PurchaseOrderStoreError::InternalError(err) => {
+                ErrorResponse::internal_error(Box::new(err))
+            }
+            PurchaseOrderStoreError::ConstraintViolationError(err) => {
+                ErrorResponse::new(400, &format!("{}", err))
+            }
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(_) => {
+                ErrorResponse::new(503, "Service Unavailable")
+            }
+            PurchaseOrderStoreError::NotFoundError(_) => ErrorResponse::new(
+                404,
+                &format!("Purchase order {} not found", purchase_order_uid),
+            ),
+        })?;
+
+    Ok(PurchaseOrderVersionSlice::from(
+        purchase_order_version.ok_or_else(|| {
+            ErrorResponse::new(
+                404,
+                &format!("Purchase order {} not found", purchase_order_uid),
+            )
+        })?,
+    ))
 }

--- a/sdk/src/rest_api/resources/purchase_order/v1/mod.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/mod.rs
@@ -15,7 +15,7 @@
 pub mod handler;
 pub mod payloads;
 
-pub use handler::{get_purchase_order, list_purchase_orders};
+pub use handler::{get_purchase_order, get_purchase_order_version, list_purchase_orders};
 pub use payloads::{
     PurchaseOrderListSlice, PurchaseOrderRevisionSlice, PurchaseOrderSlice,
     PurchaseOrderVersionSlice,

--- a/sdk/src/rest_api/resources/purchase_order/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/payloads.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{purchase_order::store::PurchaseOrder, rest_api::resources::paging::v1::Paging};
+use crate::{
+    purchase_order::store::{PurchaseOrder, PurchaseOrderVersion},
+    rest_api::resources::paging::v1::Paging,
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PurchaseOrderSlice {
@@ -56,10 +59,26 @@ pub struct PurchaseOrderListSlice {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PurchaseOrderVersionSlice {
     version_id: String,
-    workflow_status: String,
     is_draft: bool,
-    current_revision_number: u64,
-    revisions: Vec<u64>,
+    current_revision_id: String,
+    revisions: Vec<String>,
+    service_id: Option<String>,
+}
+
+impl From<PurchaseOrderVersion> for PurchaseOrderVersionSlice {
+    fn from(purchase_order_version: PurchaseOrderVersion) -> Self {
+        Self {
+            version_id: purchase_order_version.version_id().to_string(),
+            is_draft: purchase_order_version.is_draft(),
+            current_revision_id: purchase_order_version.current_revision_id().to_string(),
+            revisions: purchase_order_version
+                .revisions()
+                .into_iter()
+                .map(|version| version.revision_id().to_string())
+                .collect(),
+            service_id: purchase_order_version.service_id().map(str::to_owned),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Add a purchase order REST endpoint to retrieve a version provided a
version id and a purchase order.

Related to: https://github.com/hyperledger/grid/issues/867

Signed-off-by: Lee Bradley <bradley@bitwise.io>