### PR TITLE
Create PO in cli

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,6 +47,7 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 diesel_migrations = "1.4"
 whoami = "1"
+rand = { version = "0.7", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"
@@ -88,7 +89,7 @@ sqlite = [
 location = ["pike", "schema"]
 pike = []
 product = ["pike", "schema"]
-purchase-order = ["grid-sdk/purchase-order"]
+purchase-order = ["grid-sdk/purchase-order", "rand"]
 sawtooth = []
 schema = ["pike"]
 splinter = []

--- a/cli/man/grid-po-create.1.md
+++ b/cli/man/grid-po-create.1.md
@@ -1,4 +1,5 @@
 % GRID-PO-CREATE(1) Cargill, Incorporated | Grid
+
 <!--
   Copyright 2021 Cargill Incorporated
   Licensed under Creative Commons Attribution 4.0 International License
@@ -13,13 +14,14 @@ NAME
 SYNOPSIS
 ========
 
-**grid po create** \[**FLAGS**\] \[**OPTIONS**\] <**--org** ORGANIZATION>
+**grid po create** \[**FLAGS**\] \[**OPTIONS**\] <**--buyer-org** BUYER> <**--seller-org** SELLER>
 
 DESCRIPTION
 ===========
 
 This command allows for the creation of Grid Purchase Orders. It submits a
-Sabre transaction to create the purchase order. `--org` is required.
+Sabre transaction to create the purchase order. `--buyer-org` and
+`--seller-org` is required.
 
 FLAGS
 =====
@@ -35,32 +37,35 @@ FLAGS
 
 `-v`
 : Increases verbosity (the opposite of `-q`). Specify multiple times for more
-  output.
+output.
 
 OPTIONS
 =======
 
 `--id`
-: Optionally include an alternate ID. This may be specified multiple times. 
-  An ID is of the format `alternate_id_type:alternate_id`.
-  Examples: `po_number:12348959` and/or `internal_po_id:a8f9fke`.
+: Optionally include an alternate ID. This may be specified multiple times.
+An ID is of the format `alternate_id_type:alternate_id`.
+Examples: `po_number:12348959` and/or `internal_po_id:a8f9fke`.
 
 `-k`, `--key`
 : base name or path to a private signing key file
 
-`--org`
-: Specify the organization that owns the purchase order. This option is required.
+`--buyer-org`
+: Specify the organization that is buying the purchase order. This option is required.
+
+`--seller-org`
+: Specify the organization that is selling the purchase order. This option is required.
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format: `<circuit-id>::<service-id>`.
+Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API
 
 `--uuid`
 : Optionally specify the UUID of the purchase order. Must conform to the UUID
-  spec. If not specified, will be randomly generated.
+spec. If not specified, will be randomly generated.
 
 `--wait`
 : Maximum number of seconds to wait for the batch to be committed.
@@ -75,7 +80,8 @@ The command
 
 ```
 $ grid po create \
-    --org=crgl \
+    --buyer-org=crgl \
+    --seller-org=crgl2 \
     --workflow-status=Issued \
     --id=po_number:8329173 \
     --wait=0
@@ -99,21 +105,22 @@ ENVIRONMENT VARIABLES
 
 **`CYLINDER_PATH`**
 : Colon-separated path used to search for the key which will be used
-  to sign transactions
+to sign transactions
 
 **`GRID_DAEMON_ENDPOINT`**
 : Specifies a default value for `--url`
 
 **`GRID_DAEMON_KEY`**
-: Specifies a default value for  `-k`, `--key`
+: Specifies a default value for `-k`, `--key`
 
 **`GRID_SERVICE_ID`**
 : Specifies a default value for `--service-id`
 
 SEE ALSO
 ========
-| `grid-po-create(1)`
+
 | `grid-po-list(1)`
+| `grid-po-revision(1)`
 | `grid-po-show(1)`
 | `grid-po-update(1)`
 | `grid-po-version(1)`

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -90,7 +90,9 @@ use grid_sdk::protocol::schema::state::{LatLongBuilder, PropertyValue, PropertyV
 #[cfg(any(feature = "purchase-order"))]
 use grid_sdk::{
     data_validation::validate_order_xml_3_4,
-    protocol::purchase_order::payload::{CreateVersionPayloadBuilder, PayloadRevisionBuilder},
+    protocol::purchase_order::payload::{
+        CreatePurchaseOrderPayloadBuilder, CreateVersionPayloadBuilder, PayloadRevisionBuilder,
+    },
 };
 
 use log::Record;
@@ -1431,12 +1433,22 @@ fn run() -> Result<(), CliError> {
                     SubCommand::with_name("create")
                         .about("Create a Purchase Order")
                         .arg(
-                            Arg::with_name("org")
-                                .value_name("org_id")
-                                .long("org")
+                            Arg::with_name("buyer_org_id")
+                                .value_name("buyer_org_id")
+                                .long("buyer-org")
+                                .short("buyer")
                                 .takes_value(true)
                                 .required(true)
-                                .help("ID of the organization which owns the Purchase Order"),
+                                .help("ID of the organization which is buying the Purchase Order"),
+                        )
+                        .arg(
+                            Arg::with_name("seller_org_id")
+                                .value_name("seller_org_id")
+                                .long("seller-org")
+                                .short("seller")
+                                .takes_value(true)
+                                .required(true)
+                                .help("ID of the organization which is selling the Purchase Order"),
                         )
                         .arg(Arg::with_name("uuid").long("uuid").takes_value(true).help(
                             "UUID for Purchase Order. \
@@ -2513,7 +2525,46 @@ fn run() -> Result<(), CliError> {
             let purchase_order_client = client_factory.get_purchase_order_client(url);
 
             match m.subcommand() {
-                ("create", Some(_)) => unimplemented!(),
+                ("create", Some(m)) => {
+                    let key = m
+                        .value_of("key")
+                        .map(String::from)
+                        .or_else(|| env::var(GRID_DAEMON_KEY).ok());
+
+                    let signer = signing::load_signer(key)?;
+
+                    let wait = value_t!(m, "wait", u64).unwrap_or(0);
+
+                    let uid = m
+                        .value_of("uid")
+                        .map(String::from)
+                        .unwrap_or_else(purchase_orders::generate_purchase_order_uid);
+
+                    let payload = CreatePurchaseOrderPayloadBuilder::new()
+                        .with_uid(uid)
+                        .with_created_at(
+                            SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .map(|d| d.as_secs())
+                                .map_err(|err| CliError::PayloadError(format!("{}", err)))?,
+                        )
+                        .with_buyer_org_id(m.value_of("buyer_org_id").unwrap().into())
+                        .with_seller_org_id(m.value_of("seller_org_id").unwrap().into())
+                        .with_workflow_status(m.value_of("workflow_status").unwrap().into())
+                        .build()
+                        .map_err(|err| {
+                            CliError::UserError(format!("Could not build Purchase Order: {}", err))
+                        })?;
+
+                    info!("Submitting request to create purchase order...");
+                    purchase_orders::do_create_purchase_order(
+                        purchase_order_client,
+                        signer,
+                        wait,
+                        payload,
+                        service_id.as_deref(),
+                    )?;
+                }
                 ("update", Some(_)) => unimplemented!(),
                 ("list", Some(_)) => unimplemented!(),
                 ("show", Some(_)) => unimplemented!(),


### PR DESCRIPTION
Adding functionality to create purchase order. Based on the updated RFC,
we need buyer-org and seller-org instead of owning org. Changes are
reflected in the man pages as well as code.

Signed-off-by: Kevin Johnson <kevin_johnson@cargill.com>