### PR TITLE
Update built-in workflow display methods to designate version

### DIFF
--- a/contracts/purchase_order/src/workflow.rs
+++ b/contracts/purchase_order/src/workflow.rs
@@ -404,8 +404,8 @@ fn collaborative_sub_workflow() -> SubWorkflow {
 impl fmt::Display for POWorkflow {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            POWorkflow::SystemOfRecord => write!(f, "system_of_record"),
-            POWorkflow::Collaborative => write!(f, "collaborative"),
+            POWorkflow::SystemOfRecord => write!(f, "built-in::system_of_record::v1"),
+            POWorkflow::Collaborative => write!(f, "built-in::collaborative::v1"),
         }
     }
 }


### PR DESCRIPTION
This change updates the built-in purchase order workflows to specify the
version being used for the workflow, and to specify these workflows are
built-in. This changes the formatting of the POWorkflow's type from
`<workflow_type>` to `built-in::<workflow_type>::v1`.

Signed-off-by: Shannyn Telander <telander@bitwise.io>