### PR TITLE
Re-add `created_at` to PO migrations tables

### DIFF
--- a/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -21,6 +21,7 @@ CREATE TABLE purchase_order (
     workflow_status TEXT NOT NULL,
     is_closed BOOLEAN NOT NULL,
     accepted_version_id TEXT,
+    created_at BIGINT NOT NULL,
     workflow_type TEXT NOT NULL,
     start_commit_num BIGINT NOT NULL,
     end_commit_num BIGINT NOT NULL,

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -21,6 +21,7 @@ CREATE TABLE purchase_order (
     workflow_status TEXT NOT NULL,
     is_closed BOOLEAN NOT NULL,
     accepted_version_id TEXT,
+    created_at BIGINT NOT NULL,
     workflow_type TEXT NOT NULL,
     start_commit_num BIGINT NOT NULL,
     end_commit_num BIGINT NOT NULL,


### PR DESCRIPTION
The created_at field was omitted accidentally when consolidating the
migrations for the purchase_order table. This just adds that back in.

Signed-off-by: Davey Newhall <newhall@bitwise.io>