### PR TITLE
Fix handling of protobuf optional field

### DIFF
--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -217,8 +217,18 @@ impl FromProto<purchase_order_payload::CreatePurchaseOrderPayload> for CreatePur
     fn from_proto(
         mut proto: purchase_order_payload::CreatePurchaseOrderPayload,
     ) -> Result<Self, ProtoConversionError> {
-        let create_version_payload =
-            CreateVersionPayload::from_proto(proto.take_create_version_payload()).ok();
+        let create_version_payload = if proto
+            .get_create_version_payload()
+            .get_version_id()
+            .is_empty()
+        {
+            None
+        } else {
+            Some(CreateVersionPayload::from_proto(
+                proto.take_create_version_payload(),
+            )?)
+        };
+
         Ok(CreatePurchaseOrderPayload {
             uid: proto.take_uid(),
             created_at: proto.get_created_at(),


### PR DESCRIPTION
This change fixes how the `CreateVersionPayload` is being converted by
the purchase order protocol code. Previously, this value was being
pulled from the protobuf, but as it is optional, the value pulled from
the protobuf must first be validated as non-empty. If it is empty, this
field is set to `None`. If not, the `CreateVersionPayload` is converted
into a native struct using it's `from_proto` method.

This fixes an issue where the payload may be set with empty values from
the protobuf.

Signed-off-by: Shannyn Telander <telander@bitwise.io>