### PR TITLE
Match the db schema to model for Purchase Order

### DIFF
--- a/sdk/src/purchase_order/store/diesel/schema.rs
+++ b/sdk/src/purchase_order/store/diesel/schema.rs
@@ -16,9 +16,9 @@ table! {
     purchase_order (id) {
         id -> Int8,
         purchase_order_uid -> Text,
+        workflow_status -> Text,
         buyer_org_id -> Varchar,
         seller_org_id -> Varchar,
-        workflow_status -> Text,
         is_closed -> Bool,
         accepted_version_id -> Nullable<Text>,
         created_at -> Int8,


### PR DESCRIPTION
This change updates the `PurchaseOrder` database table schema to match
the order the fields exist in the `PurchaseOrderModel` struct.

Previously, this caused an error when diesel attempted to insert the
database model into the table, as the native model does not match the
table's schema.

Signed-off-by: Shannyn Telander <telander@bitwise.io>