### PR TITLE
Update `From` impls and migration data to match expected db schema

### DIFF
--- a/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -16,9 +16,9 @@
 CREATE TABLE purchase_order (
     id BIGSERIAL PRIMARY KEY,
     purchase_order_uid TEXT NOT NULL,
+    workflow_status TEXT NOT NULL,
     buyer_org_id VARCHAR(256) NOT NULL,
     seller_org_id VARCHAR(256) NOT NULL,
-    workflow_status TEXT NOT NULL,
     is_closed BOOLEAN NOT NULL,
     accepted_version_id TEXT,
     created_at BIGINT NOT NULL,

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -16,9 +16,9 @@
 CREATE TABLE purchase_order (
     id INTEGER PRIMARY KEY,
     purchase_order_uid TEXT NOT NULL,
+    workflow_status TEXT NOT NULL,
     buyer_org_id VARCHAR(256) NOT NULL,
     seller_org_id VARCHAR(256) NOT NULL,
-    workflow_status TEXT NOT NULL,
     is_closed BOOLEAN NOT NULL,
     accepted_version_id TEXT,
     created_at BIGINT NOT NULL,

--- a/sdk/src/purchase_order/store/diesel/models.rs
+++ b/sdk/src/purchase_order/store/diesel/models.rs
@@ -136,9 +136,9 @@ impl From<PurchaseOrder> for NewPurchaseOrderModel {
     fn from(order: PurchaseOrder) -> Self {
         Self {
             purchase_order_uid: order.purchase_order_uid.to_string(),
+            workflow_status: order.workflow_status.to_string(),
             buyer_org_id: order.buyer_org_id.to_string(),
             seller_org_id: order.seller_org_id.to_string(),
-            workflow_status: order.workflow_status.to_string(),
             is_closed: order.is_closed,
             accepted_version_id: order.accepted_version_id,
             created_at: order.created_at,
@@ -154,9 +154,9 @@ impl From<(PurchaseOrderModel, Vec<PurchaseOrderVersion>)> for PurchaseOrder {
     fn from((order, versions): (PurchaseOrderModel, Vec<PurchaseOrderVersion>)) -> Self {
         Self {
             purchase_order_uid: order.purchase_order_uid.to_string(),
+            workflow_status: order.workflow_status.to_string(),
             buyer_org_id: order.buyer_org_id.to_string(),
             seller_org_id: order.seller_org_id.to_string(),
-            workflow_status: order.workflow_status.to_string(),
             is_closed: order.is_closed,
             accepted_version_id: order.accepted_version_id,
             versions,
@@ -185,9 +185,9 @@ impl
     ) -> Self {
         Self {
             purchase_order_uid: order.purchase_order_uid.to_string(),
+            workflow_status: order.workflow_status.to_string(),
             buyer_org_id: order.buyer_org_id.to_string(),
             seller_org_id: order.seller_org_id.to_string(),
-            workflow_status: order.workflow_status.to_string(),
             is_closed: order.is_closed,
             accepted_version_id: order.accepted_version_id,
             versions: versions


### PR DESCRIPTION
This fixes two bugs present when attempting to insert a po record into the db. 

* Fixes the data type of the `id` field in the postgres migration data. Previously, this was `INTEGER` rather than `BIGSERIAL`, which caused the database to not automatically increment this field when inserting a new record into the db and would error because of this null value. 
* Fixes the migration data and `From` implementations of the `purchase_order` db table to ensure the `workflow` status field is where it is expected as defined by the purchase order schema. 