### PR TITLE
Base grid-cli on focal instead of sabre-cli

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hyperledger/grid-dev:v5 as grid-cli-builder
+FROM hyperledger/grid-dev:v9 as grid-cli-builder
 
 ENV GRID_FORCE_PANDOC=true
 
@@ -23,10 +23,6 @@ RUN apt-get update \
     pandoc \
    && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-
-# Temporary workaround until sabre is updated to focal
-RUN USER=root cargo new --bin griddle
-RUN USER=root cargo new --bin contracts/purchase_order
 
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
@@ -60,7 +56,9 @@ WORKDIR /tmp
 RUN git rev-parse HEAD > /commit-hash
 
 # -------------=== grid-cli docker build ===-------------
-FROM hyperledger/sawtooth-sabre-cli:0.5
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 ARG CARGO_ARGS
 RUN echo "CARGO_ARGS = '$CARGO_ARGS'" > CARGO_ARGS


### PR DESCRIPTION
Previously we had a need for sabre cli alongside the grid cli but this is no
longer the case.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>