### PR TITLE
Make workflow status required for `po create`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1474,6 +1474,7 @@ fn run() -> Result<(), CliError> {
                                 .value_name("status")
                                 .long("workflow-status")
                                 .takes_value(true)
+                                .required(true)
                                 .help("Workflow status of the Purchase Order"),
                         )
                         .arg(


### PR DESCRIPTION
The PO create command will panic if no workflow status is passed, and
the CreatePurchaseOrderPayloadBuilder requires it to function. This
change makes clap force the user to pass a workflow status.

Signed-off-by: Lee Bradley <bradley@bitwise.io>