### PR TITLE
Fix adding a new revision to the store

### DIFF
--- a/sdk/src/purchase_order/store/diesel/operations/add_purchase_order.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/add_purchase_order.rs
@@ -96,16 +96,16 @@ impl<'a> PurchaseOrderStoreAddPurchaseOrderOperation
                 add_alternate_id::pg::add_alternate_id(self.conn, &id)?;
             }
 
+            for version in versions {
+                add_purchase_order_version::pg::add_purchase_order_version(self.conn, &version)?;
+            }
+
             for revision in revisions {
                 add_purchase_order_version_revision::pg::add_purchase_order_version_revision(
                     self.conn,
                     &revision,
                     &order.purchase_order_uid,
                 )?;
-            }
-
-            for version in versions {
-                add_purchase_order_version::pg::add_purchase_order_version(self.conn, &version)?;
             }
 
             let mut query = purchase_order::table.into_boxed().filter(
@@ -220,17 +220,17 @@ impl<'a> PurchaseOrderStoreAddPurchaseOrderOperation
                 add_alternate_id::sqlite::add_alternate_id(self.conn, &id)?;
             }
 
+            for version in versions {
+                add_purchase_order_version::sqlite::add_purchase_order_version(
+                    self.conn, &version,
+                )?;
+            }
+
             for revision in revisions {
                 add_purchase_order_version_revision::sqlite::add_purchase_order_version_revision(
                     self.conn,
                     &revision,
                     &order.purchase_order_uid,
-                )?;
-            }
-
-            for version in versions {
-                add_purchase_order_version::sqlite::add_purchase_order_version(
-                    self.conn, &version,
                 )?;
             }
 


### PR DESCRIPTION
This fixes a bug when attempting to add a revision to the store when the
version doesn't yet exist. This now proprly creates the new version
first.

Signed-off-by: Davey Newhall <newhall@bitwise.io>