### PR TITLE
Add PO version and revision `list` and `show` CLI commands

### DIFF
--- a/cli/man/grid-po-revision-show.1.md
+++ b/cli/man/grid-po-revision-show.1.md
@@ -25,7 +25,7 @@ ARGS
 ====
 
 `PURCHASE_ORDER_ID`
-: Either a UUID or an alternate ID of a purchase order.
+: Either a UID or an alternate ID of a purchase order.
 
 `VERSION_ID`
 : The purchase order version identifier.
@@ -56,9 +56,6 @@ OPTIONS
 : Specifies the output format of the list. Possible values for formatting are
   `human`, `csv`, `yaml`, and `json`. Defaults to `human`.
 
-`--org`
-: Specify the organization that owns the purchase order.
-
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
   Splinter. Format `<circuit-id>::<service-id>`.
@@ -69,7 +66,7 @@ OPTIONS
 EXAMPLES
 ========
 
-The command 
+The command
 ```
 $ grid po revision show 82urioz098aui3871uc v3 3
 ```
@@ -86,7 +83,7 @@ Revision 3:
 
 In contrast, a summary view is available using the command
 ```
-$ grid po show --org=crgl 82urioz098aui3871uc --version v3 --revision 3
+$ grid po show 82urioz098aui3871uc --version v3 --revision 3
 ```
 with details provided in `grid-po-show(1)`.
 

--- a/cli/man/grid-po-version-show.1.md
+++ b/cli/man/grid-po-version-show.1.md
@@ -1,0 +1,97 @@
+% GRID-PO-VERSION-SHOW(1) Cargill, Incorporated | Grid
+<!--
+  Copyright 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-po-version-show** - Show the details of a purchase order's version for a
+specific purchase order.
+
+SYNOPSIS
+========
+
+**grid po version show** \[**FLAGS**\] \[**OPTIONS**\] <PURCHASE_ORDER_ID> <VERSION_ID>
+
+DESCRIPTION
+===========
+
+Show a purchase order version in grid.
+
+ARGS
+====
+
+`PURCHASE_ORDER_ID`
+: Either a UID or an alternate ID of a purchase order.
+
+`VERSION_ID`
+: The purchase order version identifier.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Do not display output.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+
+`-F`, `--format=FORMAT`
+: Specifies the output format of the list. Possible values for formatting are
+  `human`, `csv`, `yaml`, and `json`. Defaults to `human`.
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format: `<circuit-id>::<service-id>`.
+
+`--url`
+: URL for the REST API
+
+EXAMPLES
+========
+
+The command
+
+```
+$ grid po version show PO-AA11A-BB22 1
+```
+
+will show version 1 for the purchase order "PO-AA11A-BB22" in human-readable
+format:
+
+```
+VERSION_ID  WORKFLOW_STATUS  IS_DRAFT  CURRENT_REVISION  REVISIONS
+1           Editable         t         1                 1
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies a default value for `--url`
+
+**`GRID_SERVICE_ID`**
+: Specifies a default value for `--service-id`
+
+SEE ALSO
+========
+| `grid-po(1)`
+| `grid-po-version-create(1)`
+| `grid-po-version-list(1)`
+| `grid-po-version-update(1)`
+| `grid-po-revision(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.2/

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1411,6 +1411,32 @@ fn run() -> Result<(), CliError> {
                             .takes_value(true),
                     )
                     .after_help(AFTER_HELP_WITHOUT_KEY),
+            )
+            .subcommand(
+                SubCommand::with_name("show")
+                    .about("Show a Purchase Order version")
+                    .arg(
+                        Arg::with_name("po_uid")
+                            .takes_value(true)
+                            .required(true)
+                            .help("Identifier for the Purchase Order the version belongs to"),
+                    )
+                    .arg(
+                        Arg::with_name("version_id")
+                            .takes_value(true)
+                            .required(true)
+                            .help("Identifier for the Purchase Order version"),
+                    )
+                    .arg(
+                        Arg::with_name("format")
+                            .short("F")
+                            .long("format")
+                            .help("Output format")
+                            .possible_values(&["human", "csv", "yaml", "json"])
+                            .default_value("human")
+                            .takes_value(true),
+                    )
+                    .after_help(AFTER_HELP_WITHOUT_KEY),
             );
 
         let po_revision = SubCommand::with_name("revision")
@@ -2838,6 +2864,31 @@ fn run() -> Result<(), CliError> {
                             format,
                             service_id.as_deref(),
                         )?
+                    }
+                    ("show", Some(m)) => {
+                        let url = m
+                            .value_of("url")
+                            .map(String::from)
+                            .or_else(|| env::var(GRID_DAEMON_ENDPOINT).ok())
+                            .unwrap_or_else(|| String::from("http://localhost:8000"));
+
+                        let service_id = m
+                            .value_of("service_id")
+                            .map(String::from)
+                            .or_else(|| env::var(GRID_SERVICE_ID).ok());
+
+                        let purchase_order_client = client_factory.get_purchase_order_client(url);
+
+                        let po_uid = m.value_of("po_uid").unwrap();
+
+                        let version = m.value_of("version_id").unwrap();
+
+                        purchase_orders::do_show_version(
+                            &*purchase_order_client,
+                            po_uid,
+                            version,
+                            service_id.as_deref(),
+                        )?;
                     }
                     _ => return Err(CliError::UserError("Subcommand not recognized".into())),
                 },

--- a/sdk/src/client/purchase_order/mod.rs
+++ b/sdk/src/client/purchase_order/mod.rs
@@ -19,6 +19,7 @@ use crate::error::ClientError;
 use crate::protocol::purchase_order::state::{
     PurchaseOrderAlternateId, PurchaseOrderAlternateIdBuilder,
 };
+use crate::purchase_order::store::ListVersionFilters;
 
 use super::Client;
 
@@ -26,20 +27,22 @@ use super::Client;
 pub mod reqwest;
 
 pub struct PurchaseOrder {
-    pub org_id: String,
-    pub uuid: String,
+    pub purchase_order_uid: String,
     pub workflow_status: String,
+    pub buyer_org_id: String,
+    pub seller_org_id: String,
     pub is_closed: bool,
     pub accepted_version_id: Option<String>,
     pub versions: Vec<PurchaseOrderVersion>,
     pub created_at: SystemTime,
+    pub workflow_type: String,
 }
 
 pub struct PurchaseOrderVersion {
     pub version_id: String,
     pub workflow_status: String,
     pub is_draft: bool,
-    pub current_revision_id: u64,
+    pub current_revision_id: i64,
     pub revisions: Vec<PurchaseOrderRevision>,
 }
 
@@ -142,10 +145,12 @@ pub trait PurchaseOrderClient: Client {
     /// # Arguments
     ///
     /// * `id` - The uuid of the `PurchaseOrder` containing the `PurchaseOrderVersion`s to be listed
+    /// * `filters` - Optional filters for for the versions
     /// * `service_id` - The service ID to fetch the versions from
     fn list_purchase_order_versions(
         &self,
         id: String,
+        filters: ListVersionFilters,
         service_id: Option<&str>,
     ) -> Result<Vec<PurchaseOrderVersion>, ClientError>;
 

--- a/sdk/src/client/reqwest.rs
+++ b/sdk/src/client/reqwest.rs
@@ -130,7 +130,11 @@ pub fn fetch_entities_list<T: DeserializeOwned>(
     let client = BlockingClient::new();
     let mut final_url = format!("{}/{}", url, route);
     if let Some(service_id) = service_id {
-        final_url = format!("{}?service_id={}", final_url, service_id);
+        if route.contains('?') {
+            final_url = format!("{}&service_id={}", final_url, service_id)
+        } else {
+            final_url = format!("{}?service_id={}", final_url, service_id);
+        }
     }
 
     let mut entities: Vec<T> = Vec::new();


### PR DESCRIPTION
This adds CLI commands for listing and showing Grid Purchase Order versions and revisions. In support of this, the purchase order client's functions and structs are also brought up-to-date with the rest of the module's pieces.