### PR TITLE
Update schema loading for Order.xsd

### DIFF
--- a/cli/man/grid-po-version-create.1.md
+++ b/cli/man/grid-po-version-create.1.md
@@ -125,6 +125,11 @@ ENVIRONMENT VARIABLES
 **`GRID_SERVICE_ID`**
 : Specifies a default value for `--service-id`
 
+**`GRID_ORDER_SCHEMA_DIR`**
+: Specifies the local path to the directory containing the `Order.xsd`
+  schema used to validate the purchase order. The default value is
+  "/etc/grid/schemas".
+
 SEE ALSO
 ========
 | `grid-po(1)`

--- a/cli/man/grid-po-version-update.1.md
+++ b/cli/man/grid-po-version-update.1.md
@@ -118,6 +118,11 @@ ENVIRONMENT VARIABLES
 **`GRID_SERVICE_ID`**
 : Specifies a default value for `--service-id`
 
+**`GRID_ORDER_SCHEMA_DIR`**
+: Specifies the local path to the directory containing the `Order.xsd`
+  schema used to validate the purchase order. The default value is
+  "/etc/grid/schemas".
+
 SEE ALSO
 ========
 | `grid-po(1)`

--- a/cli/man/grid-product-create.1.md
+++ b/cli/man/grid-product-create.1.md
@@ -275,6 +275,11 @@ ENVIRONMENT VARIABLES
 **`GRID_SERVICE_ID`**
 : Specifies a default value for `--service-id`.
 
+**`GRID_PRODUCT_SCHEMA_DIR`**
+: Specifies the local path to the directory containing the `GridTradeItems.xsd`
+  schema used to validate the product. The default value is
+  "/etc/grid/schemas".
+
 SEE ALSO
 ========
 | `grid-product-create(1)`

--- a/cli/man/grid-product-update.1.md
+++ b/cli/man/grid-product-update.1.md
@@ -268,6 +268,11 @@ ENVIRONMENT VARIABLES
 **`GRID_SERVICE_ID`**
 : Specifies a default value for `--service-id`.
 
+**`GRID_PRODUCT_SCHEMA_DIR`**
+: Specifies the local path to the directory containing the `GridTradeItems.xsd`
+  schema used to validate the product. The default value is
+  "/etc/grid/schemas".
+
 SEE ALSO
 ========
 | `grid-product-create(1)`

--- a/cli/src/actions/mod.rs
+++ b/cli/src/actions/mod.rs
@@ -52,3 +52,6 @@ pub mod purchase_orders;
 pub mod roles;
 #[cfg(feature = "schema")]
 pub mod schemas;
+
+#[cfg(any(feature = "purchase-order", feature = "product"))]
+pub const DEFAULT_SCHEMA_DIR: &str = "/etc/grid/schemas";

--- a/cli/src/actions/products.rs
+++ b/cli/src/actions/products.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::env;
+
 use crate::transaction::product_batch_builder;
 use cylinder::Signer;
 use grid_sdk::client::product::{
@@ -42,6 +44,10 @@ use std::{
     io::prelude::*,
     time::{SystemTime, UNIX_EPOCH},
 };
+
+use super::DEFAULT_SCHEMA_DIR;
+
+const GRID_PRODUCT_SCHEMA_DIR: &str = "GRID_PRODUCT_SCHEMA_DIR";
 
 /**
  * Prints basic info for products
@@ -359,7 +365,9 @@ pub fn create_product_payloads_from_xml(
     owner: &str,
 ) -> Result<Vec<ProductCreateAction>, CliError> {
     let trade_items = get_trade_items_from_xml(path)?;
-    validate_gdsn_3_1(path, true)?;
+    let data_validation_dir =
+        env::var(GRID_PRODUCT_SCHEMA_DIR).unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string());
+    validate_gdsn_3_1(path, true, &data_validation_dir)?;
 
     let mut payloads = Vec::new();
 
@@ -396,7 +404,9 @@ pub fn create_product_payloads_from_yaml(
 
 pub fn update_product_payloads_from_xml(path: &str) -> Result<Vec<ProductUpdateAction>, CliError> {
     let trade_items = get_trade_items_from_xml(path)?;
-    validate_gdsn_3_1(path, true)?;
+    let data_validation_dir =
+        env::var(GRID_PRODUCT_SCHEMA_DIR).unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string());
+    validate_gdsn_3_1(path, true, &data_validation_dir)?;
 
     let mut payloads = Vec::new();
 

--- a/cli/src/actions/purchase_orders.rs
+++ b/cli/src/actions/purchase_orders.rs
@@ -36,6 +36,8 @@ use rand::{distributions::Alphanumeric, Rng};
 use crate::error::CliError;
 use crate::transaction::purchase_order_batch_builder;
 
+pub const GRID_ORDER_SCHEMA_DIR: &str = "GRID_ORDER_SCHEMA_DIR";
+
 pub fn do_create_purchase_order(
     client: Box<dyn PurchaseOrderClient>,
     signer: Box<dyn Signer>,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -114,6 +114,9 @@ use actions::schemas;
 #[cfg(feature = "pike")]
 use actions::{agents, organizations as orgs, roles};
 
+#[cfg(feature = "purchase-order")]
+use actions::{purchase_orders::GRID_ORDER_SCHEMA_DIR, DEFAULT_SCHEMA_DIR};
+
 const APP_NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -2763,9 +2766,11 @@ fn run() -> Result<(), CliError> {
                         let wait = value_t!(m, "wait", u64).unwrap_or(0);
 
                         let order_xml_path = m.value_of("order_xml").unwrap();
+                        let data_validation_dir = env::var(GRID_ORDER_SCHEMA_DIR)
+                            .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string());
                         let mut xml_str = String::new();
                         std::fs::File::open(order_xml_path)?.read_to_string(&mut xml_str)?;
-                        validate_order_xml_3_4(&xml_str, false)?;
+                        validate_order_xml_3_4(&xml_str, false, &data_validation_dir)?;
                         info!("Purchase order was valid.");
 
                         let version_id = m.value_of("version_id").unwrap();

--- a/sdk/src/data_validation/mod.rs
+++ b/sdk/src/data_validation/mod.rs
@@ -35,9 +35,14 @@ use xml::{validate_xml, Schema};
 ///
 /// * `data` - A path to an XML file or an XML string to be validated.
 /// * `is_path` - Whether the data provided is a path or a string.
+/// * `schema_dir` - References a path to the directory containing schema files
 ///
-pub fn validate_order_xml_3_4(data: &str, is_path: bool) -> Result<(), DataValidationError> {
-    validate_xml(data, is_path, Schema::OrderXmlV3_4)?;
+pub fn validate_order_xml_3_4(
+    data: &str,
+    is_path: bool,
+    schema_dir: &str,
+) -> Result<(), DataValidationError> {
+    validate_xml(data, is_path, Schema::OrderXmlV3_4, schema_dir)?;
     Ok(())
 }
 
@@ -60,9 +65,14 @@ pub fn validate_order_xml_3_4(data: &str, is_path: bool) -> Result<(), DataValid
 /// # Arguments
 ///
 /// * `xml_path` - The path to an XML file containing GDSN trade item definitions
+/// * `schema_dir` - References a path to the directory containing schema files
 ///
-pub fn validate_gdsn_3_1(data: &str, is_path: bool) -> Result<(), DataValidationError> {
-    validate_xml(data, is_path, Schema::GdsnXmlV3_1)?;
+pub fn validate_gdsn_3_1(
+    data: &str,
+    is_path: bool,
+    schema_dir: &str,
+) -> Result<(), DataValidationError> {
+    validate_xml(data, is_path, Schema::GdsnXmlV3_1, schema_dir)?;
     Ok(())
 }
 
@@ -88,8 +98,14 @@ mod tests {
             .unwrap()
             .read_to_string(&mut data)
             .unwrap();
+        let mut schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        schema_dir.push("src/data_validation/xml/xsd/product");
+        let schema_dir = schema_dir
+            .into_os_string()
+            .into_string()
+            .expect("Unable to convert product schema dir to string");
 
-        let result = validate_gdsn_3_1(&data, false);
+        let result = validate_gdsn_3_1(&data, false, &schema_dir);
 
         assert!(result.is_ok());
     }
@@ -101,7 +117,14 @@ mod tests {
         test_gdsn_xml_path.push("src/data_validation/test_files/gdsn_product.xml");
 
         let path_str = test_gdsn_xml_path.to_str().unwrap();
-        let result = validate_gdsn_3_1(path_str, true);
+        let mut schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        schema_dir.push("src/data_validation/xml/xsd/product");
+        let schema_dir = schema_dir
+            .into_os_string()
+            .into_string()
+            .expect("Unable to convert product schema dir to string");
+
+        let result = validate_gdsn_3_1(path_str, true, &schema_dir);
 
         assert!(result.is_ok());
     }
@@ -118,8 +141,14 @@ mod tests {
             .unwrap()
             .read_to_string(&mut data)
             .unwrap();
+        let mut schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        schema_dir.push("src/data_validation/xml/xsd/product");
+        let schema_dir = schema_dir
+            .into_os_string()
+            .into_string()
+            .expect("Unable to convert product schema dir to string");
 
-        let result = validate_gdsn_3_1(&data, false);
+        let result = validate_gdsn_3_1(&data, false, &schema_dir);
 
         assert!(result.is_err());
 
@@ -135,7 +164,15 @@ mod tests {
         test_gdsn_xml_path.push("src/data_validation/test_files/gdsn_product_invalid.xml");
 
         let path_str = test_gdsn_xml_path.to_str().unwrap();
-        let result = validate_gdsn_3_1(path_str, true);
+
+        let mut schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        schema_dir.push("src/data_validation/xml/xsd/product");
+        let schema_dir = schema_dir
+            .into_os_string()
+            .into_string()
+            .expect("Unable to convert product schema dir to string");
+
+        let result = validate_gdsn_3_1(path_str, true, &schema_dir);
 
         assert!(result.is_err());
 
@@ -159,7 +196,13 @@ mod tests {
             .read_to_string(&mut data)
             .unwrap();
 
-        let result = validate_order_xml_3_4(&data, false);
+        let mut schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        schema_dir.push("src/data_validation/xml/xsd/po/gs1/ecom");
+        let schema_dir = schema_dir
+            .into_os_string()
+            .into_string()
+            .expect("Unable to convert po schema dir to string");
+        let result = validate_order_xml_3_4(&data, false, &schema_dir);
 
         assert!(result.is_ok());
     }
@@ -171,7 +214,15 @@ mod tests {
         test_gdsn_xml_path.push("src/data_validation/test_files/order.xml");
 
         let path_str = test_gdsn_xml_path.to_str().unwrap();
-        let result = validate_order_xml_3_4(path_str, true);
+
+        let mut schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        schema_dir.push("src/data_validation/xml/xsd/po/gs1/ecom");
+        let schema_dir = schema_dir
+            .into_os_string()
+            .into_string()
+            .expect("Unable to convert po schema dir to string");
+
+        let result = validate_order_xml_3_4(path_str, true, &schema_dir);
 
         assert!(result.is_ok());
     }
@@ -189,7 +240,14 @@ mod tests {
             .read_to_string(&mut data)
             .unwrap();
 
-        let result = validate_order_xml_3_4(&data, false);
+        let mut schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        schema_dir.push("src/data_validation/xml/xsd/po/gs1/ecom");
+        let schema_dir = schema_dir
+            .into_os_string()
+            .into_string()
+            .expect("Unable to convert po schema dir to string");
+
+        let result = validate_order_xml_3_4(&data, false, &schema_dir);
 
         assert!(result.is_err());
 
@@ -205,7 +263,15 @@ mod tests {
         test_gdsn_xml_path.push("src/data_validation/test_files/order_invalid.xml");
 
         let path_str = test_gdsn_xml_path.to_str().unwrap();
-        let result = validate_order_xml_3_4(path_str, true);
+
+        let mut schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        schema_dir.push("src/data_validation/xml/xsd/po/gs1/ecom");
+        let schema_dir = schema_dir
+            .into_os_string()
+            .into_string()
+            .expect("Unable to convert po schema dir to string");
+
+        let result = validate_order_xml_3_4(path_str, true, &schema_dir);
 
         assert!(result.is_err());
 

--- a/sdk/src/data_validation/xml/xsd/po/gs1/ecom/Order.xsd
+++ b/sdk/src/data_validation/xml/xsd/po/gs1/ecom/Order.xsd
@@ -25,9 +25,9 @@ The schema and subsequent updates will be provided on the GS1 websites.
 ---------------------------
 ]]>        </xsd:documentation>
     </xsd:annotation>
-    <xsd:import namespace="http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader" schemaLocation="src/data_validation/xml/xsd/po/sbdh/StandardBusinessDocumentHeader.xsd"/>
-    <xsd:import namespace="urn:gs1:shared:shared_common:xsd:3" schemaLocation="src/data_validation/xml/xsd/po/gs1/shared/SharedCommon.xsd"/>
-    <xsd:import namespace="urn:gs1:ecom:ecom_common:xsd:3" schemaLocation="src/data_validation/xml/xsd/po/gs1/ecom/eComCommon.xsd"/>
+    <xsd:import namespace="http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader" schemaLocation="../../sbdh/StandardBusinessDocumentHeader.xsd"/>
+    <xsd:import namespace="urn:gs1:shared:shared_common:xsd:3" schemaLocation="../shared/SharedCommon.xsd"/>
+    <xsd:import namespace="urn:gs1:ecom:ecom_common:xsd:3" schemaLocation="eComCommon.xsd"/>
     <xsd:element name="orderMessage" type="order:OrderMessageType"/>
     <xsd:complexType name="OrderLineItemDetailType">
         <xsd:sequence>

--- a/sdk/src/data_validation/xml/xsd/po/gs1/ecom/eComCommon.xsd
+++ b/sdk/src/data_validation/xml/xsd/po/gs1/ecom/eComCommon.xsd
@@ -21,7 +21,7 @@ The schema and subsequent updates will be provided on the GS1 websites.
 ---------------------------
 ]]></xsd:documentation>
     </xsd:annotation>
-    <xsd:import namespace="urn:gs1:shared:shared_common:xsd:3" schemaLocation="src/data_validation/xml/xsd/po/gs1/shared/SharedCommon.xsd"/>
+    <xsd:import namespace="urn:gs1:shared:shared_common:xsd:3" schemaLocation="../shared/SharedCommon.xsd"/>
     <xsd:complexType name="AcceptableOverAllocationType">
         <xsd:sequence>
             <xsd:element minOccurs="0" name="overAllocationQuantity" type="shared_common:QuantityType"/>


### PR DESCRIPTION
This change updates the loading of the schema to be done in the
directory where schemas are specified. This directory is able to be set
with the `GRID_ORDER_SCHEMA_DIR` environment variable, or it is set by
default.

Signed-off-by: Shannyn Telander <telander@bitwise.io>