### PR TITLE
Add PO list/show CLI functionality

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,6 +30,7 @@ path = "src/main.rs"
 
 [dependencies]
 assert_cmd = "1.0"
+chrono = { version = "0.4", optional = true }
 clap = "2"
 diesel = { version = "1.0", features = ["postgres"], optional = true }
 cylinder = { version = "0.2.2", features = ["key-load"] }
@@ -44,6 +45,7 @@ protobuf = "2.19"
 users = "0.11"
 dirs = "3"
 serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", optional = true }
 serde_yaml = "0.8"
 diesel_migrations = "1.4"
 whoami = "1"
@@ -89,7 +91,7 @@ sqlite = [
 location = ["pike", "schema"]
 pike = []
 product = ["pike", "schema"]
-purchase-order = ["grid-sdk/purchase-order", "rand"]
+purchase-order = ["chrono", "grid-sdk/purchase-order", "rand", "serde_json"]
 sawtooth = []
 schema = ["pike"]
 splinter = []

--- a/cli/man/grid-po-list.1.md
+++ b/cli/man/grid-po-list.1.md
@@ -1,4 +1,5 @@
 % GRID-PO-LIST(1) Cargill, Incorporated | Grid
+
 <!--
   Copyright 2021 Cargill Incorporated
   Licensed under Creative Commons Attribution 4.0 International License
@@ -20,7 +21,6 @@ DESCRIPTION
 
 List all purchase orders in grid.
 
-
 FLAGS
 =====
 
@@ -35,7 +35,7 @@ FLAGS
 
 `--accepted`
 : Filter on whether the purchase order has an accepted version. Conflicts with
-  `--not-accepted`.
+`--not-accepted`.
 
 `--not-accepted`
 : Filter on whether the purchase order does not have an accepted version.
@@ -56,17 +56,19 @@ OPTIONS
 
 `-F`, `--format=FORMAT`
 : Specifies the output format of the list. Possible values for formatting are
-  `human`, `csv`, `yaml`, and `json`. Defaults to `human`.
-  
-`--org`
-: Optionally, filter the purchase orders for the organization specified by
-  `ORG_ID`. 
+`human`, `csv`, `yaml`, and `json`. Defaults to `human`.
+
+`--buyer-org`
+: Optionally, filter the purchase orders by the buyer's organization ID.
+
+`--seller-org`
+: Optionally, filter the purchase orders by the seller's organization ID.
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
   Splinter. Format: `<circuit-id>::<service-id>`.
 
-  `--url`
+`--url`
 : URL for the REST API.
 
 EXAMPLES
@@ -75,14 +77,14 @@ EXAMPLES
 The command
 
 ```
-$ grid po list --org=crgl
+$ grid po list --buyer-org=crgl
 ```
 
 will list all purchase orders for the org `crgl` in human-readable format:
 
 ```
-ORG   UUID                STATUS    ACCEPTED CLOSED
-crgl  82urioz098aui3871uc Confirmed v3       False
+BUYER SELLER   UID                 STATUS    ACCEPTED CLOSED
+crgl  tst      PO-1234-56789       Confirmed v3       False
 ```
 
 The command
@@ -95,11 +97,12 @@ will list all the purchase orders that have an accepted version in
 human-readable format:
 
 ```
-ORG    UUID                STATUS    ACCEPTED CLOSED
-crgl   82urioz098aui3871uc Confirmed v3       False
-tst    2389f7987d9s09df98f Issued    v1       False
-tst    f808u23hjiof09ufs0d Closed    v1       True
+BUYER SELLER   UID                 STATUS    ACCEPTED CLOSED
+crgl  tst      PO-1234-56789       Confirmed v3       False
+tst   crgl     PO-2345-67890       Issued    v1       False
+crgl  tst      PO-3456-78901       Closed    v1       True
 ```
+
 The command
 
 ```
@@ -110,12 +113,12 @@ The command
 ```
 
 will display all of the purchase orders that have an accepted version and are
-open.  The output is formatted in csv:
+open. The output is formatted in csv:
 
 ```
-ORG,UUID,STATUS,ACCEPTED,CLOSED
-crgl,82urioz098aui3871uc,Confirmed,v3,False
-tst,2389f7987d9s09df98f,Issued,v1,False
+BUYER,SELLER,UID,STATUS,ACCEPTED,CLOSED
+crgl,tst,PO-1234-56789,Confirmed,v3,False
+tst,crgl,PO-2345-67890,Issued,v1,False
 ```
 
 ENVIRONMENT VARIABLES
@@ -129,6 +132,7 @@ ENVIRONMENT VARIABLES
 
 SEE ALSO
 ========
+
 | `grid-po-show(1)`
 | `grid-po-list(1)`
 |

--- a/cli/man/grid-po-show.1.md
+++ b/cli/man/grid-po-show.1.md
@@ -1,4 +1,5 @@
 % GRID-PO-SHOW(1) Cargill, Incorporated | Grid
+
 <!--
   Copyright 2021 Cargill Incorporated
   Licensed under Creative Commons Attribution 4.0 International License
@@ -18,14 +19,14 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-Show the details of a specific purchase order.  This command displays the
+Show the details of a specific purchase order. This command displays the
 specified revision of a specified version of the purchase order.
 
 ARGS
 ====
 
 `IDENTIFIER`
-: Either a UUID or an alternate ID of a purchase order.
+: Either a UID or an alternate ID of a purchase order.
 
 FLAGS
 =====
@@ -41,32 +42,21 @@ FLAGS
 
 `-v`
 : Increases verbosity (the opposite of `-q`). Specify multiple times for more
-  output.
+output.
 
 OPTIONS
 =======
 
 `-F`, `--format=FORMAT`
 : Specifies the output format of the list. Possible values for formatting are
-  `human`, `csv`, `yaml`, and `json`. Defaults to `human`.
-
-`--org`
-: Specify the organization that owns the purchase order.
-
-`--revision`
-: Specify the revision number for the specified version. Defaults to the latest
-  revision.
+`human`, `csv`, `yaml`, and `json`. Defaults to `human`.
 
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
-  Splinter. Format: `<circuit-id>::<service-id>`.
+Splinter. Format: `<circuit-id>::<service-id>`.
 
 `--url`
 : URL for the REST API
-
-`--version`
-: Specify the version ID of the purchase order to display. Defaults to the
-  accepted version.
 
 EXAMPLES
 ========
@@ -74,35 +64,37 @@ EXAMPLES
 The command
 
 ```
-$ grid po show --org=crgl 82urioz098aui3871uc
+$ grid po show --org=crgl 809832081
 ```
 
 will display the current revision of the accepted version of the purchase order
-with UUID `82urioz098aui3871uc` in human-readable format. It will display
+with UID `809832081` in human-readable format. It will display
 output like the following:
 
 ```
-Purchase Order:
-    organization     crgl (Cargill Incorporated)
-    uuid             82urioz098aui3871uc
-    purchase_order   809832081
-    workflow status  Confirmed
-    is closed        False
-    created          <datetime string>
+Purchase Order 809832081:
+    Buyer Org        crgl (Cargill Incorporated)
+    Seller Org       crgl2 (Cargill 2)
+    Workflow status  Confirmed
+    Created At       <datetime string>
+    Closed           false
 
 Accepted Version (v3):
     workflow_status  Editable
-    draft            False
-    latest revision  4
+    draft            false
+    Revisions        4
+    Current Revision 4
 
 Revision 4:
-    <summary fields from order_xml_3_4>
+    Created At       <datetime string>
+    Submitter        0200ef9ab9243baee...
+<Revision XML file>
 ```
 
 The command
 
 ```
-$ grid po show --org=crgl purchase_order:809832081
+$ grid po show purchase_order:809832081
 ```
 
 will display the current revision of the accepted version of the purchase order
@@ -110,21 +102,23 @@ with the alternate ID of `purchase_order:809832081` in human-readable format.
 It will display output like the following:
 
 ```
-Purchase Order:
-    organization     crgl (Cargill Incorporated)
-    uuid             82urioz098aui3871uc
-    purchase_order   809832081
-    workflow status  Confirmed
-    is closed        False
-    created          <datetime string>
+Purchase Order 809832081:
+    Buyer Org        crgl (Cargill Incorporated)
+    Seller Org       crgl2 (Cargill 2)
+    Workflow status  Confirmed
+    Created At       <datetime string>
+    Closed           false
 
 Accepted Version (v3):
     workflow_status  Editable
-    draft            False
-    latest revision  4
+    draft            false
+    Revisions        4
+    Current Revision 4
 
 Revision 4:
-    <summary fields from order_xml_3_4>
+    Created At       <datetime string>
+    Submitter        0200ef9ab9243baee...
+<Revision XML file>
 ```
 
 The command
@@ -138,21 +132,23 @@ with the alternate ID of `purchase_order:809832081` in human-readable format.
 It will display output like the following:
 
 ```
-Purchase Order:
-    organization     crgl (Cargill Incorporated)
-    uuid             82urioz098aui3871uc
-    purchase_order   809832081
-    workflow status  Confirmed
-    is closed        False
-    created          <datetime string>
+Purchase Order 809832081:
+    Buyer Org        crgl (Cargill Incorporated)
+    Seller Org       crgl2 (Cargill 2)
+    Workflow status  Confirmed
+    Created At       <datetime string>
+    Closed           false
 
-Accepted Version (v2):
+Accepted Version (v3):
     workflow_status  Editable
-    draft            False
-    latest revision  4
+    draft            false
+    Revisions        4
+    Current Revision 4
 
 Revision 2:
-    <summary fields from order_xml_3_4>
+    Created At       <datetime string>
+    Submitter        0200ef9ab9243baee...
+<Revision XML file>
 ```
 
 ENVIRONMENT VARIABLES
@@ -166,6 +162,7 @@ ENVIRONMENT VARIABLES
 
 SEE ALSO
 ========
+
 | `grid-po-create(1)`
 | `grid-po-list(1)`
 | `grid-po-show(1)`

--- a/cli/src/actions/purchase_orders.rs
+++ b/cli/src/actions/purchase_orders.rs
@@ -679,3 +679,149 @@ fn print_human_readable_list(column_names: Vec<&str>, row_values: Vec<Vec<String
         println!("{}", print_row);
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    /// Tests the purchase order revisions are correctly displayed in the CLI
+    /// in the format:
+    /// Revision 4:
+    ///     Created At       <datetime string>
+    ///     Submitter        0200ef9ab9243baee...
+    /// <Revision XML file>
+    #[test]
+    fn test_display_revision() {
+        let display = "\
+Revision 1:
+	Created At        1970-05-23T21:21:18+00:00
+	Submitter         0200ef9ab9243baee54f61a64d66aeb1d33bb063f16dfaa72e61886b9870c2b7ee
+
+<tag></tag>";
+        let revision = PurchaseOrderRevisionCli {
+            revision_id: 1,
+            order_xml_v3_4: "<tag></tag>".to_string(),
+            submitter: "0200ef9ab9243baee54f61a64d66aeb1d33bb063f16dfaa72e61886b9870c2b7ee"
+                .to_string(),
+            created_at: 12345678,
+        };
+
+        assert_eq!(format!("{}", revision), display);
+    }
+
+    /// Tests the purchase order versions are correctly displayed in the CLI
+    /// in the format:
+    /// Version (1):
+    ///     workflow_status  Editable
+    ///     draft            false
+    ///     Revisions        4
+    ///     Current Revision 4
+    ///
+    /// Revision 4:
+    ///     Created At       <datetime string>
+    ///     Submitter        0200ef9ab9243baee...
+    /// <Revision XML file>
+    #[test]
+    fn test_display_version() {
+        let display = "\
+Version 1:
+	Workflow Status   proposed
+	Is Draft          true
+	Revisions         1
+	Current Revision  1
+
+Revision 1:
+	Created At        1970-05-23T21:21:18+00:00
+	Submitter         0200ef9ab9243baee54f61a64d66aeb1d33bb063f16dfaa72e61886b9870c2b7ee
+
+<tag></tag>";
+
+        let revision = PurchaseOrderRevisionCli {
+            revision_id: 1,
+            order_xml_v3_4: "<tag></tag>".to_string(),
+            submitter: "0200ef9ab9243baee54f61a64d66aeb1d33bb063f16dfaa72e61886b9870c2b7ee"
+                .to_string(),
+            created_at: 12345678,
+        };
+
+        let version = PurchaseOrderVersionCli {
+            version_id: "1".to_string(),
+            workflow_status: "proposed".to_string(),
+            is_draft: true,
+            current_revision_id: 1,
+            revisions: vec![revision],
+        };
+
+        assert_eq!(format!("{}", version), display);
+    }
+
+    /// Tests the purchase orders are correctly displayed in the CLI in the
+    /// format:
+    /// Purchase Order PO-00000-0000:
+    ///     Buyer Org        crgl (Cargill Incorporated)
+    ///     Seller Org       crgl2 (Cargill 2)
+    ///     Workflow status  Confirmed
+    ///     Created At       <datetime string>
+    ///     Closed           false
+    ///
+    /// Accepted Version (1):
+    ///     workflow_status  Editable
+    ///     draft            false
+    ///     Revisions        4
+    ///     Current Revision 4
+    ///
+    /// Revision 4:
+    ///     Created At       <datetime string>
+    ///     Submitter        0200ef9ab9243baee...
+    /// <Revision XML file>
+    #[test]
+    fn test_display_po() {
+        let display = "\
+Purchase Order PO-00000-0000:
+	Buyer Org         test
+	Seller Org        test2
+	Workflow Status   created
+	Created At        1970-05-23T21:21:17+00:00
+	Closed            false
+
+Version 1:
+	Workflow Status   proposed
+	Is Draft          true
+	Revisions         1
+	Current Revision  1
+
+Revision 1:
+	Created At        1970-05-23T21:21:18+00:00
+	Submitter         0200ef9ab9243baee54f61a64d66aeb1d33bb063f16dfaa72e61886b9870c2b7ee
+
+<tag></tag>";
+        let revision = PurchaseOrderRevisionCli {
+            revision_id: 1,
+            order_xml_v3_4: "<tag></tag>".to_string(),
+            submitter: "0200ef9ab9243baee54f61a64d66aeb1d33bb063f16dfaa72e61886b9870c2b7ee"
+                .to_string(),
+            created_at: 12345678,
+        };
+
+        let version = PurchaseOrderVersionCli {
+            version_id: "1".to_string(),
+            workflow_status: "proposed".to_string(),
+            is_draft: true,
+            current_revision_id: 1,
+            revisions: vec![revision],
+        };
+
+        let po = PurchaseOrderCli {
+            buyer_org_id: "test".to_string(),
+            seller_org_id: "test2".to_string(),
+            purchase_order_uid: "PO-00000-0000".to_string(),
+            workflow_status: "created".to_string(),
+            is_closed: false,
+            accepted_version_id: Some("1".to_string()),
+            versions: vec![version],
+            created_at: 12345677,
+        };
+
+        assert_eq!(format!("{}", po), display);
+    }
+}

--- a/cli/src/actions/purchase_orders.rs
+++ b/cli/src/actions/purchase_orders.rs
@@ -27,11 +27,13 @@ use grid_sdk::{
     },
     protos::IntoProto,
     purchase_order::addressing::GRID_PURCHASE_ORDER_NAMESPACE,
-    purchase_order::store::ListVersionFilters,
+    purchase_order::store::{ListPOFilters, ListVersionFilters},
 };
 
+use chrono::{DateTime, NaiveDateTime, Utc};
 use cylinder::Signer;
 use rand::{distributions::Alphanumeric, Rng};
+use serde::Serialize;
 
 use crate::error::CliError;
 use crate::transaction::purchase_order_batch_builder;
@@ -169,9 +171,12 @@ pub fn do_list_revisions(
     version_id: &str,
     service_id: Option<&str>,
 ) -> Result<(), CliError> {
-    let revisions = do_fetch_revisions(client, po_uid, version_id, service_id)?;
+    let revisions = do_fetch_revisions(client, po_uid, version_id, service_id)?
+        .iter()
+        .map(PurchaseOrderRevisionCli::from)
+        .collect::<Vec<PurchaseOrderRevisionCli>>();
 
-    display_revisions(revisions);
+    print_formattable_list(PurchaseOrderRevisionCliList(revisions), None)?;
     Ok(())
 }
 
@@ -190,7 +195,7 @@ pub fn do_show_revision(
     )?;
 
     if let Some(revision) = revision {
-        display_revision(revision);
+        print_formattable(PurchaseOrderRevisionCli::from(&revision), None)?;
     } else {
         println!(
             "Could not find revision {}, for version {} for order {}",
@@ -205,12 +210,15 @@ pub fn do_list_versions(
     po_uid: &str,
     accepted_filter: Option<bool>,
     draft_filter: Option<bool>,
-    _format: &str,
+    format: Option<&str>,
     service_id: Option<&str>,
 ) -> Result<(), CliError> {
-    let versions = get_versions(client, po_uid, accepted_filter, draft_filter, service_id)?;
+    let versions = get_versions(client, po_uid, accepted_filter, draft_filter, service_id)?
+        .iter()
+        .map(PurchaseOrderVersionCli::from)
+        .collect::<Vec<PurchaseOrderVersionCli>>();
 
-    display_versions(versions);
+    print_formattable_list(PurchaseOrderVersionCliList(versions), format)?;
     Ok(())
 }
 
@@ -227,7 +235,7 @@ pub fn do_show_version(
     )?;
 
     if let Some(version) = version {
-        display_version(version);
+        print_formattable(PurchaseOrderVersionCli::from(&version), None)?;
     } else {
         println!("Could not find version {} for order {}", version_id, po_uid);
     }
@@ -266,7 +274,8 @@ fn get_versions(
         is_draft: draft_filter,
     };
 
-    let versions = client.list_purchase_order_versions(po_uid.to_string(), filters, service_id)?;
+    let versions =
+        client.list_purchase_order_versions(po_uid.to_string(), Some(filters), service_id)?;
 
     Ok(versions)
 }
@@ -298,25 +307,359 @@ pub fn make_alternate_id_from_str(uid: &str, id: &str) -> Result<AlternateId, Cl
     Ok(AlternateId::new(uid, split[0], split[1]))
 }
 
-fn display_revisions(revisions: Vec<PurchaseOrderRevision>) {
-    let mut rows = vec![];
-    revisions.iter().for_each(|rev| {
-        let values = vec![
-            rev.revision_id.to_string(),
-            rev.created_at.to_string(),
-            rev.submitter.to_string(),
-        ];
+pub fn do_show_purchase_order(
+    client: Box<dyn PurchaseOrderClient>,
+    purchase_order_id: String,
+    service_id: Option<String>,
+    format: Option<&str>,
+) -> Result<(), CliError> {
+    let res = client.get_purchase_order(purchase_order_id, service_id.as_deref())?;
+    match res {
+        Some(purchase_order) => {
+            print_formattable(PurchaseOrderCli::from(&purchase_order), format)?;
+        }
+        None => {
+            println!("Purchase Order Not Found.");
+        }
+    }
+    Ok(())
+}
 
-        rows.push(values);
-    });
+pub fn do_list_purchase_orders(
+    client: Box<dyn PurchaseOrderClient>,
+    filter: Option<ListPOFilters>,
+    service_id: Option<String>,
+    format: Option<&str>,
+) -> Result<(), CliError> {
+    let res = client.list_purchase_orders(filter, service_id.as_deref())?;
+    let po_list = res
+        .iter()
+        .map(PurchaseOrderCli::from)
+        .collect::<Vec<PurchaseOrderCli>>();
+    print_formattable_list(PurchaseOrderCliList(po_list), format)?;
 
-    let column_names = vec!["REVISION_ID", "CREATED_AT", "SUBMITTER"];
+    Ok(())
+}
+#[derive(Debug, Serialize)]
+struct PurchaseOrderCli {
+    buyer_org_id: String,
+    seller_org_id: String,
+    purchase_order_uid: String,
+    workflow_status: String,
+    is_closed: bool,
+    accepted_version_id: Option<String>,
+    versions: Vec<PurchaseOrderVersionCli>,
+    created_at: i64,
+}
 
+impl From<&PurchaseOrder> for PurchaseOrderCli {
+    fn from(d: &PurchaseOrder) -> Self {
+        Self {
+            buyer_org_id: d.buyer_org_id.to_string(),
+            seller_org_id: d.seller_org_id.to_string(),
+            purchase_order_uid: d.purchase_order_uid.to_string(),
+            workflow_status: d.workflow_status.to_string(),
+            is_closed: d.is_closed,
+            accepted_version_id: d.accepted_version_id.as_ref().map(String::from),
+            versions: d
+                .versions
+                .iter()
+                .map(PurchaseOrderVersionCli::from)
+                .collect(),
+            created_at: d.created_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct PurchaseOrderVersionCli {
+    pub version_id: String,
+    pub workflow_status: String,
+    pub is_draft: bool,
+    pub current_revision_id: u64,
+    pub revisions: Vec<PurchaseOrderRevisionCli>,
+}
+
+impl From<&PurchaseOrderVersion> for PurchaseOrderVersionCli {
+    fn from(d: &PurchaseOrderVersion) -> Self {
+        Self {
+            version_id: d.version_id.to_string(),
+            workflow_status: d.workflow_status.to_string(),
+            is_draft: d.is_draft,
+            current_revision_id: d.current_revision_id,
+            revisions: d
+                .revisions
+                .iter()
+                .map(PurchaseOrderRevisionCli::from)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct PurchaseOrderRevisionCli {
+    pub revision_id: u64,
+    pub order_xml_v3_4: String,
+    pub submitter: String,
+    pub created_at: i64,
+}
+
+impl From<&PurchaseOrderRevision> for PurchaseOrderRevisionCli {
+    fn from(d: &PurchaseOrderRevision) -> Self {
+        Self {
+            revision_id: d.revision_id,
+            order_xml_v3_4: d.order_xml_v3_4.to_string(),
+            submitter: d.submitter.to_string(),
+            created_at: d.created_at,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct PurchaseOrderCliList(Vec<PurchaseOrderCli>);
+
+#[derive(Serialize)]
+pub struct PurchaseOrderVersionCliList(Vec<PurchaseOrderVersionCli>);
+
+#[derive(Serialize)]
+pub struct PurchaseOrderRevisionCliList(Vec<PurchaseOrderRevisionCli>);
+
+impl std::fmt::Display for PurchaseOrderCliList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for purchase_order in &self.0 {
+            write!(f, "\n\n{}", purchase_order)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for PurchaseOrderVersionCliList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for version in &self.0 {
+            write!(f, "\n\n{}", version)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for PurchaseOrderRevisionCliList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for revision in &self.0 {
+            write!(f, "\n\n{}", revision)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for PurchaseOrderCli {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Purchase Order {}:", &self.purchase_order_uid)?;
+        write!(f, "\n\t{:18}{}", "Buyer Org", &self.buyer_org_id)?;
+        write!(f, "\n\t{:18}{}", "Seller Org", &self.seller_org_id)?;
+        write!(f, "\n\t{:18}{}", "Workflow Status", &self.workflow_status)?;
+        write!(
+            f,
+            "\n\t{:18}{}",
+            "Created At",
+            DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(self.created_at, 0), Utc)
+                .to_rfc3339()
+        )?;
+        write!(f, "\n\t{:18}{}", "Closed", &self.is_closed)?;
+        if let Some(accepted_version_id) = &self.accepted_version_id {
+            let versions = &self.versions;
+            let version: Option<&PurchaseOrderVersionCli> = versions
+                .iter()
+                .find(|&ver| ver.version_id == *accepted_version_id);
+            if let Some(version) = version {
+                write!(f, "\n\n{}", version)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for PurchaseOrderVersionCli {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Version {}:", &self.version_id)?;
+        write!(f, "\n\t{:18}{}", "Workflow Status", &self.workflow_status)?;
+        write!(f, "\n\t{:18}{}", "Is Draft", &self.is_draft)?;
+        let revisions = &self.revisions;
+        write!(f, "\n\t{:18}{}", "Revisions", &revisions.len())?;
+        write!(
+            f,
+            "\n\t{:18}{}",
+            "Current Revision", &self.current_revision_id
+        )?;
+        let current_revision_id = &self.current_revision_id;
+        let current_revision: Option<&PurchaseOrderRevisionCli> = revisions
+            .iter()
+            .find(|&rev| &rev.revision_id == current_revision_id);
+        if let Some(current_revision) = current_revision {
+            write!(f, "\n\n{}", current_revision)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for PurchaseOrderRevisionCli {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Revision {}:", &self.revision_id)?;
+        write!(
+            f,
+            "\n\t{:18}{}",
+            "Created At",
+            DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(self.created_at, 0), Utc)
+                .to_rfc3339()
+        )?;
+        write!(f, "\n\t{:18}{}", "Submitter", &self.submitter)?;
+        write!(f, "\n\n{}", &self.order_xml_v3_4)?;
+
+        Ok(())
+    }
+}
+
+trait ListDisplay {
+    fn header() -> Vec<&'static str>;
+    fn details(&self) -> Vec<Vec<String>>;
+}
+
+impl ListDisplay for PurchaseOrderCliList {
+    fn header() -> Vec<&'static str> {
+        vec!["BUYER", "SELLER", "UID", "STATUS", "ACCEPTED", "CLOSED"]
+    }
+
+    fn details(&self) -> Vec<Vec<String>> {
+        self.0
+            .iter()
+            .map(|po| {
+                vec![
+                    po.buyer_org_id.to_string(),
+                    po.seller_org_id.to_string(),
+                    po.purchase_order_uid.to_string(),
+                    po.workflow_status.to_string(),
+                    match &po.accepted_version_id {
+                        Some(s) => s.to_string(),
+                        None => String::new(),
+                    },
+                    po.is_closed.to_string(),
+                ]
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+impl ListDisplay for PurchaseOrderVersionCliList {
+    fn header() -> Vec<&'static str> {
+        vec![
+            "VERSION_ID",
+            "WORKFLOW_STATUS",
+            "IS_DRAFT",
+            "CURRENT_REVISION",
+            "REVISIONS",
+        ]
+    }
+
+    fn details(&self) -> Vec<Vec<String>> {
+        self.0
+            .iter()
+            .map(|version| {
+                vec![
+                    version.version_id.to_string(),
+                    version.workflow_status.to_string(),
+                    version.is_draft.to_string(),
+                    version.current_revision_id.to_string(),
+                    version.revisions.len().to_string(),
+                ]
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+impl ListDisplay for PurchaseOrderRevisionCliList {
+    fn header() -> Vec<&'static str> {
+        vec!["REVISION_ID", "CREATED_AT", "SUBMITTER"]
+    }
+
+    fn details(&self) -> Vec<Vec<String>> {
+        self.0
+            .iter()
+            .map(|rev| {
+                vec![
+                    rev.revision_id.to_string(),
+                    rev.created_at.to_string(),
+                    rev.submitter.to_string(),
+                ]
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+fn print_formattable<T: std::fmt::Display + Serialize>(
+    object: T,
+    format: Option<&str>,
+) -> Result<(), CliError> {
+    match format {
+        Some("json") => {
+            let formatted = serde_json::to_string(&object).map_err(|err| {
+                CliError::ActionError(format!("Error formatting as JSON: {}", err))
+            })?;
+            println!("{}", formatted);
+        }
+        Some("yaml") => {
+            let formatted = serde_yaml::to_string(&object).map_err(|err| {
+                CliError::ActionError(format!("Error formatting as YAML: {}", err))
+            })?;
+            println!("{}", formatted);
+        }
+        _ => println!("{}", object),
+    }
+    Ok(())
+}
+
+fn print_formattable_list<T: std::fmt::Display + Serialize + ListDisplay>(
+    object: T,
+    format: Option<&str>,
+) -> Result<(), CliError> {
+    match format {
+        Some("json") => {
+            print_formattable(object, format)?;
+        }
+        Some("yaml") => {
+            print_formattable(object, format)?;
+        }
+        Some("csv") => {
+            let details = object
+                .details()
+                .iter()
+                .map(|detail| str_join(detail.to_vec(), ","))
+                .collect::<Vec<String>>()
+                .join("\n");
+
+            println!("{}\n{}", str_join(T::header(), ","), details);
+        }
+        _ => {
+            print_human_readable_list(T::header(), object.details());
+        }
+    };
+    Ok(())
+}
+
+fn str_join<T: ToString>(array: Vec<T>, delimiter: &str) -> String {
+    array
+        .iter()
+        .map(|x| x.to_string())
+        .collect::<Vec<String>>()
+        .join(delimiter)
+}
+
+fn print_human_readable_list(column_names: Vec<&str>, row_values: Vec<Vec<String>>) {
     // Calculate max-widths for columns
     let mut widths: Vec<usize> = column_names.iter().map(|name| name.len()).collect();
-    rows.iter().for_each(|row| {
+    row_values.iter().for_each(|row| {
         for i in 0..widths.len() {
-            widths[i] = cmp::max(widths[i], row[i].to_string().len())
+            widths[i] = cmp::max(widths[i], row[i].len())
         }
     });
 
@@ -328,128 +671,11 @@ fn display_revisions(revisions: Vec<PurchaseOrderRevision>) {
     println!("{}", header_row);
 
     // print each row
-    for row in rows {
+    for row in row_values {
         let mut print_row = "".to_owned();
         for i in 0..column_names.len() {
             print_row += &format!("{:width$} ", row[i], width = widths[i]);
         }
         println!("{}", print_row);
     }
-}
-
-fn display_revision(revision: PurchaseOrderRevision) {
-    let column_names = vec!["REVISION_ID", "CREATED_AT", "SUBMITTER"];
-    let table_values = vec![
-        revision.revision_id.to_string(),
-        revision.created_at.to_string(),
-        revision.submitter,
-    ];
-
-    // Calculate max-widths for columns
-    let mut widths: Vec<usize> = column_names.iter().map(|name| name.len()).collect();
-    for i in 0..widths.len() {
-        widths[i] = cmp::max(widths[i], table_values[i].to_string().len())
-    }
-
-    // print header row
-    let mut header_row = "".to_owned();
-    for i in 0..column_names.len() {
-        header_row += &format!("{:width$} ", column_names[i], width = widths[i]);
-    }
-    println!("{}", header_row);
-
-    // print revision
-    let mut print_row = "".to_owned();
-    for i in 0..column_names.len() {
-        print_row += &format!("{:width$} ", table_values[i], width = widths[i]);
-    }
-    println!("{}", print_row);
-
-    // print XML
-    println!("ORDER XML");
-    println!("{}", revision.order_xml_v3_4);
-}
-
-fn display_versions(versions: Vec<PurchaseOrderVersion>) {
-    let mut rows = vec![];
-    versions.iter().for_each(|version| {
-        let values = vec![
-            version.version_id.to_string(),
-            version.workflow_status.to_string(),
-            version.is_draft.to_string(),
-            version.current_revision_id.to_string(),
-            version.revisions.len().to_string(),
-        ];
-
-        rows.push(values);
-    });
-
-    let column_names = vec![
-        "VERSION_ID",
-        "WORKFLOW_STATUS",
-        "IS_DRAFT",
-        "CURRENT_REVISION",
-        "REVISIONS",
-    ];
-
-    // Calculate max-widths for columns
-    let mut widths: Vec<usize> = column_names.iter().map(|name| name.len()).collect();
-    rows.iter().for_each(|row| {
-        for i in 0..widths.len() {
-            widths[i] = cmp::max(widths[i], row[i].to_string().len())
-        }
-    });
-
-    // print header row
-    let mut header_row = "".to_owned();
-    for i in 0..column_names.len() {
-        header_row += &format!("{:width$} ", column_names[i], width = widths[i]);
-    }
-    println!("{}", header_row);
-
-    // print each row
-    for row in rows {
-        let mut print_row = "".to_owned();
-        for i in 0..column_names.len() {
-            print_row += &format!("{:width$} ", row[i], width = widths[i]);
-        }
-        println!("{}", print_row);
-    }
-}
-
-fn display_version(version: PurchaseOrderVersion) {
-    let column_names = vec![
-        "VERSION_ID",
-        "WORKFLOW_STATUS",
-        "IS_DRAFT",
-        "CURRENT_REVISION",
-        "REVISIONS",
-    ];
-    let table_values = vec![
-        version.version_id.to_string(),
-        version.workflow_status.to_string(),
-        version.is_draft.to_string(),
-        version.current_revision_id.to_string(),
-        version.revisions.len().to_string(),
-    ];
-
-    // Calculate max-widths for columns
-    let mut widths: Vec<usize> = column_names.iter().map(|name| name.len()).collect();
-    for i in 0..widths.len() {
-        widths[i] = cmp::max(widths[i], table_values[i].to_string().len())
-    }
-
-    // print header row
-    let mut header_row = "".to_owned();
-    for i in 0..column_names.len() {
-        header_row += &format!("{:width$} ", column_names[i], width = widths[i]);
-    }
-    println!("{}", header_row);
-
-    // print version
-    let mut print_row = "".to_owned();
-    for i in 0..column_names.len() {
-        print_row += &format!("{:width$} ", table_values[i], width = widths[i]);
-    }
-    println!("{}", print_row);
 }

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -25,6 +25,7 @@ pub enum CliError {
         feature = "location",
         feature = "pike",
         feature = "product",
+        feature = "purchase-order",
         feature = "schema",
         feature = "database",
     ))]
@@ -35,6 +36,7 @@ pub enum CliError {
         feature = "location",
         feature = "pike",
         feature = "product",
+        feature = "purchase-order",
         feature = "schema",
     ))]
     PayloadError(String),
@@ -48,6 +50,7 @@ pub enum CliError {
         feature = "location",
         feature = "pike",
         feature = "product",
+        feature = "purchase-order",
         feature = "schema",
     ))]
     DaemonError(String),
@@ -60,6 +63,7 @@ impl StdError for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
                 feature = "database",
             ))]
@@ -70,6 +74,7 @@ impl StdError for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
             ))]
             CliError::PayloadError(_) => None,
@@ -83,6 +88,7 @@ impl StdError for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
             ))]
             CliError::DaemonError(_) => None,
@@ -97,6 +103,7 @@ impl std::fmt::Display for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
                 feature = "database",
             ))]
@@ -107,6 +114,7 @@ impl std::fmt::Display for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
             ))]
             CliError::PayloadError(ref err) => write!(f, "PayloadError: {}", err),
@@ -122,6 +130,7 @@ impl std::fmt::Display for CliError {
                 feature = "location",
                 feature = "pike",
                 feature = "product",
+                feature = "purchase-order",
                 feature = "schema",
             ))]
             CliError::DaemonError(ref err) => write!(f, "{}", err.replace("\"", "")),
@@ -180,6 +189,7 @@ impl From<grid_sdk::product::gdsn::ProductGdsnError> for CliError {
     feature = "location",
     feature = "pike",
     feature = "product",
+    feature = "purchase-order",
     feature = "schema",
 ))]
 impl From<grid_sdk::error::ClientError> for CliError {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -94,6 +94,7 @@ use grid_sdk::{
         CreatePurchaseOrderPayloadBuilder, CreateVersionPayloadBuilder, PayloadRevisionBuilder,
         UpdatePurchaseOrderPayloadBuilder,
     },
+    purchase_order::store::ListPOFilters,
 };
 
 use log::Record;
@@ -1571,11 +1572,16 @@ fn run() -> Result<(), CliError> {
                     SubCommand::with_name("list")
                         .about("List Purchase Orders")
                         .arg(
-                            Arg::with_name("org")
-                                .value_name("org_id")
-                                .long("org")
+                            Arg::with_name("buyer_org")
+                                .long("buyer-org")
                                 .takes_value(true)
-                                .help("Only list Purchase Orders from the specified organization"),
+                                .help("Only list Purchase Orders from the specified buyer organization"),
+                        )
+                        .arg(
+                            Arg::with_name("seller_org")
+                                .long("seller-org")
+                                .takes_value(true)
+                                .help("Only list Purchase Orders from the specified seller organization"),
                         )
                         .arg(
                             Arg::with_name("accepted")
@@ -1677,41 +1683,12 @@ fn run() -> Result<(), CliError> {
                         .about("Show a Purchase Order")
                         .arg(
                             Arg::with_name("id")
-                                .value_name("order")
                                 .takes_value(true)
                                 .required(true)
                                 .help(
                                     "ID of the Purchase Order. \
-                                    May be the Purchase Order's UUID or an Alternate ID \
+                                    May be the Purchase Order's UID or an Alternate ID \
                                     (Alternate ID format: <alternate_id_type>:<alternate_id>)",
-                                ),
-                        )
-                        .arg(
-                            Arg::with_name("org")
-                                .value_name("org_id")
-                                .long("org")
-                                .takes_value(true)
-                                .required(true)
-                                .help("ID of the organization that owns the Purchase Order"),
-                        )
-                        .arg(
-                            Arg::with_name("version")
-                                .value_name("version_id")
-                                .long("version")
-                                .takes_value(true)
-                                .help(
-                                    "ID of the version of the Purchase Order to show. \
-                                    Defaults to an accepted version",
-                                ),
-                        )
-                        .arg(
-                            Arg::with_name("revision")
-                                .value_name("revision_id")
-                                .long("revision")
-                                .takes_value(true)
-                                .help(
-                                    "ID of the revision of the Purchase Order to show. \
-                                    Defaults to the latest revision",
                                 ),
                         )
                         .arg(
@@ -2753,8 +2730,78 @@ fn run() -> Result<(), CliError> {
                         CliError::UserError(format!("Could not fetch Purchase Order {}", &uid));
                     }
                 }
-                ("list", Some(_)) => unimplemented!(),
-                ("show", Some(_)) => unimplemented!(),
+                ("list", Some(m)) => {
+                    let url = m
+                        .value_of("url")
+                        .map(String::from)
+                        .or_else(|| env::var(GRID_DAEMON_ENDPOINT).ok())
+                        .unwrap_or_else(|| String::from("http://localhost:8000"));
+
+                    let service_id = m
+                        .value_of("service_id")
+                        .map(String::from)
+                        .or_else(|| env::var(GRID_SERVICE_ID).ok());
+
+                    let purchase_order_client = client_factory.get_purchase_order_client(url);
+
+                    let filter = ListPOFilters {
+                        is_open: if m.is_present("open") {
+                            Some(true)
+                        } else if m.is_present("closed") {
+                            Some(false)
+                        } else {
+                            None
+                        },
+                        has_accepted_version: if m.is_present("accepted") {
+                            Some(true)
+                        } else if m.is_present("not_accepted") {
+                            Some(false)
+                        } else {
+                            None
+                        },
+                        buyer_org_id: if m.is_present("buyer_org") {
+                            Some(m.value_of("buyer_org").unwrap().to_string())
+                        } else {
+                            None
+                        },
+                        seller_org_id: if m.is_present("seller_org") {
+                            Some(m.value_of("seller_org").unwrap().to_string())
+                        } else {
+                            None
+                        },
+                    };
+                    let format = m.value_of("format");
+
+                    purchase_orders::do_list_purchase_orders(
+                        purchase_order_client,
+                        Some(filter),
+                        service_id,
+                        format,
+                    )?
+                }
+                ("show", Some(m)) => {
+                    let url = m
+                        .value_of("url")
+                        .map(String::from)
+                        .or_else(|| env::var(GRID_DAEMON_ENDPOINT).ok())
+                        .unwrap_or_else(|| String::from("http://localhost:8000"));
+
+                    let service_id = m
+                        .value_of("service_id")
+                        .map(String::from)
+                        .or_else(|| env::var(GRID_SERVICE_ID).ok());
+
+                    let purchase_order_client = client_factory.get_purchase_order_client(url);
+
+                    let purchase_order_id = m.value_of("id").unwrap();
+                    let format = m.value_of("format");
+                    purchase_orders::do_show_purchase_order(
+                        purchase_order_client,
+                        purchase_order_id.to_string(),
+                        service_id,
+                        format,
+                    )?
+                }
                 ("version", Some(m)) => match m.subcommand() {
                     ("create", Some(m)) => {
                         let key = m
@@ -2859,7 +2906,7 @@ fn run() -> Result<(), CliError> {
                             draft_filter = Some(false);
                         }
 
-                        let format = m.value_of("format").unwrap();
+                        let format = Some(m.value_of("format").unwrap());
 
                         purchase_orders::do_list_versions(
                             &*purchase_order_client,

--- a/sdk/src/client/location/reqwest.rs
+++ b/sdk/src/client/location/reqwest.rs
@@ -151,8 +151,12 @@ impl LocationClient for ReqwestLocationClient {
     ///
     /// * `service_id` - optional - the service id to fetch locations from
     fn list_locations(&self, service_id: Option<&str>) -> Result<Vec<Location>, ClientError> {
-        let dto_vec =
-            fetch_entities_list::<LocationDto>(&self.url, LOCATION_ROUTE.to_string(), service_id)?;
+        let dto_vec = fetch_entities_list::<LocationDto>(
+            &self.url,
+            LOCATION_ROUTE.to_string(),
+            service_id,
+            None,
+        )?;
         Ok(dto_vec.iter().map(Location::from).collect())
     }
 }

--- a/sdk/src/client/pike/reqwest.rs
+++ b/sdk/src/client/pike/reqwest.rs
@@ -198,8 +198,12 @@ impl PikeClient for ReqwestPikeClient {
     ///
     /// * `service_id` - optional - the service id to fetch the agents from
     fn list_agents(&self, service_id: Option<&str>) -> Result<Vec<PikeAgent>, ClientError> {
-        let dto_vec =
-            fetch_entities_list::<PikeAgentDto>(&self.url, AGENT_ROUTE.to_string(), service_id)?;
+        let dto_vec = fetch_entities_list::<PikeAgentDto>(
+            &self.url,
+            AGENT_ROUTE.to_string(),
+            service_id,
+            None,
+        )?;
         Ok(dto_vec.iter().map(PikeAgent::from).collect())
     }
 
@@ -235,6 +239,7 @@ impl PikeClient for ReqwestPikeClient {
             &self.url,
             ORGANIZATION_ROUTE.to_string(),
             service_id,
+            None,
         )?;
         Ok(dto_vec.iter().map(PikeOrganization::from).collect())
     }
@@ -275,6 +280,7 @@ impl PikeClient for ReqwestPikeClient {
             &self.url,
             format!("{}/{}", ROLE_ROUTE, org_id),
             service_id,
+            None,
         )?;
         Ok(dto_vec.iter().map(PikeRole::from).collect())
     }

--- a/sdk/src/client/product/reqwest.rs
+++ b/sdk/src/client/product/reqwest.rs
@@ -134,8 +134,12 @@ impl ProductClient for ReqwestProductClient {
     ///
     /// * `service_id`: the service id to fetch the products from
     fn list_products(&self, service_id: Option<&str>) -> Result<Vec<Product>, ClientError> {
-        let dto_vec =
-            fetch_entities_list::<ProductDto>(&self.url, PRODUCT_ROUTE.to_string(), service_id)?;
+        let dto_vec = fetch_entities_list::<ProductDto>(
+            &self.url,
+            PRODUCT_ROUTE.to_string(),
+            service_id,
+            None,
+        )?;
         Ok(dto_vec.iter().map(Product::from).collect())
     }
 }

--- a/sdk/src/client/purchase_order/mod.rs
+++ b/sdk/src/client/purchase_order/mod.rs
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
-use std::time::SystemTime;
 
 use crate::error::ClientError;
 use crate::protocol::purchase_order::state::{
     PurchaseOrderAlternateId, PurchaseOrderAlternateIdBuilder,
 };
-use crate::purchase_order::store::ListVersionFilters;
+use crate::purchase_order::store::{ListPOFilters, ListVersionFilters};
 
 use super::Client;
 
@@ -34,7 +33,7 @@ pub struct PurchaseOrder {
     pub is_closed: bool,
     pub accepted_version_id: Option<String>,
     pub versions: Vec<PurchaseOrderVersion>,
-    pub created_at: SystemTime,
+    pub created_at: i64,
     pub workflow_type: String,
 }
 
@@ -42,7 +41,7 @@ pub struct PurchaseOrderVersion {
     pub version_id: String,
     pub workflow_status: String,
     pub is_draft: bool,
-    pub current_revision_id: i64,
+    pub current_revision_id: u64,
     pub revisions: Vec<PurchaseOrderRevision>,
 }
 
@@ -50,7 +49,7 @@ pub struct PurchaseOrderRevision {
     pub revision_id: u64,
     pub order_xml_v3_4: String,
     pub submitter: String,
-    pub created_at: u64,
+    pub created_at: i64,
 }
 
 pub struct AlternateId {
@@ -104,7 +103,7 @@ pub trait PurchaseOrderClient: Client {
     ///
     /// # Arguments
     ///
-    /// * `id` - The uuid of the `PurchaseOrder` containing the `PurchaseOrderVersion` to be retrieved
+    /// * `id` - The id of the `PurchaseOrder` containing the `PurchaseOrderVersion` to be retrieved
     /// * `version_id` - The version id of the `PurchaseOrderVersion` to be retrieved
     /// * `service_id` - The service ID to fetch the versions from
     fn get_purchase_order_version(
@@ -119,7 +118,7 @@ pub trait PurchaseOrderClient: Client {
     ///
     /// # Arguments
     ///
-    /// * `id` - The uuid of the `PurchaseOrder` containing the `PurchaseOrderRevision` to be retrieved
+    /// * `id` - The id of the `PurchaseOrder` containing the `PurchaseOrderRevision` to be retrieved
     /// * `version_id` - The version id of the `PurchaseOrderVersion` containing the
     ///   `PurchaseOrderRevision` to be retrieved
     /// * `revision_id` - The revision number of the `PurchaseOrderRevision` to be retrieved
@@ -137,8 +136,12 @@ pub trait PurchaseOrderClient: Client {
     /// # Arguments
     ///
     /// * `filter` - Filter to apply to the list of `PurchaseOrder`s
-    fn list_purchase_orders(&self, filter: Option<&str>)
-        -> Result<Vec<PurchaseOrder>, ClientError>;
+    /// * `service_id` - optional service id if running splinter
+    fn list_purchase_orders(
+        &self,
+        filters: Option<ListPOFilters>,
+        service_id: Option<&str>,
+    ) -> Result<Vec<PurchaseOrder>, ClientError>;
 
     /// lists the purchase order versions of a specific purchase order.
     ///
@@ -150,7 +153,7 @@ pub trait PurchaseOrderClient: Client {
     fn list_purchase_order_versions(
         &self,
         id: String,
-        filters: ListVersionFilters,
+        filters: Option<ListVersionFilters>,
         service_id: Option<&str>,
     ) -> Result<Vec<PurchaseOrderVersion>, ClientError>;
 
@@ -158,7 +161,7 @@ pub trait PurchaseOrderClient: Client {
     ///
     /// # Arguments
     ///
-    /// * `id` - The uuid of the `PurchaseOrder` containing the `PurchaseOrderRevision`s to be listed
+    /// * `id` - The id of the `PurchaseOrder` containing the `PurchaseOrderRevision`s to be listed
     /// * `version_id` - The version id of the `PurchaseOrderVersion` containing
     ///   the `PurchaseOrderRevision`s to be listed
     /// * `service_id` - The service ID to fetch the revisions from

--- a/sdk/src/client/schema/reqwest.rs
+++ b/sdk/src/client/schema/reqwest.rs
@@ -144,8 +144,12 @@ impl SchemaClient for ReqwestSchemaClient {
     ///
     /// * `service_id` - optional - the service id to fetch the schemas from
     fn list_schemas(&self, service_id: Option<&str>) -> Result<Vec<Schema>, ClientError> {
-        let dto_vec =
-            fetch_entities_list::<SchemaDto>(&self.url, SCHEMA_ROUTE.to_string(), service_id)?;
+        let dto_vec = fetch_entities_list::<SchemaDto>(
+            &self.url,
+            SCHEMA_ROUTE.to_string(),
+            service_id,
+            None,
+        )?;
         Ok(dto_vec.iter().map(Schema::from).collect())
     }
 }


### PR DESCRIPTION
This PR updates the Grid CLI to include functionality to list and show a Grid Purchase Order. This includes changes to the Purchase Order client to update the structs and functions to align with the RFC and current discussions. It also includes updates to the version and revision list/show commands to use the new display utility functions/patterns introduced here.