### PR TITLE
Validate self workflow state in `can_transition`

### DIFF
--- a/sdk/src/workflow/mod.rs
+++ b/sdk/src/workflow/mod.rs
@@ -64,7 +64,7 @@ mod tests {
         permission.add_permission("can-update-po");
         permission.add_transition("confirm");
 
-        let state = WorkflowStateBuilder::new("issued")
+        let state = WorkflowStateBuilder::new("create")
             .add_constraint("active=None")
             .add_transition("issued")
             .add_transition("confirm")

--- a/sdk/src/workflow/state.rs
+++ b/sdk/src/workflow/state.rs
@@ -22,6 +22,10 @@ pub struct WorkflowState {
 
 impl WorkflowState {
     pub fn can_transition(&self, new_state: String, pike_permissions: Vec<String>) -> bool {
+        if self.name == new_state {
+            return true;
+        }
+
         if !self.transitions.contains(&new_state) {
             return false;
         }


### PR DESCRIPTION
This change updates the workflow state module's `can_transition` method,
which validates whether an agent has the correct permissions to
transition to a new workflow state, to check the workflow state's name.
This covers a case in which an agent is not attempting to transition a
workflow, but rather update an object. 

Previously, the `can_transition`
method would return false if it did not have it's own name within it's
transitions. Rather than add all of the workflow states as transitions
to their own state, this will check if we are staying in the same
workflow state and return `true`, as we are not transitioning.

This PR also updates a test to change the name of the workflow state used. This allows an alias' transitions to be validated, while avoiding a situation where the alias is attempting to transition to the same state.