### PR TITLE
Remove `sawtooth-compat` from SDK

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -48,7 +48,7 @@ log = "0.4"
 protobuf = "2.19"
 reqwest = { version = "0.10.1", optional = true, features = ["json", "blocking"] }
 sabre-sdk = { version = "0.5", optional = true }
-sawtooth-sdk = { version = "0.4", features = ["transact-compat"] }
+sawtooth-sdk = { version = "0.4", features = ["transact-compat"], optional = true }
 scabbard = { version = "0.4", optional = true, features = ["client", "events"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
@@ -113,7 +113,8 @@ sawtooth-support = [
     "database",
     "event",
     "grid-sdk/backend-sawtooth",
-    "grid-sdk/sawtooth-compat",
+    "sawtooth-sdk",
+    "sabre-sdk",
     "rest-api"
 ]
 schema = ["grid-sdk/rest-api-endpoint-schema", "grid-sdk/schema", "pike"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -118,7 +118,6 @@ experimental = [
     "rest-api-resources-purchase-order",
     "rest-api-resources-submit",
     "rest-api-resources-track-and-trace",
-    "sawtooth-compat",
     "track-and-trace",
     "workflow"
 ]
@@ -174,9 +173,5 @@ rest-api-resources-role = ["pike", "rest-api-resources"]
 rest-api-resources-schema = ["rest-api-resources", "schema"]
 rest-api-resources-submit = ["batch-store", "cylinder", "rest-api-resources", "sabre-sdk"]
 rest-api-resources-track-and-trace = ["rest-api-resources", "track-and-trace"]
-sawtooth-compat = [
-    "sabre-sdk",
-    "sawtooth-sdk"
-]
 sqlite = ["chrono", "diesel/sqlite", "diesel_migrations", "log"]
 workflow = []


### PR DESCRIPTION
This change removes the `sawtooth-compat` feature from the SDK. The
dependencies pulled in by this feature are already pulled in based on
the `target_arch` and the `sawtooth-compat` feature itself does not
protect any code within the SDK.

This also updates the `sawtooth-support` feature in the daemon to pull
in the Sabre and Sawtooth SDKs individually.

Signed-off-by: Shannyn Telander <telander@bitwise.io>