### PR TITLE
Backport 0-2: Backport the cylinder-jwt-support feature

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -86,11 +86,13 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "cylinder-jwt-support",
     "integration",
     "purchase-order",
     "track-and-trace",
 ]
 
+cylinder-jwt-support = ["cylinder/jwt", "grid-sdk/cylinder-jwt-support"]
 event = ["database"]
 database = []
 database-postgres = ["grid-sdk/postgres"]

--- a/daemon/src/splinter/app_auth_handler/mod.rs
+++ b/daemon/src/splinter/app_auth_handler/mod.rs
@@ -62,10 +62,14 @@ pub fn run(
     handler: Box<dyn EventHandler>,
     igniter: Igniter,
     scabbard_admin_key: String,
+    #[cfg(feature = "cylinder-jwt-support")] authorization: String,
 ) -> Result<(), AppAuthHandlerError> {
     let registration_route = format!("{}/ws/admin/register/grid", &splinterd_url);
-
-    let node_id = get_node_id(splinterd_url.clone())?;
+    let node_id = get_node_id(
+        splinterd_url.clone(),
+        #[cfg(feature = "cylinder-jwt-support")]
+        &authorization,
+    )?;
 
     let ws_handler = Arc::new(Mutex::new(handler));
     let mut ws = WebSocketClient::new(&registration_route, move |_ctx, event| {
@@ -91,6 +95,9 @@ pub fn run(
         }
         WsResponse::Empty
     });
+
+    #[cfg(feature = "cylinder-jwt-support")]
+    ws.header("Authorization", authorization);
 
     ws.set_reconnect(RECONNECT);
     ws.set_reconnect_limit(RECONNECT_LIMIT);

--- a/daemon/src/splinter/app_auth_handler/mod.rs
+++ b/daemon/src/splinter/app_auth_handler/mod.rs
@@ -72,6 +72,8 @@ pub fn run(
     )?;
 
     let ws_handler = Arc::new(Mutex::new(handler));
+    #[cfg(feature = "cylinder-jwt-support")]
+    let ws_auth = authorization.clone();
     let mut ws = WebSocketClient::new(&registration_route, move |_ctx, event| {
         let handler = {
             match ws_handler.lock() {
@@ -90,6 +92,8 @@ pub fn run(
             &node_id,
             &scabbard_admin_key,
             &splinterd_url,
+            #[cfg(feature = "cylinder-jwt-support")]
+            &ws_auth,
         ) {
             error!("Failed to process admin event: {}", err);
         }
@@ -130,6 +134,7 @@ fn process_admin_event(
     node_id: &str,
     scabbard_admin_key: &str,
     splinterd_url: &str,
+    #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
 ) -> Result<(), AppAuthHandlerError> {
     debug!("Received the event at {}", event.timestamp);
     match event.admin_event {
@@ -170,9 +175,14 @@ fn process_admin_event(
                 })?;
 
             event_processors
-                .add_once(&msg_proposal.circuit_id, &service.service_id, None, || {
-                    vec![handler.cloned_box()]
-                })
+                .add_once(
+                    &msg_proposal.circuit_id,
+                    &service.service_id,
+                    None,
+                    #[cfg(feature = "cylinder-jwt-support")]
+                    authorization,
+                    || vec![handler.cloned_box()],
+                )
                 .map_err(|err| AppAuthHandlerError::from_source(Box::new(err)))?;
 
             setup_grid(

--- a/daemon/src/splinter/run.rs
+++ b/daemon/src/splinter/run.rs
@@ -203,6 +203,8 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
         chan_event_handler,
         reactor.igniter(),
         scabbard_admin_key.to_string(),
+        #[cfg(feature = "cylinder-jwt-support")]
+        authorization.clone(),
     )
     .map_err(|err| DaemonError::from_source(Box::new(err)))?;
 

--- a/daemon/src/splinter/run.rs
+++ b/daemon/src/splinter/run.rs
@@ -20,12 +20,16 @@ use std::convert::TryFrom;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::process;
+#[cfg(feature = "cylinder-jwt-support")]
+use std::sync::Mutex;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
 
 use cylinder::load_key;
+#[cfg(feature = "cylinder-jwt-support")]
+use cylinder::{secp256k1::Secp256k1Context, Context};
 use grid_sdk::backend::SplinterBackendClient;
 use grid_sdk::commits::store::Commit;
 use grid_sdk::commits::{CommitStore, DieselCommitStore};
@@ -75,10 +79,11 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
     let splinter_endpoint = Endpoint::from(config.endpoint());
     let reactor = Reactor::new();
 
-    let scabbard_admin_key = load_key("gridd", &[PathBuf::from(config.admin_key_dir())])
+    let gridd_key = load_key("gridd", &[PathBuf::from(config.admin_key_dir())])
         .map_err(|err| DaemonError::from_source(Box::new(err)))?
-        .ok_or_else(|| DaemonError::with_message("no private key found"))?
-        .as_hex();
+        .ok_or_else(|| DaemonError::with_message("no private key found"))?;
+
+    let scabbard_admin_key = &gridd_key.as_hex();
 
     let scabbard_event_connection_factory =
         ScabbardEventConnectionFactory::new(&splinter_endpoint.url(), reactor.igniter());
@@ -189,10 +194,17 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
         event_processors,
         chan_event_handler,
         reactor.igniter(),
-        scabbard_admin_key,
+        scabbard_admin_key.to_string(),
     )
     .map_err(|err| DaemonError::from_source(Box::new(err)))?;
 
+    #[cfg(feature = "cylinder-jwt-support")]
+    let signer = Secp256k1Context::new().new_signer(gridd_key);
+
+    #[cfg(feature = "cylinder-jwt-support")]
+    let backend_client =
+        SplinterBackendClient::new(splinter_endpoint.url(), Arc::new(Mutex::new(signer)));
+    #[cfg(not(feature = "cylinder-jwt-support"))]
     let backend_client = SplinterBackendClient::new(splinter_endpoint.url());
     let backend_state = BackendState::new(Arc::new(backend_client));
 

--- a/daemon/src/splinter/run.rs
+++ b/daemon/src/splinter/run.rs
@@ -191,6 +191,8 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
                     service_id.circuit_id,
                     service_id.service_id,
                     Some(&commit.commit_id),
+                    #[cfg(feature = "cylinder-jwt-support")]
+                    &authorization,
                     || vec![chan_event_handler.cloned_box()],
                 )
                 .map_err(|err| DaemonError::from_source(Box::new(err)))?;

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -105,6 +105,7 @@ experimental = [
     "batch-store",
     "client",
     "client-reqwest",
+    "cylinder-jwt-support",
     "pike-rest-api",
     "purchase-order",
     "rest-api-resources",
@@ -126,6 +127,7 @@ backend-sawtooth = ["backend", "uuid"]
 backend-splinter = ["backend", "reqwest"]
 client = []
 client-reqwest = ["client", "reqwest"]
+cylinder-jwt-support = ["cylinder/jwt"]
 location = ["pike", "schema"]
 pike = ["cfg-if"]
 pike-rest-api = ["pike", "serde_json", "rest-api-resources"]

--- a/sdk/src/backend/splinter.rs
+++ b/sdk/src/backend/splinter.rs
@@ -139,9 +139,16 @@ impl BackendClient for SplinterBackendClient {
         url.push_str("ids=");
         url.push_str(&msg.batch_ids.join(","));
 
-        let client = reqwest::Client::new();
+        let mut client = reqwest::Client::new().get(&url);
+
+        client = client.header("GridProtocolVersion", "1");
+
+        #[cfg(feature = "cylinder-jwt-support")]
+        {
+            client = client.header("Authorization", &self.authorization.to_string());
+        }
+
         client
-            .get(&url)
             .send()
             .then(|res| match res {
                 Ok(res) => res.json().boxed(),

--- a/sdk/src/backend/splinter.rs
+++ b/sdk/src/backend/splinter.rs
@@ -14,11 +14,7 @@
 
 use std::pin::Pin;
 use std::str::FromStr;
-#[cfg(feature = "cylinder-jwt-support")]
-use std::sync::{Arc, Mutex};
 
-#[cfg(feature = "cylinder-jwt-support")]
-use cylinder::{jwt::JsonWebTokenBuilder, Signer};
 use futures::prelude::*;
 use protobuf::Message;
 use sawtooth_sdk::messages::batch::Batch;
@@ -37,32 +33,25 @@ macro_rules! try_fut {
     };
 }
 
-#[cfg(feature = "cylinder-jwt-support")]
-pub fn create_cylinder_jwt_auth(signer: &dyn Signer) -> Result<String, BackendClientError> {
-    let encoded_token = JsonWebTokenBuilder::new().build(&*signer).map_err(|err| {
-        BackendClientError::BadRequestError(format!("failed to build json web token: {}", err))
-    })?;
-    Ok(format!("Bearer Cylinder:{}", encoded_token))
-}
-
 #[derive(Clone)]
 pub struct SplinterBackendClient {
     node_url: String,
     #[cfg(feature = "cylinder-jwt-support")]
-    signer: Arc<Mutex<Box<dyn Signer>>>,
+    authorization: String,
 }
 
 impl SplinterBackendClient {
     /// Constructs a new splinter BackendClient instance, using the given url for the node's REST
     /// API.
-    #[cfg(not(feature = "cylinder-jwt-support"))]
-    pub fn new(node_url: String) -> Self {
-        Self { node_url }
-    }
-
-    #[cfg(feature = "cylinder-jwt-support")]
-    pub fn new(node_url: String, signer: Arc<Mutex<Box<dyn Signer>>>) -> Self {
-        Self { node_url, signer }
+    pub fn new(
+        node_url: String,
+        #[cfg(feature = "cylinder-jwt-support")] authorization: String,
+    ) -> Self {
+        Self {
+            node_url,
+            #[cfg(feature = "cylinder-jwt-support")]
+            authorization,
+        }
     }
 }
 
@@ -76,18 +65,6 @@ impl BackendClient for SplinterBackendClient {
         }));
 
         let service_info = try_fut!(SplinterService::from_str(&service_arg));
-
-        #[cfg(feature = "cylinder-jwt-support")]
-        let signer = try_fut!(self
-            .signer
-            .lock()
-            .map_err(|err| BackendClientError::InternalError(format!(
-                "Could not get signer: {}",
-                err
-            ))));
-
-        #[cfg(feature = "cylinder-jwt-support")]
-        let auth = try_fut!(create_cylinder_jwt_auth(&**signer));
 
         let url = format!(
             "{}/scabbard/{}/{}/batches",
@@ -117,7 +94,7 @@ impl BackendClient for SplinterBackendClient {
 
         #[cfg(feature = "cylinder-jwt-support")]
         {
-            client = client.header("Authorization", auth);
+            client = client.header("Authorization", &self.authorization.to_string());
         }
 
         client


### PR DESCRIPTION
This change backports the updates made to add Cylinder JWT authorization to Grid, to allow it to run with current versions of Splinter.