### PR TITLE
Backport 0-2: Update the image used by node

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Cargill Incorporated
+# Copyright 2018-2021 Cargill Incorporated
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Canopy build stage
-FROM node:lts-alpine as canopy-app-build-stage
+FROM node:14.18.1-alpine3.11 as canopy-app-build-stage
 
 RUN apk update && apk add python g++ git make && rm -rf /var/cache/apk/*
 WORKDIR /ui
@@ -34,7 +34,7 @@ WORKDIR /tmp
 RUN git rev-parse HEAD > /commit-hash
 
 # Sapling build stage
-FROM node:lts-alpine as sapling-build-stage
+FROM node:14.18.1-alpine3.11 as sapling-build-stage
 
 RUN apk update && apk add git
 

--- a/ui/grid-ui/docker/test/Dockerfile
+++ b/ui/grid-ui/docker/test/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Cargill Incorporated
+# Copyright 2018-2021 Cargill Incorporated
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for running unit tests and lint on the Grid UI
-FROM node:lts-alpine
+FROM node:14.18.1-alpine3.11
 
 COPY ui/grid-ui/package*.json ui/grid-ui/
 

--- a/ui/saplings/product/test/Dockerfile
+++ b/ui/saplings/product/test/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Cargill Incorporated
+# Copyright 2018-2021 Cargill Incorporated
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for running unit tests and lint on the Grid UI
-FROM node:lts-alpine
+FROM node:14.18.1-alpine3.11
 
 WORKDIR /ui/saplings/product
 


### PR DESCRIPTION
This change updates the image used by node within the UI Dockerfiles,
from `lts-alpine` to `14.18.1-alpine3.11`.

This change also updates the copyright headers within the affected files
to include the current year.

Signed-off-by: Shannyn Telander <telander@bitwise.io>