### PR TITLE
Remove current revision ID from update payload

### DIFF
--- a/contracts/purchase_order/src/payload.rs
+++ b/contracts/purchase_order/src/payload.rs
@@ -189,14 +189,6 @@ pub(crate) fn validate_update_version_payload(
 
     validate_payload_revision(payload.revision())?;
 
-    if payload.current_revision_id() != payload.revision().revision_id() {
-        return Err(ApplyError::InvalidTransaction(
-            "Payload's `current_revision_id` must be equal to the `revision`'s \
-            `revision_id` within this payload"
-                .to_string(),
-        ));
-    }
-
     Ok(())
 }
 
@@ -341,7 +333,6 @@ mod tests {
         update_version_payload.set_version_id("01".to_string());
         update_version_payload.set_po_uid("PO-01".to_string());
         update_version_payload.set_workflow_status("proposed".to_string());
-        update_version_payload.set_current_revision_id(2);
         update_version_payload.set_revision(payload_revision_proto);
         let version_native = update_version_payload
             .clone()
@@ -372,7 +363,6 @@ mod tests {
             protos::purchase_order_payload::UpdateVersionPayload::new();
         update_version_payload.set_po_uid("PO-01".to_string());
         update_version_payload.set_workflow_status("proposed".to_string());
-        update_version_payload.set_current_revision_id(2);
         update_version_payload.set_revision(payload_revision_proto);
         let version_native = update_version_payload
             .clone()
@@ -403,7 +393,6 @@ mod tests {
             protos::purchase_order_payload::UpdateVersionPayload::new();
         update_version_payload.set_version_id("01".to_string());
         update_version_payload.set_workflow_status("proposed".to_string());
-        update_version_payload.set_current_revision_id(2);
         update_version_payload.set_revision(payload_revision_proto);
         let version_native = update_version_payload
             .clone()
@@ -434,38 +423,6 @@ mod tests {
             protos::purchase_order_payload::UpdateVersionPayload::new();
         update_version_payload.set_version_id("01".to_string());
         update_version_payload.set_po_uid("PO-01".to_string());
-        update_version_payload.set_current_revision_id(2);
-        update_version_payload.set_revision(payload_revision_proto);
-        let version_native = update_version_payload
-            .clone()
-            .into_native()
-            .expect("Unable to create protocol UpdateVersionPayload");
-        // Validate the update version payload is not successful
-        assert!(validate_update_version_payload(&version_native).is_err());
-    }
-
-    #[test]
-    /// Validates that an `UpdateVersionPayload` with an undefined `current_revision_id` is not
-    /// able to be validated. The test follows these steps:
-    ///
-    /// 1. Create an `UpdateVersionPayload` protobuf message and define all fields except the
-    ///    `current_revision_id` field
-    /// 2. Assert this `UpdateVersionPayload` does not successfully validate
-    ///
-    /// This test validates that a `UpdateVersionPayload` with an undefined `current_revision_id`
-    /// field produces an error on validation.
-    fn test_validate_update_version_payload_invalid_current_revision_id() {
-        let mut payload_revision_proto = protos::purchase_order_payload::PayloadRevision::new();
-        payload_revision_proto.set_revision_id(2);
-        payload_revision_proto.set_submitter(SUBMITTER.to_string());
-        payload_revision_proto.set_created_at(1);
-        payload_revision_proto.set_order_xml_v3_4(XML_TEST_STRING.to_string());
-
-        let mut update_version_payload =
-            protos::purchase_order_payload::UpdateVersionPayload::new();
-        update_version_payload.set_version_id("01".to_string());
-        update_version_payload.set_po_uid("PO-01".to_string());
-        update_version_payload.set_workflow_status("proposed".to_string());
         update_version_payload.set_revision(payload_revision_proto);
         let version_native = update_version_payload
             .clone()
@@ -491,47 +448,11 @@ mod tests {
         update_version_payload.set_version_id("01".to_string());
         update_version_payload.set_po_uid("PO-01".to_string());
         update_version_payload.set_workflow_status("proposed".to_string());
-        update_version_payload.set_current_revision_id(2);
         let version_native = update_version_payload
             .clone()
             .into_native()
             .expect("Unable to create protocol UpdateVersionPayload");
         // Validate the update version payload is not successful
-        assert!(validate_update_version_payload(&version_native).is_err());
-    }
-
-    #[test]
-    /// Validates that an `UpdateVersionPayload` is invalid if the `current_revision_id` does not
-    /// match the `revision_id` of the revision submitted in the payload. The test follows these
-    /// steps:
-    ///
-    /// 1. Create a `PayloadRevision` protobuf message and define all fields, including a
-    ///    `revision_id` of `3`
-    /// 2. Create an `UpdateVersionPayload` protobuf message and define all fields, including
-    ///    the `current_revision_id` set to `2`
-    /// 2. Assert this `UpdateVersionPayload` produces an error on validation
-    ///
-    /// This test validates that a `UpdateVersionPayload` with a mismatching `revision` and
-    /// `current_revision_id` produces an error on validation.
-    fn test_validate_update_version_payload_current_revision_id_non_matching() {
-        let mut payload_revision_proto = protos::purchase_order_payload::PayloadRevision::new();
-        payload_revision_proto.set_revision_id(3);
-        payload_revision_proto.set_submitter(SUBMITTER.to_string());
-        payload_revision_proto.set_created_at(1);
-        payload_revision_proto.set_order_xml_v3_4(XML_TEST_STRING.to_string());
-
-        let mut update_version_payload =
-            protos::purchase_order_payload::UpdateVersionPayload::new();
-        update_version_payload.set_version_id("01".to_string());
-        update_version_payload.set_po_uid("PO-01".to_string());
-        update_version_payload.set_workflow_status("proposed".to_string());
-        update_version_payload.set_current_revision_id(2);
-        update_version_payload.set_revision(payload_revision_proto);
-        let version_native = update_version_payload
-            .clone()
-            .into_native()
-            .expect("Unable to create protocol UpdateVersionPayload");
-        // Validate the update version payload is successful
         assert!(validate_update_version_payload(&version_native).is_err());
     }
 

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -64,7 +64,6 @@ message UpdateVersionPayload {
   string po_uid = 2;
   string workflow_status = 3;
   bool is_draft = 4;
-  uint64 current_revision_id = 5;
   PayloadRevision revision = 6;
 }
 

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -872,7 +872,6 @@ pub struct UpdateVersionPayload {
     po_uid: String,
     workflow_status: String,
     is_draft: bool,
-    current_revision_id: u64,
     revision: PayloadRevision,
 }
 
@@ -893,10 +892,6 @@ impl UpdateVersionPayload {
         self.is_draft
     }
 
-    pub fn current_revision_id(&self) -> u64 {
-        self.current_revision_id
-    }
-
     pub fn revision(&self) -> &PayloadRevision {
         &self.revision
     }
@@ -911,7 +906,6 @@ impl FromProto<purchase_order_payload::UpdateVersionPayload> for UpdateVersionPa
             po_uid: proto.take_po_uid(),
             workflow_status: proto.take_workflow_status(),
             is_draft: proto.get_is_draft(),
-            current_revision_id: proto.get_current_revision_id(),
             revision: PayloadRevision::from_proto(proto.take_revision())?,
         })
     }
@@ -924,7 +918,6 @@ impl FromNative<UpdateVersionPayload> for purchase_order_payload::UpdateVersionP
         proto.set_po_uid(native.po_uid().to_string());
         proto.set_workflow_status(native.workflow_status().to_string());
         proto.set_is_draft(native.is_draft());
-        proto.set_current_revision_id(native.current_revision_id());
         proto.set_revision(native.revision().clone().into_proto()?);
 
         Ok(proto)
@@ -965,7 +958,6 @@ pub struct UpdateVersionPayloadBuilder {
     po_uid: Option<String>,
     workflow_status: Option<String>,
     is_draft: Option<bool>,
-    current_revision_id: Option<u64>,
     revision: Option<PayloadRevision>,
 }
 
@@ -994,11 +986,6 @@ impl UpdateVersionPayloadBuilder {
         self
     }
 
-    pub fn with_current_revision_id(mut self, value: u64) -> Self {
-        self.current_revision_id = Some(value);
-        self
-    }
-
     pub fn with_revision(mut self, value: PayloadRevision) -> Self {
         self.revision = Some(value);
         self
@@ -1021,10 +1008,6 @@ impl UpdateVersionPayloadBuilder {
             BuilderError::MissingField("'is_draft' field is required".to_string())
         })?;
 
-        let current_revision_id = self.current_revision_id.ok_or_else(|| {
-            BuilderError::MissingField("'current_revision_id' field is required".to_string())
-        })?;
-
         let revision = self.revision.ok_or_else(|| {
             BuilderError::MissingField("'revision' field is required".to_string())
         })?;
@@ -1034,7 +1017,6 @@ impl UpdateVersionPayloadBuilder {
             po_uid,
             workflow_status,
             is_draft,
-            current_revision_id,
             revision,
         })
     }


### PR DESCRIPTION
This change removes the `current_revision_id` from the
`UpdateVersionPayload`. This payload includes a `PayloadRevision` which
is the source of this value, otherwise the value is automatically
incremented based on the previous revision. Therefore, the payload does
not need this value.

Signed-off-by: Shannyn Telander <telander@bitwise.io>