### PR TITLE
Support `alternate_id` for PO creation and lookup

### DIFF
--- a/cli/man/grid-po-create.1.md
+++ b/cli/man/grid-po-create.1.md
@@ -42,7 +42,7 @@ output.
 OPTIONS
 =======
 
-`--id`
+`--alternate-id`
 : Optionally include an alternate ID. This may be specified multiple times.
 An ID is of the format `alternate_id_type:alternate_id`.
 Examples: `po_number:12348959` and/or `internal_po_id:a8f9fke`.
@@ -83,7 +83,7 @@ $ grid po create \
     --buyer-org=crgl \
     --seller-org=crgl2 \
     --workflow-status=Issued \
-    --id=po_number:8329173 \
+    --alternate-id=po_number:8329173 \
     --wait=0
 ```
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1532,9 +1532,8 @@ fn run() -> Result<(), CliError> {
                                 Defaults to randomly-generated UUID",
                         ))
                         .arg(
-                            Arg::with_name("id")
-                                .value_name("alternate_id")
-                                .long("id")
+                            Arg::with_name("alternate_id")
+                                .long("alternate-id")
                                 .takes_value(true)
                                 .multiple(true)
                                 .help(

--- a/sdk/src/purchase_order/store/diesel/operations/add_purchase_order_version_revision.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/add_purchase_order_version_revision.rs
@@ -37,7 +37,7 @@ pub(in crate) mod pg {
     pub fn add_purchase_order_version_revision(
         conn: &diesel::pg::PgConnection,
         revision: &NewPurchaseOrderVersionRevisionModel,
-        po_id: &str,
+        purchase_order_uid: &str,
     ) -> Result<(), PurchaseOrderStoreError> {
         conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
             let mut query = purchase_order_version_revision::table.into_boxed().filter(
@@ -72,7 +72,7 @@ pub(in crate) mod pg {
 
                 let mut version_query = purchase_order_version::table.into_boxed().filter(
                     purchase_order_version::purchase_order_uid
-                        .eq(po_id)
+                        .eq(purchase_order_uid)
                         .and(purchase_order_version::version_id.eq(&revision.version_id))
                         .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
                 );
@@ -105,7 +105,7 @@ pub(in crate) mod pg {
                         update(purchase_order_version::table)
                             .filter(
                                 purchase_order_version::purchase_order_uid
-                                    .eq(po_id)
+                                    .eq(purchase_order_uid)
                                     .and(
                                         purchase_order_version::version_id.eq(&revision.version_id),
                                     )
@@ -123,7 +123,7 @@ pub(in crate) mod pg {
                         update(purchase_order_version::table)
                             .filter(
                                 purchase_order_version::purchase_order_uid
-                                    .eq(po_id)
+                                    .eq(purchase_order_uid)
                                     .and(
                                         purchase_order_version::version_id.eq(&revision.version_id),
                                     )
@@ -164,7 +164,7 @@ pub(in crate) mod sqlite {
     pub fn add_purchase_order_version_revision(
         conn: &diesel::sqlite::SqliteConnection,
         revision: &NewPurchaseOrderVersionRevisionModel,
-        po_id: &str,
+        purchase_order_uid: &str,
     ) -> Result<(), PurchaseOrderStoreError> {
         conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
             let mut query = purchase_order_version_revision::table.into_boxed().filter(
@@ -199,7 +199,7 @@ pub(in crate) mod sqlite {
 
                 let mut version_query = purchase_order_version::table.into_boxed().filter(
                     purchase_order_version::purchase_order_uid
-                        .eq(po_id)
+                        .eq(purchase_order_uid)
                         .and(purchase_order_version::version_id.eq(&revision.version_id))
                         .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
                 );
@@ -232,7 +232,7 @@ pub(in crate) mod sqlite {
                         update(purchase_order_version::table)
                             .filter(
                                 purchase_order_version::purchase_order_uid
-                                    .eq(po_id)
+                                    .eq(purchase_order_uid)
                                     .and(
                                         purchase_order_version::version_id.eq(&revision.version_id),
                                     )
@@ -250,7 +250,7 @@ pub(in crate) mod sqlite {
                         update(purchase_order_version::table)
                             .filter(
                                 purchase_order_version::purchase_order_uid
-                                    .eq(po_id)
+                                    .eq(purchase_order_uid)
                                     .and(
                                         purchase_order_version::version_id.eq(&revision.version_id),
                                     )

--- a/sdk/src/purchase_order/store/diesel/operations/get_uid_from_alternate_id.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/get_uid_from_alternate_id.rs
@@ -1,0 +1,116 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::commits::MAX_COMMIT_NUM;
+use crate::error::InternalError;
+use crate::purchase_order::store::diesel::{
+    models::PurchaseOrderAlternateIdModel, schema::purchase_order_alternate_id,
+};
+
+use crate::purchase_order::store::PurchaseOrderStoreError;
+use diesel::{prelude::*, result::Error::NotFound};
+
+#[cfg(feature = "postgres")]
+pub(in crate) mod pg {
+    use super::*;
+
+    pub fn get_uid_from_alternate_id(
+        conn: &diesel::pg::PgConnection,
+        alternate_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<String, PurchaseOrderStoreError> {
+        if !alternate_id.contains(':') {
+            return Err(PurchaseOrderStoreError::InternalError(
+                InternalError::with_message(
+                    format!("Could not find alternate ID {}. Alternate IDs must be in the format <id_type>:<id>", alternate_id)
+                )
+            ));
+        }
+        let split: Vec<&str> = alternate_id.split(':').collect();
+        let id_type = split[0];
+        let id = split[1];
+
+        let mut query = purchase_order_alternate_id::table.into_boxed().filter(
+            purchase_order_alternate_id::alternate_id_type
+                .eq(&id_type)
+                .and(purchase_order_alternate_id::alternate_id.eq(&id))
+                .and(purchase_order_alternate_id::end_commit_num.eq(MAX_COMMIT_NUM)),
+        );
+
+        if let Some(service_id) = &service_id {
+            query = query.filter(purchase_order_alternate_id::service_id.eq(service_id));
+        } else {
+            query = query.filter(purchase_order_alternate_id::service_id.is_null());
+        }
+
+        let alt_id_model = query
+            .first::<PurchaseOrderAlternateIdModel>(conn)
+            .map_err(|err| match err {
+                NotFound => PurchaseOrderStoreError::NotFoundError(format!(
+                    "Could not find alternate ID {}",
+                    alternate_id
+                )),
+                _ => PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                    err,
+                ))),
+            })?;
+
+        Ok(alt_id_model.purchase_order_uid)
+    }
+}
+
+#[cfg(feature = "sqlite")]
+pub(in crate) mod sqlite {
+    use super::*;
+
+    pub fn get_uid_from_alternate_id(
+        conn: &diesel::sqlite::SqliteConnection,
+        alternate_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<String, PurchaseOrderStoreError> {
+        if !alternate_id.contains(':') {
+            return Err(PurchaseOrderStoreError::InternalError(InternalError::with_message(format!("Could not find alternate ID {}. Alternate IDs must be in the format <id_type>:<id>", alternate_id))));
+        }
+        let split: Vec<&str> = alternate_id.split(':').collect();
+        let id_type = split[0];
+        let id = split[1];
+
+        let mut query = purchase_order_alternate_id::table.into_boxed().filter(
+            purchase_order_alternate_id::alternate_id_type
+                .eq(&id_type)
+                .and(purchase_order_alternate_id::alternate_id.eq(&id))
+                .and(purchase_order_alternate_id::end_commit_num.eq(MAX_COMMIT_NUM)),
+        );
+
+        if let Some(service_id) = &service_id {
+            query = query.filter(purchase_order_alternate_id::service_id.eq(service_id));
+        } else {
+            query = query.filter(purchase_order_alternate_id::service_id.is_null());
+        }
+
+        let alt_id_model = query
+            .first::<PurchaseOrderAlternateIdModel>(conn)
+            .map_err(|err| match err {
+                NotFound => PurchaseOrderStoreError::NotFoundError(format!(
+                    "Could not find alternate ID {}",
+                    alternate_id
+                )),
+                _ => PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(
+                    err,
+                ))),
+            })?;
+
+        Ok(alt_id_model.purchase_order_uid)
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/mod.rs
@@ -19,6 +19,7 @@ mod add_purchase_order_version_revision;
 pub(super) mod get_purchase_order;
 pub(super) mod get_purchase_order_version;
 pub(super) mod get_purchase_order_version_revision;
+mod get_uid_from_alternate_id;
 pub(super) mod list_alternate_ids_for_purchase_order;
 pub(super) mod list_purchase_order_version_revisions;
 pub(super) mod list_purchase_order_versions;

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -708,6 +708,7 @@ impl PurchaseOrderAlternateId {
     }
 }
 
+#[derive(Default, Clone)]
 pub struct PurchaseOrderAlternateIdBuilder {
     purchase_order_uid: String,
     id_type: String,


### PR DESCRIPTION
This updates the Grid PO store, SDE, and CLI to support PO creation and lookup using a properly formatted (`<id_type>:<id>`) alternate ID. This change includes an update to the `grid create po` CLI command to update the flag for specifying an alternate ID to `--alternate-id` from the less descriptive `--id`.