### PR TITLE
Change keygen priv key file permissions

### DIFF
--- a/cli/src/actions/keygen.rs
+++ b/cli/src/actions/keygen.rs
@@ -113,7 +113,7 @@ pub fn create_key_pair(
         let private_key_file = OpenOptions::new()
             .write(true)
             .create(true)
-            .mode(0o640)
+            .mode(0o600)
             .open(private_key_path.as_path())
             .map_err(|err| {
                 CliError::UserError(format!(


### PR DESCRIPTION
Changes private key file perms from 640 to 600. This matches
ssh-keygen (as a standard).

Resolves: #1020

Signed-off-by: Chris Eckhardt <eckhardt@bitwise.io>