### PR TITLE
Add paging query string support, tests, and docs

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -44,7 +44,7 @@ sawtooth-sdk = { version = "0.4", features = ["transact-compat"], optional = tru
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = { version = "1.0" }
 serde_json = { version = "1.0", optional = true }
-url = { version = "2.1", optional = true }
+url = { version = "2.1", optional = true, features = ["serde"] }
 uuid = { version = "0.8", features = ["v4"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/src/client/reqwest.rs
+++ b/sdk/src/client/reqwest.rs
@@ -86,7 +86,7 @@ pub struct Paging {
     limit: i64,
     total: i64,
     first: String,
-    prev: String,
+    prev: Option<String>,
     next: Option<String>,
     last: String,
 }
@@ -151,7 +151,7 @@ pub fn fetch_entities_list<T: DeserializeOwned>(
         entities.append(&mut entity_list_slice.data);
 
         if let Some(next) = entity_list_slice.paging.next {
-            final_url = format!("{}{}", url, next);
+            final_url = next;
             query_params.clear();
         } else {
             break;

--- a/sdk/src/rest_api/actix_web_3/mod.rs
+++ b/sdk/src/rest_api/actix_web_3/mod.rs
@@ -30,3 +30,30 @@ pub use paging::QueryPaging;
 pub use run::run;
 pub use service::{AcceptServiceIdParam, QueryServiceId};
 pub use store_state::StoreState;
+
+#[cfg(any(
+    feature = "rest-api-endpoint-agent",
+    feature = "rest-api-endpoint-location",
+    feature = "rest-api-endpoint-organization",
+    feature = "rest-api-endpoint-product",
+    feature = "rest-api-endpoint-purchase-order",
+    feature = "rest-api-endpoint-record",
+    feature = "rest-api-endpoint-role",
+    feature = "rest-api-endpoint-schema",
+))]
+pub(crate) mod request {
+    use crate::rest_api::resources::error::ErrorResponse;
+    use actix_web::HttpRequest;
+    use url::Url;
+
+    pub fn get_base_url(req: &HttpRequest) -> Result<Url, ErrorResponse> {
+        let connection_info = req.connection_info();
+        Url::parse(&format!(
+            "{}://{}{}",
+            connection_info.scheme(),
+            connection_info.host(),
+            req.path()
+        ))
+        .map_err(|err| ErrorResponse::internal_error(Box::new(err)))
+    }
+}

--- a/sdk/src/rest_api/actix_web_3/routes/agents.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/agents.rs
@@ -16,7 +16,7 @@ use actix_web::{dev, get, http::StatusCode, web, FromRequest, HttpRequest, HttpR
 use futures::future;
 
 use crate::rest_api::{
-    actix_web_3::{AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
+    actix_web_3::{request, AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
     resources::agents::v1,
 };
 
@@ -51,6 +51,7 @@ pub async fn get_agent(
 
 #[get("/agent")]
 pub async fn list_agents(
+    req: HttpRequest,
     store_state: web::Data<StoreState>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
@@ -62,12 +63,15 @@ pub async fn list_agents(
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
-            match v1::list_agents(
-                store,
-                service_id.as_deref(),
-                paging.offset(),
-                paging.limit(),
-            ) {
+            match request::get_base_url(&req).and_then(|url| {
+                v1::list_agents(
+                    url,
+                    store,
+                    service_id.as_deref(),
+                    paging.offset(),
+                    paging.limit(),
+                )
+            }) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/locations.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/locations.rs
@@ -16,7 +16,7 @@ use actix_web::{dev, get, http::StatusCode, web, FromRequest, HttpRequest, HttpR
 use futures::future;
 
 use crate::rest_api::{
-    actix_web_3::{AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
+    actix_web_3::{request, AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
     resources::locations::v1,
 };
 
@@ -51,6 +51,7 @@ pub async fn get_location(
 
 #[get("/location")]
 pub async fn list_locations(
+    req: HttpRequest,
     store_state: web::Data<StoreState>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
@@ -62,12 +63,15 @@ pub async fn list_locations(
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
-            match v1::list_locations(
-                store,
-                service_id.as_deref(),
-                paging.offset(),
-                paging.limit(),
-            ) {
+            match request::get_base_url(&req).and_then(|url| {
+                v1::list_locations(
+                    url,
+                    store,
+                    service_id.as_deref(),
+                    paging.offset(),
+                    paging.limit(),
+                )
+            }) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/products.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/products.rs
@@ -16,7 +16,7 @@ use actix_web::{dev, get, http::StatusCode, web, FromRequest, HttpRequest, HttpR
 use futures::future;
 
 use crate::rest_api::{
-    actix_web_3::{AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
+    actix_web_3::{request, AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
     resources::products::v1,
 };
 
@@ -51,6 +51,7 @@ pub async fn get_product(
 
 #[get("/product")]
 pub async fn list_products(
+    req: HttpRequest,
     store_state: web::Data<StoreState>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
@@ -62,12 +63,15 @@ pub async fn list_products(
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
-            match v1::list_products(
-                store,
-                service_id.as_deref(),
-                paging.offset(),
-                paging.limit(),
-            ) {
+            match request::get_base_url(&req).and_then(|url| {
+                v1::list_products(
+                    url,
+                    store,
+                    service_id.as_deref(),
+                    paging.offset(),
+                    paging.limit(),
+                )
+            }) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
@@ -16,7 +16,7 @@ use actix_web::{dev, get, http::StatusCode, web, FromRequest, HttpRequest, HttpR
 use futures::future;
 
 use crate::rest_api::{
-    actix_web_3::{AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
+    actix_web_3::{request, AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
     resources::purchase_order::v1,
 };
 
@@ -41,6 +41,7 @@ pub struct QueryRevisionNumber {
 
 #[get("/purchase_order")]
 pub async fn list_purchase_orders(
+    req: HttpRequest,
     store_state: web::Data<StoreState>,
     query_filters: web::Query<ListPOFilters>,
     query_service_id: web::Query<QueryServiceId>,
@@ -54,13 +55,16 @@ pub async fn list_purchase_orders(
             let filters = query_filters.into_inner();
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
-            match v1::list_purchase_orders(
-                store,
-                filters,
-                service_id.as_deref(),
-                paging.offset(),
-                paging.limit(),
-            ) {
+            match request::get_base_url(&req).and_then(|url| {
+                v1::list_purchase_orders(
+                    url,
+                    store,
+                    filters,
+                    service_id.as_deref(),
+                    paging.offset(),
+                    paging.limit(),
+                )
+            }) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -105,6 +109,7 @@ pub async fn get_purchase_order(
 
 #[get("/purchase_order/{uid}/version")]
 pub async fn list_purchase_order_versions(
+    req: HttpRequest,
     store_state: web::Data<StoreState>,
     uid: web::Path<String>,
     query_filters: web::Query<ListVersionFilters>,
@@ -118,14 +123,17 @@ pub async fn list_purchase_order_versions(
     match version {
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
-            match v1::list_purchase_order_versions(
-                store,
-                uid.into_inner(),
-                filters,
-                query_service_id.into_inner().service_id.as_deref(),
-                paging.offset(),
-                paging.limit(),
-            ) {
+            match request::get_base_url(&req).and_then(|url| {
+                v1::list_purchase_order_versions(
+                    url,
+                    store,
+                    uid.into_inner(),
+                    filters,
+                    query_service_id.into_inner().service_id.as_deref(),
+                    paging.offset(),
+                    paging.limit(),
+                )
+            }) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())
@@ -168,6 +176,7 @@ pub async fn get_purchase_order_version(
 
 #[get("/purchase_order/{uid}/version/{version_id}/revision")]
 pub async fn list_purchase_order_version_revisions(
+    req: HttpRequest,
     store_state: web::Data<StoreState>,
     path: web::Path<(String, String)>,
     query_service_id: web::Query<QueryServiceId>,
@@ -180,14 +189,17 @@ pub async fn list_purchase_order_version_revisions(
     match version {
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
-            match v1::list_purchase_order_revisions(
-                store,
-                uid,
-                version_id,
-                query_service_id.into_inner().service_id.as_deref(),
-                paging.offset(),
-                paging.limit(),
-            ) {
+            match request::get_base_url(&req).and_then(|url| {
+                v1::list_purchase_order_revisions(
+                    url,
+                    store,
+                    uid,
+                    version_id,
+                    query_service_id.into_inner().service_id.as_deref(),
+                    paging.offset(),
+                    paging.limit(),
+                )
+            }) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/purchase_orders.rs
@@ -116,7 +116,6 @@ pub async fn list_purchase_order_versions(
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
     version: ProtocolVersion,
-    _: AcceptServiceIdParam,
 ) -> HttpResponse {
     let store = store_state.store_factory.get_grid_purchase_order_store();
     let filters = query_filters.into_inner();

--- a/sdk/src/rest_api/actix_web_3/routes/records.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/records.rs
@@ -16,7 +16,7 @@ use actix_web::{dev, get, http::StatusCode, web, FromRequest, HttpRequest, HttpR
 use futures::future;
 
 use crate::rest_api::{
-    actix_web_3::{AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
+    actix_web_3::{request, AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
     resources::track_and_trace::v1,
 };
 
@@ -51,6 +51,7 @@ pub async fn get_record(
 
 #[get("/record")]
 pub async fn list_records(
+    req: HttpRequest,
     store_state: web::Data<StoreState>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
@@ -62,12 +63,15 @@ pub async fn list_records(
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
-            match v1::list_records(
-                store,
-                service_id.as_deref(),
-                paging.offset(),
-                paging.limit(),
-            ) {
+            match request::get_base_url(&req).and_then(|url| {
+                v1::list_records(
+                    url,
+                    store,
+                    service_id.as_deref(),
+                    paging.offset(),
+                    paging.limit(),
+                )
+            }) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/actix_web_3/routes/schemas.rs
+++ b/sdk/src/rest_api/actix_web_3/routes/schemas.rs
@@ -16,7 +16,7 @@ use actix_web::{dev, get, http::StatusCode, web, FromRequest, HttpRequest, HttpR
 use futures::future;
 
 use crate::rest_api::{
-    actix_web_3::{AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
+    actix_web_3::{request, AcceptServiceIdParam, QueryPaging, QueryServiceId, StoreState},
     resources::schemas::v1,
 };
 
@@ -51,6 +51,7 @@ pub async fn get_schema(
 
 #[get("/schema")]
 pub async fn list_schemas(
+    req: HttpRequest,
     store_state: web::Data<StoreState>,
     query_service_id: web::Query<QueryServiceId>,
     query_paging: web::Query<QueryPaging>,
@@ -62,12 +63,15 @@ pub async fn list_schemas(
         ProtocolVersion::V1 => {
             let paging = query_paging.into_inner();
             let service_id = query_service_id.into_inner().service_id;
-            match v1::list_schemas(
-                store,
-                service_id.as_deref(),
-                paging.offset(),
-                paging.limit(),
-            ) {
+            match request::get_base_url(&req).and_then(|url| {
+                v1::list_schemas(
+                    url,
+                    store,
+                    service_id.as_deref(),
+                    paging.offset(),
+                    paging.limit(),
+                )
+            }) {
                 Ok(res) => HttpResponse::Ok().json(res),
                 Err(err) => HttpResponse::build(
                     StatusCode::from_u16(err.status_code())

--- a/sdk/src/rest_api/resources/agents/v1/handler.rs
+++ b/sdk/src/rest_api/resources/agents/v1/handler.rs
@@ -23,6 +23,7 @@ use crate::{
 use super::payloads::{AgentListSlice, AgentSlice};
 
 pub fn list_agents<'a>(
+    url: Url,
     store: Box<dyn PikeStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
@@ -51,9 +52,7 @@ pub fn list_agents<'a>(
         .map(AgentSlice::try_from)
         .collect::<Result<Vec<AgentSlice>, ErrorResponse>>()?;
 
-    let base_url =
-        Url::parse("/agent").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
-    let paging = Paging::new(base_url, agent_list.paging, service_id);
+    let paging = Paging::new(url, agent_list.paging, service_id);
 
     Ok(AgentListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/agents/v1/handler.rs
+++ b/sdk/src/rest_api/resources/agents/v1/handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
+use url::Url;
 
 use crate::{
     pike::store::{PikeStore, PikeStoreError},
@@ -50,7 +51,9 @@ pub fn list_agents<'a>(
         .map(AgentSlice::try_from)
         .collect::<Result<Vec<AgentSlice>, ErrorResponse>>()?;
 
-    let paging = Paging::new("/agent", agent_list.paging, service_id);
+    let base_url =
+        Url::parse("/agent").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+    let paging = Paging::new(base_url, agent_list.paging, service_id);
 
     Ok(AgentListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/locations/v1/handler.rs
+++ b/sdk/src/rest_api/resources/locations/v1/handler.rs
@@ -23,6 +23,7 @@ use crate::{
 use super::payloads::{LocationListSlice, LocationSlice};
 
 pub fn list_locations<'a>(
+    url: Url,
     store: Box<dyn LocationStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
@@ -56,9 +57,7 @@ pub fn list_locations<'a>(
         .map(LocationSlice::from)
         .collect();
 
-    let base_url =
-        Url::parse("/location").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
-    let paging = Paging::new(base_url, location_list.paging, service_id);
+    let paging = Paging::new(url, location_list.paging, service_id);
 
     Ok(LocationListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/locations/v1/handler.rs
+++ b/sdk/src/rest_api/resources/locations/v1/handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
+use url::Url;
 
 use crate::{
     location::store::{LocationStore, LocationStoreError},
@@ -55,7 +56,9 @@ pub fn list_locations<'a>(
         .map(LocationSlice::from)
         .collect();
 
-    let paging = Paging::new("/location", location_list.paging, service_id);
+    let base_url =
+        Url::parse("/location").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+    let paging = Paging::new(base_url, location_list.paging, service_id);
 
     Ok(LocationListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/organizations/v1/handler.rs
+++ b/sdk/src/rest_api/resources/organizations/v1/handler.rs
@@ -23,6 +23,7 @@ use crate::{
 use super::payloads::{OrganizationListSlice, OrganizationSlice};
 
 pub fn list_organizations<'a>(
+    url: Url,
     store: Box<dyn PikeStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
@@ -51,9 +52,7 @@ pub fn list_organizations<'a>(
         .map(OrganizationSlice::from)
         .collect();
 
-    let base_url =
-        Url::parse("/organization").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
-    let paging = Paging::new(base_url, organization_list.paging, service_id);
+    let paging = Paging::new(url, organization_list.paging, service_id);
 
     Ok(OrganizationListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/organizations/v1/handler.rs
+++ b/sdk/src/rest_api/resources/organizations/v1/handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
+use url::Url;
 
 use crate::{
     pike::store::{PikeStore, PikeStoreError},
@@ -50,7 +51,9 @@ pub fn list_organizations<'a>(
         .map(OrganizationSlice::from)
         .collect();
 
-    let paging = Paging::new("/organization", organization_list.paging, service_id);
+    let base_url =
+        Url::parse("/organization").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+    let paging = Paging::new(base_url, organization_list.paging, service_id);
 
     Ok(OrganizationListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/paging/v1/mod.rs
+++ b/sdk/src/rest_api/resources/paging/v1/mod.rs
@@ -96,24 +96,31 @@ struct Offsets {
 
 impl Offsets {
     fn new(paging: &paging::Paging) -> Self {
+        // The offset for the very last page
         let last_offset = cmp::max(((paging.total - 1) / paging.limit) * paging.limit, 0);
 
         Offsets {
             first: 0,
-            prev: if paging.offset <= 0 {
+            prev: if paging.offset == 0 {
+                // There is no previous page if we're at the beginning
                 None
             } else if paging.offset > paging.total {
+                // Default to the last page if we've passed the end of the list
                 Some(last_offset)
             } else {
+                // Calculate the previous page normally using increments of the limit
                 Some(cmp::max(paging.offset - paging.limit, 0))
             },
             last: last_offset,
             next: if paging.offset >= last_offset {
+                // There is no next page if we're on or further than the last page
                 None
             } else {
                 Some(if paging.offset + paging.limit > last_offset {
+                    // Default to the last page if we're about to hit the end of the list
                     last_offset
                 } else {
+                    // Calculate the next page normally using increments of the limit
                     paging.offset + paging.limit
                 })
             },

--- a/sdk/src/rest_api/resources/paging/v1/mod.rs
+++ b/sdk/src/rest_api/resources/paging/v1/mod.rs
@@ -13,101 +13,298 @@
 // limitations under the License.
 
 use crate::paging;
+use std::cmp;
+use url::Url;
 
+/// Paging data for a REST API dataset, intended to be returned with REST response data
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Paging {
-    current: String,
+    /// URL for the current page of records
+    current: Url,
+
+    /// Numerical index of the first record
     offset: i64,
+
+    /// Max number of records per page
     limit: i64,
+
+    /// Total number of records
     total: i64,
-    first: String,
-    prev: String,
-    next: Option<String>,
-    last: String,
+
+    /// URL for the first page of records
+    first: Url,
+
+    /// URL for the previous page of records
+    prev: Option<Url>,
+
+    /// URL for the next page of records, if one exists
+    next: Option<Url>,
+
+    /// URL for the last page of records
+    last: Url,
 }
 
 impl Paging {
-    pub fn new(base_link: &str, paging: paging::Paging, service_id: Option<&str>) -> Self {
-        let current = if let Some(service_id) = service_id {
-            format!(
-                "{}?offset={}&limit={}&service_id={}",
-                base_link, paging.offset, paging.limit, service_id
-            )
-        } else {
-            format!(
-                "{}?offset={}&limit={}",
-                base_link, paging.offset, paging.limit
-            )
-        };
-        let first = if let Some(service_id) = service_id {
-            format!(
-                "{}?offset=0&limit={}&service_id={}",
-                base_link, paging.limit, service_id
-            )
-        } else {
-            format!("{}?offset=0&limit={}", base_link, paging.limit)
-        };
-        let previous_offset = if paging.offset > paging.limit {
-            paging.offset - paging.limit
-        } else {
-            0
-        };
-        let prev = if let Some(service_id) = service_id {
-            format!(
-                "{}?offset={}&limit={}&service_id={}",
-                base_link, previous_offset, paging.limit, service_id
-            )
-        } else {
-            format!(
-                "{}?offset={}&limit={}",
-                base_link, previous_offset, paging.limit
-            )
-        };
+    /// Create a new Paging object
+    ///
+    /// # Arguments
+    ///
+    /// * `base_url` - The base URL for paging
+    /// * `paging` - Struct with dataset size, page size, and index
+    /// * `service_id` - The service id on the circuit, if applicable
+    pub fn new(mut base_url: Url, paging: paging::Paging, service_id: Option<&str>) -> Self {
+        let limit = paging.limit.to_string();
+        base_url.query_pairs_mut().append_pair("limit", &limit);
 
-        let last_offset = if paging.total > 0 {
-            ((paging.total - 1) / paging.limit) * paging.limit
-        } else {
-            0
-        };
-        let last = if let Some(service_id) = service_id {
-            format!(
-                "{}?offset={}&limit={}&service_id={}",
-                base_link, last_offset, paging.limit, service_id
-            )
-        } else {
-            format!(
-                "{}?offset={}&limit={}",
-                base_link, last_offset, paging.limit
-            )
-        };
+        if let Some(service_id) = service_id {
+            base_url
+                .query_pairs_mut()
+                .append_pair("service_id", service_id);
+        }
 
-        let next_offset = if paging.offset + paging.limit > last_offset {
-            last_offset
-        } else {
-            paging.offset + paging.limit
-        };
-
-        let next = if let Some(service_id) = service_id {
-            format!(
-                "{}?offset={}&limit={}&service_id={}",
-                base_link, next_offset, paging.limit, service_id
-            )
-        } else {
-            format!(
-                "{}?offset={}&limit={}",
-                base_link, next_offset, paging.limit
-            )
-        };
+        let generator = PageUrlGenerator { url: base_url };
+        let offsets = Offsets::new(&paging);
 
         Paging {
-            current,
+            current: generator.url_with_offset(paging.offset),
             offset: paging.offset,
             limit: paging.limit,
             total: paging.total,
-            first,
-            prev,
-            next: if next == last { None } else { Some(next) },
-            last,
+            first: generator.url_with_offset(offsets.first),
+            prev: offsets.prev.map(|v| generator.url_with_offset(v)),
+            last: generator.url_with_offset(offsets.last),
+            next: offsets.next.map(|v| generator.url_with_offset(v)),
         }
+    }
+}
+
+/// Numerical representation of pagination offsets for any given page
+#[derive(Debug, Eq, PartialEq)]
+struct Offsets {
+    /// Offset for first page of records
+    first: i64,
+
+    /// Offset for the previous page of records
+    prev: Option<i64>,
+
+    /// Offset for the next page of records, if one exists
+    next: Option<i64>,
+
+    /// Offset for the last page of records
+    last: i64,
+}
+
+impl Offsets {
+    fn new(paging: &paging::Paging) -> Self {
+        let last_offset = cmp::max(((paging.total - 1) / paging.limit) * paging.limit, 0);
+
+        Offsets {
+            first: 0,
+            prev: if paging.offset <= 0 {
+                None
+            } else if paging.offset > paging.total {
+                Some(last_offset)
+            } else {
+                Some(cmp::max(paging.offset - paging.limit, 0))
+            },
+            last: last_offset,
+            next: if paging.offset >= last_offset {
+                None
+            } else {
+                Some(if paging.offset + paging.limit > last_offset {
+                    last_offset
+                } else {
+                    paging.offset + paging.limit
+                })
+            },
+        }
+    }
+}
+
+/// Utility to generate a URL at a given offset
+struct PageUrlGenerator {
+    url: Url,
+}
+
+impl PageUrlGenerator {
+    fn url_with_offset<T: ToString>(&self, offset: T) -> Url {
+        let mut url = self.url.clone();
+        url.query_pairs_mut()
+            .append_pair("offset", &offset.to_string());
+        url
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_offset_second_page() {
+        assert_eq!(
+            Offsets::new(&paging::Paging {
+                offset: 20,
+                limit: 10,
+                total: 80
+            }),
+            Offsets {
+                first: 0,
+                prev: Some(10),
+                next: Some(30),
+                last: 70
+            }
+        );
+    }
+
+    #[test]
+    fn test_offset_first_page() {
+        assert_eq!(
+            Offsets::new(&paging::Paging {
+                offset: 0,
+                limit: 10,
+                total: 80
+            }),
+            Offsets {
+                first: 0,
+                prev: None,
+                next: Some(10),
+                last: 70
+            }
+        );
+    }
+
+    #[test]
+    fn test_offset_last_page() {
+        assert_eq!(
+            Offsets::new(&paging::Paging {
+                offset: 70,
+                limit: 10,
+                total: 80
+            }),
+            Offsets {
+                first: 0,
+                prev: Some(60),
+                next: None,
+                last: 70
+            }
+        );
+    }
+
+    #[test]
+    fn test_offset_beyond_limit_prev_is_offset_to_last_page() {
+        assert_eq!(
+            Offsets::new(&paging::Paging {
+                offset: 100,
+                limit: 10,
+                total: 80
+            }),
+            Offsets {
+                first: 0,
+                prev: Some(70),
+                next: None,
+                last: 70
+            }
+        );
+    }
+
+    #[test]
+    fn test_offset_not_aligned_with_limit() {
+        assert_eq!(
+            Offsets::new(&paging::Paging {
+                offset: 5,
+                limit: 10,
+                total: 80
+            }),
+            Offsets {
+                first: 0,
+                prev: Some(0),
+                next: Some(15),
+                last: 70
+            }
+        );
+    }
+
+    #[test]
+    fn test_offset_total_smaller_than_limit() {
+        assert_eq!(
+            Offsets::new(&paging::Paging {
+                offset: 5,
+                limit: 100,
+                total: 80
+            }),
+            Offsets {
+                first: 0,
+                prev: Some(0),
+                next: None,
+                last: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_paging_absolute_url() {
+        assert_eq!(
+            Paging::new(
+                Url::parse("http://base/").unwrap(),
+                paging::Paging {
+                    offset: 20,
+                    limit: 10,
+                    total: 80
+                },
+                Some("fakeserviceid"),
+            ),
+            Paging {
+                current: Url::parse("http://base/?limit=10&service_id=fakeserviceid&offset=20")
+                    .unwrap(),
+                offset: 20,
+                limit: 10,
+                total: 80,
+                first: Url::parse("http://base/?limit=10&service_id=fakeserviceid&offset=0")
+                    .unwrap(),
+                prev: Some(
+                    Url::parse("http://base/?limit=10&service_id=fakeserviceid&offset=10").unwrap()
+                ),
+                next: Some(
+                    Url::parse("http://base/?limit=10&service_id=fakeserviceid&offset=30").unwrap()
+                ),
+                last: Url::parse("http://base/?limit=10&service_id=fakeserviceid&offset=70")
+                    .unwrap(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_paging_query_params() {
+        assert_eq!(
+            Paging::new(
+                Url::parse("http://base/?unrelated_filter=9").unwrap(),
+                paging::Paging {
+                    offset: 20,
+                    limit: 10,
+                    total: 80
+                },
+                Some("fakeserviceid"),
+            ),
+            Paging {
+                current: Url::parse(
+                    "http://base/?unrelated_filter=9&limit=10&service_id=fakeserviceid&offset=20"
+                ).unwrap(),
+                offset: 20,
+                limit: 10,
+                total: 80,
+                first: Url::parse(
+                    "http://base/?unrelated_filter=9&limit=10&service_id=fakeserviceid&offset=0"
+                ).unwrap(),
+                prev: Some(Url::parse(
+                    "http://base/?unrelated_filter=9&limit=10&service_id=fakeserviceid&offset=10"
+                ).unwrap()),
+                next: Some(Url::parse(
+                    "http://base/?unrelated_filter=9&limit=10&service_id=fakeserviceid&offset=30"
+                ).unwrap()),
+                last: Url::parse(
+                    "http://base/?unrelated_filter=9&limit=10&service_id=fakeserviceid&offset=70"
+                ).unwrap(),
+            }
+        );
     }
 }

--- a/sdk/src/rest_api/resources/products/v1/handler.rs
+++ b/sdk/src/rest_api/resources/products/v1/handler.rs
@@ -23,6 +23,7 @@ use crate::{
 use super::payloads::{ProductListSlice, ProductSlice};
 
 pub fn list_products<'a>(
+    url: Url,
     store: Box<dyn ProductStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
@@ -51,9 +52,7 @@ pub fn list_products<'a>(
         .map(ProductSlice::from)
         .collect();
 
-    let base_url =
-        Url::parse("/product").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
-    let paging = Paging::new(base_url, product_list.paging().clone(), service_id);
+    let paging = Paging::new(url, product_list.paging().clone(), service_id);
 
     Ok(ProductListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/products/v1/handler.rs
+++ b/sdk/src/rest_api/resources/products/v1/handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
+use url::Url;
 
 use crate::{
     product::store::{ProductStore, ProductStoreError},
@@ -50,7 +51,9 @@ pub fn list_products<'a>(
         .map(ProductSlice::from)
         .collect();
 
-    let paging = Paging::new("/product", product_list.paging().clone(), service_id);
+    let base_url =
+        Url::parse("/product").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+    let paging = Paging::new(base_url, product_list.paging().clone(), service_id);
 
     Ok(ProductListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/purchase_order/v1/handler.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
+use url::Url;
 
 use crate::{
     purchase_order::store::{
@@ -60,7 +61,9 @@ pub fn list_purchase_orders<'a>(
         .map(PurchaseOrderSlice::from)
         .collect();
 
-    let paging = Paging::new("/purchase_order", purchase_order_list.paging, service_id);
+    let base_url = Url::parse("/purchase_order")
+        .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+    let paging = Paging::new(base_url, purchase_order_list.paging, service_id);
 
     Ok(PurchaseOrderListSlice { data, paging })
 }
@@ -170,11 +173,9 @@ pub fn list_purchase_order_versions<'a>(
         .map(PurchaseOrderVersionSlice::from)
         .collect();
 
-    let paging = Paging::new(
-        &format!("/purchase_order/{}/versions", purchase_order_uid),
-        purchase_order_version_list.paging,
-        service_id,
-    );
+    let base_url = Url::parse(&format!("/purchase_order/{}/versions", purchase_order_uid))
+        .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+    let paging = Paging::new(base_url, purchase_order_version_list.paging, service_id);
 
     Ok(PurchaseOrderVersionListSlice { data, paging })
 }
@@ -218,14 +219,12 @@ pub fn list_purchase_order_revisions<'a>(
         .map(PurchaseOrderRevisionSlice::from)
         .collect();
 
-    let paging = Paging::new(
-        &format!(
-            "/purchase_order/{}/versions/{}/revisions",
-            purchase_order_uid, version_id
-        ),
-        purchase_order_revision_list.paging,
-        service_id,
-    );
+    let base_url = Url::parse(&format!(
+        "/purchase_order/{}/versions/{}/revisions",
+        purchase_order_uid, version_id
+    ))
+    .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+    let paging = Paging::new(base_url, purchase_order_revision_list.paging, service_id);
 
     Ok(PurchaseOrderRevisionListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/purchase_order/v1/handler.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/handler.rs
@@ -28,6 +28,7 @@ use super::payloads::{
 };
 
 pub fn list_purchase_orders<'a>(
+    url: Url,
     store: Box<dyn PurchaseOrderStore + 'a>,
     filters: ListPOFilters,
     service_id: Option<&str>,
@@ -61,9 +62,7 @@ pub fn list_purchase_orders<'a>(
         .map(PurchaseOrderSlice::from)
         .collect();
 
-    let base_url = Url::parse("/purchase_order")
-        .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
-    let paging = Paging::new(base_url, purchase_order_list.paging, service_id);
+    let paging = Paging::new(url, purchase_order_list.paging, service_id);
 
     Ok(PurchaseOrderListSlice { data, paging })
 }
@@ -138,6 +137,7 @@ pub fn get_purchase_order_version<'a>(
 }
 
 pub fn list_purchase_order_versions<'a>(
+    url: Url,
     store: Box<dyn PurchaseOrderStore + 'a>,
     purchase_order_uid: String,
     filters: ListVersionFilters,
@@ -173,14 +173,13 @@ pub fn list_purchase_order_versions<'a>(
         .map(PurchaseOrderVersionSlice::from)
         .collect();
 
-    let base_url = Url::parse(&format!("/purchase_order/{}/versions", purchase_order_uid))
-        .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
-    let paging = Paging::new(base_url, purchase_order_version_list.paging, service_id);
+    let paging = Paging::new(url, purchase_order_version_list.paging, service_id);
 
     Ok(PurchaseOrderVersionListSlice { data, paging })
 }
 
 pub fn list_purchase_order_revisions<'a>(
+    url: Url,
     store: Box<dyn PurchaseOrderStore + 'a>,
     purchase_order_uid: String,
     version_id: String,
@@ -219,12 +218,7 @@ pub fn list_purchase_order_revisions<'a>(
         .map(PurchaseOrderRevisionSlice::from)
         .collect();
 
-    let base_url = Url::parse(&format!(
-        "/purchase_order/{}/versions/{}/revisions",
-        purchase_order_uid, version_id
-    ))
-    .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
-    let paging = Paging::new(base_url, purchase_order_revision_list.paging, service_id);
+    let paging = Paging::new(url, purchase_order_revision_list.paging, service_id);
 
     Ok(PurchaseOrderRevisionListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/roles/v1/handler.rs
+++ b/sdk/src/rest_api/resources/roles/v1/handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
+use url::Url;
 
 use crate::{
     pike::store::{PikeStore, PikeStoreError},
@@ -47,7 +48,9 @@ pub fn list_roles_for_organization<'a>(
 
     let data = role_list.data.into_iter().map(RoleSlice::from).collect();
 
-    let paging = Paging::new("/role", role_list.paging, service_id);
+    let base_url =
+        Url::parse("/role").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+    let paging = Paging::new(base_url, role_list.paging, service_id);
 
     Ok(RoleListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/roles/v1/handler.rs
+++ b/sdk/src/rest_api/resources/roles/v1/handler.rs
@@ -23,6 +23,7 @@ use crate::{
 use super::payloads::{RoleListSlice, RoleSlice};
 
 pub fn list_roles_for_organization<'a>(
+    url: Url,
     store: Box<dyn PikeStore + 'a>,
     org_id: String,
     service_id: Option<&str>,
@@ -48,9 +49,7 @@ pub fn list_roles_for_organization<'a>(
 
     let data = role_list.data.into_iter().map(RoleSlice::from).collect();
 
-    let base_url =
-        Url::parse("/role").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
-    let paging = Paging::new(base_url, role_list.paging, service_id);
+    let paging = Paging::new(url, role_list.paging, service_id);
 
     Ok(RoleListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/schemas/v1/handler.rs
+++ b/sdk/src/rest_api/resources/schemas/v1/handler.rs
@@ -23,6 +23,7 @@ use crate::{
 use super::payloads::{SchemaListSlice, SchemaSlice};
 
 pub fn list_schemas<'a>(
+    url: Url,
     store: Box<dyn SchemaStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
@@ -51,9 +52,7 @@ pub fn list_schemas<'a>(
         .map(SchemaSlice::from)
         .collect();
 
-    let base_url =
-        Url::parse("/schema").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
-    let paging = Paging::new(base_url, schema_list.paging, service_id);
+    let paging = Paging::new(url, schema_list.paging, service_id);
 
     Ok(SchemaListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/schemas/v1/handler.rs
+++ b/sdk/src/rest_api/resources/schemas/v1/handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
+use url::Url;
 
 use crate::{
     rest_api::resources::{error::ErrorResponse, paging::v1::Paging},
@@ -50,7 +51,9 @@ pub fn list_schemas<'a>(
         .map(SchemaSlice::from)
         .collect();
 
-    let paging = Paging::new("/schema", schema_list.paging, service_id);
+    let base_url =
+        Url::parse("/schema").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+    let paging = Paging::new(base_url, schema_list.paging, service_id);
 
     Ok(SchemaListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/track_and_trace/v1/handler.rs
+++ b/sdk/src/rest_api/resources/track_and_trace/v1/handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
+use url::Url;
 
 use crate::{
     rest_api::resources::{error::ErrorResponse, paging::v1::Paging},
@@ -138,7 +139,9 @@ pub fn list_records<'a>(
         })
         .collect();
 
-    let paging = Paging::new("/record", record_list.paging, service_id);
+    let base_url =
+        Url::parse("/record").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+    let paging = Paging::new(base_url, record_list.paging, service_id);
 
     Ok(RecordListSlice { data, paging })
 }

--- a/sdk/src/rest_api/resources/track_and_trace/v1/handler.rs
+++ b/sdk/src/rest_api/resources/track_and_trace/v1/handler.rs
@@ -28,6 +28,7 @@ use super::payloads::{
 };
 
 pub fn list_records<'a>(
+    url: Url,
     store: Box<dyn TrackAndTraceStore + 'a>,
     service_id: Option<&str>,
     offset: u64,
@@ -139,9 +140,7 @@ pub fn list_records<'a>(
         })
         .collect();
 
-    let base_url =
-        Url::parse("/record").map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
-    let paging = Paging::new(base_url, record_list.paging, service_id);
+    let paging = Paging::new(url, record_list.paging, service_id);
 
     Ok(RecordListSlice { data, paging })
 }


### PR DESCRIPTION
This is a rewrite of the paging module with several notable differences
from the original.

The first and most notable change is the addition of arbitary query
string support in the base URL, so we can add filters to the paging
URLs. To facilitate this, this change uses the Rust url crate for both
the external API and internal URL representation. This change also adds
the serde feature to the url library to allow the Paging object to
serialize.

The second change is to modify the returned object to make the "prev"
link optional. This mirrors "next" which was already optional.

Other notable changes include splitting up the internal structure for
ease of reading and testing, added tests to verify offset and
serialization output, and added documentation in anticipation of
Paging module stabilization.

Signed-off-by: Lee Bradley <bradley@bitwise.io>