### PR TITLE
Replace `workflow_status` with `workflow_state`

### DIFF
--- a/cli/man/grid-po-create.1.md
+++ b/cli/man/grid-po-create.1.md
@@ -70,7 +70,7 @@ spec. If not specified, will be randomly generated.
 `--wait`
 : Maximum number of seconds to wait for the batch to be committed.
 
-`--workflow-status`
+`--workflow-state`
 : Specifies the initial workflow state of the purchase order.
 
 EXAMPLES
@@ -82,12 +82,12 @@ The command
 $ grid po create \
     --buyer-org=crgl \
     --seller-org=crgl2 \
-    --workflow-status=Issued \
+    --workflow-state=Issued \
     --alternate-id=po_number:8329173 \
     --wait=0
 ```
 
-will generate a purchase order owned by the `crgl` organization, with the status
+will generate a purchase order owned by the `crgl` organization, with the state
 of `Issued`, and an alternate ID of `po_number:8329173`. It will generate
 output similar to the following (the UUID is randomly generated in this case):
 

--- a/cli/man/grid-po-show.1.md
+++ b/cli/man/grid-po-show.1.md
@@ -75,12 +75,12 @@ output like the following:
 Purchase Order 809832081:
     Buyer Org        crgl (Cargill Incorporated)
     Seller Org       crgl2 (Cargill 2)
-    Workflow status  Confirmed
+    Workflow state  Confirmed
     Created At       <datetime string>
     Closed           false
 
 Accepted Version (v3):
-    workflow_status  Editable
+    workflow_state  Editable
     draft            false
     Revisions        4
     Current Revision 4
@@ -105,12 +105,12 @@ It will display output like the following:
 Purchase Order 809832081:
     Buyer Org        crgl (Cargill Incorporated)
     Seller Org       crgl2 (Cargill 2)
-    Workflow status  Confirmed
+    Workflow state  Confirmed
     Created At       <datetime string>
     Closed           false
 
 Accepted Version (v3):
-    workflow_status  Editable
+    workflow_state  Editable
     draft            false
     Revisions        4
     Current Revision 4
@@ -135,12 +135,12 @@ It will display output like the following:
 Purchase Order 809832081:
     Buyer Org        crgl (Cargill Incorporated)
     Seller Org       crgl2 (Cargill 2)
-    Workflow status  Confirmed
+    Workflow state  Confirmed
     Created At       <datetime string>
     Closed           false
 
 Accepted Version (v3):
-    workflow_status  Editable
+    workflow_state  Editable
     draft            false
     Revisions        4
     Current Revision 4

--- a/cli/man/grid-po-update.1.md
+++ b/cli/man/grid-po-update.1.md
@@ -79,7 +79,7 @@ OPTIONS
 `--wait`
 : Maximum number of seconds to wait for the batch to be committed.
 
-`--workflow-status`
+`--workflow-state`
 : Specifies the workflow state of the purchase order.
 
 EXAMPLES
@@ -112,14 +112,14 @@ The command
 ```
 $ grid po update \
     --org=crgl \
-    --workflow-status=Confirmed \
+    --workflow-state=Confirmed \
     --accepted-version=v3 \
     --wait \
     po_number:809832081
 ```
 
 will update the purchase order with alternate ID `po_number:809832081`, set the
-workflow status to `Confirmed`, and the accepted version to `v3`. It will
+workflow state to `Confirmed`, and the accepted version to `v3`. It will
 generate output like the following:
 
 ```

--- a/cli/man/grid-po-version-create.1.md
+++ b/cli/man/grid-po-version-create.1.md
@@ -77,7 +77,7 @@ OPTIONS
 `--wait`
 : Maximum number of seconds to wait for the batch to be committed.
 
-`--workflow-status`
+`--workflow-state`
 : Specifies the initial workflow state of the purchase order.
 
 EXAMPLES
@@ -91,13 +91,13 @@ $ grid po version create \
     --po=82urioz098aui3871uc \
     --order-xml ./my_test_order.xml \
     --draft \
-    --workflow-status=Editable \
+    --workflow-state=Editable \
     --wait \
     v3
 ```
 
 will generate version `v3` of purchase order `82urioz098aui3871uc` owned by the
-organization `crgl`. It will be created as a draft and have the workflow status
+organization `crgl`. It will be created as a draft and have the workflow state
 of `Editable`.  It will generate output like the following:
 
 ```

--- a/cli/man/grid-po-version-show.1.md
+++ b/cli/man/grid-po-version-show.1.md
@@ -73,7 +73,7 @@ will show version 1 for the purchase order "PO-AA11A-BB22" in human-readable
 format:
 
 ```
-VERSION_ID  WORKFLOW_STATUS  IS_DRAFT  CURRENT_REVISION  REVISIONS
+VERSION_ID  WORKFLOW_STATE  IS_DRAFT  CURRENT_REVISION  REVISIONS
 1           Editable         t         1                 1
 ```
 

--- a/cli/man/grid-po-version-update.1.md
+++ b/cli/man/grid-po-version-update.1.md
@@ -76,7 +76,7 @@ OPTIONS
 `--wait`
 : Maximum number of seconds to wait for the batch to be committed.
 
-`--workflow-status`
+`--workflow-state`
 : Specifies the initial workflow state of the purchase order.
 
 EXAMPLES
@@ -87,13 +87,13 @@ The command
 ```
 $ grid po version update \
     --po PO-00000-1111 \
-    --workflow-status Review \
+    --workflow-state Review \
     --wait \
     v3
 ```
 
 will update the version `v3` of purchase order `PO-00000-1111` to have the
-workflow status of `Review`. It will generate output like the following:
+workflow state of `Review`. It will generate output like the following:
 
 ```
 Submitting request to update version...

--- a/cli/src/actions/purchase_orders.rs
+++ b/cli/src/actions/purchase_orders.rs
@@ -364,7 +364,7 @@ struct PurchaseOrderCli {
     buyer_org_id: String,
     seller_org_id: String,
     purchase_order_uid: String,
-    workflow_status: String,
+    workflow_state: String,
     is_closed: bool,
     accepted_version_id: Option<String>,
     versions: Vec<PurchaseOrderVersionCli>,
@@ -377,7 +377,7 @@ impl From<&PurchaseOrder> for PurchaseOrderCli {
             buyer_org_id: d.buyer_org_id.to_string(),
             seller_org_id: d.seller_org_id.to_string(),
             purchase_order_uid: d.purchase_order_uid.to_string(),
-            workflow_status: d.workflow_status.to_string(),
+            workflow_state: d.workflow_state.to_string(),
             is_closed: d.is_closed,
             accepted_version_id: d.accepted_version_id.as_ref().map(String::from),
             versions: d
@@ -393,7 +393,7 @@ impl From<&PurchaseOrder> for PurchaseOrderCli {
 #[derive(Debug, Serialize)]
 struct PurchaseOrderVersionCli {
     pub version_id: String,
-    pub workflow_status: String,
+    pub workflow_state: String,
     pub is_draft: bool,
     pub current_revision_id: u64,
     pub revisions: Vec<PurchaseOrderRevisionCli>,
@@ -403,7 +403,7 @@ impl From<&PurchaseOrderVersion> for PurchaseOrderVersionCli {
     fn from(d: &PurchaseOrderVersion) -> Self {
         Self {
             version_id: d.version_id.to_string(),
-            workflow_status: d.workflow_status.to_string(),
+            workflow_state: d.workflow_state.to_string(),
             is_draft: d.is_draft,
             current_revision_id: d.current_revision_id,
             revisions: d
@@ -475,7 +475,7 @@ impl std::fmt::Display for PurchaseOrderCli {
         write!(f, "Purchase Order {}:", &self.purchase_order_uid)?;
         write!(f, "\n\t{:18}{}", "Buyer Org", &self.buyer_org_id)?;
         write!(f, "\n\t{:18}{}", "Seller Org", &self.seller_org_id)?;
-        write!(f, "\n\t{:18}{}", "Workflow Status", &self.workflow_status)?;
+        write!(f, "\n\t{:18}{}", "Workflow State", &self.workflow_state)?;
         write!(
             f,
             "\n\t{:18}{}",
@@ -501,7 +501,7 @@ impl std::fmt::Display for PurchaseOrderCli {
 impl std::fmt::Display for PurchaseOrderVersionCli {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Version {}:", &self.version_id)?;
-        write!(f, "\n\t{:18}{}", "Workflow Status", &self.workflow_status)?;
+        write!(f, "\n\t{:18}{}", "Workflow State", &self.workflow_state)?;
         write!(f, "\n\t{:18}{}", "Is Draft", &self.is_draft)?;
         let revisions = &self.revisions;
         write!(f, "\n\t{:18}{}", "Revisions", &revisions.len())?;
@@ -557,7 +557,7 @@ impl ListDisplay for PurchaseOrderCliList {
                     po.buyer_org_id.to_string(),
                     po.seller_org_id.to_string(),
                     po.purchase_order_uid.to_string(),
-                    po.workflow_status.to_string(),
+                    po.workflow_state.to_string(),
                     match &po.accepted_version_id {
                         Some(s) => s.to_string(),
                         None => String::new(),
@@ -573,7 +573,7 @@ impl ListDisplay for PurchaseOrderVersionCliList {
     fn header() -> Vec<&'static str> {
         vec![
             "VERSION_ID",
-            "WORKFLOW_STATUS",
+            "WORKFLOW_STATE",
             "IS_DRAFT",
             "CURRENT_REVISION",
             "REVISIONS",
@@ -586,7 +586,7 @@ impl ListDisplay for PurchaseOrderVersionCliList {
             .map(|version| {
                 vec![
                     version.version_id.to_string(),
-                    version.workflow_status.to_string(),
+                    version.workflow_state.to_string(),
                     version.is_draft.to_string(),
                     version.current_revision_id.to_string(),
                     version.revisions.len().to_string(),
@@ -731,7 +731,7 @@ Revision 1:
     /// Tests the purchase order versions are correctly displayed in the CLI
     /// in the format:
     /// Version (1):
-    ///     workflow_status  Editable
+    ///     workflow_state  Editable
     ///     draft            false
     ///     Revisions        4
     ///     Current Revision 4
@@ -744,7 +744,7 @@ Revision 1:
     fn test_display_version() {
         let display = "\
 Version 1:
-	Workflow Status   proposed
+	Workflow State    proposed
 	Is Draft          true
 	Revisions         1
 	Current Revision  1
@@ -765,7 +765,7 @@ Revision 1:
 
         let version = PurchaseOrderVersionCli {
             version_id: "1".to_string(),
-            workflow_status: "proposed".to_string(),
+            workflow_state: "proposed".to_string(),
             is_draft: true,
             current_revision_id: 1,
             revisions: vec![revision],
@@ -779,12 +779,12 @@ Revision 1:
     /// Purchase Order PO-00000-0000:
     ///     Buyer Org        crgl (Cargill Incorporated)
     ///     Seller Org       crgl2 (Cargill 2)
-    ///     Workflow status  Confirmed
+    ///     Workflow state  Confirmed
     ///     Created At       <datetime string>
     ///     Closed           false
     ///
     /// Accepted Version (1):
-    ///     workflow_status  Editable
+    ///     workflow_state  Editable
     ///     draft            false
     ///     Revisions        4
     ///     Current Revision 4
@@ -799,12 +799,12 @@ Revision 1:
 Purchase Order PO-00000-0000:
 	Buyer Org         test
 	Seller Org        test2
-	Workflow Status   created
+	Workflow State    created
 	Created At        1970-05-23T21:21:17+00:00
 	Closed            false
 
 Version 1:
-	Workflow Status   proposed
+	Workflow State    proposed
 	Is Draft          true
 	Revisions         1
 	Current Revision  1
@@ -824,7 +824,7 @@ Revision 1:
 
         let version = PurchaseOrderVersionCli {
             version_id: "1".to_string(),
-            workflow_status: "proposed".to_string(),
+            workflow_state: "proposed".to_string(),
             is_draft: true,
             current_revision_id: 1,
             revisions: vec![revision],
@@ -834,7 +834,7 @@ Revision 1:
             buyer_org_id: "test".to_string(),
             seller_org_id: "test2".to_string(),
             purchase_order_uid: "PO-00000-0000".to_string(),
-            workflow_status: "created".to_string(),
+            workflow_state: "created".to_string(),
             is_closed: false,
             accepted_version_id: Some("1".to_string()),
             versions: vec![version],

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1272,12 +1272,12 @@ fn run() -> Result<(), CliError> {
                             ),
                     )
                     .arg(
-                        Arg::with_name("workflow_status")
+                        Arg::with_name("workflow_state")
                             .value_name("status")
-                            .long("workflow-status")
+                            .long("workflow-state")
                             .takes_value(true)
                             .required(true)
-                            .help("Workflow status of this Purchase Order version"),
+                            .help("Workflow state of this Purchase Order version"),
                     )
                     .arg(
                         Arg::with_name("draft")
@@ -1346,11 +1346,11 @@ fn run() -> Result<(), CliError> {
                             ),
                     )
                     .arg(
-                        Arg::with_name("workflow_status")
+                        Arg::with_name("workflow_state")
                             .value_name("status")
-                            .long("workflow-status")
+                            .long("workflow-state")
                             .takes_value(true)
-                            .help("The updated workflow status of this Purchase Order version"),
+                            .help("The updated workflow state of this Purchase Order version"),
                     )
                     .arg(
                         Arg::with_name("draft")
@@ -1562,12 +1562,12 @@ fn run() -> Result<(), CliError> {
                                 ),
                         )
                         .arg(
-                            Arg::with_name("workflow_status")
+                            Arg::with_name("workflow_state")
                                 .value_name("status")
-                                .long("workflow-status")
+                                .long("workflow-state")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Workflow status of the Purchase Order"),
+                                .help("Workflow state of the Purchase Order"),
                         )
                         .arg(
                             Arg::with_name("key")
@@ -1661,11 +1661,11 @@ fn run() -> Result<(), CliError> {
                                 ),
                         )
                         .arg(
-                            Arg::with_name("workflow_status")
+                            Arg::with_name("workflow_state")
                                 .value_name("status")
-                                .long("workflow-status")
+                                .long("workflow-state")
                                 .takes_value(true)
-                                .help("The updated workflow status of the Purchase Order"),
+                                .help("The updated workflow state of the Purchase Order"),
                         )
                         .arg(
                             Arg::with_name("is_closed")
@@ -2531,7 +2531,7 @@ fn run() -> Result<(), CliError> {
                     )
                     .with_buyer_org_id(m.value_of("buyer_org_id").unwrap().into())
                     .with_seller_org_id(m.value_of("seller_org_id").unwrap().into())
-                    .with_workflow_status(m.value_of("workflow_status").unwrap().into())
+                    .with_workflow_state(m.value_of("workflow_state").unwrap().into())
                     .with_alternate_ids(alternate_ids)
                     .build()
                     .map_err(|err| {
@@ -2564,8 +2564,7 @@ fn run() -> Result<(), CliError> {
                 )?;
 
                 if let Some(po) = po {
-                    let workflow_status =
-                        m.value_of("workflow_status").unwrap_or(&po.workflow_status);
+                    let workflow_state = m.value_of("workflow_state").unwrap_or(&po.workflow_state);
 
                     let mut is_closed = po.is_closed;
                     if m.is_present("is_closed") {
@@ -2615,7 +2614,7 @@ fn run() -> Result<(), CliError> {
 
                     let payload = UpdatePurchaseOrderPayloadBuilder::new()
                         .with_uid(uid)
-                        .with_workflow_status(workflow_status.to_string())
+                        .with_workflow_state(workflow_state.to_string())
                         .with_is_closed(is_closed)
                         .with_accepted_version_number(
                             accepted_version.as_deref().map(|s| s.to_string()),
@@ -2712,7 +2711,7 @@ fn run() -> Result<(), CliError> {
 
                     let po = m.value_of("po").unwrap();
 
-                    let workflow_status = m.value_of("workflow_status").unwrap();
+                    let workflow_state = m.value_of("workflow_state").unwrap();
 
                     let revision_id = purchase_orders::get_latest_revision_id(
                         &*purchase_order_client,
@@ -2727,7 +2726,7 @@ fn run() -> Result<(), CliError> {
                         CreateVersionPayloadBuilder::new()
                             .with_version_id(version_id.to_string())
                             .with_po_uid(po.to_string())
-                            .with_workflow_status(workflow_status.to_string())
+                            .with_workflow_state(workflow_state.to_string())
                             .with_is_draft(draft)
                             .with_revision(
                                 PayloadRevisionBuilder::new()
@@ -2847,9 +2846,9 @@ fn run() -> Result<(), CliError> {
                         service_id.as_deref(),
                     )?;
 
-                    let workflow_status = m
-                        .value_of("workflow_status")
-                        .unwrap_or(&version.workflow_status);
+                    let workflow_state = m
+                        .value_of("workflow_state")
+                        .unwrap_or(&version.workflow_state);
 
                     let mut current_revision_id: u64 = version.current_revision_id;
 
@@ -2924,7 +2923,7 @@ fn run() -> Result<(), CliError> {
                     let action = UpdateVersionPayloadBuilder::new()
                         .with_version_id(version_id.to_string())
                         .with_po_uid(po.to_string())
-                        .with_workflow_status(workflow_status.to_string())
+                        .with_workflow_state(workflow_state.to_string())
                         .with_is_draft(draft)
                         .with_revision(payload_revision)
                         .build()

--- a/contracts/purchase_order/src/payload.rs
+++ b/contracts/purchase_order/src/payload.rs
@@ -69,9 +69,9 @@ pub(crate) fn validate_create_po_payload(
         ));
     }
 
-    if payload.workflow_status().is_empty() {
+    if payload.workflow_state().is_empty() {
         return Err(ApplyError::InvalidTransaction(
-            "`workflow_status` is required to create a purchase order".to_string(),
+            "`workflow_state` is required to create a purchase order".to_string(),
         ));
     }
 
@@ -92,9 +92,9 @@ pub(crate) fn validate_update_po_payload(
         ));
     }
 
-    if payload.workflow_status().is_empty() {
+    if payload.workflow_state().is_empty() {
         return Err(ApplyError::InvalidTransaction(
-            "`workflow_status` is required to update a purchase order".to_string(),
+            "`workflow_state` is required to update a purchase order".to_string(),
         ));
     }
 
@@ -154,9 +154,9 @@ pub(crate) fn validate_create_version_payload(
         ));
     }
 
-    if payload.workflow_status().is_empty() {
+    if payload.workflow_state().is_empty() {
         return Err(ApplyError::InvalidTransaction(
-            "`workflow_status` is required to create a purchase order version".to_string(),
+            "`workflow_state` is required to create a purchase order version".to_string(),
         ));
     }
 
@@ -181,9 +181,9 @@ pub(crate) fn validate_update_version_payload(
         ));
     }
 
-    if payload.workflow_status().is_empty() {
+    if payload.workflow_state().is_empty() {
         return Err(ApplyError::InvalidTransaction(
-            "`workflow_status` is required to update a purchase order version".to_string(),
+            "`workflow_state` is required to update a purchase order version".to_string(),
         ));
     }
 
@@ -332,7 +332,7 @@ mod tests {
             protos::purchase_order_payload::UpdateVersionPayload::new();
         update_version_payload.set_version_id("01".to_string());
         update_version_payload.set_po_uid("PO-01".to_string());
-        update_version_payload.set_workflow_status("proposed".to_string());
+        update_version_payload.set_workflow_state("proposed".to_string());
         update_version_payload.set_revision(payload_revision_proto);
         let version_native = update_version_payload
             .clone()
@@ -362,7 +362,7 @@ mod tests {
         let mut update_version_payload =
             protos::purchase_order_payload::UpdateVersionPayload::new();
         update_version_payload.set_po_uid("PO-01".to_string());
-        update_version_payload.set_workflow_status("proposed".to_string());
+        update_version_payload.set_workflow_state("proposed".to_string());
         update_version_payload.set_revision(payload_revision_proto);
         let version_native = update_version_payload
             .clone()
@@ -392,7 +392,7 @@ mod tests {
         let mut update_version_payload =
             protos::purchase_order_payload::UpdateVersionPayload::new();
         update_version_payload.set_version_id("01".to_string());
-        update_version_payload.set_workflow_status("proposed".to_string());
+        update_version_payload.set_workflow_state("proposed".to_string());
         update_version_payload.set_revision(payload_revision_proto);
         let version_native = update_version_payload
             .clone()
@@ -403,16 +403,16 @@ mod tests {
     }
 
     #[test]
-    /// Validates that an `UpdateVersionPayload` with an undefined `workflow_status` is not able
+    /// Validates that an `UpdateVersionPayload` with an undefined `workflow_state` is not able
     /// to be validated. The test follows these steps:
     ///
     /// 1. Create an `UpdateVersionPayload` protobuf message and define all fields except the
-    ///    `workflow_status` field
+    ///    `workflow_state` field
     /// 2. Assert this `UpdateVersionPayload` does not successfully validate
     ///
-    /// This test validates that a `UpdateVersionPayload` with an undefined `workflow_status`
+    /// This test validates that a `UpdateVersionPayload` with an undefined `workflow_state`
     /// field produces an error on validation.
-    fn test_validate_update_version_payload_invalid_workflow_status() {
+    fn test_validate_update_version_payload_invalid_workflow_state() {
         let mut payload_revision_proto = protos::purchase_order_payload::PayloadRevision::new();
         payload_revision_proto.set_revision_id(2);
         payload_revision_proto.set_submitter(SUBMITTER.to_string());
@@ -447,7 +447,7 @@ mod tests {
             protos::purchase_order_payload::UpdateVersionPayload::new();
         update_version_payload.set_version_id("01".to_string());
         update_version_payload.set_po_uid("PO-01".to_string());
-        update_version_payload.set_workflow_status("proposed".to_string());
+        update_version_payload.set_workflow_state("proposed".to_string());
         let version_native = update_version_payload
             .clone()
             .into_native()
@@ -476,7 +476,7 @@ mod tests {
             protos::purchase_order_payload::CreateVersionPayload::new();
         create_version_payload.set_version_id("01".to_string());
         create_version_payload.set_po_uid("PO-01".to_string());
-        create_version_payload.set_workflow_status("proposed".to_string());
+        create_version_payload.set_workflow_state("proposed".to_string());
         create_version_payload.set_revision(payload_revision_proto);
         let payload_native = create_version_payload
             .clone()
@@ -506,7 +506,7 @@ mod tests {
         let mut create_version_payload =
             protos::purchase_order_payload::CreateVersionPayload::new();
         create_version_payload.set_po_uid("PO-01".to_string());
-        create_version_payload.set_workflow_status("proposed".to_string());
+        create_version_payload.set_workflow_state("proposed".to_string());
         create_version_payload.set_revision(payload_revision_proto);
         let payload_native = create_version_payload
             .clone()
@@ -536,7 +536,7 @@ mod tests {
         let mut create_version_payload =
             protos::purchase_order_payload::CreateVersionPayload::new();
         create_version_payload.set_version_id("01".to_string());
-        create_version_payload.set_workflow_status("proposed".to_string());
+        create_version_payload.set_workflow_state("proposed".to_string());
         create_version_payload.set_revision(payload_revision_proto);
         let payload_native = create_version_payload
             .clone()
@@ -547,16 +547,16 @@ mod tests {
     }
 
     #[test]
-    /// Validates that a `CreateVersionPayload` with an undefined `workflow_status` is not
+    /// Validates that a `CreateVersionPayload` with an undefined `workflow_state` is not
     /// able to be validated. The test follows these steps:
     ///
     /// 1. Create a `CreateVersionPayload` protobuf message and define all fields except the
-    ///    `workflow_status` field
+    ///    `workflow_state` field
     /// 2. Assert this `CreateVersionPayload` does not successfully validate
     ///
-    /// This test validates that a `CreateVersionPayload` with an undefined `workflow_status`
+    /// This test validates that a `CreateVersionPayload` with an undefined `workflow_state`
     /// field produces an error on validation.
-    fn test_validate_create_version_payload_invalid_workflow_status() {
+    fn test_validate_create_version_payload_invalid_workflow_state() {
         let mut payload_revision_proto = protos::purchase_order_payload::PayloadRevision::new();
         payload_revision_proto.set_revision_id(1);
         payload_revision_proto.set_submitter(SUBMITTER.to_string());
@@ -591,7 +591,7 @@ mod tests {
             protos::purchase_order_payload::CreateVersionPayload::new();
         create_version_payload.set_version_id("01".to_string());
         create_version_payload.set_po_uid("PO-01".to_string());
-        create_version_payload.set_workflow_status("proposed".to_string());
+        create_version_payload.set_workflow_state("proposed".to_string());
         let payload_native = create_version_payload
             .clone()
             .into_native()
@@ -613,7 +613,7 @@ mod tests {
         let mut update_po_payload =
             protos::purchase_order_payload::UpdatePurchaseOrderPayload::new();
         update_po_payload.set_po_uid("PO-01".to_string());
-        update_po_payload.set_workflow_status("issued".to_string());
+        update_po_payload.set_workflow_state("issued".to_string());
         let payload_native = update_po_payload
             .clone()
             .into_native()
@@ -635,7 +635,7 @@ mod tests {
     fn test_validate_update_po_payload_invalid_po_uid() {
         let mut update_po_payload =
             protos::purchase_order_payload::UpdatePurchaseOrderPayload::new();
-        update_po_payload.set_workflow_status("issued".to_string());
+        update_po_payload.set_workflow_state("issued".to_string());
         let payload_native = update_po_payload
             .clone()
             .into_native()
@@ -645,16 +645,16 @@ mod tests {
     }
 
     #[test]
-    /// Validates that an `UpdatePurchaseOrderPayload` with an undefined `workflow_status` field
+    /// Validates that an `UpdatePurchaseOrderPayload` with an undefined `workflow_state` field
     /// is unable to be validated. The test follows these steps:
     ///
     /// 1. Create an `UpdatePurchaseOrderPayload` protobuf message and define all fields except
-    ///    the `workflow_status` field
+    ///    the `workflow_state` field
     /// 2. Assert this `UpdatePurchaseOrderPayload` does not validate
     ///
-    /// This test validates that a `UpdatePurchaseOrderPayload` with an undefined `workflow_status`
+    /// This test validates that a `UpdatePurchaseOrderPayload` with an undefined `workflow_state`
     /// field is unable to be validated
-    fn test_validate_update_po_payload_invalid_workflow_status() {
+    fn test_validate_update_po_payload_invalid_workflow_state() {
         let mut update_po_payload =
             protos::purchase_order_payload::UpdatePurchaseOrderPayload::new();
         update_po_payload.set_po_uid("PO-01".to_string());
@@ -682,7 +682,7 @@ mod tests {
         create_po_payload.set_created_at(1);
         create_po_payload.set_buyer_org_id("buyer".to_string());
         create_po_payload.set_seller_org_id("seller".to_string());
-        create_po_payload.set_workflow_status("issued".to_string());
+        create_po_payload.set_workflow_state("issued".to_string());
         let payload_native = create_po_payload
             .clone()
             .into_native()
@@ -707,7 +707,7 @@ mod tests {
         create_po_payload.set_created_at(1);
         create_po_payload.set_buyer_org_id("buyer".to_string());
         create_po_payload.set_seller_org_id("seller".to_string());
-        create_po_payload.set_workflow_status("issued".to_string());
+        create_po_payload.set_workflow_state("issued".to_string());
         let payload_native = create_po_payload
             .clone()
             .into_native()
@@ -732,7 +732,7 @@ mod tests {
         create_po_payload.set_uid("PO-01".to_string());
         create_po_payload.set_buyer_org_id("buyer".to_string());
         create_po_payload.set_seller_org_id("seller".to_string());
-        create_po_payload.set_workflow_status("issued".to_string());
+        create_po_payload.set_workflow_state("issued".to_string());
         let payload_native = create_po_payload
             .clone()
             .into_native()
@@ -757,7 +757,7 @@ mod tests {
         create_po_payload.set_uid("PO-01".to_string());
         create_po_payload.set_created_at(1);
         create_po_payload.set_seller_org_id("seller".to_string());
-        create_po_payload.set_workflow_status("issued".to_string());
+        create_po_payload.set_workflow_state("issued".to_string());
         let payload_native = create_po_payload
             .clone()
             .into_native()
@@ -782,7 +782,7 @@ mod tests {
         create_po_payload.set_uid("PO-01".to_string());
         create_po_payload.set_created_at(1);
         create_po_payload.set_buyer_org_id("buyer".to_string());
-        create_po_payload.set_workflow_status("issued".to_string());
+        create_po_payload.set_workflow_state("issued".to_string());
         let payload_native = create_po_payload
             .clone()
             .into_native()
@@ -792,16 +792,16 @@ mod tests {
     }
 
     #[test]
-    /// Validates that a `CreatePurchaseOrderPayload` with an undefind `workflow_status` field is
+    /// Validates that a `CreatePurchaseOrderPayload` with an undefind `workflow_state` field is
     /// not validated. The test follows these steps:
     ///
-    /// 1. Create an `CreatePurchaseOrderPayload` protobuf message, leaving the `workflow_status`
+    /// 1. Create an `CreatePurchaseOrderPayload` protobuf message, leaving the `workflow_state`
     ///    field undefined and filling in the remaining values
     /// 2. Assert this `CreatePurchaseOrderPayload` does not successfully validate
     ///
-    /// This test validates that a `CreatePurchaseOrderPayload` with an undefined `workflow_status`
+    /// This test validates that a `CreatePurchaseOrderPayload` with an undefined `workflow_state`
     /// field is not succesfully validated.
-    fn test_validate_create_po_payload_invalid_workflow_status() {
+    fn test_validate_create_po_payload_invalid_workflow_state() {
         let mut create_po_payload =
             protos::purchase_order_payload::CreatePurchaseOrderPayload::new();
         create_po_payload.set_uid("PO-01".to_string());

--- a/contracts/purchase_order/src/permissions.rs
+++ b/contracts/purchase_order/src/permissions.rs
@@ -63,7 +63,7 @@ impl fmt::Display for Permission {
 }
 
 impl Permission {
-    /// Get the relevant permission for transitioning to a workflow status
+    /// Get the relevant permission for transitioning to a workflow state
     pub fn can_transition(to_status: &str) -> Option<Permission> {
         match to_status {
             "issued" => Some(Permission::CanTransitionIssued),

--- a/contracts/purchase_order/src/state.rs
+++ b/contracts/purchase_order/src/state.rs
@@ -453,7 +453,7 @@ mod tests {
     fn purchase_order_basic() -> PurchaseOrder {
         PurchaseOrderBuilder::new()
             .with_uid(PO_UID.to_string())
-            .with_workflow_status("Issued".to_string())
+            .with_workflow_state("Issued".to_string())
             .with_created_at(1)
             .with_buyer_org_id(ORG_1.to_string())
             .with_seller_org_id(ORG_2.to_string())
@@ -467,7 +467,7 @@ mod tests {
     fn purchase_order_multiple_versions() -> PurchaseOrder {
         PurchaseOrderBuilder::new()
             .with_uid(PO_UID.to_string())
-            .with_workflow_status("Issued".to_string())
+            .with_workflow_state("Issued".to_string())
             .with_created_at(2)
             .with_buyer_org_id(ORG_1.to_string())
             .with_seller_org_id(ORG_2.to_string())
@@ -484,7 +484,7 @@ mod tests {
     fn purchase_order_version(version_id: &str) -> PurchaseOrderVersion {
         PurchaseOrderVersionBuilder::new()
             .with_version_id(version_id.to_string())
-            .with_workflow_status("Editable".to_string())
+            .with_workflow_state("Editable".to_string())
             .with_is_draft(true)
             .with_current_revision_id(1)
             .with_revisions(purchase_order_revision())

--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -1019,7 +1019,7 @@ components:
         uid:
           type: string
           example: 0099474000005
-        workflow_status:
+        workflow_state:
           type: string
           example: ACCEPTED
         accepted_version_id:
@@ -1047,7 +1047,7 @@ components:
         version_id:
           type: string
           example: 02cd3181dbd7d1539f470436ce222c53ab5e514f67809dc0095895e6cdfba97612
-        workflow_status:
+        workflow_state:
           type: string
           example: ISSUED
         is_draft:

--- a/daemon/src/event/db_handler.rs
+++ b/daemon/src/event/db_handler.rs
@@ -723,7 +723,7 @@ fn state_change_to_db_operation(
                         .map(|po| {
                             let mut builder = PurchaseOrderBuilder::default()
                                 .with_purchase_order_uid(po.uid().to_string())
-                                .with_workflow_status(po.workflow_status().to_string())
+                                .with_workflow_state(po.workflow_state().to_string())
                                 .with_versions(make_po_versions(
                                     po.versions().to_vec(),
                                     commit_num,
@@ -1042,7 +1042,7 @@ fn make_po_versions(
                     make_po_revisions(version.revisions().to_vec(), start_commit_num, service_id)
                         .map_err(|err| PurchaseOrderBuilderError::BuildError(Box::new(err)))?,
                 )
-                .with_workflow_status(version.workflow_status().to_string())
+                .with_workflow_state(version.workflow_state().to_string())
                 .with_start_commit_number(start_commit_num)
                 .with_end_commit_number(MAX_COMMIT_NUM)
                 .with_service_id(service_id.cloned())

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -38,14 +38,14 @@ message CreatePurchaseOrderPayload {
   uint64 created_at = 2;
   string buyer_org_id = 3;
   string seller_org_id = 4;
-  string workflow_status = 5;
+  string workflow_state = 5;
   repeated PurchaseOrderAlternateId alternate_ids = 6;
   CreateVersionPayload create_version_payload = 7;
 }
 
 message UpdatePurchaseOrderPayload {
   string po_uid = 1;
-  string workflow_status = 2;
+  string workflow_state = 2;
   bool is_closed = 3;
   string accepted_version_number = 4;
   repeated PurchaseOrderAlternateId alternate_ids = 5;
@@ -55,14 +55,14 @@ message CreateVersionPayload {
   string version_id = 1;
   string po_uid = 2;
   bool is_draft = 3;
-  string workflow_status = 4;
+  string workflow_state = 4;
   PayloadRevision revision = 5;
 }
 
 message UpdateVersionPayload {
   string version_id = 1;
   string po_uid = 2;
-  string workflow_status = 3;
+  string workflow_state = 3;
   bool is_draft = 4;
   PayloadRevision revision = 6;
 }

--- a/sdk/protos/purchase_order_state.proto
+++ b/sdk/protos/purchase_order_state.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 
 message PurchaseOrder {
   string uid = 1;
-  string workflow_status = 2;
+  string workflow_state = 2;
   string buyer_org_id = 3;
   string seller_org_id = 4;
   repeated PurchaseOrderVersion versions = 5;
@@ -34,7 +34,7 @@ message PurchaseOrderList {
 
 message PurchaseOrderVersion {
   string version_id = 1;
-  string workflow_status = 2;
+  string workflow_state = 2;
   bool is_draft = 3;
   uint64 current_revision_id = 4;
   repeated PurchaseOrderRevision revisions = 5;

--- a/sdk/src/client/purchase_order.rs
+++ b/sdk/src/client/purchase_order.rs
@@ -26,7 +26,7 @@ use super::Client;
 #[derive(Debug, Clone, PartialEq)]
 pub struct PurchaseOrder {
     pub purchase_order_uid: String,
-    pub workflow_status: String,
+    pub workflow_state: String,
     pub buyer_org_id: String,
     pub seller_org_id: String,
     pub is_closed: bool,
@@ -41,7 +41,7 @@ pub struct PurchaseOrder {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PurchaseOrderVersion {
     pub version_id: String,
-    pub workflow_status: String,
+    pub workflow_state: String,
     pub is_draft: bool,
     pub current_revision_id: u64,
     pub revisions: Vec<PurchaseOrderRevision>,

--- a/sdk/src/client/reqwest/purchase_order/data.rs
+++ b/sdk/src/client/reqwest/purchase_order/data.rs
@@ -21,7 +21,7 @@ use crate::client::purchase_order::{
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PurchaseOrder {
     purchase_order_uid: String,
-    workflow_status: String,
+    workflow_state: String,
     buyer_org_id: String,
     seller_org_id: String,
     is_closed: bool,
@@ -36,7 +36,7 @@ impl From<&PurchaseOrder> for ClientPurchaseOrder {
     fn from(d: &PurchaseOrder) -> Self {
         Self {
             purchase_order_uid: d.purchase_order_uid.to_string(),
-            workflow_status: d.workflow_status.to_string(),
+            workflow_state: d.workflow_state.to_string(),
             buyer_org_id: d.buyer_org_id.to_string(),
             seller_org_id: d.seller_org_id.to_string(),
             is_closed: d.is_closed,
@@ -60,7 +60,7 @@ impl From<&PurchaseOrder> for ClientPurchaseOrder {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PurchaseOrderVersion {
     version_id: String,
-    workflow_status: String,
+    workflow_state: String,
     is_draft: bool,
     current_revision_id: u64,
     revisions: Vec<PurchaseOrderRevision>,
@@ -70,7 +70,7 @@ impl From<&PurchaseOrderVersion> for ClientPurchaseOrderVersion {
     fn from(d: &PurchaseOrderVersion) -> Self {
         Self {
             version_id: d.version_id.to_string(),
-            workflow_status: d.workflow_status.to_string(),
+            workflow_state: d.workflow_state.to_string(),
             is_draft: d.is_draft,
             current_revision_id: d.current_revision_id,
             revisions: d

--- a/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -16,7 +16,7 @@
 CREATE TABLE purchase_order (
     id BIGSERIAL PRIMARY KEY,
     purchase_order_uid TEXT NOT NULL,
-    workflow_status TEXT NOT NULL,
+    workflow_state TEXT NOT NULL,
     buyer_org_id VARCHAR(256) NOT NULL,
     seller_org_id VARCHAR(256) NOT NULL,
     is_closed BOOLEAN NOT NULL,
@@ -34,7 +34,7 @@ CREATE TABLE purchase_order_version (
     version_id TEXT NOT NULL,
     is_draft BOOLEAN NOT NULL,
     current_revision_id BIGINT NOT NULL,
-    workflow_status TEXT NOT NULL,
+    workflow_state TEXT NOT NULL,
     start_commit_num BIGINT NOT NULL,
     end_commit_num BIGINT NOT NULL,
     service_id TEXT

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -16,7 +16,7 @@
 CREATE TABLE purchase_order (
     id INTEGER PRIMARY KEY,
     purchase_order_uid TEXT NOT NULL,
-    workflow_status TEXT NOT NULL,
+    workflow_state TEXT NOT NULL,
     buyer_org_id VARCHAR(256) NOT NULL,
     seller_org_id VARCHAR(256) NOT NULL,
     is_closed BOOLEAN NOT NULL,
@@ -34,7 +34,7 @@ CREATE TABLE purchase_order_version (
     version_id TEXT NOT NULL,
     is_draft BOOLEAN NOT NULL,
     current_revision_id BIGINT NOT NULL,
-    workflow_status TEXT NOT NULL,
+    workflow_state TEXT NOT NULL,
     start_commit_num BIGINT NOT NULL,
     end_commit_num BIGINT NOT NULL,
     service_id TEXT

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -185,7 +185,7 @@ pub struct CreatePurchaseOrderPayload {
     created_at: u64,
     buyer_org_id: String,
     seller_org_id: String,
-    workflow_status: String,
+    workflow_state: String,
     alternate_ids: Vec<PurchaseOrderAlternateId>,
     create_version_payload: Option<CreateVersionPayload>,
 }
@@ -207,8 +207,8 @@ impl CreatePurchaseOrderPayload {
         &self.seller_org_id
     }
 
-    pub fn workflow_status(&self) -> &str {
-        &self.workflow_status
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
     }
 
     pub fn alternate_ids(&self) -> &[PurchaseOrderAlternateId] {
@@ -241,7 +241,7 @@ impl FromProto<purchase_order_payload::CreatePurchaseOrderPayload> for CreatePur
             created_at: proto.get_created_at(),
             buyer_org_id: proto.take_buyer_org_id(),
             seller_org_id: proto.take_seller_org_id(),
-            workflow_status: proto.take_workflow_status(),
+            workflow_state: proto.take_workflow_state(),
             alternate_ids: proto
                 .get_alternate_ids()
                 .to_vec()
@@ -271,7 +271,7 @@ impl FromNative<CreatePurchaseOrderPayload> for purchase_order_payload::CreatePu
                     ProtoConversionError,
                 >>()?,
         ));
-        proto.set_workflow_status(native.workflow_status().to_string());
+        proto.set_workflow_state(native.workflow_state().to_string());
 
         if let Some(payload) = native.create_version_payload() {
             let proto_payload: purchase_order_payload::CreateVersionPayload =
@@ -317,7 +317,7 @@ pub struct CreatePurchaseOrderPayloadBuilder {
     created_at: Option<u64>,
     buyer_org_id: Option<String>,
     seller_org_id: Option<String>,
-    workflow_status: Option<String>,
+    workflow_state: Option<String>,
     alternate_ids: Vec<PurchaseOrderAlternateId>,
     create_version_payload: Option<CreateVersionPayload>,
 }
@@ -347,8 +347,8 @@ impl CreatePurchaseOrderPayloadBuilder {
         self
     }
 
-    pub fn with_workflow_status(mut self, value: String) -> Self {
-        self.workflow_status = Some(value);
+    pub fn with_workflow_state(mut self, value: String) -> Self {
+        self.workflow_state = Some(value);
         self
     }
 
@@ -379,8 +379,8 @@ impl CreatePurchaseOrderPayloadBuilder {
             BuilderError::MissingField("'seller_org_id' field is required".to_string())
         })?;
 
-        let workflow_status = self.workflow_status.ok_or_else(|| {
-            BuilderError::MissingField("'workflow_status' field is required".to_string())
+        let workflow_state = self.workflow_state.ok_or_else(|| {
+            BuilderError::MissingField("'workflow_state' field is required".to_string())
         })?;
 
         let alternate_ids = self.alternate_ids;
@@ -392,7 +392,7 @@ impl CreatePurchaseOrderPayloadBuilder {
             created_at,
             buyer_org_id,
             seller_org_id,
-            workflow_status,
+            workflow_state,
             alternate_ids,
             create_version_payload,
         })
@@ -403,7 +403,7 @@ impl CreatePurchaseOrderPayloadBuilder {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct UpdatePurchaseOrderPayload {
     uid: String,
-    workflow_status: String,
+    workflow_state: String,
     is_closed: bool,
     accepted_version_number: Option<String>,
     alternate_ids: Vec<PurchaseOrderAlternateId>,
@@ -414,8 +414,8 @@ impl UpdatePurchaseOrderPayload {
         &self.uid
     }
 
-    pub fn workflow_status(&self) -> &str {
-        &self.workflow_status
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
     }
 
     pub fn is_closed(&self) -> bool {
@@ -437,7 +437,7 @@ impl FromProto<purchase_order_payload::UpdatePurchaseOrderPayload> for UpdatePur
     ) -> Result<Self, ProtoConversionError> {
         Ok(UpdatePurchaseOrderPayload {
             uid: proto.take_po_uid(),
-            workflow_status: proto.take_workflow_status(),
+            workflow_state: proto.take_workflow_state(),
             is_closed: proto.get_is_closed(),
             accepted_version_number: match proto.get_accepted_version_number().is_empty() {
                 false => Some(proto.take_accepted_version_number()),
@@ -457,7 +457,7 @@ impl FromNative<UpdatePurchaseOrderPayload> for purchase_order_payload::UpdatePu
     fn from_native(native: UpdatePurchaseOrderPayload) -> Result<Self, ProtoConversionError> {
         let mut proto = purchase_order_payload::UpdatePurchaseOrderPayload::new();
         proto.set_po_uid(native.uid().to_string());
-        proto.set_workflow_status(native.workflow_status().to_string());
+        proto.set_workflow_state(native.workflow_state().to_string());
         proto.set_is_closed(native.is_closed());
         proto.set_accepted_version_number(
             native.accepted_version_number().unwrap_or("").to_string(),
@@ -508,7 +508,7 @@ impl IntoNative<UpdatePurchaseOrderPayload> for purchase_order_payload::UpdatePu
 #[derive(Default, Debug)]
 pub struct UpdatePurchaseOrderPayloadBuilder {
     uid: Option<String>,
-    workflow_status: Option<String>,
+    workflow_state: Option<String>,
     is_closed: Option<bool>,
     accepted_version_number: Option<String>,
     alternate_ids: Vec<PurchaseOrderAlternateId>,
@@ -524,8 +524,8 @@ impl UpdatePurchaseOrderPayloadBuilder {
         self
     }
 
-    pub fn with_workflow_status(mut self, value: String) -> Self {
-        self.workflow_status = Some(value);
+    pub fn with_workflow_state(mut self, value: String) -> Self {
+        self.workflow_state = Some(value);
         self
     }
 
@@ -549,8 +549,8 @@ impl UpdatePurchaseOrderPayloadBuilder {
             .uid
             .ok_or_else(|| BuilderError::MissingField("'uid' field is required".to_string()))?;
 
-        let workflow_status = self.workflow_status.ok_or_else(|| {
-            BuilderError::MissingField("'workflow_status' field is required".to_string())
+        let workflow_state = self.workflow_state.ok_or_else(|| {
+            BuilderError::MissingField("'workflow_state' field is required".to_string())
         })?;
 
         let is_closed = self.is_closed.ok_or_else(|| {
@@ -561,7 +561,7 @@ impl UpdatePurchaseOrderPayloadBuilder {
 
         Ok(UpdatePurchaseOrderPayload {
             uid,
-            workflow_status,
+            workflow_state,
             is_closed,
             accepted_version_number: self.accepted_version_number,
             alternate_ids,
@@ -714,7 +714,7 @@ pub struct CreateVersionPayload {
     version_id: String,
     po_uid: String,
     is_draft: bool,
-    workflow_status: String,
+    workflow_state: String,
     revision: PayloadRevision,
 }
 
@@ -731,8 +731,8 @@ impl CreateVersionPayload {
         self.is_draft
     }
 
-    pub fn workflow_status(&self) -> &str {
-        &self.workflow_status
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
     }
 
     pub fn revision(&self) -> &PayloadRevision {
@@ -748,7 +748,7 @@ impl FromProto<purchase_order_payload::CreateVersionPayload> for CreateVersionPa
             version_id: proto.take_version_id(),
             po_uid: proto.take_po_uid(),
             is_draft: proto.get_is_draft(),
-            workflow_status: proto.take_workflow_status(),
+            workflow_state: proto.take_workflow_state(),
             revision: PayloadRevision::from_proto(proto.take_revision())?,
         })
     }
@@ -760,7 +760,7 @@ impl FromNative<CreateVersionPayload> for purchase_order_payload::CreateVersionP
         proto.set_version_id(native.version_id().to_string());
         proto.set_po_uid(native.po_uid().to_string());
         proto.set_is_draft(native.is_draft());
-        proto.set_workflow_status(native.workflow_status().to_string());
+        proto.set_workflow_state(native.workflow_state().to_string());
         proto.set_revision(native.revision().clone().into_proto()?);
 
         Ok(proto)
@@ -800,7 +800,7 @@ pub struct CreateVersionPayloadBuilder {
     version_id: Option<String>,
     po_uid: Option<String>,
     is_draft: Option<bool>,
-    workflow_status: Option<String>,
+    workflow_state: Option<String>,
     revision: Option<PayloadRevision>,
 }
 
@@ -824,8 +824,8 @@ impl CreateVersionPayloadBuilder {
         self
     }
 
-    pub fn with_workflow_status(mut self, value: String) -> Self {
-        self.workflow_status = Some(value);
+    pub fn with_workflow_state(mut self, value: String) -> Self {
+        self.workflow_state = Some(value);
         self
     }
 
@@ -847,8 +847,8 @@ impl CreateVersionPayloadBuilder {
             BuilderError::MissingField("'is_draft' field is required".to_string())
         })?;
 
-        let workflow_status = self.workflow_status.ok_or_else(|| {
-            BuilderError::MissingField("'workflow_status' field is required".to_string())
+        let workflow_state = self.workflow_state.ok_or_else(|| {
+            BuilderError::MissingField("'workflow_state' field is required".to_string())
         })?;
 
         let revision = self.revision.ok_or_else(|| {
@@ -859,7 +859,7 @@ impl CreateVersionPayloadBuilder {
             version_id,
             po_uid,
             is_draft,
-            workflow_status,
+            workflow_state,
             revision,
         })
     }
@@ -870,7 +870,7 @@ impl CreateVersionPayloadBuilder {
 pub struct UpdateVersionPayload {
     version_id: String,
     po_uid: String,
-    workflow_status: String,
+    workflow_state: String,
     is_draft: bool,
     revision: PayloadRevision,
 }
@@ -884,8 +884,8 @@ impl UpdateVersionPayload {
         &self.po_uid
     }
 
-    pub fn workflow_status(&self) -> &str {
-        &self.workflow_status
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
     }
 
     pub fn is_draft(&self) -> bool {
@@ -904,7 +904,7 @@ impl FromProto<purchase_order_payload::UpdateVersionPayload> for UpdateVersionPa
         Ok(UpdateVersionPayload {
             version_id: proto.take_version_id(),
             po_uid: proto.take_po_uid(),
-            workflow_status: proto.take_workflow_status(),
+            workflow_state: proto.take_workflow_state(),
             is_draft: proto.get_is_draft(),
             revision: PayloadRevision::from_proto(proto.take_revision())?,
         })
@@ -916,7 +916,7 @@ impl FromNative<UpdateVersionPayload> for purchase_order_payload::UpdateVersionP
         let mut proto = purchase_order_payload::UpdateVersionPayload::new();
         proto.set_version_id(native.version_id().to_string());
         proto.set_po_uid(native.po_uid().to_string());
-        proto.set_workflow_status(native.workflow_status().to_string());
+        proto.set_workflow_state(native.workflow_state().to_string());
         proto.set_is_draft(native.is_draft());
         proto.set_revision(native.revision().clone().into_proto()?);
 
@@ -956,7 +956,7 @@ impl IntoNative<UpdateVersionPayload> for purchase_order_payload::UpdateVersionP
 pub struct UpdateVersionPayloadBuilder {
     version_id: Option<String>,
     po_uid: Option<String>,
-    workflow_status: Option<String>,
+    workflow_state: Option<String>,
     is_draft: Option<bool>,
     revision: Option<PayloadRevision>,
 }
@@ -976,8 +976,8 @@ impl UpdateVersionPayloadBuilder {
         self
     }
 
-    pub fn with_workflow_status(mut self, value: String) -> Self {
-        self.workflow_status = Some(value);
+    pub fn with_workflow_state(mut self, value: String) -> Self {
+        self.workflow_state = Some(value);
         self
     }
 
@@ -1000,8 +1000,8 @@ impl UpdateVersionPayloadBuilder {
             .po_uid
             .ok_or_else(|| BuilderError::MissingField("'po_uid' field is required".to_string()))?;
 
-        let workflow_status = self.workflow_status.ok_or_else(|| {
-            BuilderError::MissingField("'workflow_status' field is required".to_string())
+        let workflow_state = self.workflow_state.ok_or_else(|| {
+            BuilderError::MissingField("'workflow_state' field is required".to_string())
         })?;
 
         let is_draft = self.is_draft.ok_or_else(|| {
@@ -1015,7 +1015,7 @@ impl UpdateVersionPayloadBuilder {
         Ok(UpdateVersionPayload {
             version_id,
             po_uid,
-            workflow_status,
+            workflow_state,
             is_draft,
             revision,
         })
@@ -1032,7 +1032,7 @@ mod test {
         // Validate with all fields filled out
         let proto_update_po = UpdatePurchaseOrderPayload {
             uid: "uid".to_string(),
-            workflow_status: "status".to_string(),
+            workflow_state: "status".to_string(),
             is_closed: true,
             accepted_version_number: Some("version".to_string()),
             alternate_ids: Vec::new(),
@@ -1040,14 +1040,14 @@ mod test {
         .into_proto()
         .expect("could not transform into proto");
         assert_eq!(proto_update_po.get_po_uid(), "uid");
-        assert_eq!(proto_update_po.get_workflow_status(), "status");
+        assert_eq!(proto_update_po.get_workflow_state(), "status");
         assert!(proto_update_po.get_is_closed());
         assert_eq!(proto_update_po.get_accepted_version_number(), "version");
 
         // Validate with optional fields not filled out
         let proto_update_po = UpdatePurchaseOrderPayload {
             uid: "uid".to_string(),
-            workflow_status: "status".to_string(),
+            workflow_state: "status".to_string(),
             is_closed: true,
             accepted_version_number: None,
             alternate_ids: Vec::new(),
@@ -1063,7 +1063,7 @@ mod test {
         // Validate with all fields filled out
         let mut proto_update_po = purchase_order_payload::UpdatePurchaseOrderPayload::new();
         proto_update_po.set_po_uid("uid".to_string());
-        proto_update_po.set_workflow_status("status".to_string());
+        proto_update_po.set_workflow_state("status".to_string());
         proto_update_po.set_is_closed(true);
         proto_update_po.set_accepted_version_number("version".to_string());
 
@@ -1071,14 +1071,14 @@ mod test {
             .into_native()
             .expect("could not transform into native");
         assert_eq!(update_po.uid(), "uid");
-        assert_eq!(update_po.workflow_status(), "status");
+        assert_eq!(update_po.workflow_state(), "status");
         assert!(update_po.is_closed());
         assert_eq!(update_po.accepted_version_number(), Some("version"));
 
         // Validate with optional fields not filled out
         let mut proto_update_po = purchase_order_payload::UpdatePurchaseOrderPayload::new();
         proto_update_po.set_po_uid("uid".to_string());
-        proto_update_po.set_workflow_status("status".to_string());
+        proto_update_po.set_workflow_state("status".to_string());
         proto_update_po.set_is_closed(true);
         proto_update_po.set_accepted_version_number("".to_string());
 

--- a/sdk/src/protocol/purchase_order/state.rs
+++ b/sdk/src/protocol/purchase_order/state.rs
@@ -202,7 +202,7 @@ impl PurchaseOrderRevisionBuilder {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PurchaseOrderVersion {
     version_id: String,
-    workflow_status: String,
+    workflow_state: String,
     is_draft: bool,
     current_revision_id: u64,
     revisions: Vec<PurchaseOrderRevision>,
@@ -213,8 +213,8 @@ impl PurchaseOrderVersion {
         &self.version_id
     }
 
-    pub fn workflow_status(&self) -> &str {
-        &self.workflow_status
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
     }
 
     pub fn is_draft(&self) -> bool {
@@ -232,7 +232,7 @@ impl PurchaseOrderVersion {
     pub fn into_builder(self) -> PurchaseOrderVersionBuilder {
         PurchaseOrderVersionBuilder::new()
             .with_version_id(self.version_id)
-            .with_workflow_status(self.workflow_status)
+            .with_workflow_state(self.workflow_state)
             .with_is_draft(self.is_draft)
             .with_current_revision_id(self.current_revision_id)
             .with_revisions(self.revisions)
@@ -245,7 +245,7 @@ impl FromProto<purchase_order_state::PurchaseOrderVersion> for PurchaseOrderVers
     ) -> Result<Self, ProtoConversionError> {
         Ok(PurchaseOrderVersion {
             version_id: version.take_version_id(),
-            workflow_status: version.take_workflow_status(),
+            workflow_state: version.take_workflow_state(),
             is_draft: version.get_is_draft(),
             current_revision_id: version.get_current_revision_id(),
             revisions: version
@@ -261,7 +261,7 @@ impl FromNative<PurchaseOrderVersion> for purchase_order_state::PurchaseOrderVer
     fn from_native(version: PurchaseOrderVersion) -> Result<Self, ProtoConversionError> {
         let mut proto = purchase_order_state::PurchaseOrderVersion::new();
         proto.set_version_id(version.version_id().to_string());
-        proto.set_workflow_status(version.workflow_status().to_string());
+        proto.set_workflow_state(version.workflow_state().to_string());
         proto.set_is_draft(version.is_draft());
         proto.set_current_revision_id(version.current_revision_id());
         proto.set_revisions(RepeatedField::from_vec(
@@ -322,7 +322,7 @@ impl std::fmt::Display for PurchaseOrderVersionBuildError {
 #[derive(Default, Clone, PartialEq)]
 pub struct PurchaseOrderVersionBuilder {
     version_id: Option<String>,
-    workflow_status: Option<String>,
+    workflow_state: Option<String>,
     is_draft: Option<bool>,
     current_revision_id: Option<u64>,
     revisions: Option<Vec<PurchaseOrderRevision>>,
@@ -338,8 +338,8 @@ impl PurchaseOrderVersionBuilder {
         self
     }
 
-    pub fn with_workflow_status(mut self, workflow_status: String) -> Self {
-        self.workflow_status = Some(workflow_status);
+    pub fn with_workflow_state(mut self, workflow_state: String) -> Self {
+        self.workflow_state = Some(workflow_state);
         self
     }
 
@@ -365,9 +365,9 @@ impl PurchaseOrderVersionBuilder {
             )
         })?;
 
-        let workflow_status = self.workflow_status.ok_or_else(|| {
+        let workflow_state = self.workflow_state.ok_or_else(|| {
             PurchaseOrderVersionBuildError::MissingField(
-                "'workflow_status' field is required".to_string(),
+                "'workflow_state' field is required".to_string(),
             )
         })?;
 
@@ -389,7 +389,7 @@ impl PurchaseOrderVersionBuilder {
 
         Ok(PurchaseOrderVersion {
             version_id,
-            workflow_status,
+            workflow_state,
             is_draft,
             current_revision_id,
             revisions,
@@ -403,7 +403,7 @@ impl PurchaseOrderVersionBuilder {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PurchaseOrder {
     uid: String,
-    workflow_status: String,
+    workflow_state: String,
     versions: Vec<PurchaseOrderVersion>,
     accepted_version_number: Option<String>,
     alternate_ids: Vec<PurchaseOrderAlternateId>,
@@ -419,8 +419,8 @@ impl PurchaseOrder {
         &self.uid
     }
 
-    pub fn workflow_status(&self) -> &str {
-        &self.workflow_status
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
     }
 
     pub fn versions(&self) -> &[PurchaseOrderVersion] {
@@ -458,7 +458,7 @@ impl PurchaseOrder {
     pub fn into_builder(self) -> PurchaseOrderBuilder {
         let mut builder = PurchaseOrderBuilder::new()
             .with_uid(self.uid)
-            .with_workflow_status(self.workflow_status)
+            .with_workflow_state(self.workflow_state)
             .with_versions(self.versions)
             .with_created_at(self.created_at)
             .with_alternate_ids(self.alternate_ids)
@@ -489,7 +489,7 @@ impl FromProto<purchase_order_state::PurchaseOrder> for PurchaseOrder {
         };
         Ok(PurchaseOrder {
             uid: order.take_uid(),
-            workflow_status: order.take_workflow_status(),
+            workflow_state: order.take_workflow_state(),
             versions: order
                 .take_versions()
                 .into_iter()
@@ -514,7 +514,7 @@ impl FromNative<PurchaseOrder> for purchase_order_state::PurchaseOrder {
     fn from_native(order: PurchaseOrder) -> Result<Self, ProtoConversionError> {
         let mut proto = purchase_order_state::PurchaseOrder::new();
         proto.set_uid(order.uid().to_string());
-        proto.set_workflow_status(order.workflow_status().to_string());
+        proto.set_workflow_state(order.workflow_state().to_string());
         proto.set_versions(RepeatedField::from_vec(
             order
                 .versions()
@@ -590,7 +590,7 @@ impl std::fmt::Display for PurchaseOrderBuildError {
 #[derive(Default, Clone, PartialEq)]
 pub struct PurchaseOrderBuilder {
     uid: Option<String>,
-    workflow_status: Option<String>,
+    workflow_state: Option<String>,
     versions: Option<Vec<PurchaseOrderVersion>>,
     accepted_version_number: Option<String>,
     created_at: Option<u64>,
@@ -611,8 +611,8 @@ impl PurchaseOrderBuilder {
         self
     }
 
-    pub fn with_workflow_status(mut self, workflow_status: String) -> Self {
-        self.workflow_status = Some(workflow_status);
+    pub fn with_workflow_state(mut self, workflow_state: String) -> Self {
+        self.workflow_state = Some(workflow_state);
         self
     }
 
@@ -661,8 +661,8 @@ impl PurchaseOrderBuilder {
             PurchaseOrderBuildError::MissingField("'uid' field is required".to_string())
         })?;
 
-        let workflow_status = self.workflow_status.ok_or_else(|| {
-            PurchaseOrderBuildError::MissingField("'workflow_status' field is required".to_string())
+        let workflow_state = self.workflow_state.ok_or_else(|| {
+            PurchaseOrderBuildError::MissingField("'workflow_state' field is required".to_string())
         })?;
 
         let versions = self.versions.ok_or_else(|| {
@@ -695,7 +695,7 @@ impl PurchaseOrderBuilder {
 
         Ok(PurchaseOrder {
             uid,
-            workflow_status,
+            workflow_state,
             versions,
             accepted_version_number,
             created_at,

--- a/sdk/src/purchase_order/store/diesel/models.rs
+++ b/sdk/src/purchase_order/store/diesel/models.rs
@@ -22,7 +22,7 @@ use crate::purchase_order::store::diesel::schema::*;
 #[table_name = "purchase_order"]
 pub struct NewPurchaseOrderModel {
     pub purchase_order_uid: String,
-    pub workflow_status: String,
+    pub workflow_state: String,
     pub buyer_org_id: String,
     pub seller_org_id: String,
     pub is_closed: bool,
@@ -39,7 +39,7 @@ pub struct NewPurchaseOrderModel {
 pub struct PurchaseOrderModel {
     pub id: i64,
     pub purchase_order_uid: String,
-    pub workflow_status: String,
+    pub workflow_state: String,
     pub buyer_org_id: String,
     pub seller_org_id: String,
     pub is_closed: bool,
@@ -58,7 +58,7 @@ pub struct NewPurchaseOrderVersionModel {
     pub version_id: String,
     pub is_draft: bool,
     pub current_revision_id: i64,
-    pub workflow_status: String,
+    pub workflow_state: String,
     pub start_commit_num: i64,
     pub end_commit_num: i64,
     pub service_id: Option<String>,
@@ -72,7 +72,7 @@ pub struct PurchaseOrderVersionModel {
     pub version_id: String,
     pub is_draft: bool,
     pub current_revision_id: i64,
-    pub workflow_status: String,
+    pub workflow_state: String,
     pub start_commit_num: i64,
     pub end_commit_num: i64,
     pub service_id: Option<String>,
@@ -134,7 +134,7 @@ impl From<PurchaseOrder> for NewPurchaseOrderModel {
     fn from(order: PurchaseOrder) -> Self {
         Self {
             purchase_order_uid: order.purchase_order_uid.to_string(),
-            workflow_status: order.workflow_status.to_string(),
+            workflow_state: order.workflow_state.to_string(),
             buyer_org_id: order.buyer_org_id.to_string(),
             seller_org_id: order.seller_org_id.to_string(),
             is_closed: order.is_closed,
@@ -164,7 +164,7 @@ impl
     ) -> Self {
         Self {
             purchase_order_uid: order.purchase_order_uid.to_string(),
-            workflow_status: order.workflow_status.to_string(),
+            workflow_state: order.workflow_state.to_string(),
             buyer_org_id: order.buyer_org_id.to_string(),
             seller_org_id: order.seller_org_id.to_string(),
             is_closed: order.is_closed,
@@ -198,7 +198,7 @@ impl
     ) -> Self {
         Self {
             purchase_order_uid: order.purchase_order_uid.to_string(),
-            workflow_status: order.workflow_status.to_string(),
+            workflow_state: order.workflow_state.to_string(),
             buyer_org_id: order.buyer_org_id.to_string(),
             seller_org_id: order.seller_org_id.to_string(),
             is_closed: order.is_closed,
@@ -241,7 +241,7 @@ impl
                 .filter(|r| r.version_id == version.version_id)
                 .map(PurchaseOrderVersionRevision::from)
                 .collect(),
-            workflow_status: version.workflow_status.to_string(),
+            workflow_state: version.workflow_state.to_string(),
             start_commit_num: version.start_commit_num,
             end_commit_num: version.end_commit_num,
             service_id: version.service_id.clone(),
@@ -258,7 +258,7 @@ impl From<(PurchaseOrderVersionModel, &i64, &i64)> for NewPurchaseOrderVersionMo
             version_id: version.version_id,
             is_draft: version.is_draft,
             current_revision_id: *current_revision_id,
-            workflow_status: version.workflow_status,
+            workflow_state: version.workflow_state,
             start_commit_num: *start_commit_num,
             end_commit_num: MAX_COMMIT_NUM,
             service_id: version.service_id,
@@ -341,7 +341,7 @@ pub fn make_purchase_order_versions(order: &PurchaseOrder) -> Vec<NewPurchaseOrd
             version_id: version.version_id.to_string(),
             is_draft: version.is_draft,
             current_revision_id: version.current_revision_id,
-            workflow_status: version.workflow_status.to_string(),
+            workflow_state: version.workflow_state.to_string(),
             start_commit_num: version.start_commit_num,
             end_commit_num: MAX_COMMIT_NUM,
             service_id: version.service_id.clone(),

--- a/sdk/src/purchase_order/store/diesel/schema.rs
+++ b/sdk/src/purchase_order/store/diesel/schema.rs
@@ -16,7 +16,7 @@ table! {
     purchase_order (id) {
         id -> Int8,
         purchase_order_uid -> Text,
-        workflow_status -> Text,
+        workflow_state -> Text,
         buyer_org_id -> Varchar,
         seller_org_id -> Varchar,
         is_closed -> Bool,
@@ -36,7 +36,7 @@ table! {
         version_id -> Text,
         is_draft -> Bool,
         current_revision_id -> Int8,
-        workflow_status -> Text,
+        workflow_state -> Text,
         start_commit_num -> Int8,
         end_commit_num -> Int8,
         service_id -> Nullable<Text>,

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -39,7 +39,7 @@ impl PurchaseOrderList {
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct PurchaseOrder {
     purchase_order_uid: String,
-    workflow_status: String,
+    workflow_state: String,
     buyer_org_id: String,
     seller_org_id: String,
     is_closed: bool,
@@ -59,9 +59,9 @@ impl PurchaseOrder {
         &self.purchase_order_uid
     }
 
-    /// Returns the workflow status for the PO
-    pub fn workflow_status(&self) -> &str {
-        &self.workflow_status
+    /// Returns the workflow state for the PO
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
     }
 
     /// Returns the buyer's org ID for the PO
@@ -123,7 +123,7 @@ impl PurchaseOrder {
 #[derive(Default, Clone)]
 pub struct PurchaseOrderBuilder {
     purchase_order_uid: String,
-    workflow_status: String,
+    workflow_state: String,
     buyer_org_id: String,
     seller_org_id: String,
     is_closed: bool,
@@ -144,9 +144,9 @@ impl PurchaseOrderBuilder {
         self
     }
 
-    /// Sets the workflow status for this PO
-    pub fn with_workflow_status(mut self, status: String) -> Self {
-        self.workflow_status = status;
+    /// Sets the workflow state for this PO
+    pub fn with_workflow_state(mut self, status: String) -> Self {
+        self.workflow_state = status;
         self
     }
 
@@ -219,7 +219,7 @@ impl PurchaseOrderBuilder {
     pub fn build(self) -> Result<PurchaseOrder, PurchaseOrderBuilderError> {
         let PurchaseOrderBuilder {
             purchase_order_uid,
-            workflow_status,
+            workflow_state,
             buyer_org_id,
             seller_org_id,
             is_closed,
@@ -251,9 +251,9 @@ impl PurchaseOrderBuilder {
             ));
         };
 
-        if workflow_status.is_empty() {
+        if workflow_state.is_empty() {
             return Err(PurchaseOrderBuilderError::MissingRequiredField(
-                "workflow_status".to_string(),
+                "workflow_state".to_string(),
             ));
         };
 
@@ -277,7 +277,7 @@ impl PurchaseOrderBuilder {
 
         Ok(PurchaseOrder {
             purchase_order_uid,
-            workflow_status,
+            workflow_state,
             buyer_org_id,
             seller_org_id,
             is_closed,
@@ -313,7 +313,7 @@ pub struct PurchaseOrderVersion {
     is_draft: bool,
     current_revision_id: i64,
     revisions: Vec<PurchaseOrderVersionRevision>,
-    workflow_status: String,
+    workflow_state: String,
     start_commit_num: i64,
     end_commit_num: i64,
     service_id: Option<String>,
@@ -340,9 +340,9 @@ impl PurchaseOrderVersion {
         self.revisions.to_vec()
     }
 
-    /// Returns the workflow status of the PO version
-    pub fn workflow_status(&self) -> &str {
-        &self.workflow_status
+    /// Returns the workflow state of the PO version
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
     }
 
     /// Returns the start_commit_num for the PO version
@@ -367,7 +367,7 @@ pub struct PurchaseOrderVersionBuilder {
     is_draft: bool,
     current_revision_id: i64,
     revisions: Vec<PurchaseOrderVersionRevision>,
-    workflow_status: String,
+    workflow_state: String,
     start_commit_num: i64,
     end_commit_num: i64,
     service_id: Option<String>,
@@ -398,9 +398,9 @@ impl PurchaseOrderVersionBuilder {
         self
     }
 
-    /// Sets the workflow status for this PO version
-    pub fn with_workflow_status(mut self, workflow_status: String) -> Self {
-        self.workflow_status = workflow_status;
+    /// Sets the workflow state for this PO version
+    pub fn with_workflow_state(mut self, workflow_state: String) -> Self {
+        self.workflow_state = workflow_state;
         self
     }
 
@@ -428,7 +428,7 @@ impl PurchaseOrderVersionBuilder {
             is_draft,
             current_revision_id,
             revisions,
-            workflow_status,
+            workflow_state,
             start_commit_num,
             end_commit_num,
             service_id,
@@ -452,9 +452,9 @@ impl PurchaseOrderVersionBuilder {
             ));
         };
 
-        if workflow_status.is_empty() {
+        if workflow_state.is_empty() {
             return Err(PurchaseOrderBuilderError::MissingRequiredField(
-                "workflow_status".to_string(),
+                "workflow_state".to_string(),
             ));
         };
 
@@ -475,7 +475,7 @@ impl PurchaseOrderVersionBuilder {
             is_draft,
             current_revision_id,
             revisions,
-            workflow_status,
+            workflow_state,
             start_commit_num,
             end_commit_num,
             service_id,

--- a/sdk/src/rest_api/resources/purchase_order/v1/payloads.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/payloads.rs
@@ -22,7 +22,7 @@ use crate::{
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PurchaseOrderSlice {
     pub purchase_order_uid: String,
-    pub workflow_status: String,
+    pub workflow_state: String,
     pub buyer_org_id: String,
     pub seller_org_id: String,
     #[serde(default)]
@@ -43,7 +43,7 @@ impl From<PurchaseOrder> for PurchaseOrderSlice {
     fn from(purchase_order: PurchaseOrder) -> Self {
         Self {
             purchase_order_uid: purchase_order.purchase_order_uid().to_string(),
-            workflow_status: purchase_order.workflow_status().to_string(),
+            workflow_state: purchase_order.workflow_state().to_string(),
             buyer_org_id: purchase_order.buyer_org_id().to_string(),
             seller_org_id: purchase_order.seller_org_id().to_string(),
             accepted_version_id: purchase_order.accepted_version_id().map(ToOwned::to_owned),
@@ -80,7 +80,7 @@ pub struct PurchaseOrderVersionSlice {
     is_draft: bool,
     current_revision_id: i64,
     revisions: Vec<PurchaseOrderRevisionSlice>,
-    workflow_status: String,
+    workflow_state: String,
 }
 
 impl From<PurchaseOrderVersion> for PurchaseOrderVersionSlice {
@@ -94,7 +94,7 @@ impl From<PurchaseOrderVersion> for PurchaseOrderVersionSlice {
                 .into_iter()
                 .map(PurchaseOrderRevisionSlice::from)
                 .collect(),
-            workflow_status: purchase_order_version.workflow_status().to_string(),
+            workflow_state: purchase_order_version.workflow_state().to_string(),
         }
     }
 }


### PR DESCRIPTION
This replaces all references/arguments/variables called
`workflow_status` with the name `workflow_state`. This is for
consistency and accuracy.

Signed-off-by: Davey Newhall <newhall@bitwise.io>