### PR TITLE
Fix po update cli command

### DIFF
--- a/cli/src/actions/purchase_orders.rs
+++ b/cli/src/actions/purchase_orders.rs
@@ -184,16 +184,6 @@ pub fn do_fetch_revisions(
     Ok(revisions)
 }
 
-pub fn do_fetch_alternate_ids(
-    client: &dyn PurchaseOrderClient,
-    po_uid: &str,
-    service_id: Option<&str>,
-) -> Result<Vec<AlternateId>, CliError> {
-    let alternate_ids = client.list_alternate_ids(po_uid.to_string(), service_id)?;
-
-    Ok(alternate_ids)
-}
-
 pub fn do_list_revisions(
     client: &dyn PurchaseOrderClient,
     po_uid: &str,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2578,11 +2578,7 @@ fn run() -> Result<(), CliError> {
                             .unwrap();
                     }
 
-                    let mut alternate_ids = purchase_orders::do_fetch_alternate_ids(
-                        &*purchase_order_client,
-                        &uid,
-                        service_id.as_deref(),
-                    )?;
+                    let mut alternate_ids = po.alternate_ids.clone();
 
                     if m.is_present("add_id") {
                         let adds: Vec<&str> = m.values_of("add_id").unwrap().collect();

--- a/sdk/src/client/purchase_order.rs
+++ b/sdk/src/client/purchase_order.rs
@@ -177,16 +177,4 @@ pub trait PurchaseOrderClient: Client {
         version_id: String,
         service_id: Option<&str>,
     ) -> Result<Vec<PurchaseOrderRevision>, ClientError>;
-
-    /// Lists the purchase order's alternate IDs
-    ///
-    /// # Arguments
-    ///
-    /// * `id` - The UID of the `PurchaseOrder` for the `AlternateId`s to be listed
-    /// * `service_id` - optional - the service ID to fetch the alternate IDs from
-    fn list_alternate_ids(
-        &self,
-        id: String,
-        service_id: Option<&str>,
-    ) -> Result<Vec<AlternateId>, ClientError>;
 }

--- a/sdk/src/client/purchase_order.rs
+++ b/sdk/src/client/purchase_order.rs
@@ -23,7 +23,7 @@ use crate::purchase_order::store::{ListPOFilters, ListVersionFilters};
 use super::Client;
 
 /// The client representation of Grid Purchase Order
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PurchaseOrder {
     pub purchase_order_uid: String,
     pub workflow_status: String,
@@ -37,7 +37,7 @@ pub struct PurchaseOrder {
 }
 
 /// The client representation of Grid Purchase Order version
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PurchaseOrderVersion {
     pub version_id: String,
     pub workflow_status: String,
@@ -47,7 +47,7 @@ pub struct PurchaseOrderVersion {
 }
 
 /// The client representation of Grid Purchase Order version revision
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PurchaseOrderRevision {
     pub revision_id: u64,
     pub order_xml_v3_4: String,
@@ -56,7 +56,7 @@ pub struct PurchaseOrderRevision {
 }
 
 /// The client representation of Grid Purchase Order alternate ID
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AlternateId {
     pub purchase_order_uid: String,
     pub alternate_id_type: String,

--- a/sdk/src/client/purchase_order.rs
+++ b/sdk/src/client/purchase_order.rs
@@ -30,6 +30,7 @@ pub struct PurchaseOrder {
     pub buyer_org_id: String,
     pub seller_org_id: String,
     pub is_closed: bool,
+    pub alternate_ids: Vec<AlternateId>,
     pub accepted_version_id: Option<String>,
     pub versions: Vec<PurchaseOrderVersion>,
     pub created_at: i64,

--- a/sdk/src/client/reqwest/purchase_order/data.rs
+++ b/sdk/src/client/reqwest/purchase_order/data.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use crate::client::purchase_order::{
-    PurchaseOrder as ClientPurchaseOrder, PurchaseOrderRevision as ClientPurchaseOrderRevision,
+    AlternateId as ClientAlternateId, PurchaseOrder as ClientPurchaseOrder,
+    PurchaseOrderRevision as ClientPurchaseOrderRevision,
     PurchaseOrderVersion as ClientPurchaseOrderVersion,
 };
 
@@ -24,6 +25,7 @@ pub struct PurchaseOrder {
     buyer_org_id: String,
     seller_org_id: String,
     is_closed: bool,
+    alternate_ids: Vec<AlternateId>,
     accepted_version_id: Option<String>,
     versions: Vec<PurchaseOrderVersion>,
     created_at: i64,
@@ -38,6 +40,11 @@ impl From<&PurchaseOrder> for ClientPurchaseOrder {
             buyer_org_id: d.buyer_org_id.to_string(),
             seller_org_id: d.seller_org_id.to_string(),
             is_closed: d.is_closed,
+            alternate_ids: d
+                .alternate_ids
+                .iter()
+                .map(ClientAlternateId::from)
+                .collect(),
             accepted_version_id: d.accepted_version_id.as_ref().map(String::from),
             versions: d
                 .versions
@@ -90,6 +97,23 @@ impl From<&PurchaseOrderRevision> for ClientPurchaseOrderRevision {
             order_xml_v3_4: d.order_xml_v3_4.to_string(),
             submitter: d.submitter.to_string(),
             created_at: d.created_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AlternateId {
+    pub purchase_order_uid: String,
+    pub id_type: String,
+    pub id: String,
+}
+
+impl From<&AlternateId> for ClientAlternateId {
+    fn from(d: &AlternateId) -> Self {
+        Self {
+            purchase_order_uid: d.purchase_order_uid.to_string(),
+            alternate_id_type: d.id_type.to_string(),
+            alternate_id: d.id.to_string(),
         }
     }
 }

--- a/sdk/src/client/reqwest/purchase_order/mod.rs
+++ b/sdk/src/client/reqwest/purchase_order/mod.rs
@@ -22,7 +22,7 @@ use crate::error::ClientError;
 use crate::purchase_order::store::{ListPOFilters, ListVersionFilters};
 
 use crate::client::purchase_order::{
-    AlternateId, PurchaseOrder, PurchaseOrderClient, PurchaseOrderRevision, PurchaseOrderVersion,
+    PurchaseOrder, PurchaseOrderClient, PurchaseOrderRevision, PurchaseOrderVersion,
 };
 
 use sawtooth_sdk::messages::batch::BatchList;
@@ -187,14 +187,5 @@ impl PurchaseOrderClient for ReqwestPurchaseOrderClient {
         )?;
 
         Ok(dto.iter().map(PurchaseOrderRevision::from).collect())
-    }
-
-    /// Lists the purchase order's alternate IDs
-    fn list_alternate_ids(
-        &self,
-        _id: String,
-        _service_id: Option<&str>,
-    ) -> Result<Vec<AlternateId>, ClientError> {
-        unimplemented!()
     }
 }


### PR DESCRIPTION
This change fixes the po update cli command by changing it to use the alternate id from the po get endpoint (which is already called earlier and therefore its result is available) instead of the unimplemented `list_alternate_ids` REST client fn.