### PR TITLE
Enforce uniqueness for PO alternate IDs

### DIFF
--- a/sdk/src/client/purchase_order.rs
+++ b/sdk/src/client/purchase_order.rs
@@ -91,6 +91,23 @@ impl TryFrom<AlternateId> for PurchaseOrderAlternateId {
     }
 }
 
+impl TryFrom<&AlternateId> for PurchaseOrderAlternateId {
+    type Error = ClientError;
+
+    fn try_from(id: &AlternateId) -> Result<PurchaseOrderAlternateId, Self::Error> {
+        let po = PurchaseOrderAlternateIdBuilder::new()
+            .with_id_type(id.alternate_id_type.to_string())
+            .with_id(id.alternate_id.to_string())
+            .with_purchase_order_uid(id.purchase_order_uid.to_string())
+            .build()
+            .map_err(|err| {
+                Self::Error::DaemonError(format!("Could not convert Alternate ID: {}", err))
+            })?;
+
+        Ok(po)
+    }
+}
+
 pub trait PurchaseOrderClient: Client {
     /// Retrieves the purchase order with the specified `id`
     ///

--- a/sdk/src/client/reqwest/purchase_order/mod.rs
+++ b/sdk/src/client/reqwest/purchase_order/mod.rs
@@ -133,6 +133,9 @@ impl PurchaseOrderClient for ReqwestPurchaseOrderClient {
             if let Some(seller_org_id) = filters.seller_org_id {
                 filter_map.insert("seller_org_id", seller_org_id);
             }
+            if let Some(alternate_ids) = filters.alternate_ids {
+                filter_map.insert("alternate_ids", alternate_ids);
+            }
         }
         let dto_vec = fetch_entities_list::<data::PurchaseOrder>(
             &self.url,

--- a/sdk/src/purchase_order/store/diesel/operations/get_uid_from_alternate_id.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/get_uid_from_alternate_id.rs
@@ -32,9 +32,11 @@ pub(in crate) mod pg {
     ) -> Result<String, PurchaseOrderStoreError> {
         if !alternate_id.contains(':') {
             return Err(PurchaseOrderStoreError::InternalError(
-                InternalError::with_message(
-                    format!("Could not find alternate ID {}. Alternate IDs must be in the format <id_type>:<id>", alternate_id)
-                )
+                InternalError::with_message(format!(
+                    "Could not find alternate ID {}.
+                    Alternate IDs must be in the format <id_type>:<id>",
+                    alternate_id
+                )),
             ));
         }
         let split: Vec<&str> = alternate_id.split(':').collect();
@@ -80,7 +82,13 @@ pub(in crate) mod sqlite {
         service_id: Option<&str>,
     ) -> Result<String, PurchaseOrderStoreError> {
         if !alternate_id.contains(':') {
-            return Err(PurchaseOrderStoreError::InternalError(InternalError::with_message(format!("Could not find alternate ID {}. Alternate IDs must be in the format <id_type>:<id>", alternate_id))));
+            return Err(PurchaseOrderStoreError::InternalError(
+                InternalError::with_message(format!(
+                    "Could not find alternate ID {}.
+                Alternate IDs must be in the format <id_type>:<id>",
+                    alternate_id
+                )),
+            ));
         }
         let split: Vec<&str> = alternate_id.split(':').collect();
         let id_type = split[0];

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -812,6 +812,8 @@ pub struct ListPOFilters {
     pub seller_org_id: Option<String>,
     pub has_accepted_version: Option<bool>,
     pub is_open: Option<bool>,
+    // Comma separated list of alternate IDs in the format <id_type>:<id>
+    pub alternate_ids: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -833,7 +835,8 @@ pub trait PurchaseOrderStore {
     /// # Arguments
     ///
     ///  * `filters` - Optional filters for the POs: `buyer_org_id`,
-    ///    `seller_org_id`, `has_accepted_version`, and `is_open`
+    ///    `seller_org_id`, `has_accepted_version`, `is_open`, and
+    ///    `alternate_ids`
     ///  * `service_id` - The service ID
     ///  * `offset` - The index of the first in storage to retrieve
     ///  * `limit` - The number of items to retrieve from the offset


### PR DESCRIPTION
This updates the purchase order code to enforce uniqueness for alternate IDs. This adds checks to both the client and PO store to make sure that alternate IDs are only used once per splinter circuit or sawtooth instance.