### PR TITLE
Remove `pike-rest-api` feature

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -100,7 +100,6 @@ database-sqlite = ["grid-sdk/sqlite"]
 location = ["grid-sdk/location", "grid-sdk/rest-api-endpoint-location", "pike", "schema"]
 pike = [
     "grid-sdk/pike",
-    "grid-sdk/pike-rest-api",
     "grid-sdk/rest-api-endpoint-agent",
     "grid-sdk/rest-api-endpoint-organization",
     "grid-sdk/rest-api-endpoint-role",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -107,7 +107,6 @@ experimental = [
     "client-reqwest",
     "cylinder-jwt-support",
     "data-validation",
-    "pike-rest-api",
     "purchase-order",
     "rest-api-resources",
     "rest-api-actix-web-3",
@@ -131,7 +130,6 @@ cylinder-jwt-support = ["cylinder/jwt"]
 data-validation = [ "libc", "quick-xml", "reqwest"]
 location = ["pike", "schema"]
 pike = ["cfg-if", "workflow"]
-pike-rest-api = ["pike", "serde_json", "rest-api-resources"]
 product-gdsn = [ "libc", "quick-xml", "reqwest" ]
 purchase-order = ["pike"]
 product = ["pike", "schema"]


### PR DESCRIPTION
This change removes the `pike-rest-api` feature from the SDK. This
feature is a duplicate of the `rest-api-resources-agent` feature.

Signed-off-by: Shannyn Telander <telander@bitwise.io>