### PR TITLE
Stabilize SDK's "cylinder-jwt-support" by removing it

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -92,7 +92,7 @@ experimental = [
     "track-and-trace",
 ]
 
-cylinder-jwt-support = ["cylinder/jwt", "grid-sdk/cylinder-jwt-support"]
+cylinder-jwt-support = ["cylinder/jwt"]
 event = ["database"]
 database = []
 database-postgres = ["grid-sdk/postgres"]

--- a/daemon/src/splinter/run.rs
+++ b/daemon/src/splinter/run.rs
@@ -220,6 +220,8 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
         splinter_endpoint.url(),
         #[cfg(feature = "cylinder-jwt-support")]
         authorization,
+        #[cfg(not(feature = "cylinder-jwt-support"))]
+        "".to_string(),
     );
     let backend_state = BackendState::new(Arc::new(backend_client));
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -52,7 +52,7 @@ rust-crypto-wasm = "0.3"
 sabre-sdk = "0.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cylinder = { version = "0.2.2", features = ["key-load"], optional = true}
+cylinder = { version = "0.2.2", features = ["key-load", "jwt"], optional = true}
 rust-crypto = "0.2"
 sawtooth-sdk = "0.4"
 quick-xml = { version = "0.22", features = [ "serialize" ], optional = true }
@@ -105,7 +105,6 @@ experimental = [
     "batch-store",
     "client",
     "client-reqwest",
-    "cylinder-jwt-support",
     "data-validation",
     "purchase-order",
     "rest-api-resources",
@@ -126,7 +125,6 @@ backend-sawtooth = ["backend", "uuid"]
 backend-splinter = ["backend", "reqwest"]
 client = []
 client-reqwest = ["client", "reqwest"]
-cylinder-jwt-support = ["cylinder/jwt"]
 data-validation = [ "libc", "quick-xml", "reqwest"]
 location = ["pike", "schema"]
 pike = ["cfg-if", "workflow"]

--- a/sdk/src/backend/splinter.rs
+++ b/sdk/src/backend/splinter.rs
@@ -36,20 +36,15 @@ macro_rules! try_fut {
 #[derive(Clone)]
 pub struct SplinterBackendClient {
     node_url: String,
-    #[cfg(feature = "cylinder-jwt-support")]
     authorization: String,
 }
 
 impl SplinterBackendClient {
     /// Constructs a new splinter BackendClient instance, using the given url for the node's REST
     /// API.
-    pub fn new(
-        node_url: String,
-        #[cfg(feature = "cylinder-jwt-support")] authorization: String,
-    ) -> Self {
+    pub fn new(node_url: String, authorization: String) -> Self {
         Self {
             node_url,
-            #[cfg(feature = "cylinder-jwt-support")]
             authorization,
         }
     }
@@ -86,18 +81,11 @@ impl BackendClient for SplinterBackendClient {
         response_url.set_query(Some(&format!("id={}", batch_query)));
         let link = response_url.to_string();
 
-        let mut client = reqwest::Client::new().post(&url);
-
-        client = client
+        reqwest::Client::new()
+            .post(&url)
             .header("GridProtocolVersion", "1")
-            .header("Content-Type", "octet-stream");
-
-        #[cfg(feature = "cylinder-jwt-support")]
-        {
-            client = client.header("Authorization", &self.authorization.to_string());
-        }
-
-        client
+            .header("Content-Type", "octet-stream")
+            .header("Authorization", &self.authorization.to_string())
             .body(batch_list_bytes)
             .send()
             .then(|res| {
@@ -139,16 +127,10 @@ impl BackendClient for SplinterBackendClient {
         url.push_str("ids=");
         url.push_str(&msg.batch_ids.join(","));
 
-        let mut client = reqwest::Client::new().get(&url);
-
-        client = client.header("GridProtocolVersion", "1");
-
-        #[cfg(feature = "cylinder-jwt-support")]
-        {
-            client = client.header("Authorization", &self.authorization.to_string());
-        }
-
-        client
+        reqwest::Client::new()
+            .get(&url)
+            .header("GridProtocolVersion", "1")
+            .header("Authorization", &self.authorization.to_string())
             .send()
             .then(|res| match res {
                 Ok(res) => res.json().boxed(),


### PR DESCRIPTION
This change stabilizes the "cylinder-jwt-support" feature by removing it
from the Grid SDK.

Signed-off-by: Shannyn Telander <telander@bitwise.io>