### PR TITLE
Add Pike namespace to transaction inputs

### DIFF
--- a/cli/src/actions/purchase_order.rs
+++ b/cli/src/actions/purchase_order.rs
@@ -21,6 +21,7 @@ use grid_sdk::{
         AlternateId, PurchaseOrder, PurchaseOrderClient, PurchaseOrderRevision,
         PurchaseOrderVersion,
     },
+    pike::addressing::GRID_PIKE_NAMESPACE,
     protocol::purchase_order::payload::{
         Action, CreatePurchaseOrderPayload, CreateVersionPayload, PurchaseOrderPayloadBuilder,
         UpdatePurchaseOrderPayload, UpdateVersionPayload,
@@ -61,7 +62,10 @@ pub fn do_create_purchase_order(
     let batch_list = purchase_order_batch_builder(signer)
         .add_transaction(
             &payload.into_proto()?,
-            &[GRID_PURCHASE_ORDER_NAMESPACE.to_string()],
+            &[
+                GRID_PURCHASE_ORDER_NAMESPACE.to_string(),
+                GRID_PIKE_NAMESPACE.to_string(),
+            ],
             &[GRID_PURCHASE_ORDER_NAMESPACE.to_string()],
         )?
         .create_batch_list();
@@ -91,7 +95,10 @@ pub fn do_update_purchase_order(
     let batch_list = purchase_order_batch_builder(signer)
         .add_transaction(
             &payload.into_proto()?,
-            &[GRID_PURCHASE_ORDER_NAMESPACE.to_string()],
+            &[
+                GRID_PURCHASE_ORDER_NAMESPACE.to_string(),
+                GRID_PIKE_NAMESPACE.to_string(),
+            ],
             &[GRID_PURCHASE_ORDER_NAMESPACE.to_string()],
         )?
         .create_batch_list();
@@ -121,7 +128,10 @@ pub fn do_create_version(
     let batch_list = purchase_order_batch_builder(signer)
         .add_transaction(
             &payload.into_proto()?,
-            &[GRID_PURCHASE_ORDER_NAMESPACE.to_string()],
+            &[
+                GRID_PURCHASE_ORDER_NAMESPACE.to_string(),
+                GRID_PIKE_NAMESPACE.to_string(),
+            ],
             &[GRID_PURCHASE_ORDER_NAMESPACE.to_string()],
         )?
         .create_batch_list();
@@ -160,7 +170,10 @@ pub fn do_update_version(
     let batch_list = purchase_order_batch_builder(signer)
         .add_transaction(
             &payload.into_proto()?,
-            &[GRID_PURCHASE_ORDER_NAMESPACE.to_string()],
+            &[
+                GRID_PURCHASE_ORDER_NAMESPACE.to_string(),
+                GRID_PIKE_NAMESPACE.to_string(),
+            ],
             &[GRID_PURCHASE_ORDER_NAMESPACE.to_string()],
         )?
         .create_batch_list();

--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -29,7 +29,7 @@ cfg_if! {
 
 use grid_sdk::protos::FromBytes;
 use grid_sdk::{
-    pike::permissions::PermissionChecker,
+    pike::{addressing::GRID_PIKE_NAMESPACE, permissions::PermissionChecker},
     protocol::purchase_order::{
         payload::{
             Action, CreatePurchaseOrderPayload, CreateVersionPayload, PurchaseOrderPayload,
@@ -78,7 +78,10 @@ impl PurchaseOrderTransactionHandler {
         Self {
             family_name: "grid_purchase_order".to_string(),
             family_versions: vec!["1".to_string()],
-            namespaces: vec![GRID_PURCHASE_ORDER_NAMESPACE.to_string()],
+            namespaces: vec![
+                GRID_PURCHASE_ORDER_NAMESPACE.to_string(),
+                GRID_PIKE_NAMESPACE.to_string(),
+            ],
         }
     }
 }


### PR DESCRIPTION
This change adds the Pike namespace to the Purchase Order smart
contract's transaction inputs. This allows the purchase order smart
contract to access the state within the Pike namespace.

Before this change, the sawtooth example would be unable to submit a purchase order smart contract action without receiving an error about attempting to access an unauthorized namespace (Pike Organization namespace, specifically).
```
sawtooth-sabre-tp                  | 2021-11-19 21:29:53,500 INFO  [sawtooth_sdk::processor] TP_PROCESS_REQUEST sending TpProcessResponse: ExternalsError { message: "Trap(Trap { kind: Host(ExternalsError { message: \"AuthorizationError(\\\"Tried to get unauthorized addresses: [\\\\\\\"621dee0501ba3ce58667ca9b12b3c0cdcc4da57f9962aeca7065c43a7d9c027332fdb9\\\\\\\"]\\\")\" }) })" }
```