### PR TITLE
Stabilize gridd "cylinder-jwt-support" by removing

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -37,7 +37,7 @@ byteorder = "1"
 cfg-if = "1"
 clap = "2"
 ctrlc = "3.0"
-cylinder = "0.2.2"
+cylinder = { version = "0.2.2", features = ["jwt"], optional = true }
 diesel = { version = "1.0.0", features = ["r2d2", "serde_json"] }
 diesel_migrations = "1.4"
 flexi_logger = "0.17"
@@ -86,13 +86,11 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
-    "cylinder-jwt-support",
     "integration",
     "purchase-order",
     "track-and-trace",
 ]
 
-cylinder-jwt-support = ["cylinder/jwt"]
 event = ["database"]
 database = []
 database-postgres = ["grid-sdk/postgres"]

--- a/daemon/src/splinter/app_auth_handler/mod.rs
+++ b/daemon/src/splinter/app_auth_handler/mod.rs
@@ -65,17 +65,12 @@ pub fn run(
     handler: Box<dyn EventHandler>,
     igniter: Igniter,
     scabbard_admin_key: String,
-    #[cfg(feature = "cylinder-jwt-support")] authorization: String,
+    authorization: String,
 ) -> Result<(), AppAuthHandlerError> {
     let registration_route = format!("{}/ws/admin/register/grid", &splinterd_url);
-    let node_id = get_node_id(
-        splinterd_url.clone(),
-        #[cfg(feature = "cylinder-jwt-support")]
-        &authorization,
-    )?;
+    let node_id = get_node_id(splinterd_url.clone(), &authorization)?;
 
     let ws_handler = Arc::new(Mutex::new(handler));
-    #[cfg(feature = "cylinder-jwt-support")]
     let ws_auth = authorization.clone();
     let mut ws = WebSocketClient::new(&registration_route, move |_ctx, event| {
         let handler = {
@@ -95,7 +90,6 @@ pub fn run(
             &node_id,
             &scabbard_admin_key,
             &splinterd_url,
-            #[cfg(feature = "cylinder-jwt-support")]
             &ws_auth,
         ) {
             error!("Failed to process admin event: {}", err);
@@ -103,7 +97,6 @@ pub fn run(
         WsResponse::Empty
     });
 
-    #[cfg(feature = "cylinder-jwt-support")]
     ws.header("Authorization", authorization);
     ws.header(
         "SplinterProtocolVersion",
@@ -141,7 +134,7 @@ fn process_admin_event(
     node_id: &str,
     scabbard_admin_key: &str,
     splinterd_url: &str,
-    #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
+    authorization: &str,
 ) -> Result<(), AppAuthHandlerError> {
     debug!("Received the event at {}", event.timestamp);
     match event.admin_event {
@@ -186,7 +179,6 @@ fn process_admin_event(
                     &msg_proposal.circuit_id,
                     &service.service_id,
                     None,
-                    #[cfg(feature = "cylinder-jwt-support")]
                     authorization,
                     || vec![handler.cloned_box()],
                 )

--- a/daemon/src/splinter/app_auth_handler/node.rs
+++ b/daemon/src/splinter/app_auth_handler/node.rs
@@ -35,17 +35,10 @@ impl fmt::Display for GetNodeError {
     }
 }
 
-pub fn get_node_id(
-    splinterd_url: String,
-    #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
-) -> Result<String, GetNodeError> {
+pub fn get_node_id(splinterd_url: String, authorization: &str) -> Result<String, GetNodeError> {
     let uri = format!("{}/status", splinterd_url);
 
-    let body = wait_for_status(
-        &uri,
-        #[cfg(feature = "cylinder-jwt-support")]
-        authorization,
-    )?;
+    let body = wait_for_status(&uri, authorization)?;
 
     let node_id_val = body
         .get("node_id")
@@ -58,22 +51,15 @@ pub fn get_node_id(
     Ok(node_id.to_string())
 }
 
-fn wait_for_status(
-    uri: &str,
-    #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
-) -> Result<Value, GetNodeError> {
+fn wait_for_status(uri: &str, authorization: &str) -> Result<Value, GetNodeError> {
     let mut wait_time = 1;
     let client = reqwest::blocking::Client::new();
     loop {
-        #[allow(unused_mut)]
-        let mut request = client.get(uri);
-
-        #[cfg(feature = "cylinder-jwt-support")]
+        match client
+            .get(uri)
+            .header("Authorization", authorization.to_string())
+            .send()
         {
-            request = request.header("Authorization", authorization.to_string());
-        }
-
-        match request.send() {
             Ok(res) => {
                 return res.json().map_err(|err| {
                     GetNodeError(format!("Failed to parse response body: {}", err))

--- a/daemon/src/splinter/event/mod.rs
+++ b/daemon/src/splinter/event/mod.rs
@@ -50,7 +50,7 @@ impl ScabbardEventConnectionFactory {
         &self,
         circuit_id: &str,
         service_id: &str,
-        #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
+        authorization: &str,
     ) -> Result<ScabbardEventConnection, ScabbardEventConnectionError> {
         let source = format!("{}::{}", circuit_id, service_id);
         let connection_url = format!(
@@ -62,7 +62,6 @@ impl ScabbardEventConnectionFactory {
             source,
             connection_url,
             self.igniter.clone(),
-            #[cfg(feature = "cylinder-jwt-support")]
             authorization.to_string(),
         ))
     }
@@ -84,23 +83,16 @@ pub struct ScabbardEventConnection {
     connection_url: String,
     igniter: Igniter,
     connection_state: RefCell<ConnectionState>,
-    #[cfg(feature = "cylinder-jwt-support")]
     authorization: String,
 }
 
 impl ScabbardEventConnection {
-    fn new(
-        name: String,
-        connection_url: String,
-        igniter: Igniter,
-        #[cfg(feature = "cylinder-jwt-support")] authorization: String,
-    ) -> Self {
+    fn new(name: String, connection_url: String, igniter: Igniter, authorization: String) -> Self {
         Self {
             name,
             connection_url,
             igniter,
             connection_state: RefCell::new(ConnectionState::Disconnected),
-            #[cfg(feature = "cylinder-jwt-support")]
             authorization,
         }
     }
@@ -145,7 +137,6 @@ impl EventConnection for ScabbardEventConnection {
             WsResponse::Empty
         });
 
-        #[cfg(feature = "cylinder-jwt-support")]
         state_delta_ws.header("Authorization", self.authorization.to_string());
 
         state_delta_ws.on_error(move |err, ctx| {

--- a/daemon/src/splinter/event/processors.rs
+++ b/daemon/src/splinter/event/processors.rs
@@ -47,7 +47,7 @@ impl EventProcessors {
         circuit_id: &str,
         service_id: &str,
         last_seen_id: Option<&str>,
-        #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
+        authorization: &str,
         handlers_factory_fn: F,
     ) -> Result<(), InternalError>
     where
@@ -60,7 +60,6 @@ impl EventProcessors {
             circuit_id,
             service_id,
             last_seen_id,
-            #[cfg(feature = "cylinder-jwt-support")]
             authorization,
             handlers_factory_fn,
         )
@@ -85,7 +84,7 @@ impl Inner {
         circuit_id: &str,
         service_id: &str,
         last_seen_id: Option<&str>,
-        #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
+        authorization: &str,
         factory_fn: F,
     ) -> Result<(), InternalError>
     where
@@ -95,12 +94,7 @@ impl Inner {
         if let Entry::Vacant(entry) = self.processors.entry(key) {
             let event_connection = self
                 .event_connection_factory
-                .create_connection(
-                    circuit_id,
-                    service_id,
-                    #[cfg(feature = "cylinder-jwt-support")]
-                    authorization,
-                )
+                .create_connection(circuit_id, service_id, authorization)
                 .map_err(|err| InternalError::from_source(Box::new(err)))?;
 
             let evt_processor = EventProcessor::start(event_connection, last_seen_id, factory_fn())

--- a/daemon/src/splinter/run.rs
+++ b/daemon/src/splinter/run.rs
@@ -25,9 +25,7 @@ use std::sync::{
     Arc,
 };
 
-use cylinder::load_key;
-#[cfg(feature = "cylinder-jwt-support")]
-use cylinder::{jwt::JsonWebTokenBuilder, secp256k1::Secp256k1Context, Context};
+use cylinder::{jwt::JsonWebTokenBuilder, load_key, secp256k1::Secp256k1Context, Context};
 use grid_sdk::backend::SplinterBackendClient;
 use grid_sdk::commits::store::Commit;
 use grid_sdk::commits::{CommitStore, DieselCommitStore};
@@ -82,10 +80,8 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
 
     let scabbard_admin_key = &gridd_key.as_hex();
 
-    #[cfg(feature = "cylinder-jwt-support")]
     let signer = Secp256k1Context::new().new_signer(gridd_key);
 
-    #[cfg(feature = "cylinder-jwt-support")]
     let authorization = {
         let jwt = JsonWebTokenBuilder::new()
             .build(&*signer)
@@ -197,7 +193,6 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
                     service_id.circuit_id,
                     service_id.service_id,
                     Some(&commit.commit_id),
-                    #[cfg(feature = "cylinder-jwt-support")]
                     &authorization,
                     || vec![chan_event_handler.cloned_box()],
                 )
@@ -211,18 +206,11 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
         chan_event_handler,
         reactor.igniter(),
         scabbard_admin_key.to_string(),
-        #[cfg(feature = "cylinder-jwt-support")]
         authorization.clone(),
     )
     .map_err(|err| DaemonError::from_source(Box::new(err)))?;
 
-    let backend_client = SplinterBackendClient::new(
-        splinter_endpoint.url(),
-        #[cfg(feature = "cylinder-jwt-support")]
-        authorization,
-        #[cfg(not(feature = "cylinder-jwt-support"))]
-        "".to_string(),
-    );
+    let backend_client = SplinterBackendClient::new(splinter_endpoint.url(), authorization);
     let backend_state = BackendState::new(Arc::new(backend_client));
 
     #[cfg(feature = "integration")]


### PR DESCRIPTION
This change stabilizes the grid daemon's experimental
"cylinder-jwt-support" feature by removing it.

Signed-off-by: Shannyn Telander <telander@bitwise.io>