### PR TITLE
Use as_ptr method for clarity

### DIFF
--- a/sdk/src/data_validation/xml/xml_ffi.rs
+++ b/sdk/src/data_validation/xml/xml_ffi.rs
@@ -69,7 +69,7 @@ impl XmlSchema {
 impl Drop for XmlSchema {
     fn drop(&mut self) {
         unsafe {
-            xmlSchemaFree(self.0);
+            xmlSchemaFree(self.as_ptr());
         }
     }
 }
@@ -109,7 +109,7 @@ impl XmlSchemaParserCtxt {
 impl Drop for XmlSchemaParserCtxt {
     fn drop(&mut self) {
         unsafe {
-            xmlSchemaFreeParserCtxt(self.0);
+            xmlSchemaFreeParserCtxt(self.as_ptr());
         }
     }
 }
@@ -146,7 +146,7 @@ impl XmlSchemaValidCtxt {
 impl Drop for XmlSchemaValidCtxt {
     fn drop(&mut self) {
         unsafe {
-            xmlSchemaFreeValidCtxt(self.0);
+            xmlSchemaFreeValidCtxt(self.as_ptr());
         }
     }
 }


### PR DESCRIPTION
Update the drop implementations to use the as_ptr method instead of
self.0 for clarity.

Signed-off-by: Lee Bradley <bradley@bitwise.io>