### PR TITLE
Update po version create and update commands

### DIFF
--- a/cli/man/grid-po-version-create.1.md
+++ b/cli/man/grid-po-version-create.1.md
@@ -13,7 +13,7 @@ NAME
 SYNOPSIS
 ========
 
-**grid po version create** \[**FLAGS**\] \[**OPTIONS**\] <VERSION_ID>
+**grid po version create** \[**FLAGS**\] \[**OPTIONS**\] <PO_NUMBER> <VERSION_ID>
 
 DESCRIPTION
 ===========
@@ -21,10 +21,13 @@ DESCRIPTION
 This command allows for the creation of Grid Purchase Orders versions. It
 submits a Sabre transaction to create the purchase order version.
 
-The VERSION_ID argument is required.
+The PO_NUMBER and VERSION_ID arguments are required.
 
 ARGS
 ====
+
+`PO_NUMBER`
+: The UID or an alternate ID of the purchase order this version is for.
 
 `VERSION_ID`
 : The user-specified version identifier.
@@ -64,9 +67,6 @@ OPTIONS
 `--org`
 : Specify the organization that owns the purchase order. This option is required.
 
-`--po`
-: Either a UID or an alternate ID of a purchase order.
-
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
   Splinter. Format: `<circuit-id>::<service-id>`.
@@ -87,12 +87,12 @@ The command
 
 ```
 $ grid po version create \
-    --po PO-1234-56789 \
+    PO-1234-56789 \
+    v3 \
     --order-xml ./my_test_order.xml \
     --draft \
     --workflow-state editable \
-    --wait 10 \
-    v3
+    --wait 10
 ```
 
 will generate version `v3` of purchase order `PO-1234-56789`. It will be

--- a/cli/man/grid-po-version-update.1.md
+++ b/cli/man/grid-po-version-update.1.md
@@ -13,7 +13,7 @@ NAME
 SYNOPSIS
 ========
 
-**grid po version update** \[**FLAGS**\] \[**OPTIONS**\] <VERSION_ID>
+**grid po version update** \[**FLAGS**\] \[**OPTIONS**\] <PO_NUMBER> <VERSION_ID>
 
 DESCRIPTION
 ===========
@@ -22,11 +22,14 @@ This command allows for the update of Grid Purchase Orders versions. It
 submits a Sabre transaction to create the purchase order version. Each update
 creates a new revision of that version.
 
-VERSION_ID argument and the --po option are required.
+The PO_NUMBER and VERSION_ID arguments are required.
 
 
 ARGS
 ====
+
+`PO_NUMBER`
+: The UID or an alternate ID of the purchase order this version is for.
 
 `VERSION_ID`
 : The user-specified version identifier.
@@ -63,9 +66,6 @@ OPTIONS
 : Specify the path to an order xml FILE to load.  The file must conform to the
   GS1 Order spec v3.4
 
-`--po`
-: Either a UID or an alternate ID of a purchase order.
-
 `--service-id`
 : The ID of the service the payload should be sent to; required if running on
   Splinter. Format: `<circuit-id>::<service-id>`.
@@ -86,10 +86,10 @@ The command
 
 ```
 $ grid po version update \
-    --po PO-00000-1111 \
+    PO-00000-1111 \
+    v3 \
     --workflow-state review \
-    --wait=10 \
-    v3
+    --wait=10
 ```
 
 will update the version `v3` of purchase order `PO-00000-1111` to have the

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1255,16 +1255,8 @@ fn run() -> Result<(), CliError> {
                 SubCommand::with_name("create")
                     .about("Create a Purchase Order version")
                     .arg(
-                        Arg::with_name("version_id")
-                            .value_name("version_id")
-                            .takes_value(true)
-                            .required(true)
-                            .help("Identifier for this Purchase Order version"),
-                    )
-                    .arg(
                         Arg::with_name("po")
                             .value_name("order_id")
-                            .long("po")
                             .takes_value(true)
                             .required(true)
                             .help(
@@ -1272,6 +1264,13 @@ fn run() -> Result<(), CliError> {
                         May be the Purchase Order's unique ID or an Alternate ID \
                         (Alternate ID format: <alternate_id_type>:<alternate_id>)",
                             ),
+                    )
+                    .arg(
+                        Arg::with_name("version_id")
+                            .value_name("version_id")
+                            .takes_value(true)
+                            .required(true)
+                            .help("Identifier for this Purchase Order version"),
                     )
                     .arg(
                         Arg::with_name("workflow_state")
@@ -1329,16 +1328,8 @@ fn run() -> Result<(), CliError> {
                 SubCommand::with_name("update")
                     .about("Update a Purchase Order version")
                     .arg(
-                        Arg::with_name("version_id")
-                            .value_name("version_id")
-                            .takes_value(true)
-                            .required(true)
-                            .help("ID of the Purchase Order version to be updated"),
-                    )
-                    .arg(
                         Arg::with_name("po")
                             .value_name("order_id")
-                            .long("po")
                             .takes_value(true)
                             .required(true)
                             .help(
@@ -1346,6 +1337,13 @@ fn run() -> Result<(), CliError> {
                         May be the Purchase Order's UID or an Alternate ID \
                         (Alternate ID format: <alternate_id_type>:<alternate_id>)",
                             ),
+                    )
+                    .arg(
+                        Arg::with_name("version_id")
+                            .value_name("version_id")
+                            .takes_value(true)
+                            .required(true)
+                            .help("ID of the Purchase Order version to be updated"),
                     )
                     .arg(
                         Arg::with_name("workflow_state")


### PR DESCRIPTION
This updates the `grid po version create` and `grid po version update`
cli commands to take the po number as the first positional argument
rather than a required flag. This seems more natural and is the pattern
used for the list and show version commands.

Signed-off-by: Davey Newhall <newhall@bitwise.io>