### PR TITLE
Stabilize data-validation by removing it

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,7 +39,7 @@ log = "0.4"
 flexi_logger = "0.17"
 sawtooth-sdk = "0.4"
 sabre-sdk = "0.5"
-grid-sdk = { path = "../sdk", features = ["postgres", "sqlite", "pike", "schema", "product", "product-gdsn", "location", "client", "client-reqwest", "data-validation"] }
+grid-sdk = { path = "../sdk", features = ["postgres", "sqlite", "pike", "schema", "product", "product-gdsn", "location", "client", "client-reqwest"] }
 rust-crypto = "0.2"
 protobuf = "2.19"
 users = "0.11"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -55,8 +55,8 @@ sabre-sdk = "0.5"
 cylinder = { version = "0.2.2", features = ["key-load", "jwt"], optional = true}
 rust-crypto = "0.2"
 sawtooth-sdk = "0.4"
-quick-xml = { version = "0.22", features = [ "serialize" ], optional = true }
-libc = { version = "0.2.94", optional = true}
+quick-xml = { version = "0.22", features = [ "serialize" ] }
+libc = { version = "0.2.94" }
 tempfile = "3"
 
 [build-dependencies]
@@ -106,7 +106,6 @@ experimental = [
     "batch-processor",
     "batch-store",
     "client-reqwest",
-    "data-validation",
     "purchase-order",
     "rest-api-actix-web-3",
     "rest-api-actix-web-3-run",
@@ -125,10 +124,9 @@ backend-sawtooth = ["backend", "uuid"]
 backend-splinter = ["backend", "reqwest"]
 client = []
 client-reqwest = ["client", "reqwest"]
-data-validation = [ "libc", "quick-xml", "reqwest"]
 location = ["pike", "schema"]
 pike = ["cfg-if", "workflow"]
-product-gdsn = [ "libc", "quick-xml", "reqwest" ]
+product-gdsn = [ "reqwest" ]
 purchase-order = ["pike"]
 product = ["pike", "schema"]
 schema = ["pike"]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -40,7 +40,6 @@ pub mod batches;
 #[cfg(feature = "client")]
 pub mod client;
 pub mod commits;
-#[cfg(feature = "data-validation")]
 pub mod data_validation;
 pub mod error;
 mod hex;


### PR DESCRIPTION
Stabilize the data-validation feature. This has the side effect of
making libc and quick-xml no longer optional.

Signed-off-by: Lee Bradley <bradley@bitwise.io>