### PR TITLE
Fix alternate ID bugs

### DIFF
--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -523,6 +523,7 @@ fn update_purchase_order(
     let builder = PurchaseOrderBuilder::new()
         .with_uid(po_uid.to_string())
         .with_workflow_state(payload.workflow_state().to_string())
+        .with_alternate_ids(payload.alternate_ids().to_vec())
         .with_is_closed(payload.is_closed())
         .with_versions(purchase_order.versions().to_vec())
         .with_created_at(purchase_order.created_at())

--- a/sdk/src/purchase_order/store/diesel/operations/add_purchase_order.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/add_purchase_order.rs
@@ -87,7 +87,7 @@ impl<'a> PurchaseOrderStoreAddPurchaseOrderOperation
                     remove_alternate_id::pg::remove_alternate_id(
                         self.conn,
                         &e,
-                        &order.end_commit_num,
+                        &order.start_commit_num,
                     )?;
                 }
             }


### PR DESCRIPTION
This fixes a couple bugs related to alternate IDs for purchase orders. There were two separate bugs that affected the ability to update the alternate IDs for a purchase order. One bug prevented adding new IDs and one prevented properly removing IDs.