### PR TITLE
Add xsd files to docker images

### DIFF
--- a/cli/src/actions/product.rs
+++ b/cli/src/actions/product.rs
@@ -365,8 +365,8 @@ pub fn create_product_payloads_from_xml(
     owner: &str,
 ) -> Result<Vec<ProductCreateAction>, CliError> {
     let trade_items = get_trade_items_from_xml(path)?;
-    let data_validation_dir =
-        env::var(GRID_PRODUCT_SCHEMA_DIR).unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string());
+    let data_validation_dir = env::var(GRID_PRODUCT_SCHEMA_DIR)
+        .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string() + "/product");
     validate_gdsn_3_1(path, true, &data_validation_dir)?;
 
     let mut payloads = Vec::new();
@@ -404,8 +404,8 @@ pub fn create_product_payloads_from_yaml(
 
 pub fn update_product_payloads_from_xml(path: &str) -> Result<Vec<ProductUpdateAction>, CliError> {
     let trade_items = get_trade_items_from_xml(path)?;
-    let data_validation_dir =
-        env::var(GRID_PRODUCT_SCHEMA_DIR).unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string());
+    let data_validation_dir = env::var(GRID_PRODUCT_SCHEMA_DIR)
+        .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string() + "/product");
     validate_gdsn_3_1(path, true, &data_validation_dir)?;
 
     let mut payloads = Vec::new();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2726,7 +2726,7 @@ fn run() -> Result<(), CliError> {
 
                     let order_xml_path = m.value_of("order_xml").unwrap();
                     let data_validation_dir = env::var(GRID_ORDER_SCHEMA_DIR)
-                        .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string());
+                        .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string() + "/po/gs1/ecom");
                     let mut xml_str = String::new();
                     std::fs::File::open(order_xml_path)?.read_to_string(&mut xml_str)?;
                     validate_order_xml_3_4(&xml_str, false, &data_validation_dir)?;
@@ -2883,7 +2883,7 @@ fn run() -> Result<(), CliError> {
                         new_xml = true;
                         let order_xml_path = m.value_of("order_xml").unwrap();
                         let data_validation_dir = env::var(GRID_ORDER_SCHEMA_DIR)
-                            .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string());
+                            .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string() + "/po/gs1/ecom");
                         xml_str = String::new();
                         std::fs::File::open(order_xml_path)?.read_to_string(&mut xml_str)?;
                         validate_order_xml_3_4(&xml_str, false, &data_validation_dir)?;

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -69,6 +69,10 @@ COPY --from=gridd-builder /build/target/debian/grid-cli_*.deb /tmp
 COPY --from=gridd-builder /build/target/debian/grid-daemon_*.deb /tmp
 COPY --from=gridd-builder /commit-hash /commit-hash
 
+# Copy over files needed for examples
+COPY sdk/src/data_validation/xml/xsd/product/ /etc/grid/schemas/product/
+COPY sdk/src/data_validation/xml/xsd/po/ /etc/grid/schemas/po/
+
 RUN apt-get update \
  && apt-get install -y -q \
     postgresql-client \


### PR DESCRIPTION
Adds product and purchase order xsd files to default locations so users running through the examples can create products and purchase order versions. Previously, users would have to copy the files from the Grid directory into the running container and in the correct location.

Resolves: #1141, #1155