### PR TITLE
Stabilize `client-reqwest` feature

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -74,6 +74,7 @@ stable = [
     "backend-sawtooth",
     "backend-splinter",
     "client",
+    "client-reqwest",
     "data-validation",
     "location",
     "pike",
@@ -106,7 +107,6 @@ experimental = [
     # The following features are experimental:
     "batch-processor",
     "batch-store",
-    "client-reqwest",
     "purchase-order",
     "rest-api-actix-web-3",
     "rest-api-actix-web-3-run",


### PR DESCRIPTION
This stabilizes the `client-reqwest` feature by moving it into "stable"
in the sdk/Cargo.toml file.

Signed-off-by: Davey Newhall <newhall@bitwise.io>