### PR TITLE
Stabilization updates for `workflow`

### DIFF
--- a/sdk/src/pike/permissions/mod.rs
+++ b/sdk/src/pike/permissions/mod.rs
@@ -242,7 +242,7 @@ impl<'a> PermissionChecker<'a> {
 
         // Validate the agent is able to make the desired transition, based on the agent's
         // permission aliases
-        let can_transition = workflow_state.can_transition(desired_state.to_string(), agent_perms);
+        let can_transition = workflow_state.can_transition(desired_state.to_string(), &agent_perms);
 
         Ok(has_perm_alias && has_permission && can_transition)
     }

--- a/sdk/src/workflow/mod.rs
+++ b/sdk/src/workflow/mod.rs
@@ -91,12 +91,12 @@ mod tests {
 
         assert_eq!(
             true,
-            state.can_transition("confirm".to_string(), vec!["po::seller".to_string()]),
+            state.can_transition("confirm".to_string(), &["po::seller".to_string()]),
         );
 
         assert_eq!(
             false,
-            state.can_transition("issued".to_string(), vec!["po::seller".to_string()]),
+            state.can_transition("issued".to_string(), &["po::seller".to_string()]),
         );
     }
 

--- a/sdk/src/workflow/mod.rs
+++ b/sdk/src/workflow/mod.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Defines an API to manage and utilize workflows. Grid Workflow provides a framework for modeling
-//! business workflows as state transitions within smart contracts.
+//! The goal of Grid Workflow is to make permissioning and state code for smart contracts easier to
+//! write and maintain by offering a flexible framework for implementing it. Grid Workflow provides
+//! a framework for modeling business workflows as state transitions within smart contracts. The
+//! Grid Workflow module encapsulates business process complexity and allows for those rules to
+//! become decoupled from the smart contract logic.
 
 mod state;
 mod subworkflow;
@@ -22,16 +25,18 @@ pub use state::{PermissionAlias, WorkflowState, WorkflowStateBuilder};
 pub use subworkflow::{SubWorkflow, SubWorkflowBuilder};
 
 /// A single workflow may involve multiple processes; these processes are defined by the list of
-/// subworkflows.
+/// subworkflows, which are different smaller workflows that make up the overall workflow.
 pub struct Workflow {
     subworkflow: Vec<SubWorkflow>,
 }
 
 impl Workflow {
+    /// Create a workflow by explicitly defining the workflow's processes
     pub fn new(subworkflow: Vec<SubWorkflow>) -> Self {
         Self { subworkflow }
     }
 
+    /// Retrieve a specific process within the overall workflow
     pub fn subworkflow(&self, name: &str) -> Option<SubWorkflow> {
         for sub_wf in &self.subworkflow {
             if sub_wf.name() == name {
@@ -48,6 +53,7 @@ mod tests {
     use super::*;
 
     #[test]
+    /// Validate a `PermissionAlias` is able to be built successfully.
     fn test_permission_alias() {
         let mut permission = PermissionAlias::new("po::seller");
         permission.add_permission("can-create-po");
@@ -63,6 +69,8 @@ mod tests {
     }
 
     #[test]
+    /// Validate a `WorkflowState` object is able to be built successfully, with specific
+    /// permissions.
     fn test_workflow_state() {
         let mut permission = PermissionAlias::new("po::seller");
         permission.add_permission("can-create-po");
@@ -93,6 +101,8 @@ mod tests {
     }
 
     #[test]
+    /// Validate a `SubWorkflow` is able to be built successfully, containing permissions
+    /// and workflow states.
     fn test_subworkflow() {
         let mut permission = PermissionAlias::new("po::seller");
         permission.add_permission("can-create-po");
@@ -121,6 +131,7 @@ mod tests {
     }
 
     #[test]
+    /// Validate a `Workflow` object is able to be built successfully.
     fn test_workflow() {
         let mut permission = PermissionAlias::new("po::seller");
         permission.add_permission("can-create-po");

--- a/sdk/src/workflow/state.rs
+++ b/sdk/src/workflow/state.rs
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Representation of a single state within a workflow
+//! Representation of a single state of a process within a workflow which describes the possible
+//! state transitions the SubWorkflow can make, the constraints that need to be met to make said
+//! transitions, and a list of permissions that are required by the acting entity to initiate a
+//! transition.
 
-/// Defines the current state of an item within a workflow. WorkflowState represents a single
-/// point within a workflow and defines the logic used by the smart contract to determine if an
-/// item may be in this workflow state.
+/// Defines the current state of an item within a workflow. A `WorkflowState` contains a list of
+/// constraints for items within this state, permission aliases to allow for operations to be made
+/// within this state, and a list of transitions that can be made from this state.
 #[derive(Clone)]
 pub struct WorkflowState {
     name: String,
@@ -29,7 +32,7 @@ pub struct WorkflowState {
 }
 
 impl WorkflowState {
-    /// Determines if an item may be transitioned to a new workflow state, considering the
+    /// Determines if an entity may execute a transition to a given state, considering the
     /// permissions of the submitter and the `permission_aliases` defined within this workflow
     /// state.
     ///
@@ -58,7 +61,7 @@ impl WorkflowState {
         false
     }
 
-    /// List the workflow permissions available to a permission alias
+    /// List the workflow permissions stored under the specified permission aliases
     ///
     /// # Arguments
     ///
@@ -77,7 +80,8 @@ impl WorkflowState {
         perms
     }
 
-    /// Retrieve the aliases that contain the specified workflow permissions
+    /// Retrieve all aliases defined within this state that contain the specified workflow
+    /// permission
     ///
     /// # Arguments
     ///
@@ -94,7 +98,7 @@ impl WorkflowState {
         aliases
     }
 
-    /// Check if a workflow state contains the specified constraint
+    /// Returns true if this state contains the specified constraint
     ///
     /// # Arguments
     ///
@@ -125,16 +129,22 @@ impl WorkflowStateBuilder {
         }
     }
 
+    /// Add a constraint to this workflow state. A constraint is interpreted by the smart contract
+    /// as a guidelines that must be met before a transition to this workflow state is able to be
+    /// made.
     pub fn add_constraint(mut self, constraint: &str) -> Self {
         self.constraints.push(constraint.to_string());
         self
     }
 
+    /// Add the name of a workflow state that may be transitioned to from this state
     pub fn add_transition(mut self, transition: &str) -> Self {
         self.transitions.push(transition.to_string());
         self
     }
 
+    /// Add a `PermissionAlias` to allow certain entities to perform certain actions within this
+    /// workflow state
     pub fn add_permission_alias(mut self, alias: PermissionAlias) -> Self {
         self.permission_aliases.push(alias);
         self
@@ -150,11 +160,11 @@ impl WorkflowStateBuilder {
     }
 }
 
-/// An alias that houses multiple permissions
+/// An alias for multiple permissions
 #[derive(Clone, Default)]
 pub struct PermissionAlias {
     name: String,
-    /// Permissions granted to this alias
+    /// Permissions assigned to this alias
     permissions: Vec<String>,
     /// Workflow states this alias is able to transition an object to
     transitions: Vec<String>,
@@ -169,22 +179,27 @@ impl PermissionAlias {
         }
     }
 
+    /// Assign a permission to this alias
     pub fn add_permission(&mut self, permission: &str) {
         self.permissions.push(permission.to_string());
     }
 
+    /// Add a workflow state this alias is able to transition objects to
     pub fn add_transition(&mut self, transition: &str) {
         self.transitions.push(transition.to_string());
     }
 
+    /// Return the name of this alias
     pub fn name(&self) -> &str {
         &self.name
     }
 
+    /// Return the permissions assigned to this alias
     pub fn permissions(&self) -> &[String] {
         &self.permissions
     }
 
+    /// Return the state transitions available to this alias
     pub fn transitions(&self) -> &[String] {
         &self.transitions
     }

--- a/sdk/src/workflow/state.rs
+++ b/sdk/src/workflow/state.rs
@@ -41,7 +41,7 @@ impl WorkflowState {
     /// * `new_state` - Name of the workflow state an item is attempting to be transitioned to
     /// * `pike_permissions` - List of Grid Pike permissions assigned to the submitter of the
     /// request
-    pub fn can_transition(&self, new_state: String, pike_permissions: Vec<String>) -> bool {
+    pub fn can_transition(&self, new_state: String, pike_permissions: &[String]) -> bool {
         if self.name == new_state {
             return true;
         }

--- a/sdk/src/workflow/subworkflow.rs
+++ b/sdk/src/workflow/subworkflow.rs
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! An API for managing a subprocess of a workflow
+//! An API for managing a subprocess within a workflow, which contains the list of states involved
+//! in this subprocess
 
 use super::state::WorkflowState;
 
-/// A subprocess of a workflow
+/// A smaller more specific version of a workflow used to define a more complicated business
+/// process within a workflow
 #[derive(Clone)]
 pub struct SubWorkflow {
     name: String,
-    /// All states an object may be in within this subworkflow
+    /// The states an object may be in within this subworkflow
     states: Vec<WorkflowState>,
     /// The states an object may begin at within this subworkflow
     starting_states: Vec<String>,
@@ -31,6 +33,8 @@ impl SubWorkflow {
         &self.name
     }
 
+    /// Retrieve a specific workflow state from this subworkflow. Returns `None` if the state
+    /// does not exist in this subworkflow.
     pub fn state(&self, name: &str) -> Option<WorkflowState> {
         for state in &self.states {
             if state.name() == name {
@@ -41,6 +45,7 @@ impl SubWorkflow {
         None
     }
 
+    /// Return the workflow states an object must enter the subworkflow at
     pub fn starting_states(&self) -> &[String] {
         &self.starting_states
     }
@@ -62,11 +67,13 @@ impl SubWorkflowBuilder {
         }
     }
 
+    /// Add a workflow state to this subworkflow
     pub fn add_state(mut self, state: WorkflowState) -> Self {
         self.states.push(state);
         self
     }
 
+    /// Add the name of a workflow state an object must enter this subworkflow at
     pub fn add_starting_state(mut self, starting_state: &str) -> Self {
         self.starting_states.push(starting_state.to_string());
         self


### PR DESCRIPTION
This adds a few more stabilization updates, including beefed up module lvl and rustdoc comments and an update to the `can_transition` method.