### PR TITLE
`purchase-order` SDK feature stabilization work

### DIFF
--- a/sdk/src/client/purchase_order.rs
+++ b/sdk/src/client/purchase_order.rs
@@ -101,7 +101,7 @@ impl TryFrom<&AlternateId> for PurchaseOrderAlternateId {
             .with_purchase_order_uid(id.purchase_order_uid.to_string())
             .build()
             .map_err(|err| {
-                Self::Error::DaemonError(format!("Could not convert Alternate ID: {}", err))
+                Self::Error::InternalError(format!("Could not convert Alternate ID: {}", err))
             })?;
 
         Ok(po)

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -310,7 +310,7 @@ impl IntoBytes for CreatePurchaseOrderPayload {
 impl IntoProto<purchase_order_payload::CreatePurchaseOrderPayload> for CreatePurchaseOrderPayload {}
 impl IntoNative<CreatePurchaseOrderPayload> for purchase_order_payload::CreatePurchaseOrderPayload {}
 
-/// Builder used to create the "create agent" payload
+/// Builder used to create the "create purchase order" payload
 #[derive(Default, Debug)]
 pub struct CreatePurchaseOrderPayloadBuilder {
     uid: Option<String>,

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -1025,17 +1025,25 @@ impl UpdateVersionPayloadBuilder {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::protocol::purchase_order::state::PurchaseOrderAlternateIdBuilder;
 
     /// Validate UpdatePurchaseOrderPayload protobuf translates to native
     #[test]
     fn update_po_transforms_to_update_po_protobuf_correctly() {
+        let alternate_ids = vec![PurchaseOrderAlternateIdBuilder::new()
+            .with_id_type("type".to_string())
+            .with_id("id".to_string())
+            .with_purchase_order_uid("uid".to_string())
+            .build()
+            .unwrap()];
+
         // Validate with all fields filled out
         let proto_update_po = UpdatePurchaseOrderPayload {
             uid: "uid".to_string(),
             workflow_state: "status".to_string(),
             is_closed: true,
             accepted_version_number: Some("version".to_string()),
-            alternate_ids: Vec::new(),
+            alternate_ids,
         }
         .into_proto()
         .expect("could not transform into proto");
@@ -1060,12 +1068,22 @@ mod test {
     /// Validate UpdatePurchaseOrderPayload native translates to protobuf
     #[test]
     fn update_po_protobuf_transforms_to_update_po_correctly() {
+        let alternate_ids = vec![PurchaseOrderAlternateIdBuilder::new()
+            .with_id_type("type".to_string())
+            .with_id("id".to_string())
+            .with_purchase_order_uid("uid".to_string())
+            .build()
+            .unwrap()
+            .into_proto()
+            .unwrap()];
+
         // Validate with all fields filled out
         let mut proto_update_po = purchase_order_payload::UpdatePurchaseOrderPayload::new();
         proto_update_po.set_po_uid("uid".to_string());
         proto_update_po.set_workflow_state("status".to_string());
         proto_update_po.set_is_closed(true);
         proto_update_po.set_accepted_version_number("version".to_string());
+        proto_update_po.set_alternate_ids(RepeatedField::from(alternate_ids.to_vec()));
 
         let update_po = proto_update_po
             .into_native()
@@ -1074,6 +1092,14 @@ mod test {
         assert_eq!(update_po.workflow_state(), "status");
         assert!(update_po.is_closed());
         assert_eq!(update_po.accepted_version_number(), Some("version"));
+        assert_eq!(
+            update_po.alternate_ids(),
+            alternate_ids
+                .to_vec()
+                .into_iter()
+                .map(|id| PurchaseOrderAlternateId::from_proto(id).unwrap())
+                .collect::<Vec<PurchaseOrderAlternateId>>()
+        );
 
         // Validate with optional fields not filled out
         let mut proto_update_po = purchase_order_payload::UpdatePurchaseOrderPayload::new();
@@ -1086,5 +1112,6 @@ mod test {
             .into_native()
             .expect("could not transform into native");
         assert_eq!(update_po.accepted_version_number(), None);
+        assert_eq!(update_po.alternate_ids(), Vec::new());
     }
 }

--- a/sdk/src/purchase_order/addressing.rs
+++ b/sdk/src/purchase_order/addressing.rs
@@ -25,15 +25,15 @@ pub const ALTERNATE_ID_PREFIX: &str = "01";
 pub const GRID_PURCHASE_ORDER_PO_NAMESPACE: &str = "621dee0600";
 pub const GRID_PURCHASE_ORDER_ALT_ID_NAMESPACE: &str = "621dee0601";
 
-/// Computes the Merkle address of a Purchase Order based on its UUID.
-pub fn compute_purchase_order_address(uuid: &str) -> String {
+/// Computes the Merkle address of a Purchase Order based on its UID.
+pub fn compute_purchase_order_address(uid: &str) -> String {
     let mut sha = Sha512::new();
-    sha.input(uuid.as_bytes());
+    sha.input(uid.as_bytes());
     let hash_str = String::from(GRID_PURCHASE_ORDER_NAMESPACE) + PO_PREFIX + &sha.result_str();
     hash_str[..70].to_string()
 }
 
-/// Computes the Merkle address of a Alternate ID based on its type and id.
+/// Computes the Merkle address of a Alternate ID based on its type and ID.
 pub fn compute_alternate_id_address(
     po_uid: &str,
     alternate_id_type: &str,

--- a/sdk/src/purchase_order/store/diesel/models.rs
+++ b/sdk/src/purchase_order/store/diesel/models.rs
@@ -12,6 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! The structs in these files are the rust representations of what are stored
+//! in the database. These are similar to the Grid structs that they correspond
+//! to but may contain several database-specific fields such as the database ID
+//! and fields for managing slowly-changing dimensions. There should be two
+//! structs for each database table: one representing a new record which will
+//! not contain a field for the database ID, and one representing an existing
+//! record which will. The order of the fields in the struct must match with
+//! the corresponding table declaration in the schema.rs file in this module.
+//!
+//! Additionally, conversion methods for converting these structs to their Grid
+//! counterparts are provided.
+
 use super::{
     PurchaseOrder, PurchaseOrderAlternateId, PurchaseOrderVersion, PurchaseOrderVersionRevision,
 };


### PR DESCRIPTION
This PR includes several updates to the SDK code guarded by the `purchase-order` feature. These changes were requested during the first round of stabilization reviews.