### PR TITLE
Backport: Stabilize `cylinder-jwt-support` to 0-2 branch & adding ScabbardClient auth

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -92,7 +92,7 @@ experimental = [
     "track-and-trace",
 ]
 
-cylinder-jwt-support = ["cylinder/jwt", "grid-sdk/cylinder-jwt-support"]
+cylinder-jwt-support = ["cylinder/jwt"]
 event = ["database"]
 database = []
 database-postgres = ["grid-sdk/postgres"]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -37,7 +37,7 @@ byteorder = "1"
 cfg-if = "1"
 clap = "2"
 ctrlc = "3.0"
-cylinder = "0.2.2"
+cylinder = { version = "0.2.2", features = ["jwt"], optional = true }
 diesel = { version = "1.0.0", features = ["r2d2", "serde_json"] }
 diesel_migrations = "1.4"
 flexi_logger = "0.17"
@@ -86,13 +86,11 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
-    "cylinder-jwt-support",
     "integration",
     "purchase-order",
     "track-and-trace",
 ]
 
-cylinder-jwt-support = ["cylinder/jwt"]
 event = ["database"]
 database = []
 database-postgres = ["grid-sdk/postgres"]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -49,7 +49,7 @@ protobuf = "2.19"
 reqwest = { version = "0.10.1", optional = true, features = ["json", "blocking"] }
 sabre-sdk = { version = "0.5", optional = true }
 sawtooth-sdk = { version = "0.4", features = ["transact-compat"] }
-scabbard = { version = "0.4", optional = true, features = ["client", "events"] }
+scabbard = { version = "0.4.3", optional = true, features = ["client", "events"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 transact = { version = "0.2", optional = true }
@@ -57,7 +57,7 @@ url = "2.1"
 uuid = { version = "0.8", features = ["v4"] }
 
 [dependencies.splinter]
-version = "0.4"
+version = "0.4.3"
 optional = true
 features = [ "events" ]
 

--- a/daemon/src/splinter/app_auth_handler/mod.rs
+++ b/daemon/src/splinter/app_auth_handler/mod.rs
@@ -65,17 +65,12 @@ pub fn run(
     handler: Box<dyn EventHandler>,
     igniter: Igniter,
     scabbard_admin_key: String,
-    #[cfg(feature = "cylinder-jwt-support")] authorization: String,
+    authorization: String,
 ) -> Result<(), AppAuthHandlerError> {
     let registration_route = format!("{}/ws/admin/register/grid", &splinterd_url);
-    let node_id = get_node_id(
-        splinterd_url.clone(),
-        #[cfg(feature = "cylinder-jwt-support")]
-        &authorization,
-    )?;
+    let node_id = get_node_id(splinterd_url.clone(), &authorization)?;
 
     let ws_handler = Arc::new(Mutex::new(handler));
-    #[cfg(feature = "cylinder-jwt-support")]
     let ws_auth = authorization.clone();
     let mut ws = WebSocketClient::new(&registration_route, move |_ctx, event| {
         let handler = {
@@ -95,7 +90,6 @@ pub fn run(
             &node_id,
             &scabbard_admin_key,
             &splinterd_url,
-            #[cfg(feature = "cylinder-jwt-support")]
             &ws_auth,
         ) {
             error!("Failed to process admin event: {}", err);
@@ -103,7 +97,6 @@ pub fn run(
         WsResponse::Empty
     });
 
-    #[cfg(feature = "cylinder-jwt-support")]
     ws.header("Authorization", authorization);
     ws.header(
         "SplinterProtocolVersion",
@@ -141,7 +134,7 @@ fn process_admin_event(
     node_id: &str,
     scabbard_admin_key: &str,
     splinterd_url: &str,
-    #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
+    authorization: &str,
 ) -> Result<(), AppAuthHandlerError> {
     debug!("Received the event at {}", event.timestamp);
     match event.admin_event {
@@ -186,7 +179,6 @@ fn process_admin_event(
                     &msg_proposal.circuit_id,
                     &service.service_id,
                     None,
-                    #[cfg(feature = "cylinder-jwt-support")]
                     authorization,
                     || vec![handler.cloned_box()],
                 )

--- a/daemon/src/splinter/app_auth_handler/mod.rs
+++ b/daemon/src/splinter/app_auth_handler/mod.rs
@@ -190,6 +190,7 @@ fn process_admin_event(
                 splinterd_url,
                 &service.service_id,
                 &msg_proposal.circuit_id,
+                authorization,
             )?;
             Ok(())
         }

--- a/daemon/src/splinter/app_auth_handler/node.rs
+++ b/daemon/src/splinter/app_auth_handler/node.rs
@@ -35,17 +35,10 @@ impl fmt::Display for GetNodeError {
     }
 }
 
-pub fn get_node_id(
-    splinterd_url: String,
-    #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
-) -> Result<String, GetNodeError> {
+pub fn get_node_id(splinterd_url: String, authorization: &str) -> Result<String, GetNodeError> {
     let uri = format!("{}/status", splinterd_url);
 
-    let body = wait_for_status(
-        &uri,
-        #[cfg(feature = "cylinder-jwt-support")]
-        authorization,
-    )?;
+    let body = wait_for_status(&uri, authorization)?;
 
     let node_id_val = body
         .get("node_id")
@@ -58,22 +51,15 @@ pub fn get_node_id(
     Ok(node_id.to_string())
 }
 
-fn wait_for_status(
-    uri: &str,
-    #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
-) -> Result<Value, GetNodeError> {
+fn wait_for_status(uri: &str, authorization: &str) -> Result<Value, GetNodeError> {
     let mut wait_time = 1;
     let client = reqwest::blocking::Client::new();
     loop {
-        #[allow(unused_mut)]
-        let mut request = client.get(uri);
-
-        #[cfg(feature = "cylinder-jwt-support")]
+        match client
+            .get(uri)
+            .header("Authorization", authorization.to_string())
+            .send()
         {
-            request = request.header("Authorization", authorization.to_string());
-        }
-
-        match request.send() {
             Ok(res) => {
                 return res.json().map_err(|err| {
                     GetNodeError(format!("Failed to parse response body: {}", err))

--- a/daemon/src/splinter/app_auth_handler/sabre.rs
+++ b/daemon/src/splinter/app_auth_handler/sabre.rs
@@ -73,6 +73,7 @@ pub fn setup_grid(
     splinterd_url: &str,
     service_id: &str,
     circuit_id: &str,
+    authorization: &str,
 ) -> Result<(), AppAuthHandlerError> {
     #[cfg(any(
         feature = "location",
@@ -121,7 +122,9 @@ pub fn setup_grid(
 
     let batch = BatchBuilder::new().with_transactions(txns).build(&signer)?;
 
-    ScabbardClient::new(splinterd_url)
+    let mut client = ScabbardClient::new(splinterd_url);
+    client.set_auth(authorization.to_string());
+    client
         .submit(
             &ServiceId::new(circuit_id, service_id),
             vec![batch],

--- a/daemon/src/splinter/event/mod.rs
+++ b/daemon/src/splinter/event/mod.rs
@@ -50,7 +50,7 @@ impl ScabbardEventConnectionFactory {
         &self,
         circuit_id: &str,
         service_id: &str,
-        #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
+        authorization: &str,
     ) -> Result<ScabbardEventConnection, ScabbardEventConnectionError> {
         let source = format!("{}::{}", circuit_id, service_id);
         let connection_url = format!(
@@ -62,7 +62,6 @@ impl ScabbardEventConnectionFactory {
             source,
             connection_url,
             self.igniter.clone(),
-            #[cfg(feature = "cylinder-jwt-support")]
             authorization.to_string(),
         ))
     }
@@ -84,23 +83,16 @@ pub struct ScabbardEventConnection {
     connection_url: String,
     igniter: Igniter,
     connection_state: RefCell<ConnectionState>,
-    #[cfg(feature = "cylinder-jwt-support")]
     authorization: String,
 }
 
 impl ScabbardEventConnection {
-    fn new(
-        name: String,
-        connection_url: String,
-        igniter: Igniter,
-        #[cfg(feature = "cylinder-jwt-support")] authorization: String,
-    ) -> Self {
+    fn new(name: String, connection_url: String, igniter: Igniter, authorization: String) -> Self {
         Self {
             name,
             connection_url,
             igniter,
             connection_state: RefCell::new(ConnectionState::Disconnected),
-            #[cfg(feature = "cylinder-jwt-support")]
             authorization,
         }
     }
@@ -145,7 +137,6 @@ impl EventConnection for ScabbardEventConnection {
             WsResponse::Empty
         });
 
-        #[cfg(feature = "cylinder-jwt-support")]
         state_delta_ws.header("Authorization", self.authorization.to_string());
 
         state_delta_ws.on_error(move |err, ctx| {

--- a/daemon/src/splinter/event/processors.rs
+++ b/daemon/src/splinter/event/processors.rs
@@ -47,7 +47,7 @@ impl EventProcessors {
         circuit_id: &str,
         service_id: &str,
         last_seen_id: Option<&str>,
-        #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
+        authorization: &str,
         handlers_factory_fn: F,
     ) -> Result<(), InternalError>
     where
@@ -60,7 +60,6 @@ impl EventProcessors {
             circuit_id,
             service_id,
             last_seen_id,
-            #[cfg(feature = "cylinder-jwt-support")]
             authorization,
             handlers_factory_fn,
         )
@@ -85,7 +84,7 @@ impl Inner {
         circuit_id: &str,
         service_id: &str,
         last_seen_id: Option<&str>,
-        #[cfg(feature = "cylinder-jwt-support")] authorization: &str,
+        authorization: &str,
         factory_fn: F,
     ) -> Result<(), InternalError>
     where
@@ -95,12 +94,7 @@ impl Inner {
         if let Entry::Vacant(entry) = self.processors.entry(key) {
             let event_connection = self
                 .event_connection_factory
-                .create_connection(
-                    circuit_id,
-                    service_id,
-                    #[cfg(feature = "cylinder-jwt-support")]
-                    authorization,
-                )
+                .create_connection(circuit_id, service_id, authorization)
                 .map_err(|err| InternalError::from_source(Box::new(err)))?;
 
             let evt_processor = EventProcessor::start(event_connection, last_seen_id, factory_fn())

--- a/daemon/src/splinter/run.rs
+++ b/daemon/src/splinter/run.rs
@@ -25,9 +25,7 @@ use std::sync::{
     Arc,
 };
 
-use cylinder::load_key;
-#[cfg(feature = "cylinder-jwt-support")]
-use cylinder::{jwt::JsonWebTokenBuilder, secp256k1::Secp256k1Context, Context};
+use cylinder::{jwt::JsonWebTokenBuilder, load_key, secp256k1::Secp256k1Context, Context};
 use grid_sdk::backend::SplinterBackendClient;
 use grid_sdk::commits::store::Commit;
 use grid_sdk::commits::{CommitStore, DieselCommitStore};
@@ -82,10 +80,8 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
 
     let scabbard_admin_key = &gridd_key.as_hex();
 
-    #[cfg(feature = "cylinder-jwt-support")]
     let signer = Secp256k1Context::new().new_signer(gridd_key);
 
-    #[cfg(feature = "cylinder-jwt-support")]
     let authorization = {
         let jwt = JsonWebTokenBuilder::new()
             .build(&*signer)
@@ -191,7 +187,6 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
                     service_id.circuit_id,
                     service_id.service_id,
                     Some(&commit.commit_id),
-                    #[cfg(feature = "cylinder-jwt-support")]
                     &authorization,
                     || vec![chan_event_handler.cloned_box()],
                 )
@@ -205,18 +200,11 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
         chan_event_handler,
         reactor.igniter(),
         scabbard_admin_key.to_string(),
-        #[cfg(feature = "cylinder-jwt-support")]
         authorization.clone(),
     )
     .map_err(|err| DaemonError::from_source(Box::new(err)))?;
 
-    let backend_client = SplinterBackendClient::new(
-        splinter_endpoint.url(),
-        #[cfg(feature = "cylinder-jwt-support")]
-        authorization,
-        #[cfg(not(feature = "cylinder-jwt-support"))]
-        "".to_string(),
-    );
+    let backend_client = SplinterBackendClient::new(splinter_endpoint.url(), authorization);
     let backend_state = BackendState::new(Arc::new(backend_client));
 
     #[cfg(feature = "integration")]

--- a/daemon/src/splinter/run.rs
+++ b/daemon/src/splinter/run.rs
@@ -214,6 +214,8 @@ pub fn run_splinter(config: GridConfig) -> Result<(), DaemonError> {
         splinter_endpoint.url(),
         #[cfg(feature = "cylinder-jwt-support")]
         authorization,
+        #[cfg(not(feature = "cylinder-jwt-support"))]
+        "".to_string(),
     );
     let backend_state = BackendState::new(Arc::new(backend_client));
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -52,7 +52,7 @@ rust-crypto-wasm = "0.3"
 sabre-sdk = "0.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cylinder = { version = "0.2.2", features = ["key-load"], optional = true}
+cylinder = { version = "0.2.2", features = ["key-load", "jwt"], optional = true}
 rust-crypto = "0.2"
 sawtooth-sdk = "0.4"
 quick-xml = { version = "0.22", features = [ "serialize" ], optional = true }
@@ -105,7 +105,6 @@ experimental = [
     "batch-store",
     "client",
     "client-reqwest",
-    "cylinder-jwt-support",
     "pike-rest-api",
     "purchase-order",
     "rest-api-resources",
@@ -127,7 +126,6 @@ backend-sawtooth = ["backend", "uuid"]
 backend-splinter = ["backend", "reqwest"]
 client = []
 client-reqwest = ["client", "reqwest"]
-cylinder-jwt-support = ["cylinder/jwt"]
 location = ["pike", "schema"]
 pike = ["cfg-if"]
 pike-rest-api = ["pike", "serde_json", "rest-api-resources"]

--- a/sdk/src/backend/splinter.rs
+++ b/sdk/src/backend/splinter.rs
@@ -36,20 +36,15 @@ macro_rules! try_fut {
 #[derive(Clone)]
 pub struct SplinterBackendClient {
     node_url: String,
-    #[cfg(feature = "cylinder-jwt-support")]
     authorization: String,
 }
 
 impl SplinterBackendClient {
     /// Constructs a new splinter BackendClient instance, using the given url for the node's REST
     /// API.
-    pub fn new(
-        node_url: String,
-        #[cfg(feature = "cylinder-jwt-support")] authorization: String,
-    ) -> Self {
+    pub fn new(node_url: String, authorization: String) -> Self {
         Self {
             node_url,
-            #[cfg(feature = "cylinder-jwt-support")]
             authorization,
         }
     }
@@ -86,18 +81,11 @@ impl BackendClient for SplinterBackendClient {
         response_url.set_query(Some(&format!("id={}", batch_query)));
         let link = response_url.to_string();
 
-        let mut client = reqwest::Client::new().post(&url);
-
-        client = client
+        reqwest::Client::new()
+            .post(&url)
             .header("GridProtocolVersion", "1")
-            .header("Content-Type", "octet-stream");
-
-        #[cfg(feature = "cylinder-jwt-support")]
-        {
-            client = client.header("Authorization", &self.authorization.to_string());
-        }
-
-        client
+            .header("Content-Type", "octet-stream")
+            .header("Authorization", &self.authorization.to_string())
             .body(batch_list_bytes)
             .send()
             .then(|res| {
@@ -139,16 +127,10 @@ impl BackendClient for SplinterBackendClient {
         url.push_str("ids=");
         url.push_str(&msg.batch_ids.join(","));
 
-        let mut client = reqwest::Client::new().get(&url);
-
-        client = client.header("GridProtocolVersion", "1");
-
-        #[cfg(feature = "cylinder-jwt-support")]
-        {
-            client = client.header("Authorization", &self.authorization.to_string());
-        }
-
-        client
+        reqwest::Client::new()
+            .get(&url)
+            .header("GridProtocolVersion", "1")
+            .header("Authorization", &self.authorization.to_string())
             .send()
             .then(|res| match res {
                 Ok(res) => res.json().boxed(),


### PR DESCRIPTION
This includes the commit used to stabilize the `cylinder-jwt-support` feature in both the SDK and the daemon.

Also backports #1188 