### PR TITLE
Fix lint

### DIFF
--- a/contracts/purchase_order/src/workflow.rs
+++ b/contracts/purchase_order/src/workflow.rs
@@ -101,8 +101,6 @@ fn default_sub_workflow() -> SubWorkflow {
         partner.add_transition("confirmed");
         partner.add_transition("closed");
 
-
-
         WorkflowStateBuilder::new("issued")
             .add_transition("confirmed")
             .add_transition("closed")


### PR DESCRIPTION
This change removes two empty lines. This was causing a lint error for
the main build of Grid.

Signed-off-by: Shannyn Telander <telander@bitwise.io>