### PR TITLE
Fix CLI display of many results

### DIFF
--- a/daemon/openapi.yaml
+++ b/daemon/openapi.yaml
@@ -685,6 +685,47 @@ paths:
           $ref: "#/components/responses/500ServerError"
         "503":
           $ref: "#/components/responses/503ServiceUnavailable"
+  /purchase_order/{uid}/version/{version_id}/revision/latest:
+    get:
+      tags:
+        - Purchase Order
+      summary: |
+        Fetches a single purchase order version revision with the latest revision
+        ID for the given version
+      operationId: get_latest_revision_id
+      parameters:
+        - name: version_id
+          in: path
+          description: ID of the version to fetch
+          required: true
+          schema:
+            type: string
+        - name: uid
+          in: path
+          description: ID of the PO to fetch
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/service_id"
+        - $ref: "#/components/parameters/page_offset"
+        - $ref: "#/components/parameters/page_limit"
+      responses:
+        "200":
+          description: |
+            Successful request. The response will include a JSON object
+            representing the purchase order revision ID.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PurchaseOrderRevision"
+        "400":
+          $ref: "#/components/responses/400BadRequest"
+        "404":
+          $ref: "#/components/responses/404NotFound"
+        "500":
+          $ref: "#/components/responses/500ServerError"
+        "503":
+          $ref: "#/components/responses/503ServiceUnavailable"
 
   # Schema
   /schema:

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -123,6 +123,7 @@ pub fn run(
                         .service(routes::list_purchase_order_versions)
                         .service(routes::get_purchase_order_version)
                         .service(routes::list_purchase_order_version_revisions)
+                        .service(routes::get_latest_revision_id)
                         .service(routes::get_purchase_order_version_revision)
                 }
 

--- a/sdk/src/client/purchase_order.rs
+++ b/sdk/src/client/purchase_order.rs
@@ -164,7 +164,7 @@ pub trait PurchaseOrderClient: Client {
         &self,
         filters: Option<ListPOFilters>,
         service_id: Option<&str>,
-    ) -> Result<Vec<PurchaseOrder>, ClientError>;
+    ) -> Result<Box<dyn Iterator<Item = Result<PurchaseOrder, ClientError>>>, ClientError>;
 
     /// Lists the purchase order versions of a specific purchase order.
     ///
@@ -178,7 +178,7 @@ pub trait PurchaseOrderClient: Client {
         id: String,
         filters: Option<ListVersionFilters>,
         service_id: Option<&str>,
-    ) -> Result<Vec<PurchaseOrderVersion>, ClientError>;
+    ) -> Result<Box<dyn Iterator<Item = Result<PurchaseOrderVersion, ClientError>>>, ClientError>;
 
     /// Lists the purchase order revisions of a specific purchase order version.
     ///
@@ -193,7 +193,7 @@ pub trait PurchaseOrderClient: Client {
         id: String,
         version_id: String,
         service_id: Option<&str>,
-    ) -> Result<Vec<PurchaseOrderRevision>, ClientError>;
+    ) -> Result<Box<dyn Iterator<Item = Result<PurchaseOrderRevision, ClientError>>>, ClientError>;
 
     /// Retrieves the purchase order revision with the latest `revision_id` of
     /// the purchase order version with the given `version_id` of the purchase

--- a/sdk/src/client/purchase_order.rs
+++ b/sdk/src/client/purchase_order.rs
@@ -194,4 +194,21 @@ pub trait PurchaseOrderClient: Client {
         version_id: String,
         service_id: Option<&str>,
     ) -> Result<Vec<PurchaseOrderRevision>, ClientError>;
+
+    /// Retrieves the purchase order revision with the latest `revision_id` of
+    /// the purchase order version with the given `version_id` of the purchase
+    /// order with the given `purchase_order_uid`
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - the UID of the `PurchaseOrder` containing the `PurchaseOrderRevision` to be retrieved
+    /// * `version_id` - the version ID of the `PurchaseOrderVersion` containing the
+    ///   `PurchaseOrderRevision` to be retrieved
+    /// * `service_id` - optional - the service ID to fetch the revision from
+    fn get_latest_revision_id(
+        &self,
+        purchase_order_uid: String,
+        version_id: String,
+        service_id: Option<&str>,
+    ) -> Result<Option<i64>, ClientError>;
 }

--- a/sdk/src/client/reqwest/purchase_order/data.rs
+++ b/sdk/src/client/reqwest/purchase_order/data.rs
@@ -61,6 +61,31 @@ impl From<&PurchaseOrder> for ClientPurchaseOrder {
     }
 }
 
+impl From<PurchaseOrder> for ClientPurchaseOrder {
+    fn from(d: PurchaseOrder) -> Self {
+        Self {
+            purchase_order_uid: d.purchase_order_uid.to_string(),
+            workflow_state: d.workflow_state.to_string(),
+            buyer_org_id: d.buyer_org_id.to_string(),
+            seller_org_id: d.seller_org_id.to_string(),
+            is_closed: d.is_closed,
+            alternate_ids: d
+                .alternate_ids
+                .iter()
+                .map(ClientAlternateId::from)
+                .collect(),
+            accepted_version_id: d.accepted_version_id.as_ref().map(String::from),
+            versions: d
+                .versions
+                .iter()
+                .map(ClientPurchaseOrderVersion::from)
+                .collect(),
+            created_at: d.created_at,
+            workflow_type: d.workflow_type.to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PurchaseOrderVersion {
     version_id: String,
@@ -86,6 +111,22 @@ impl From<&PurchaseOrderVersion> for ClientPurchaseOrderVersion {
     }
 }
 
+impl From<PurchaseOrderVersion> for ClientPurchaseOrderVersion {
+    fn from(d: PurchaseOrderVersion) -> Self {
+        Self {
+            version_id: d.version_id.to_string(),
+            workflow_state: d.workflow_state.to_string(),
+            is_draft: d.is_draft,
+            current_revision_id: d.current_revision_id,
+            revisions: d
+                .revisions
+                .iter()
+                .map(ClientPurchaseOrderRevision::from)
+                .collect(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PurchaseOrderRevision {
     revision_id: u64,
@@ -96,6 +137,17 @@ pub struct PurchaseOrderRevision {
 
 impl From<&PurchaseOrderRevision> for ClientPurchaseOrderRevision {
     fn from(d: &PurchaseOrderRevision) -> Self {
+        Self {
+            revision_id: d.revision_id,
+            order_xml_v3_4: d.order_xml_v3_4.to_string(),
+            submitter: d.submitter.to_string(),
+            created_at: d.created_at,
+        }
+    }
+}
+
+impl From<PurchaseOrderRevision> for ClientPurchaseOrderRevision {
+    fn from(d: PurchaseOrderRevision) -> Self {
         Self {
             revision_id: d.revision_id,
             order_xml_v3_4: d.order_xml_v3_4.to_string(),

--- a/sdk/src/client/reqwest/purchase_order/mod.rs
+++ b/sdk/src/client/reqwest/purchase_order/mod.rs
@@ -30,6 +30,7 @@ use sawtooth_sdk::messages::batch::BatchList;
 const PO_ROUTE: &str = "purchase_order";
 const VERSION_ROUTE: &str = "version";
 const REVISION_ROUTE: &str = "revision";
+const LATEST_ROUTE: &str = "latest";
 
 /// The Reqwest implementation of the Purchase Order client
 pub struct ReqwestPurchaseOrderClient {
@@ -190,5 +191,28 @@ impl PurchaseOrderClient for ReqwestPurchaseOrderClient {
         )?;
 
         Ok(dto.iter().map(PurchaseOrderRevision::from).collect())
+    }
+
+    fn get_latest_revision_id(
+        &self,
+        purchase_order_uid: String,
+        version_id: String,
+        service_id: Option<&str>,
+    ) -> Result<Option<i64>, ClientError> {
+        let dto = fetch_entity::<Option<i64>>(
+            &self.url,
+            format!(
+                "{}/{}/{}/{}/{}/{}",
+                PO_ROUTE,
+                purchase_order_uid,
+                VERSION_ROUTE,
+                version_id,
+                REVISION_ROUTE,
+                LATEST_ROUTE,
+            ),
+            service_id,
+        )?;
+
+        Ok(dto)
     }
 }

--- a/sdk/src/purchase_order/store/diesel/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/mod.rs
@@ -34,6 +34,7 @@ use models::{
 use crate::error::ResourceTemporarilyUnavailableError;
 
 use operations::add_purchase_order::PurchaseOrderStoreAddPurchaseOrderOperation as _;
+use operations::get_latest_revision_id::PurchaseOrderStoreGetLatestRevisionIdOperation as _;
 use operations::get_purchase_order::PurchaseOrderStoreGetPurchaseOrderOperation as _;
 use operations::get_purchase_order_version::PurchaseOrderStoreGetPurchaseOrderVersionOperation as _;
 use operations::get_purchase_order_version_revision::PurchaseOrderStoreGetPurchaseOrderRevisionOperation as _;
@@ -190,6 +191,20 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::pg::PgConnection> {
             limit,
         )
     }
+
+    fn get_latest_revision_id(
+        &self,
+        purchase_order_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<i64>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .get_latest_revision_id(purchase_order_uid, version_id, service_id)
+    }
 }
 
 #[cfg(feature = "sqlite")]
@@ -322,6 +337,20 @@ impl PurchaseOrderStore for DieselPurchaseOrderStore<diesel::sqlite::SqliteConne
             limit,
         )
     }
+
+    fn get_latest_revision_id(
+        &self,
+        purchase_order_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<i64>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            PurchaseOrderStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .get_latest_revision_id(purchase_order_uid, version_id, service_id)
+    }
 }
 
 pub struct DieselConnectionPurchaseOrderStore<'a, C>
@@ -446,6 +475,19 @@ impl<'a> PurchaseOrderStore for DieselConnectionPurchaseOrderStore<'a, diesel::p
             limit,
         )
     }
+
+    fn get_latest_revision_id(
+        &self,
+        purchase_order_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<i64>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(self.connection).get_latest_revision_id(
+            purchase_order_uid,
+            version_id,
+            service_id,
+        )
+    }
 }
 
 #[cfg(feature = "sqlite")]
@@ -552,6 +594,19 @@ impl<'a> PurchaseOrderStore
             service_id,
             offset,
             limit,
+        )
+    }
+
+    fn get_latest_revision_id(
+        &self,
+        purchase_order_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<i64>, PurchaseOrderStoreError> {
+        PurchaseOrderStoreOperations::new(self.connection).get_latest_revision_id(
+            purchase_order_uid,
+            version_id,
+            service_id,
         )
     }
 }

--- a/sdk/src/purchase_order/store/diesel/operations/get_latest_revision_id.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/get_latest_revision_id.rs
@@ -1,0 +1,122 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{get_uid_from_alternate_id, PurchaseOrderStoreOperations};
+use crate::commits::MAX_COMMIT_NUM;
+use crate::error::InternalError;
+
+use crate::purchase_order::store::diesel::schema::purchase_order_version_revision;
+
+use crate::purchase_order::store::PurchaseOrderStoreError;
+use diesel::dsl::max;
+use diesel::prelude::*;
+
+pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreGetLatestRevisionIdOperation {
+    fn get_latest_revision_id(
+        &self,
+        purchase_order_id: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<i64>, PurchaseOrderStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> PurchaseOrderStoreGetLatestRevisionIdOperation
+    for PurchaseOrderStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn get_latest_revision_id(
+        &self,
+        purchase_order_id: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<i64>, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut purchase_order_uid = purchase_order_id.to_string();
+            if purchase_order_id.contains(':') {
+                purchase_order_uid = get_uid_from_alternate_id::pg::get_uid_from_alternate_id(
+                    self.conn,
+                    purchase_order_id,
+                    service_id,
+                )?;
+            }
+
+            let mut query = purchase_order_version_revision::table
+                .into_boxed()
+                .select(max(purchase_order_version_revision::revision_id))
+                .filter(
+                    purchase_order_version_revision::purchase_order_uid
+                        .eq(&purchase_order_uid)
+                        .and(purchase_order_version_revision::version_id.eq(&version_id))
+                        .and(purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version_revision::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version_revision::service_id.is_null());
+            }
+
+            let num = query.first::<Option<i64>>(self.conn).map_err(|err| {
+                PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
+
+            Ok(num)
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> PurchaseOrderStoreGetLatestRevisionIdOperation
+    for PurchaseOrderStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn get_latest_revision_id(
+        &self,
+        purchase_order_id: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<i64>, PurchaseOrderStoreError> {
+        self.conn.transaction::<_, PurchaseOrderStoreError, _>(|| {
+            let mut purchase_order_uid = purchase_order_id.to_string();
+            if purchase_order_id.contains(':') {
+                purchase_order_uid = get_uid_from_alternate_id::sqlite::get_uid_from_alternate_id(
+                    self.conn,
+                    purchase_order_id,
+                    service_id,
+                )?;
+            }
+
+            let mut query = purchase_order_version_revision::table
+                .into_boxed()
+                .select(max(purchase_order_version_revision::revision_id))
+                .filter(
+                    purchase_order_version_revision::purchase_order_uid
+                        .eq(&purchase_order_uid)
+                        .and(purchase_order_version_revision::version_id.eq(&version_id))
+                        .and(purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM)),
+                );
+
+            if let Some(service_id) = service_id {
+                query = query.filter(purchase_order_version_revision::service_id.eq(service_id));
+            } else {
+                query = query.filter(purchase_order_version_revision::service_id.is_null());
+            }
+
+            let num = query.first::<Option<i64>>(self.conn).map_err(|err| {
+                PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
+
+            Ok(num)
+        })
+    }
+}

--- a/sdk/src/purchase_order/store/diesel/operations/mod.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/mod.rs
@@ -16,6 +16,7 @@ pub(super) mod add_alternate_id;
 pub(super) mod add_purchase_order;
 mod add_purchase_order_version;
 mod add_purchase_order_version_revision;
+pub(super) mod get_latest_revision_id;
 pub(super) mod get_purchase_order;
 pub(super) mod get_purchase_order_version;
 pub(super) mod get_purchase_order_version_revision;

--- a/sdk/src/purchase_order/store/mod.rs
+++ b/sdk/src/purchase_order/store/mod.rs
@@ -946,6 +946,21 @@ pub trait PurchaseOrderStore {
         offset: i64,
         limit: i64,
     ) -> Result<PurchaseOrderAlternateIdList, PurchaseOrderStoreError>;
+
+    /// Fetches a latest revision ID for a purchase order version from the
+    /// underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `purchase_order_uid` - The UID of the purchase order the revision belongs to
+    ///  * `version_id` - The ID of the version the revision is for
+    ///  * `service_id` - The service ID
+    fn get_latest_revision_id(
+        &self,
+        purchase_order_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<i64>, PurchaseOrderStoreError>;
 }
 
 impl<PS> PurchaseOrderStore for Box<PS>
@@ -1030,5 +1045,14 @@ where
             offset,
             limit,
         )
+    }
+
+    fn get_latest_revision_id(
+        &self,
+        purchase_order_uid: &str,
+        version_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<i64>, PurchaseOrderStoreError> {
+        (**self).get_latest_revision_id(purchase_order_uid, version_id, service_id)
     }
 }

--- a/sdk/src/rest_api/resources/purchase_order/v1/mod.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/mod.rs
@@ -16,8 +16,9 @@ pub mod handler;
 pub mod payloads;
 
 pub use handler::{
-    get_purchase_order, get_purchase_order_revision, get_purchase_order_version,
-    list_purchase_order_revisions, list_purchase_order_versions, list_purchase_orders,
+    get_latest_revision_id, get_purchase_order, get_purchase_order_revision,
+    get_purchase_order_version, list_purchase_order_revisions, list_purchase_order_versions,
+    list_purchase_orders,
 };
 pub use payloads::{
     PurchaseOrderListSlice, PurchaseOrderRevisionSlice, PurchaseOrderSlice,


### PR DESCRIPTION
This fixes the performance of the CLI when attempting to display many purchase order results. Previously, no results would be shown until all records were fetched from storage. With this update, a special iterator is used to take advantage of the REST API's paging and cache records so the CLI can print as soon as the first result comes back. This required significant rewrites to the CLI printing functionality.