### PR TITLE
Add xsd files to gridd .deb package

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -138,6 +138,10 @@ integration = ["grid-sdk/batch-processor", "grid-sdk/rest-api-endpoint-submit"]
 maintainer = "The Hyperledger Grid Team"
 depends = "$auto"
 assets = [
+    ["/build/daemon/packaging/schemas/po/gs1/ecom/*.xsd", "/etc/grid/schemas/po/gs1/ecom/", "644"],
+    ["/build/daemon/packaging/schemas/po/gs1/shared/*.xsd", "/etc/grid/schemas/po/gs1/shared/", "644"],
+    ["/build/daemon/packaging/schemas/po/sbdh/*.xsd", "/etc/grid/schemas/po/sbdh/", "644"],
+    ["/build/daemon/packaging/schemas/product/*.xsd", "/etc/grid/schemas/product/", "644"],
     ["target/release/gridd", "/usr/bin/gridd", "755"]
 ]
 maintainer-scripts = "packaging/ubuntu"

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -38,6 +38,10 @@ COPY cli /build/cli
 COPY daemon /build/daemon
 COPY sdk /build/sdk
 
+# Copy over files needed for examples
+COPY sdk/src/data_validation/xml/xsd/product/ /build/daemon/packaging/schemas/product/
+COPY sdk/src/data_validation/xml/xsd/po/ /build/daemon/packaging/schemas/po/
+
 # Build the gridd package
 ARG CARGO_ARGS
 ARG REPO_VERSION
@@ -68,10 +72,6 @@ RUN echo "CARGO_ARGS = '$CARGO_ARGS'" > CARGO_ARGS
 COPY --from=gridd-builder /build/target/debian/grid-cli_*.deb /tmp
 COPY --from=gridd-builder /build/target/debian/grid-daemon_*.deb /tmp
 COPY --from=gridd-builder /commit-hash /commit-hash
-
-# Copy over files needed for examples
-COPY sdk/src/data_validation/xml/xsd/product/ /etc/grid/schemas/product/
-COPY sdk/src/data_validation/xml/xsd/po/ /etc/grid/schemas/po/
 
 RUN apt-get update \
  && apt-get install -y -q \


### PR DESCRIPTION
Including these in the package ensures they're available if the package
is copied out of the Docker image and installed elsewhere.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>