### PR TITLE
Stabilize `purchase-order` feature in sdk

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -81,6 +81,7 @@ stable = [
     "postgres",
     "product",
     "product-gdsn",
+    "purchase-order",
     "rest-api",
     "rest-api-endpoint-agent",
     "rest-api-endpoint-batches",
@@ -107,7 +108,6 @@ experimental = [
     # The following features are experimental:
     "batch-processor",
     "batch-store",
-    "purchase-order",
     "rest-api-actix-web-3",
     "rest-api-actix-web-3-run",
     "rest-api-endpoint-purchase-order",


### PR DESCRIPTION
This stabilizes the `purchase-order` feature in the Grid SDK by moving
the feature from `experimental` to `stable`.

Signed-off-by: Davey Newhall <newhall@bitwise.io>