### PR TITLE
Fix revision count in po and po version `list` and `show` commands

### DIFF
--- a/sdk/src/purchase_order/store/diesel/operations/get_purchase_order.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/get_purchase_order.rs
@@ -121,8 +121,9 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderOperation
                     .into_boxed()
                     .select(purchase_order_version_revision::all_columns)
                     .filter(
-                        purchase_order_version_revision::version_id
-                            .eq(&v.version_id)
+                        purchase_order_version_revision::purchase_order_uid
+                            .eq(&purchase_order_uid)
+                            .and(purchase_order_version_revision::version_id.eq(&v.version_id))
                             .and(
                                 purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
                             ),
@@ -266,8 +267,9 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderOperation
                     .into_boxed()
                     .select(purchase_order_version_revision::all_columns)
                     .filter(
-                        purchase_order_version_revision::version_id
-                            .eq(&v.version_id)
+                        purchase_order_version_revision::purchase_order_uid
+                            .eq(&purchase_order_uid)
+                            .and(purchase_order_version_revision::version_id.eq(&v.version_id))
                             .and(
                                 purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
                             ),

--- a/sdk/src/purchase_order/store/diesel/operations/get_purchase_order_version.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/get_purchase_order_version.rs
@@ -84,8 +84,12 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderVersionOperation
                         .into_boxed()
                         .select(purchase_order_version_revision::all_columns)
                         .filter(
-                            purchase_order_version_revision::version_id
-                                .eq(&version_id)
+                            purchase_order_version_revision::purchase_order_uid
+                                .eq(&purchase_order_uid)
+                                .and(
+                                    purchase_order_version_revision::version_id
+                                        .eq(&version.version_id),
+                                )
                                 .and(
                                     purchase_order_version_revision::end_commit_num
                                         .eq(MAX_COMMIT_NUM),
@@ -168,8 +172,12 @@ impl<'a> PurchaseOrderStoreGetPurchaseOrderVersionOperation
                         .into_boxed()
                         .select(purchase_order_version_revision::all_columns)
                         .filter(
-                            purchase_order_version_revision::version_id
-                                .eq(&version_id)
+                            purchase_order_version_revision::purchase_order_uid
+                                .eq(&purchase_order_uid)
+                                .and(
+                                    purchase_order_version_revision::version_id
+                                        .eq(&version.version_id),
+                                )
                                 .and(
                                     purchase_order_version_revision::end_commit_num
                                         .eq(MAX_COMMIT_NUM),

--- a/sdk/src/purchase_order/store/diesel/operations/list_purchase_order_versions.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_purchase_order_versions.rs
@@ -154,8 +154,11 @@ impl<'a> PurchaseOrderStoreListPurchaseOrderVersionsOperation
                     .into_boxed()
                     .select(purchase_order_version_revision::all_columns)
                     .filter(
-                        purchase_order_version_revision::version_id
-                            .eq(&version.version_id)
+                        purchase_order_version_revision::purchase_order_uid
+                            .eq(&purchase_order_uid)
+                            .and(
+                                purchase_order_version_revision::version_id.eq(&version.version_id),
+                            )
                             .and(
                                 purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
                             ),
@@ -304,8 +307,11 @@ impl<'a> PurchaseOrderStoreListPurchaseOrderVersionsOperation
                     .into_boxed()
                     .select(purchase_order_version_revision::all_columns)
                     .filter(
-                        purchase_order_version_revision::version_id
-                            .eq(&version.version_id)
+                        purchase_order_version_revision::purchase_order_uid
+                            .eq(&purchase_order_uid)
+                            .and(
+                                purchase_order_version_revision::version_id.eq(&version.version_id),
+                            )
                             .and(
                                 purchase_order_version_revision::end_commit_num.eq(MAX_COMMIT_NUM),
                             ),

--- a/sdk/src/purchase_order/store/diesel/operations/list_purchase_orders.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_purchase_orders.rs
@@ -179,8 +179,9 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
                         .into_boxed()
                         .select(purchase_order_version_revision::all_columns)
                         .filter(
-                            purchase_order_version_revision::version_id
-                                .eq(&v.version_id)
+                            purchase_order_version_revision::purchase_order_uid
+                                .eq(&o.purchase_order_uid)
+                                .and(purchase_order_version_revision::version_id.eq(&v.version_id))
                                 .and(
                                     purchase_order_version_revision::end_commit_num
                                         .eq(MAX_COMMIT_NUM),
@@ -379,8 +380,9 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
                         .into_boxed()
                         .select(purchase_order_version_revision::all_columns)
                         .filter(
-                            purchase_order_version_revision::version_id
-                                .eq(&v.version_id)
+                            purchase_order_version_revision::purchase_order_uid
+                                .eq(&o.purchase_order_uid)
+                                .and(purchase_order_version_revision::version_id.eq(&v.version_id))
                                 .and(
                                     purchase_order_version_revision::end_commit_num
                                         .eq(MAX_COMMIT_NUM),


### PR DESCRIPTION
Adds filter to select only revisions of the same purchase order.
Previously, if versions of different purchase orders had the same
version ID, the revision count would include all revisions of
versions with that name.

Resolves: #1170

Signed-off-by: Chris Eckhardt <eckhardt@bitwise.io>