### PR TITLE
Re-scope REST API modules

### DIFF
--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -199,7 +199,10 @@ mod test {
             PurchaseOrderVersion, PurchaseOrderVersionBuilder, PurchaseOrderVersionRevision,
             PurchaseOrderVersionRevisionBuilder,
         },
-        rest_api::resources::purchase_order::v1::payloads::*,
+        rest_api::resources::purchase_order::v1::{
+            PurchaseOrderListSlice, PurchaseOrderRevisionListSlice, PurchaseOrderRevisionSlice,
+            PurchaseOrderSlice, PurchaseOrderVersionListSlice, PurchaseOrderVersionSlice,
+        },
     };
     use sawtooth_sdk::messages::batch::{Batch, BatchList};
     use sawtooth_sdk::messages::client_batch_submit::{

--- a/sdk/src/rest_api/resources/purchase_order/v1/mod.rs
+++ b/sdk/src/rest_api/resources/purchase_order/v1/mod.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod handler;
-pub mod payloads;
+mod handler;
+mod payloads;
 
 pub use handler::{
     get_purchase_order, get_purchase_order_revision, get_purchase_order_version,
     list_purchase_order_revisions, list_purchase_order_versions, list_purchase_orders,
 };
 pub use payloads::{
-    PurchaseOrderListSlice, PurchaseOrderRevisionSlice, PurchaseOrderSlice,
-    PurchaseOrderVersionSlice,
+    PurchaseOrderListSlice, PurchaseOrderRevisionListSlice, PurchaseOrderRevisionSlice,
+    PurchaseOrderSlice, PurchaseOrderVersionListSlice, PurchaseOrderVersionSlice,
 };


### PR DESCRIPTION
This removes the `pub` re-export of the `handler` and `payloads`
modules. Only the required elements from these modules are now exported.