### PR TITLE
Purchase Order protobuf updates

### DIFF
--- a/cli/src/actions/purchase_order.rs
+++ b/cli/src/actions/purchase_order.rs
@@ -802,6 +802,7 @@ pub mod tests {
             .with_seller_org_id("seller".to_string())
             .with_workflow_state("created".to_string())
             .with_created_at(100)
+            .with_workflow_id("workflow".to_string())
             .build()
             .expect("Could not build create po payload");
 

--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -1215,6 +1215,7 @@ mod tests {
             .with_buyer_org_id(ORG_ID_1.to_string())
             .with_seller_org_id(ORG_ID_2.to_string())
             .with_workflow_state("proposed".to_string())
+            .with_workflow_id("workflow".to_string())
             .build()
             .expect("Unable to build CreatePurchaseOrderPayload");
 
@@ -1241,6 +1242,7 @@ mod tests {
             .with_buyer_org_id(ORG_ID_1.to_string())
             .with_seller_org_id(ORG_ID_2.to_string())
             .with_workflow_state("proposed".to_string())
+            .with_workflow_id("workflow".to_string())
             .build()
             .expect("Unable to build CreatePurchaseOrderPayload");
 
@@ -1265,6 +1267,7 @@ mod tests {
             .with_buyer_org_id(ORG_ID_1.to_string())
             .with_seller_org_id(ORG_ID_2.to_string())
             .with_workflow_state("proposed".to_string())
+            .with_workflow_id("workflow".to_string())
             .build()
             .expect("Unable to build CreatePurchaseOrderPayload");
 
@@ -1291,6 +1294,7 @@ mod tests {
             .with_buyer_org_id(ORG_ID_1.to_string())
             .with_seller_org_id(ORG_ID_2.to_string())
             .with_workflow_state("proposed".to_string())
+            .with_workflow_id("workflow".to_string())
             .build()
             .expect("Unable to build CreatePurchaseOrderPayload");
 
@@ -1319,6 +1323,7 @@ mod tests {
             .with_buyer_org_id(ORG_ID_1.to_string())
             .with_seller_org_id(ORG_ID_2.to_string())
             .with_workflow_state("issued".to_string())
+            .with_workflow_id("workflow".to_string())
             .build()
             .expect("Unable to build CreatePurchaseOrderPayload");
         if let Err(err) =
@@ -1350,6 +1355,7 @@ mod tests {
             .with_buyer_org_id(ORG_ID_1.to_string())
             .with_seller_org_id(ORG_ID_2.to_string())
             .with_workflow_state("confirmed".to_string())
+            .with_workflow_id("workflow".to_string())
             .build()
             .expect("Unable to build CreatePurchaseOrderPayload");
         let expected = "Desired workflow state `confirmed` has `Accepted` constraint, \

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -41,6 +41,7 @@ message CreatePurchaseOrderPayload {
   string workflow_state = 5;
   repeated PurchaseOrderAlternateId alternate_ids = 6;
   CreateVersionPayload create_version_payload = 7;
+  string workflow_id = 8;
 }
 
 message UpdatePurchaseOrderPayload {

--- a/sdk/protos/purchase_order_payload.proto
+++ b/sdk/protos/purchase_order_payload.proto
@@ -50,6 +50,7 @@ message UpdatePurchaseOrderPayload {
   bool is_closed = 3;
   string accepted_version_number = 4;
   repeated PurchaseOrderAlternateId alternate_ids = 5;
+  repeated UpdateVersionPayload version_updates = 6;
 }
 
 message CreateVersionPayload {

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -188,6 +188,7 @@ pub struct CreatePurchaseOrderPayload {
     workflow_state: String,
     alternate_ids: Vec<PurchaseOrderAlternateId>,
     create_version_payload: Option<CreateVersionPayload>,
+    workflow_id: String,
 }
 
 impl CreatePurchaseOrderPayload {
@@ -217,6 +218,10 @@ impl CreatePurchaseOrderPayload {
 
     pub fn create_version_payload(&self) -> Option<CreateVersionPayload> {
         self.create_version_payload.clone()
+    }
+
+    pub fn workflow_id(&self) -> &str {
+        &self.workflow_id
     }
 }
 
@@ -249,6 +254,7 @@ impl FromProto<purchase_order_payload::CreatePurchaseOrderPayload> for CreatePur
                 .map(PurchaseOrderAlternateId::from_proto)
                 .collect::<Result<Vec<PurchaseOrderAlternateId>, ProtoConversionError>>()?,
             create_version_payload,
+            workflow_id: proto.take_workflow_id(),
         })
     }
 }
@@ -272,6 +278,7 @@ impl FromNative<CreatePurchaseOrderPayload> for purchase_order_payload::CreatePu
                 >>()?,
         ));
         proto.set_workflow_state(native.workflow_state().to_string());
+        proto.set_workflow_id(native.workflow_id().to_string());
 
         if let Some(payload) = native.create_version_payload() {
             let proto_payload: purchase_order_payload::CreateVersionPayload =
@@ -320,6 +327,7 @@ pub struct CreatePurchaseOrderPayloadBuilder {
     workflow_state: Option<String>,
     alternate_ids: Vec<PurchaseOrderAlternateId>,
     create_version_payload: Option<CreateVersionPayload>,
+    workflow_id: Option<String>,
 }
 
 impl CreatePurchaseOrderPayloadBuilder {
@@ -362,6 +370,11 @@ impl CreatePurchaseOrderPayloadBuilder {
         self
     }
 
+    pub fn with_workflow_id(mut self, value: String) -> Self {
+        self.workflow_id = Some(value);
+        self
+    }
+
     pub fn build(self) -> Result<CreatePurchaseOrderPayload, BuilderError> {
         let uid = self
             .uid
@@ -387,6 +400,10 @@ impl CreatePurchaseOrderPayloadBuilder {
 
         let create_version_payload = self.create_version_payload;
 
+        let workflow_id = self.workflow_id.ok_or_else(|| {
+            BuilderError::MissingField("'workflow_id' field is required".to_string())
+        })?;
+
         Ok(CreatePurchaseOrderPayload {
             uid,
             created_at,
@@ -395,6 +412,7 @@ impl CreatePurchaseOrderPayloadBuilder {
             workflow_state,
             alternate_ids,
             create_version_payload,
+            workflow_id,
         })
     }
 }


### PR DESCRIPTION
This change  makes updates to the "CreatePurchaseOrderPayload" and "UpdatePurchaseOrderPayload". The "create" payload has a new field, `workflow_type`, which allows a user to select which workflow the purchase order should be in. The "update" payload also has a new field, `version_updates`. This new field is a list of `UpdateVersionPayload`s to allow a user to update multiple versions of a purchase order within a single transaction.