### PR TITLE
Make `check_permission_with_workflow` take reference

### DIFF
--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -213,7 +213,7 @@ fn create_purchase_order(
                     &perm_string,
                     signer,
                     agent.org_id(),
-                    start_state,
+                    &start_state,
                     payload_version.workflow_state(),
                 )
                 .map_err(|err| {
@@ -316,7 +316,7 @@ fn create_purchase_order(
             &perm_string,
             signer,
             agent.org_id(),
-            start_state,
+            &start_state,
             payload.workflow_state(),
         )
         .map_err(|err| {
@@ -412,7 +412,7 @@ fn update_purchase_order(
             &perm_string.to_string(),
             signer,
             agent.org_id(),
-            workflow
+            &workflow
                 .subworkflow("po")
                 .ok_or_else(|| {
                     ApplyError::InvalidTransaction("Subworkflow `po` does not exist".to_string())
@@ -655,7 +655,7 @@ fn create_version(
             &perm_string,
             signer,
             &agent_org_id,
-            create_workflow_state,
+            &create_workflow_state,
             &desired_workflow_state_string,
         )
         .map_err(|err| {
@@ -757,7 +757,7 @@ fn update_version(
             &perm_string.to_string(),
             signer,
             agent.org_id(),
-            version_subworkflow
+            &version_subworkflow
                 .state(original_version.workflow_state())
                 .ok_or_else(|| {
                     ApplyError::InvalidTransaction(format!(

--- a/sdk/src/pike/permissions/mod.rs
+++ b/sdk/src/pike/permissions/mod.rs
@@ -201,7 +201,7 @@ impl<'a> PermissionChecker<'a> {
         permission: &str,
         signer: &str,
         record_owner: &str,
-        workflow_state: WorkflowState,
+        workflow_state: &WorkflowState,
         desired_state: &str,
     ) -> Result<bool, PermissionCheckerError> {
         let agent = self.get_agent(signer)?.ok_or_else(|| {
@@ -673,7 +673,7 @@ mod tests {
                 PERM_CAN_CREATE_PO,
                 PUBLIC_KEY_ALPHA,
                 ORG_ID_ALPHA,
-                state,
+                &state,
                 "issued",
             )
             .expect("Unable to check permission with workflow");
@@ -748,7 +748,7 @@ mod tests {
                 PERM_CAN_CREATE_PO,
                 PUBLIC_KEY_ALPHA,
                 ORG_ID_ALPHA,
-                state,
+                &state,
                 "issued",
             )
             .expect("Unable to check permission with workflow");
@@ -812,7 +812,7 @@ mod tests {
                 PERM_CAN_UPDATE_PO_VERSION,
                 PUBLIC_KEY_ALPHA,
                 ORG_ID_ALPHA,
-                state,
+                &state,
                 "confirmed",
             )
             .expect("Unable to check permission with workflow");
@@ -893,7 +893,7 @@ mod tests {
                 PERM_CAN_CREATE_PO,
                 PUBLIC_KEY_BETA,
                 ORG_ID_ALPHA,
-                state,
+                &state,
                 "issued",
             )
             .expect("Unable to check permission with workflow");
@@ -969,7 +969,7 @@ mod tests {
                 PERM_CAN_CREATE_PO,
                 PUBLIC_KEY_BETA,
                 ORG_ID_ALPHA,
-                state,
+                &state,
                 "issued",
             )
             .expect("Unable to check permission with workflow");

--- a/sdk/src/pike/permissions/mod.rs
+++ b/sdk/src/pike/permissions/mod.rs
@@ -289,7 +289,6 @@ mod tests {
     const ROLE_ALPHA_BUYER: &str = "buyer";
     const ROLE_BETA_BUYER: &str = "buyer";
     const ROLE_ALPHA_SELLER: &str = "seller";
-    const ROLE_BETA_SELLER: &str = "seller";
 
     const PERM_ALIAS_BUYER: &str = "po::buyer";
     const PERM_ALIAS_SELLER: &str = "po::seller";


### PR DESCRIPTION
This change updates the `check_permission_with_workflow` method to take a reference to the workflow state. Ownership is not required for this function. This allows the smart contract to maintain ownership over the workflow state for further processing.