### PR TITLE
Add `workflow_id` arg to `grid po create`

### DIFF
--- a/cli/man/grid-po-create.1.md
+++ b/cli/man/grid-po-create.1.md
@@ -20,8 +20,8 @@ DESCRIPTION
 ===========
 
 This command allows for the creation of Grid Purchase Orders. It submits a
-Sabre transaction to create the purchase order. The options `--buyer-org` and
-`--seller-org` are required.
+Sabre transaction to create the purchase order. The options `--buyer-org`,
+`--seller-org`, `--workflow-state`, and `--workflow-id` are required.
 
 FLAGS
 =====
@@ -73,6 +73,12 @@ will be randomly generated.
 `--workflow-state`
 : Specifies the initial workflow state of the purchase order.
 
+`--workflow-id`
+: Specifies the ID of the workflow to be used for the purchase order.
+Built-in workflows are "built-in::system_of_record::v1", which uses buyer and seller roles, and
+"built-in::collaborative::v1", which uses collaborative partner roles.
+For more information on these workflows, see https://github.com/hyperledger/grid-rfcs/pull/25 .
+
 EXAMPLES
 ========
 
@@ -83,14 +89,15 @@ $ grid po create \
     --buyer-org crgl \
     --seller-org crgl2 \
     --workflow-state issued \
+    --workflow-id built-in::collaborative::v1
     --alternate-id po_number:8329173 \
     --wait 10
 ```
 
 will generate a purchase order owned by the `crgl` organization, with the state
-of `issued`, and an alternate ID of `po_number:8329173`. It will generate
-output similar to the following (the unique ID is randomly generated in this
-case):
+of `issued` in the built-in `collaborative` workflow, and an alternate ID of
+`po_number:8329173`. It will generate output similar to the following (the unique
+ID is randomly generated in this case):
 
 ```
 Submitting request to create purchase order...

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -176,6 +176,21 @@ const AFTER_HELP_WITH_KEY: &str = r"ENV:
     GRID_DAEMON_KEY        Specifies a default value for -k, --key
     GRID_SERVICE_ID        Specifies a default value for --service-id";
 
+#[cfg(feature = "purchase-order")]
+const AFTER_HELP_PO_CREATE: &str = r"ENV:
+    CYLINDER_PATH          Path to search for private signing keys
+    GRID_DAEMON_ENDPOINT   Specifies a default value for --url
+    GRID_DAEMON_KEY        Specifies a default value for -k, --key
+    GRID_SERVICE_ID        Specifies a default value for --service-id
+
+Details:
+    Built-in workflow IDs:
+      -  built-in::system_of_record::v1     Uses buyer and seller roles
+      -  built-in::collaborative::v1        Uses collaborative partner roles
+
+    For more information regarding these workflows, see the purchase order RFC here:
+    https://github.com/hyperledger/grid-rfcs/pull/25";
+
 // log format for cli that will only show the log message
 pub fn log_format(
     w: &mut dyn std::io::Write,
@@ -1566,6 +1581,13 @@ fn run() -> Result<(), CliError> {
                                 ),
                         )
                         .arg(
+                            Arg::with_name("workflow_id")
+                                .long("workflow-id")
+                                .takes_value(true)
+                                .required(true)
+                                .help("ID of the workflow the Purchase Order will use")
+                        )
+                        .arg(
                             Arg::with_name("workflow_state")
                                 .value_name("status")
                                 .long("workflow-state")
@@ -1586,7 +1608,7 @@ fn run() -> Result<(), CliError> {
                                 .takes_value(true)
                                 .help("How long to wait for transaction to be committed"),
                         )
-                        .after_help(AFTER_HELP_WITH_KEY),
+                        .after_help(AFTER_HELP_PO_CREATE),
                 )
                 .subcommand(
                     SubCommand::with_name("list")
@@ -2550,6 +2572,7 @@ fn run() -> Result<(), CliError> {
                     .with_buyer_org_id(m.value_of("buyer_org_id").unwrap().into())
                     .with_seller_org_id(m.value_of("seller_org_id").unwrap().into())
                     .with_alternate_ids(protocol_alternate_ids)
+                    .with_workflow_id(m.value_of("workflow_id").unwrap().into())
                     .with_workflow_state(m.value_of("workflow_state").unwrap().into())
                     .build()
                     .map_err(|err| {

--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -862,6 +862,7 @@ fn update_version(
 mod tests {
     use super::*;
 
+    use crate::workflow::POWorkflow;
     use std::cell::RefCell;
     use std::collections::HashMap;
 
@@ -1322,7 +1323,7 @@ mod tests {
             .with_buyer_org_id(ORG_ID_1.to_string())
             .with_seller_org_id(ORG_ID_2.to_string())
             .with_workflow_state("issued".to_string())
-            .with_workflow_id("workflow".to_string())
+            .with_workflow_id("built-in::collaborative::v1".to_string())
             .build()
             .expect("Unable to build CreatePurchaseOrderPayload");
         if let Err(err) =
@@ -1354,7 +1355,7 @@ mod tests {
             .with_buyer_org_id(ORG_ID_1.to_string())
             .with_seller_org_id(ORG_ID_2.to_string())
             .with_workflow_state("confirmed".to_string())
-            .with_workflow_id("workflow".to_string())
+            .with_workflow_id("built-in::collaborative::v1".to_string())
             .build()
             .expect("Unable to build CreatePurchaseOrderPayload");
         let expected = "Desired workflow state `confirmed` has `Accepted` constraint, \

--- a/contracts/purchase_order/src/payload.rs
+++ b/contracts/purchase_order/src/payload.rs
@@ -706,6 +706,7 @@ mod tests {
         create_po_payload.set_buyer_org_id("buyer".to_string());
         create_po_payload.set_seller_org_id("seller".to_string());
         create_po_payload.set_workflow_state("issued".to_string());
+        create_po_payload.set_workflow_id(POWorkflow::SystemOfRecord.to_string());
         let payload_native = create_po_payload
             .clone()
             .into_native()


### PR DESCRIPTION
Adds a required arg to specify the po workflow when
creating a PO. Previously, all POs defaulted to the
collaborative workflow. Uses workflow-name instead
of workflow-type to be consistent with the CLI
display.

Resolves: #1201

Requires: https://github.com/hyperledger/grid/pull/1199

Signed-off-by: Chris Eckhardt <eckhardt@bitwise.io>