### PR TITLE
Update `po update` command to allow simultaneous version updates

### DIFF
--- a/cli/man/grid-po-update.1.md
+++ b/cli/man/grid-po-update.1.md
@@ -30,6 +30,21 @@ ARGS
 FLAGS
 =====
 
+`--is-closed`
+: Specify the Purchase Order has been closed.
+
+`--set-accepted-version`
+: Set the supplied version ID as the accepted Purchase Order version.
+
+`--rm-accepted-version`
+: Unset the Purchase Order's current accepted version ID.
+
+`--version-is-draft`
+: Set the specified version as a draft; version-id must be supplied.
+
+`--version-not-draft`
+: Set the specified version as not a draft; version-id must be supplied.
+
 `-h`, `--help`
 : Prints help information.
 
@@ -46,23 +61,13 @@ FLAGS
 OPTIONS
 =======
 
-`--accepted-version`
-: Specifies the accepted version ID of the purchase order.
-
 `--add-id`
 : Add an alternate ID. This may be specified multiple times.
   An ID is of the format `alternate_id_type:alternate_id`.  Examples:
   `po_number:12348959` and/or `internal_po_id:a8f9fke`.
 
-`--is-closed`
-: Specifies if the purchase order is closed or open. Possible values are `true`
-  or `false`.
-
 `-k`, `--key`
 : base name or path to a private signing key file
-
-`--org`
-: Specify the organization that owns the purchase order.
 
 `--rm-id`
 : Remove an alternate ID. This may be specified multiple times.
@@ -75,6 +80,12 @@ OPTIONS
 
 `--url`
 : URL for the REST API
+
+`--version-id`
+: Specify the Purchase Order version to be simultaneously updated or added as accepted.
+
+`--version-workflow-state`
+: Update the Purchase Order version's workflow state; version-id must be supplied.
 
 `--wait`
 : Maximum number of seconds to wait for the batch to be committed.
@@ -90,7 +101,6 @@ The command
 ```
 
 $ grid po update \
-    --org crgl \
     --add-id po_number:809832081 \
     --wait 10 \
     PO-1234-56789
@@ -109,15 +119,18 @@ The command
 
 ```
 $ grid po update \
-    --org crgl \
     --workflow-state confirmed \
-    --accepted-version v3 \
+    --version-id v3 \
+    --version-workflow-state accepted \
+    --version-not-draft \
+    --set-accepted-version \
     --wait 10 \
     po_number:809832081
 ```
 
-will update the purchase order with alternate ID `po_number:809832081`, set the
-workflow state to `confirmed`, and the accepted version to `v3`. It will
+will update the purchase order with alternate ID `po_number:809832081`, setting its
+workflow state to `confirmed` and the accepted version to `v3` while updating version `v3`
+to no longer be a draft and to have a version workflow state of `accepted`. It will
 generate output like the following:
 
 ```

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1682,6 +1682,11 @@ fn run() -> Result<(), CliError> {
                                 .help("Set the supplied version ID as the accepted Purchase Order version"),
                         )
                         .arg(
+                            Arg::with_name("rm_accepted_version")
+                                .long("rm-accepted-version")
+                                .help("Unset the Purchase Order's current accepted version ID")
+                        )
+                        .arg(
                             Arg::with_name("version_id")
                                 .value_name("version-id")
                                 .long("version-id")
@@ -2595,6 +2600,14 @@ fn run() -> Result<(), CliError> {
                         is_closed = true;
                     }
 
+                    if m.is_present("set_accepted_version") & m.is_present("rm_accepted_version") {
+                        return Err(CliError::UserError(
+                            "Both set and remove accepted version flags were supplied; \
+                        only one of these operations is allowed at a time"
+                                .to_string(),
+                        ));
+                    }
+
                     let mut accepted_version = po.accepted_version_id;
                     if m.is_present("set_accepted_version") {
                         match m.value_of("version_id") {
@@ -2606,6 +2619,10 @@ fn run() -> Result<(), CliError> {
                                 ))
                             }
                         }
+                    }
+
+                    if m.is_present("rm_accepted_version") {
+                        accepted_version = Some(String::from(""));
                     }
 
                     let mut alternate_ids = po.alternate_ids.clone();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1695,6 +1695,23 @@ fn run() -> Result<(), CliError> {
                                     updated or set as accepted")
                         )
                         .arg(
+                            Arg::with_name("version_is_draft")
+                                .long("version-is-draft")
+                                .help("Set the specified version as a draft; version-id must be supplied")
+                        )
+                        .arg(
+                            Arg::with_name("version_not_draft")
+                                .long("version-not-draft")
+                                .help("Set the specified version as not a draft; version-id must be supplied")
+                        )
+                        .arg(
+                            Arg::with_name("version_workflow_state")
+                                .value_name("version-workflow-state")
+                                .long("version-workflow-state")
+                                .takes_value(true)
+                                .help("Update the Purchase Order version's workflow state; version-id must be supplied")
+                        )
+                        .arg(
                             Arg::with_name("key")
                                 .long("key")
                                 .short("k")
@@ -2664,18 +2681,108 @@ fn run() -> Result<(), CliError> {
                         converted_ids.push(converted);
                     }
 
-                    let payload = UpdatePurchaseOrderPayloadBuilder::new()
-                        .with_uid(uid)
+                    let mut payload_builder = UpdatePurchaseOrderPayloadBuilder::new()
+                        .with_uid(uid.clone())
                         .with_workflow_state(workflow_state.to_string())
                         .with_is_closed(is_closed)
                         .with_accepted_version_number(
                             accepted_version.as_deref().map(|s| s.to_string()),
                         )
-                        .with_alternate_ids(converted_ids)
-                        .build()
-                        .map_err(|err| {
-                            CliError::UserError(format!("Could not build Purchase Order: {}", err))
-                        })?;
+                        .with_alternate_ids(converted_ids);
+
+                    if m.is_present("version_id")
+                        && !(m.is_present("version_is_draft")
+                            || m.is_present("version_not_draft")
+                            || m.is_present("version_workflow_state"))
+                    {
+                        return Err(CliError::UserError(
+                            "Version ID was supllied without version-related action".to_string(),
+                        ));
+                    }
+
+                    // If an update to the version is required, add this update to the purchase
+                    // order update builder
+                    if m.is_present("version_is_draft")
+                        || m.is_present("version_not_draft")
+                        || m.is_present("version_workflow_state")
+                    {
+                        if let Some(version_id) = m.value_of("version_id") {
+                            let current_version = purchase_order::get_purchase_order_version(
+                                &*purchase_order_client,
+                                &uid,
+                                version_id,
+                                service_id.as_deref(),
+                            )?;
+
+                            let mut draft_state = current_version.is_draft;
+                            if m.is_present("version_is_draft") & m.is_present("version_not_draft")
+                            {
+                                return Err(CliError::UserError(
+                                    "Both version draft and not-draft flags were supplied; \
+                                only one of these operations is allowed at a time"
+                                        .to_string(),
+                                ));
+                            } else if m.is_present("version_is_draft") {
+                                draft_state = true;
+                            } else if m.is_present("version_not_draft") {
+                                draft_state = false;
+                            }
+
+                            let mut version_workflow_state = current_version.workflow_state.clone();
+                            if let Some(workflow_state) = m.value_of("version_workflow_state") {
+                                version_workflow_state = workflow_state.to_string();
+                            }
+
+                            // Copy current revision since new revisions are not allowed in this command
+                            let current_revision =
+                                purchase_order::get_current_revision_for_version(
+                                    &*purchase_order_client,
+                                    &uid,
+                                    &current_version,
+                                    service_id.as_deref(),
+                                )?;
+                            let created_at = current_revision
+                                .created_at
+                                .try_into()
+                                .map_err(|err| CliError::PayloadError(format!("{}", err)))?;
+
+                            let revision_payload = PayloadRevisionBuilder::new()
+                                .with_revision_id(current_revision.revision_id)
+                                .with_submitter(current_revision.submitter.to_string())
+                                .with_created_at(created_at)
+                                .with_order_xml_v3_4(current_revision.order_xml_v3_4)
+                                .build()
+                                .map_err(|err| {
+                                    CliError::UserError(format!(
+                                        "Could not build PO revision: {}",
+                                        err
+                                    ))
+                                })?;
+                            let version_payload = UpdateVersionPayloadBuilder::new()
+                                .with_po_uid(uid)
+                                .with_version_id(version_id.to_string())
+                                .with_is_draft(draft_state)
+                                .with_workflow_state(version_workflow_state)
+                                .with_revision(revision_payload)
+                                .build()
+                                .map_err(|err| {
+                                    CliError::UserError(format!(
+                                        "Could not build Purchase Order Version: {}",
+                                        err
+                                    ))
+                                })?;
+
+                            payload_builder =
+                                payload_builder.with_version_updates(vec![version_payload]);
+                        } else {
+                            return Err(CliError::UserError(
+                                "Cannot update version: no version ID supplied".to_string(),
+                            ));
+                        }
+                    }
+                    let payload = payload_builder.build().map_err(|err| {
+                        CliError::UserError(format!("Could not build Purchase Order: {}", err))
+                    })?;
 
                     info!("Submitting request to update purchase order...");
                     purchase_order::do_update_purchase_order(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1677,11 +1677,17 @@ fn run() -> Result<(), CliError> {
                                 .help("Specify the Purchase Order has been closed"),
                         )
                         .arg(
-                            Arg::with_name("accepted_version")
-                                .value_name("version_id")
-                                .long("accepted-version")
+                            Arg::with_name("set_accepted_version")
+                                .long("set-accepted-version")
+                                .help("Set the supplied version ID as the accepted Purchase Order version"),
+                        )
+                        .arg(
+                            Arg::with_name("version_id")
+                                .value_name("version-id")
+                                .long("version-id")
                                 .takes_value(true)
-                                .help("Specify the ID of the accepted Purchase Order version"),
+                                .help("Specify the Purchase Order version to be simultaneously \
+                                    updated or set as accepted")
                         )
                         .arg(
                             Arg::with_name("key")
@@ -2590,13 +2596,16 @@ fn run() -> Result<(), CliError> {
                     }
 
                     let mut accepted_version = po.accepted_version_id;
-
-                    if m.is_present("accepted_version") {
-                        accepted_version = m
-                            .value_of("accepted_version")
-                            .map(String::from)
-                            .map(Some)
-                            .unwrap();
+                    if m.is_present("set_accepted_version") {
+                        match m.value_of("version_id") {
+                            Some(v) => accepted_version = Some(v.to_string()),
+                            None => {
+                                return Err(CliError::UserError(
+                                    "Version ID was not supllied; cannot set accepted version"
+                                        .to_string(),
+                                ))
+                            }
+                        }
                     }
 
                     let mut alternate_ids = po.alternate_ids.clone();


### PR DESCRIPTION
Adds options and flags to enable simultaneous changes to purchase orders and
versions in situations where step-wise updates would lead to invalid states.

Users may only update the components of the version workflow state that must
be changed to avoid invalid states when updating purchase orders.

Resolves: #1202, #1183

Requires: #1199