### PR TITLE
Validate alternate ID formats

### DIFF
--- a/cli/src/actions/purchase_order.rs
+++ b/cli/src/actions/purchase_order.rs
@@ -953,6 +953,30 @@ Revision 1:
 
         assert_eq!(format!("{}", po), display);
     }
+
+    /// Tests that alternate IDs are parsed correctly
+    #[test]
+    fn test_alt_id_parsing() {
+        let valid_id = "test:test_id";
+        let invalid_ids = vec![
+            "test_id",
+            "test:test:test_id",
+            "::test_id",
+            ":test_id",
+            "::",
+            ":",
+            ":test:test_id",
+        ];
+        let _valid_output = AlternateId::new("uid", "test", "test_id");
+
+        assert!(matches!(
+            make_alternate_id_from_str(&"uid", &valid_id).unwrap(),
+            _valid_output
+        ));
+        for inv in invalid_ids {
+            assert!(make_alternate_id_from_str(&"uid", &inv).is_err());
+        }
+    }
 }
 
 pub fn get_current_revision_for_version(

--- a/cli/src/actions/purchase_order.rs
+++ b/cli/src/actions/purchase_order.rs
@@ -19,6 +19,7 @@ use grid_sdk::{
         AlternateId, PurchaseOrder, PurchaseOrderClient, PurchaseOrderRevision,
         PurchaseOrderVersion,
     },
+    data_validation::purchase_order::validate_alt_id_format,
     error::ClientError,
     pike::addressing::GRID_PIKE_NAMESPACE,
     protocol::purchase_order::payload::{
@@ -296,13 +297,9 @@ fn generate_random_base62_string(len: usize) -> String {
 }
 
 pub fn make_alternate_id_from_str(uid: &str, id: &str) -> Result<AlternateId, CliError> {
+    validate_alt_id_format(&id.to_string())?;
+
     let split: Vec<&str> = id.split(':').collect();
-    if split.len() != 2 {
-        return Err(CliError::UserError(format!(
-            "Could not parse alternate ID: {}",
-            id
-        )));
-    }
 
     Ok(AlternateId::new(uid, split[0], split[1]))
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -88,7 +88,7 @@ use grid_sdk::protocol::schema::state::{LatLongBuilder, PropertyValue, PropertyV
 #[cfg(any(feature = "purchase-order"))]
 use grid_sdk::{
     client::purchase_order::AlternateId as POClientAlternateId,
-    data_validation::validate_order_xml_3_4,
+    data_validation::{purchase_order::validate_alt_id_format, validate_order_xml_3_4},
     protocol::purchase_order::payload::{
         CreatePurchaseOrderPayloadBuilder, CreateVersionPayloadBuilder, PayloadRevisionBuilder,
         UpdatePurchaseOrderPayloadBuilder, UpdateVersionPayloadBuilder,
@@ -2518,6 +2518,9 @@ fn run() -> Result<(), CliError> {
                     .collect();
 
                 if !alternate_ids.is_empty() {
+                    for id in &alternate_ids {
+                        validate_alt_id_format(id)?;
+                    }
                     purchase_order::do_check_alternate_ids_are_unique(
                         &*purchase_order_client,
                         alternate_ids.to_vec(),
@@ -2600,7 +2603,9 @@ fn run() -> Result<(), CliError> {
                     if m.is_present("add_id") {
                         let adds: Vec<String> =
                             m.values_of("add_id").unwrap().map(String::from).collect();
-
+                        for id in &adds {
+                            validate_alt_id_format(id)?;
+                        }
                         purchase_order::do_check_alternate_ids_are_unique(
                             &*purchase_order_client,
                             adds.to_vec(),

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -39,6 +39,7 @@ futures = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true }
 reqwest = { version = "0.10.1", features = ["blocking", "json"], optional = true }
 protobuf = "2.19"
+regex = { version = "1", optional = true }
 sabre-sdk = { version = "0.5", optional = true }
 sawtooth-sdk = { version = "0.4", features = ["transact-compat"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -129,7 +130,7 @@ data-validation = [ "libc", "quick-xml", "reqwest"]
 location = ["pike", "schema"]
 pike = ["cfg-if", "workflow"]
 product-gdsn = [ "libc", "quick-xml", "reqwest" ]
-purchase-order = ["pike"]
+purchase-order = ["pike", "regex"]
 product = ["pike", "schema"]
 schema = ["pike"]
 track-and-trace = ["base64"]

--- a/sdk/src/data_validation/mod.rs
+++ b/sdk/src/data_validation/mod.rs
@@ -16,6 +16,8 @@
 */
 
 mod error;
+#[cfg(feature = "purchase-order")]
+pub mod purchase_order;
 mod xml;
 
 pub use error::DataValidationError;

--- a/sdk/src/data_validation/purchase_order.rs
+++ b/sdk/src/data_validation/purchase_order.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+*/
+
+use regex::Regex;
+
+use crate::data_validation::error::DataValidationError;
+use crate::error::InvalidArgumentError;
+
+pub const ALT_ID_FORMAT: &str =
+    "^[\\w\\-\\+=/~!@#\\$%\\^&\\*{}|\\[\\]<>\\?]+:[\\w\\-\\+=/~!@#\\$%\\^&\\*{}|\\[\\]<>\\?]+$";
+
+pub fn validate_alt_id_format(id: &str) -> Result<(), DataValidationError> {
+    let alt_id_format = Regex::new(ALT_ID_FORMAT).unwrap();
+    if !alt_id_format.is_match(id) {
+        return Err(DataValidationError::InvalidArgument(
+            InvalidArgumentError::new(
+                "alternate_id".to_string(),
+                format!(
+            "Invalid alternate ID format: '{}'; must match <alternate_id_type>:<alternate_id>",
+            id
+        ),
+            ),
+        ));
+    }
+    Ok(())
+}


### PR DESCRIPTION
Adds tests to validate alt ID parsing. Enforces format of alt ID inputs.

Previously, invalid alt IDs were accepted. Also, users would receive
`status_code:500` errors when invalid alt IDs were provided.

Resolves: #1212