### PR TITLE
Stabilize `rest-api-resources-purchase-order`

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -97,6 +97,7 @@ stable = [
     "rest-api-resources-location",
     "rest-api-resources-organization",
     "rest-api-resources-product",
+    "rest-api-resources-purchase-order",
     "rest-api-resources-role",
     "rest-api-resources-schema",
     "schema",
@@ -114,7 +115,6 @@ experimental = [
     "rest-api-actix-web-3-run",
     "rest-api-endpoint-record",
     "rest-api-endpoint-submit",
-    "rest-api-resources-purchase-order",
     "rest-api-resources-submit",
     "rest-api-resources-track-and-trace",
     "track-and-trace"


### PR DESCRIPTION
This stabilizes the `rest-api-resources-purchase-order` feature by
moving it from `experimental` to `stable`.

Signed-off-by: Davey Newhall <newhall@bitwise.io>