### PR TITLE
Update schema directory to /usr/share/grid/schemas

### DIFF
--- a/cli/man/grid-po-version-create.1.md
+++ b/cli/man/grid-po-version-create.1.md
@@ -124,7 +124,7 @@ ENVIRONMENT VARIABLES
 **`GRID_ORDER_SCHEMA_DIR`**
 : Specifies the local path to the directory containing the `Order.xsd`
   schema used to validate the purchase order. The default value is
-  "/usr/share/grid/schemas".
+  "/usr/share/grid/xsd".
 
 SEE ALSO
 ========

--- a/cli/man/grid-po-version-update.1.md
+++ b/cli/man/grid-po-version-update.1.md
@@ -120,7 +120,7 @@ ENVIRONMENT VARIABLES
 **`GRID_ORDER_SCHEMA_DIR`**
 : Specifies the local path to the directory containing the `Order.xsd`
   schema used to validate the purchase order. The default value is
-  "/usr/share/grid/schemas".
+  "/usr/share/grid/xsd".
 
 SEE ALSO
 ========

--- a/cli/man/grid-product-create.1.md
+++ b/cli/man/grid-product-create.1.md
@@ -278,7 +278,7 @@ ENVIRONMENT VARIABLES
 **`GRID_PRODUCT_SCHEMA_DIR`**
 : Specifies the local path to the directory containing the `GridTradeItems.xsd`
   schema used to validate the product. The default value is
-  "/usr/share/grid/schemas".
+  "/usr/share/grid/xsd".
 
 SEE ALSO
 ========

--- a/cli/man/grid-product-update.1.md
+++ b/cli/man/grid-product-update.1.md
@@ -271,7 +271,7 @@ ENVIRONMENT VARIABLES
 **`GRID_PRODUCT_SCHEMA_DIR`**
 : Specifies the local path to the directory containing the `GridTradeItems.xsd`
   schema used to validate the product. The default value is
-  "/usr/share/grid/schemas".
+  "/usr/share/grid/xsd".
 
 SEE ALSO
 ========

--- a/cli/src/actions/mod.rs
+++ b/cli/src/actions/mod.rs
@@ -39,7 +39,7 @@ pub mod role;
 pub mod schema;
 
 #[cfg(any(feature = "purchase-order", feature = "product"))]
-pub const DEFAULT_SCHEMA_DIR: &str = "/usr/share/grid/schemas";
+pub const DEFAULT_SCHEMA_DIR: &str = "/usr/share/grid/xsd";
 
 fn chown(path: &Path, uid: u32, gid: u32) -> Result<(), CliError> {
     let pathstr = path

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -138,10 +138,10 @@ integration = ["grid-sdk/batch-processor", "grid-sdk/rest-api-endpoint-submit"]
 maintainer = "The Hyperledger Grid Team"
 depends = "$auto"
 assets = [
-    ["/build/daemon/packaging/schemas/po/gs1/ecom/*.xsd", "/usr/share/grid/schemas/po/gs1/ecom/", "644"],
-    ["/build/daemon/packaging/schemas/po/gs1/shared/*.xsd", "/usr/share/grid/schemas/po/gs1/shared/", "644"],
-    ["/build/daemon/packaging/schemas/po/sbdh/*.xsd", "/usr/share/grid/schemas/po/sbdh/", "644"],
-    ["/build/daemon/packaging/schemas/product/*.xsd", "/usr/share/grid/schemas/product/", "644"],
+    ["/build/daemon/packaging/xsd/po/gs1/ecom/*.xsd", "/usr/share/grid/xsd/po/gs1/ecom/", "644"],
+    ["/build/daemon/packaging/xsd/po/gs1/shared/*.xsd", "/usr/share/grid/xsd/po/gs1/shared/", "644"],
+    ["/build/daemon/packaging/xsd/po/sbdh/*.xsd", "/usr/share/grid/xsd/po/sbdh/", "644"],
+    ["/build/daemon/packaging/xsd/product/*.xsd", "/usr/share/grid/xsd/product/", "644"],
     ["target/release/gridd", "/usr/bin/gridd", "755"]
 ]
 maintainer-scripts = "packaging/ubuntu"

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -39,8 +39,8 @@ COPY daemon /build/daemon
 COPY sdk /build/sdk
 
 # Copy over files needed for examples
-COPY sdk/src/data_validation/xml/xsd/product/ /build/daemon/packaging/schemas/product/
-COPY sdk/src/data_validation/xml/xsd/po/ /build/daemon/packaging/schemas/po/
+COPY sdk/src/data_validation/xml/xsd/product/ /build/daemon/packaging/xsd/product/
+COPY sdk/src/data_validation/xml/xsd/po/ /build/daemon/packaging/xsd/po/
 
 # Build the gridd package
 ARG CARGO_ARGS


### PR DESCRIPTION
XML schema files now go into /usr/share, which is for
architecture-independent shareable files.

Signed-off-by: Lee Bradley <bradley@bitwise.io>