### PR TITLE
Use functions as opposed to pub schema const

### DIFF
--- a/cli/src/actions/mod.rs
+++ b/cli/src/actions/mod.rs
@@ -39,7 +39,7 @@ pub mod role;
 pub mod schema;
 
 #[cfg(any(feature = "purchase-order", feature = "product"))]
-pub const DEFAULT_SCHEMA_DIR: &str = "/usr/share/grid/xsd";
+const DEFAULT_SCHEMA_DIR: &str = "/usr/share/grid/xsd";
 
 fn chown(path: &Path, uid: u32, gid: u32) -> Result<(), CliError> {
     let pathstr = path

--- a/cli/src/actions/product.rs
+++ b/cli/src/actions/product.rs
@@ -47,8 +47,6 @@ use std::{
 
 use super::DEFAULT_SCHEMA_DIR;
 
-const GRID_PRODUCT_SCHEMA_DIR: &str = "GRID_PRODUCT_SCHEMA_DIR";
-
 /**
  * Prints basic info for products
  *
@@ -365,8 +363,7 @@ pub fn create_product_payloads_from_xml(
     owner: &str,
 ) -> Result<Vec<ProductCreateAction>, CliError> {
     let trade_items = get_trade_items_from_xml(path)?;
-    let data_validation_dir = env::var(GRID_PRODUCT_SCHEMA_DIR)
-        .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string() + "/product");
+    let data_validation_dir = get_product_schema_dir();
     validate_gdsn_3_1(path, true, &data_validation_dir)?;
 
     let mut payloads = Vec::new();
@@ -404,8 +401,7 @@ pub fn create_product_payloads_from_yaml(
 
 pub fn update_product_payloads_from_xml(path: &str) -> Result<Vec<ProductUpdateAction>, CliError> {
     let trade_items = get_trade_items_from_xml(path)?;
-    let data_validation_dir = env::var(GRID_PRODUCT_SCHEMA_DIR)
-        .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string() + "/product");
+    let data_validation_dir = get_product_schema_dir();
     validate_gdsn_3_1(path, true, &data_validation_dir)?;
 
     let mut payloads = Vec::new();
@@ -683,4 +679,9 @@ impl From<Namespace> for String {
             Namespace::Gs1 => "GS1".to_string(),
         }
     }
+}
+
+fn get_product_schema_dir() -> String {
+    env::var("GRID_PRODUCT_SCHEMA_DIR")
+        .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string() + "/product")
 }

--- a/cli/src/actions/purchase_order.rs
+++ b/cli/src/actions/purchase_order.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::env;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use grid_sdk::{
@@ -36,10 +37,9 @@ use rand::{distributions::Alphanumeric, Rng};
 use sawtooth_sdk::messages::batch::BatchList;
 use serde::Serialize;
 
+use super::DEFAULT_SCHEMA_DIR;
 use crate::error::CliError;
 use crate::transaction::purchase_order_batch_builder;
-
-pub const GRID_ORDER_SCHEMA_DIR: &str = "GRID_ORDER_SCHEMA_DIR";
 
 fn create_po_batchlist(signer: Box<dyn Signer>, action: Action) -> Result<BatchList, CliError> {
     let timestamp = SystemTime::now()
@@ -999,4 +999,9 @@ pub fn get_purchase_order_version(
             version_id, po_uid
         )))
     }
+}
+
+pub fn get_order_schema_dir() -> String {
+    env::var("GRID_ORDER_SCHEMA_DIR")
+        .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string() + "/po/gs1/ecom")
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -119,7 +119,7 @@ use actions::schema;
 use actions::{agent, organization as orgs, role};
 
 #[cfg(feature = "purchase-order")]
-use actions::{purchase_order::GRID_ORDER_SCHEMA_DIR, DEFAULT_SCHEMA_DIR};
+use actions::purchase_order::get_order_schema_dir;
 
 const APP_NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -2750,8 +2750,7 @@ fn run() -> Result<(), CliError> {
                     let wait = value_t!(m, "wait", u64).unwrap_or(0);
 
                     let order_xml_path = m.value_of("order_xml").unwrap();
-                    let data_validation_dir = env::var(GRID_ORDER_SCHEMA_DIR)
-                        .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string() + "/po/gs1/ecom");
+                    let data_validation_dir = get_order_schema_dir();
                     let mut xml_str = String::new();
                     std::fs::File::open(order_xml_path)?.read_to_string(&mut xml_str)?;
                     validate_order_xml_3_4(&xml_str, false, &data_validation_dir)?;
@@ -2907,8 +2906,7 @@ fn run() -> Result<(), CliError> {
                     if m.is_present("order_xml") {
                         new_xml = true;
                         let order_xml_path = m.value_of("order_xml").unwrap();
-                        let data_validation_dir = env::var(GRID_ORDER_SCHEMA_DIR)
-                            .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string() + "/po/gs1/ecom");
+                        let data_validation_dir = get_order_schema_dir();
                         xml_str = String::new();
                         std::fs::File::open(order_xml_path)?.read_to_string(&mut xml_str)?;
                         validate_order_xml_3_4(&xml_str, false, &data_validation_dir)?;


### PR DESCRIPTION
All external references to the schema directory should be based on both
the base schema dir and environment variables. This change creates
functions to facilitate that, and removes the public modifier from the
schema const.

Signed-off-by: Lee Bradley <bradley@bitwise.io>