### PR TITLE
Fix paging `total` count across Grid modules

### DIFF
--- a/sdk/src/pike/store/diesel/operations/list_agents.rs
+++ b/sdk/src/pike/store/diesel/operations/list_agents.rs
@@ -24,7 +24,9 @@ use crate::pike::store::diesel::{
 use crate::commits::MAX_COMMIT_NUM;
 use crate::error::InternalError;
 use crate::pike::store::diesel::models::{AgentModel, RoleAssociationModel};
+
 use diesel::prelude::*;
+use std::convert::TryInto;
 
 pub(in crate::pike::store::diesel) trait PikeStoreListAgentsOperation {
     fn list_agents(
@@ -61,17 +63,9 @@ impl<'a> PikeStoreListAgentsOperation for PikeStoreOperations<'a, diesel::pg::Pg
                 PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
             })?;
 
-            let mut count_query = pike_agent::table
-                .into_boxed()
-                .select(pike_agent::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query = count_query.filter(pike_agent::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(pike_agent::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = agent_models.len().try_into().map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let mut agents = Vec::new();
 
@@ -134,17 +128,9 @@ impl<'a> PikeStoreListAgentsOperation
                 PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
             })?;
 
-            let mut count_query = pike_agent::table
-                .into_boxed()
-                .select(pike_agent::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query = count_query.filter(pike_agent::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(pike_agent::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = agent_models.len().try_into().map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let mut agents = Vec::new();
 

--- a/sdk/src/pike/store/diesel/operations/list_organizations.rs
+++ b/sdk/src/pike/store/diesel/operations/list_organizations.rs
@@ -31,6 +31,7 @@ use crate::pike::store::diesel::{
 use crate::pike::store::{Organization, OrganizationList};
 
 use diesel::prelude::*;
+use std::convert::TryInto;
 
 pub(in crate::pike::store::diesel) trait PikeStoreListOrganizationsOperation {
     fn list_organizations(
@@ -65,17 +66,9 @@ impl<'a> PikeStoreListOrganizationsOperation for PikeStoreOperations<'a, diesel:
                 PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
             })?;
 
-            let mut count_query = pike_organization::table
-                .into_boxed()
-                .select(pike_organization::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query = count_query.filter(pike_organization::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(pike_organization::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = org_models.len().try_into().map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let mut orgs = Vec::new();
 
@@ -187,17 +180,9 @@ impl<'a> PikeStoreListOrganizationsOperation
                 PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
             })?;
 
-            let mut count_query = pike_organization::table
-                .into_boxed()
-                .select(pike_organization::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query = count_query.filter(pike_organization::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(pike_organization::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = org_models.len().try_into().map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let mut orgs = Vec::new();
 

--- a/sdk/src/pike/store/diesel/operations/list_roles_for_organization.rs
+++ b/sdk/src/pike/store/diesel/operations/list_roles_for_organization.rs
@@ -22,13 +22,13 @@ use crate::pike::store::diesel::models::{
     AllowedOrgModel, InheritFromModel, PermissionModel, RoleModel,
 };
 use crate::pike::store::diesel::{
-    schema::{
-        pike_allowed_orgs, pike_inherit_from, pike_organization, pike_permissions, pike_role,
-    },
+    schema::{pike_allowed_orgs, pike_inherit_from, pike_permissions, pike_role},
     PikeStoreError,
 };
 use crate::pike::store::{Role, RoleList};
+
 use diesel::prelude::*;
+use std::convert::TryInto;
 
 pub(in crate::pike::store::diesel) trait PikeStoreListRolesForOrganizationOperation {
     fn list_roles_for_organization(
@@ -71,17 +71,9 @@ impl<'a> PikeStoreListRolesForOrganizationOperation
                 PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
             })?;
 
-            let mut count_query = pike_organization::table
-                .into_boxed()
-                .select(pike_organization::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query = count_query.filter(pike_organization::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(pike_organization::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = role_models.len().try_into().map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let mut roles = Vec::new();
 
@@ -185,17 +177,9 @@ impl<'a> PikeStoreListRolesForOrganizationOperation
                 PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
             })?;
 
-            let mut count_query = pike_organization::table
-                .into_boxed()
-                .select(pike_organization::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query = count_query.filter(pike_organization::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(pike_organization::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = role_models.len().try_into().map_err(|err| {
+                PikeStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let mut roles = Vec::new();
 

--- a/sdk/src/purchase_order/store/diesel/operations/list_alternate_ids_for_purchase_order.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_alternate_ids_for_purchase_order.rs
@@ -22,7 +22,9 @@ use crate::purchase_order::store::diesel::{
 };
 
 use crate::purchase_order::store::PurchaseOrderStoreError;
+
 use diesel::prelude::*;
+use std::convert::TryInto;
 
 pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation
 {
@@ -70,18 +72,9 @@ impl<'a> PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation
                     )))
                 })?;
 
-            let mut count_query = purchase_order_alternate_id::table
-                .into_boxed()
-                .select(purchase_order_alternate_id::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query =
-                    count_query.filter(purchase_order_alternate_id::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(purchase_order_alternate_id::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = alt_id_models.len().try_into().map_err(|err| {
+                PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let ids = alt_id_models
                 .iter()
@@ -131,18 +124,9 @@ impl<'a> PurchaseOrderStoreListAlternateIdsForPurchaseOrderOperation
                     )))
                 })?;
 
-            let mut count_query = purchase_order_alternate_id::table
-                .into_boxed()
-                .select(purchase_order_alternate_id::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query =
-                    count_query.filter(purchase_order_alternate_id::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(purchase_order_alternate_id::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = alt_id_models.len().try_into().map_err(|err| {
+                PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let ids = alt_id_models
                 .iter()

--- a/sdk/src/purchase_order/store/diesel/operations/list_purchase_order_version_revisions.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_purchase_order_version_revisions.rs
@@ -22,7 +22,9 @@ use crate::purchase_order::store::diesel::{
 };
 
 use crate::purchase_order::store::PurchaseOrderStoreError;
+
 use diesel::prelude::*;
+use std::convert::TryInto;
 
 pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreListPurchaseOrderRevisionsOperation
 {
@@ -81,19 +83,9 @@ impl<'a> PurchaseOrderStoreListPurchaseOrderRevisionsOperation
                     )))
                 })?;
 
-            let mut count_query = purchase_order_version_revision::table
-                .into_boxed()
-                .select(purchase_order_version_revision::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query =
-                    count_query.filter(purchase_order_version_revision::service_id.eq(service_id));
-            } else {
-                count_query =
-                    count_query.filter(purchase_order_version_revision::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = revision_models.len().try_into().map_err(|err| {
+                PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let revs = revision_models
                 .iter()
@@ -153,19 +145,9 @@ impl<'a> PurchaseOrderStoreListPurchaseOrderRevisionsOperation
                     )))
                 })?;
 
-            let mut count_query = purchase_order_version_revision::table
-                .into_boxed()
-                .select(purchase_order_version_revision::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query =
-                    count_query.filter(purchase_order_version_revision::service_id.eq(service_id));
-            } else {
-                count_query =
-                    count_query.filter(purchase_order_version_revision::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = revision_models.len().try_into().map_err(|err| {
+                PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let revs = revision_models
                 .iter()

--- a/sdk/src/purchase_order/store/diesel/operations/list_purchase_order_versions.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_purchase_order_versions.rs
@@ -23,7 +23,9 @@ use crate::purchase_order::store::diesel::{
 };
 
 use crate::purchase_order::store::PurchaseOrderStoreError;
+
 use diesel::prelude::*;
+use std::convert::TryInto;
 
 pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreListPurchaseOrderVersionsOperation
 {
@@ -135,22 +137,9 @@ impl<'a> PurchaseOrderStoreListPurchaseOrderVersionsOperation
                         ))
                     })?;
 
-            let mut count_query = purchase_order_version::table
-                .into_boxed()
-                .select(purchase_order_version::all_columns)
-                .filter(
-                    purchase_order_version::purchase_order_uid
-                        .eq(&purchase_order_uid)
-                        .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
-                );
-
-            if let Some(service_id) = service_id {
-                count_query = count_query.filter(purchase_order_version::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(purchase_order_version::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = version_models.len().try_into().map_err(|err| {
+                PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let mut versions = Vec::new();
 
@@ -293,22 +282,9 @@ impl<'a> PurchaseOrderStoreListPurchaseOrderVersionsOperation
                         ))
                     })?;
 
-            let mut count_query = purchase_order_version::table
-                .into_boxed()
-                .select(purchase_order_version::all_columns)
-                .filter(
-                    purchase_order_version::purchase_order_uid
-                        .eq(&purchase_order_uid)
-                        .and(purchase_order_version::end_commit_num.eq(MAX_COMMIT_NUM)),
-                );
-
-            if let Some(service_id) = service_id {
-                count_query = count_query.filter(purchase_order_version::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(purchase_order_version::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = version_models.len().try_into().map_err(|err| {
+                PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let mut versions = Vec::new();
 

--- a/sdk/src/purchase_order/store/diesel/operations/list_purchase_orders.rs
+++ b/sdk/src/purchase_order/store/diesel/operations/list_purchase_orders.rs
@@ -32,6 +32,7 @@ use crate::purchase_order::store::diesel::{
 use crate::purchase_order::store::PurchaseOrderStoreError;
 use diesel::dsl::*;
 use diesel::prelude::*;
+use std::convert::TryInto;
 
 pub(in crate::purchase_order::store::diesel) trait PurchaseOrderStoreListPurchaseOrdersOperation {
     fn list_purchase_orders(
@@ -132,17 +133,9 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
                     )))
                 })?;
 
-            let mut count_query = purchase_order::table
-                .into_boxed()
-                .select(purchase_order::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query = count_query.filter(purchase_order::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(purchase_order::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = purchase_order_models.len().try_into().map_err(|err| {
+                PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let mut orders = Vec::new();
 
@@ -333,17 +326,9 @@ impl<'a> PurchaseOrderStoreListPurchaseOrdersOperation
                     )))
                 })?;
 
-            let mut count_query = purchase_order::table
-                .into_boxed()
-                .select(purchase_order::all_columns);
-
-            if let Some(service_id) = service_id {
-                count_query = count_query.filter(purchase_order::service_id.eq(service_id));
-            } else {
-                count_query = count_query.filter(purchase_order::service_id.is_null());
-            }
-
-            let total = count_query.count().get_result(self.conn)?;
+            let total = purchase_order_models.len().try_into().map_err(|err| {
+                PurchaseOrderStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
 
             let mut orders = Vec::new();
 

--- a/sdk/src/schema/store/diesel/mod.rs
+++ b/sdk/src/schema/store/diesel/mod.rs
@@ -16,10 +16,7 @@ pub(in crate::schema) mod models;
 mod operations;
 pub(in crate) mod schema;
 
-use crate::error::{
-    ConstraintViolationError, ConstraintViolationType, InternalError,
-    ResourceTemporarilyUnavailableError,
-};
+use crate::error::ResourceTemporarilyUnavailableError;
 
 use models::{GridPropertyDefinition, GridSchema, NewGridPropertyDefinition, NewGridSchema};
 use operations::{
@@ -424,39 +421,5 @@ impl From<(GridPropertyDefinition, Vec<PropertyDefinition>)> for PropertyDefinit
             struct_properties: children,
             service_id: model.service_id,
         }
-    }
-}
-
-impl From<diesel::result::Error> for SchemaStoreError {
-    fn from(err: diesel::result::Error) -> SchemaStoreError {
-        match err {
-            diesel::result::Error::DatabaseError(
-                diesel::result::DatabaseErrorKind::UniqueViolation,
-                _,
-            ) => SchemaStoreError::ConstraintViolationError(
-                ConstraintViolationError::from_source_with_violation_type(
-                    ConstraintViolationType::Unique,
-                    Box::new(err),
-                ),
-            ),
-            diesel::result::Error::DatabaseError(
-                diesel::result::DatabaseErrorKind::ForeignKeyViolation,
-                _,
-            ) => SchemaStoreError::ConstraintViolationError(
-                ConstraintViolationError::from_source_with_violation_type(
-                    ConstraintViolationType::ForeignKey,
-                    Box::new(err),
-                ),
-            ),
-            _ => SchemaStoreError::InternalError(InternalError::from_source(Box::new(err))),
-        }
-    }
-}
-
-impl From<diesel::r2d2::PoolError> for SchemaStoreError {
-    fn from(err: diesel::r2d2::PoolError) -> SchemaStoreError {
-        SchemaStoreError::ResourceTemporarilyUnavailableError(
-            ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
-        )
     }
 }

--- a/sdk/src/schema/store/error.rs
+++ b/sdk/src/schema/store/error.rs
@@ -15,6 +15,8 @@
 use std::error::Error;
 use std::fmt;
 
+#[cfg(feature = "diesel")]
+use crate::error::ConstraintViolationType;
 use crate::error::{ConstraintViolationError, InternalError, ResourceTemporarilyUnavailableError};
 
 /// Represents Store errors
@@ -45,5 +47,41 @@ impl fmt::Display for SchemaStoreError {
             SchemaStoreError::ResourceTemporarilyUnavailableError(err) => err.fmt(f),
             SchemaStoreError::NotFoundError(ref s) => write!(f, "Element not found: {}", s),
         }
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<diesel::result::Error> for SchemaStoreError {
+    fn from(err: diesel::result::Error) -> Self {
+        match err {
+            diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::UniqueViolation,
+                _,
+            ) => SchemaStoreError::ConstraintViolationError(
+                ConstraintViolationError::from_source_with_violation_type(
+                    ConstraintViolationType::Unique,
+                    Box::new(err),
+                ),
+            ),
+            diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::ForeignKeyViolation,
+                _,
+            ) => SchemaStoreError::ConstraintViolationError(
+                ConstraintViolationError::from_source_with_violation_type(
+                    ConstraintViolationType::ForeignKey,
+                    Box::new(err),
+                ),
+            ),
+            _ => SchemaStoreError::InternalError(InternalError::from_source(Box::new(err))),
+        }
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<diesel::r2d2::PoolError> for SchemaStoreError {
+    fn from(err: diesel::r2d2::PoolError) -> SchemaStoreError {
+        SchemaStoreError::ResourceTemporarilyUnavailableError(
+            ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+        )
     }
 }


### PR DESCRIPTION
This updates the way the `total` is calculated for Grid DB operations.
This simplifies the way the number of records is calculated to make it
both more accurate and reduce the number of DB queries.

Signed-off-by: Davey Newhall <newhall@bitwise.io>