### PR TITLE
Stabilize Grid CLI `purchase-order` feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -62,6 +62,7 @@ default = [
     "pike",
     "postgres",
     "product",
+    "purchase-order",
     "schema",
     "sqlite",
 ]
@@ -76,7 +77,6 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
-    "purchase-order",
 ]
 
 database = ["diesel"]


### PR DESCRIPTION
This stabilizes the `purchase-order` feature by moving it from
experimental to stable.

Signed-off-by: Lee Bradley <bradley@bitwise.io>