### PR TITLE
Update man page links to Grid docs

### DIFF
--- a/cli/man/grid-admin-keygen.1.md
+++ b/cli/man/grid-admin-keygen.1.md
@@ -48,4 +48,4 @@ SEE ALSO
 ========
 | `grid admin(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-admin.1.md
+++ b/cli/man/grid-admin.1.md
@@ -49,4 +49,4 @@ SEE ALSO
 ========
 | `grid admin keygen(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-agent-create.1.md
+++ b/cli/man/grid-agent-create.1.md
@@ -101,4 +101,4 @@ SEE ALSO
 | `grid agent update(1)`
 | `grid role(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-agent-list.1.md
+++ b/cli/man/grid-agent-list.1.md
@@ -103,4 +103,4 @@ SEE ALSO
 | `grid agent update(1)`
 | `grid role(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-agent-show.1.md
+++ b/cli/man/grid-agent-show.1.md
@@ -96,4 +96,4 @@ SEE ALSO
 | `grid agent update(1)`
 | `grid role(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-agent-update.1.md
+++ b/cli/man/grid-agent-update.1.md
@@ -99,4 +99,4 @@ SEE ALSO
 | `grid agent show(1)`
 | `grid role(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-agent.1.md
+++ b/cli/man/grid-agent.1.md
@@ -80,4 +80,4 @@ SEE ALSO
 | `grid organization(1)`
 | `grid role(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-database-migrate.1.md
+++ b/cli/man/grid-database-migrate.1.md
@@ -46,4 +46,4 @@ SEE ALSO
 ========
 | `grid database(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-database.1.md
+++ b/cli/man/grid-database.1.md
@@ -48,4 +48,4 @@ SEE ALSO
 ========
 | `grid database migrate(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-keygen.1.md
+++ b/cli/man/grid-keygen.1.md
@@ -48,4 +48,4 @@ SEE ALSO
 ========
 | `grid admin(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-location-create.1.md
+++ b/cli/man/grid-location-create.1.md
@@ -157,4 +157,4 @@ SEE ALSO
 | `grid-location-show(1)`
 | `grid-location-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-location-delete.1.md
+++ b/cli/man/grid-location-delete.1.md
@@ -98,4 +98,4 @@ SEE ALSO
 | `grid-location-show(1)`
 | `grid-location-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-location-list.1.md
+++ b/cli/man/grid-location-list.1.md
@@ -112,4 +112,4 @@ SEE ALSO
 | `grid-location-show(1)`
 | `grid-location-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-location-show.1.md
+++ b/cli/man/grid-location-show.1.md
@@ -102,4 +102,4 @@ SEE ALSO
 | `grid-location-show(1)`
 | `grid-location-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-location-update.1.md
+++ b/cli/man/grid-location-update.1.md
@@ -152,4 +152,4 @@ SEE ALSO
 | `grid-location-show(1)`
 | `grid-location-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-location.1.md
+++ b/cli/man/grid-location.1.md
@@ -82,4 +82,4 @@ SEE ALSO
 | `grid location show(1)`
 | `grid location update(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-organization-create.1.md
+++ b/cli/man/grid-organization-create.1.md
@@ -88,4 +88,4 @@ SEE ALSO
 | `grid agent(1)`
 | `grid role(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-organization-list.1.md
+++ b/cli/man/grid-organization-list.1.md
@@ -92,4 +92,4 @@ SEE ALSO
 | `grid agent(1)`
 | `grid role(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-organization-show.1.md
+++ b/cli/man/grid-organization-show.1.md
@@ -109,4 +109,4 @@ SEE ALSO
 | `grid agent(1)`
 | `grid role(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-organization-update.1.md
+++ b/cli/man/grid-organization-update.1.md
@@ -91,4 +91,4 @@ SEE ALSO
 | `grid agent(1)`
 | `grid role(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-organization.1.md
+++ b/cli/man/grid-organization.1.md
@@ -80,4 +80,4 @@ SEE ALSO
 | `grid agent(1)`
 | `grid role(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-create.1.md
+++ b/cli/man/grid-po-create.1.md
@@ -130,4 +130,4 @@ SEE ALSO
 | `grid-po-update(1)`
 | `grid-po-version(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-list.1.md
+++ b/cli/man/grid-po-list.1.md
@@ -136,4 +136,4 @@ SEE ALSO
 | `grid-po-show(1)`
 | `grid-po-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-revision-list.1.md
+++ b/cli/man/grid-po-revision-list.1.md
@@ -108,4 +108,4 @@ SEE ALSO
 | `grid-po-version(1)`
 | `grid-po-version-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-revision-show.1.md
+++ b/cli/man/grid-po-revision-show.1.md
@@ -102,4 +102,4 @@ SEE ALSO
 | `grid-po-revision-list(1)`
 | `grid-po-version(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-revision.1.md
+++ b/cli/man/grid-po-revision.1.md
@@ -72,4 +72,4 @@ SEE ALSO
 | `grid-po-revision-list(1)`
 | `grid-po-revision-show(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-show.1.md
+++ b/cli/man/grid-po-show.1.md
@@ -169,4 +169,4 @@ SEE ALSO
 | `grid-po-update(1)`
 | `grid-po-version(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-update.1.md
+++ b/cli/man/grid-po-update.1.md
@@ -163,4 +163,4 @@ SEE ALSO
 | `grid-po-update(1)`
 | `grid-po-version(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-version-create.1.md
+++ b/cli/man/grid-po-version-create.1.md
@@ -134,6 +134,6 @@ SEE ALSO
 | `grid-po-version-update(1)`
 | `grid-po-revision(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/
 | GS1 Order 3.4:
 | https://www.gs1.org/sites/default/files/docs/EDI/ecom-xml/functional-user-guide/3_4/HTML/O/a1.htm

--- a/cli/man/grid-po-version-list.1.md
+++ b/cli/man/grid-po-version-list.1.md
@@ -110,4 +110,4 @@ SEE ALSO
 | `grid-po-version-update(1)`
 | `grid-po-revision(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-version-show.1.md
+++ b/cli/man/grid-po-version-show.1.md
@@ -102,4 +102,4 @@ SEE ALSO
 | `grid-po-version-update(1)`
 | `grid-po-revision(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-version-update.1.md
+++ b/cli/man/grid-po-version-update.1.md
@@ -130,4 +130,4 @@ SEE ALSO
 | `grid-po-version-update(1)`
 | `grid-po-revision(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-version.1.md
+++ b/cli/man/grid-po-version.1.md
@@ -92,4 +92,4 @@ SEE ALSO
 | `grid-po-version-update(1)`
 | `grid-po-version-show(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po.1.md
+++ b/cli/man/grid-po.1.md
@@ -97,4 +97,4 @@ SEE ALSO
 | `grid-po-update(1)`
 | `grid-po-version(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.1/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-product-create.1.md
+++ b/cli/man/grid-product-create.1.md
@@ -288,4 +288,4 @@ SEE ALSO
 | `grid-product-show(1)`
 | `grid-product-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-product-delete.1.md
+++ b/cli/man/grid-product-delete.1.md
@@ -97,4 +97,4 @@ SEE ALSO
 | `grid-product-show(1)`
 | `grid-product-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-product-list.1.md
+++ b/cli/man/grid-product-list.1.md
@@ -86,4 +86,4 @@ SEE ALSO
 | `grid-product-show(1)`
 | `grid-product-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-product-show.1.md
+++ b/cli/man/grid-product-show.1.md
@@ -92,4 +92,4 @@ SEE ALSO
 | `grid-product-show(1)`
 | `grid-product-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-product-update.1.md
+++ b/cli/man/grid-product-update.1.md
@@ -281,4 +281,4 @@ SEE ALSO
 | `grid-product-show(1)`
 | `grid-product-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-product.1.md
+++ b/cli/man/grid-product.1.md
@@ -97,4 +97,4 @@ SEE ALSO
 | `grid-product-show(1)`
 | `grid-product-list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-role-create.1.md
+++ b/cli/man/grid-role-create.1.md
@@ -100,4 +100,4 @@ SEE ALSO
 | `grid role list(1)`
 | `grid role show(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-role-delete.1.md
+++ b/cli/man/grid-role-delete.1.md
@@ -74,4 +74,4 @@ SEE ALSO
 | `grid role list(1)`
 | `grid role show(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-role-list.1.md
+++ b/cli/man/grid-role-list.1.md
@@ -55,4 +55,4 @@ SEE ALSO
 | `grid role update(1)`
 | `grid role show(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-role-show.1.md
+++ b/cli/man/grid-role-show.1.md
@@ -55,4 +55,4 @@ SEE ALSO
 | `grid role(1)`
 | `grid role list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-role-update.1.md
+++ b/cli/man/grid-role-update.1.md
@@ -101,4 +101,4 @@ SEE ALSO
 | `grid role list(1)`
 | `grid role show(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-role.1.md
+++ b/cli/man/grid-role.1.md
@@ -85,4 +85,4 @@ SEE ALSO
 | `grid role list(1)`
 | `grid role show(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-schema-create.1.md
+++ b/cli/man/grid-schema-create.1.md
@@ -147,4 +147,4 @@ SEE ALSO
 | `grid schema list(1)`
 | `grid schema show(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-schema-list.1.md
+++ b/cli/man/grid-schema-list.1.md
@@ -62,4 +62,4 @@ SEE ALSO
 | `grid schema update(1)`
 | `grid schema show(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-schema-show.1.md
+++ b/cli/man/grid-schema-show.1.md
@@ -68,4 +68,4 @@ SEE ALSO
 | `grid schema update(1)`
 | `grid schema list(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-schema-update.1.md
+++ b/cli/man/grid-schema-update.1.md
@@ -147,4 +147,4 @@ SEE ALSO
 | `grid schema list(1)`
 | `grid schema show(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-schema.1.md
+++ b/cli/man/grid-schema.1.md
@@ -90,4 +90,4 @@ SEE ALSO
 | `grid schema list(1)`
 | `grid schema show(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid.1.md
+++ b/cli/man/grid.1.md
@@ -125,4 +125,4 @@ SEE ALSO
 | `grid role(1)`
 | `grid schema(1)`
 |
-| Grid documentation: https://grid.hyperledger.org/docs/0.2/
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/


### PR DESCRIPTION
Updates the link at the end of each man page to point to 0.3 on the
Grid website. Previously, they pointed to 0.2 or 0.1 docs.

Resolves: #1228

Signed-off-by: Chris Eckhardt <eckhardt@bitwise.io>