### PR TITLE
Add `StartWorkflowState`

### DIFF
--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -174,22 +174,14 @@ fn create_purchase_order(
     let workflow = get_workflow(&workflow_id).ok_or_else(|| {
         ApplyError::InvalidTransaction(format!("Cannot build `{}` Workflow", workflow_id))
     })?;
-    // Get the desired workflow state of this purchase order
-    let desired_po_workflow_state = workflow
-        .subworkflow("po")
-        .ok_or_else(|| {
-            ApplyError::InvalidTransaction(format!(
-                "Workflow `{}` does not contain a `po` subworkflow",
-                payload.workflow_id(),
-            ))
-        })?
-        .state(payload.workflow_state())
-        .ok_or_else(|| {
-            ApplyError::InvalidTransaction(format!(
-                "Workflow state `{}` does not exist in `po` subworkflow",
-                payload.workflow_state()
-            ))
-        })?;
+
+    // Retrieve the workflow for this purchase order
+    let po_subworkflow = workflow.subworkflow("po").ok_or_else(|| {
+        ApplyError::InvalidTransaction(format!(
+            "Workflow `{}` does not contain a `po` subworkflow",
+            payload.workflow_id(),
+        ))
+    })?;
 
     // Retrieve the workflow for this purchase order
     let version_subworkflow = workflow.subworkflow("version").ok_or_else(|| {
@@ -198,6 +190,18 @@ fn create_purchase_order(
             payload.workflow_id(),
         ))
     })?;
+
+    // Get the desired workflow state of this purchase order
+    let desired_po_workflow_state =
+        po_subworkflow
+            .state(payload.workflow_state())
+            .ok_or_else(|| {
+                ApplyError::InvalidTransaction(format!(
+                    "Workflow state `{}` does not exist in `po` subworkflow",
+                    payload.workflow_state()
+                ))
+            })?;
+
     /* ------------------ Verify submitter's permissions ------------------------ */
     let (versions, version_desired_state): (Vec<_>, Option<WorkflowState>) =
         match payload.create_version_payload() {
@@ -212,11 +216,16 @@ fn create_purchase_order(
                         ))
                     })?;
                 let perm_result = perm_checker
-                    .check_permission_within_workflow(
+                    .check_permission_to_enter_workflow(
                         &perm_string,
                         signer,
                         agent.org_id(),
-                        &desired_version_workflow_state,
+                        version_subworkflow.start_state().ok_or_else(|| {
+                            ApplyError::InvalidTransaction(
+                                "Workflow start state does not exist in version subworkflow"
+                                    .to_string(),
+                            )
+                        })?,
                         payload_version.workflow_state(),
                     )
                     .map_err(|err| {
@@ -273,11 +282,15 @@ fn create_purchase_order(
 
     let perm_string = Permission::CanCreatePo.to_string();
     let perm_result = perm_checker
-        .check_permission_within_workflow(
+        .check_permission_to_enter_workflow(
             &perm_string,
             signer,
             agent.org_id(),
-            &desired_po_workflow_state,
+            po_subworkflow.start_state().ok_or_else(|| {
+                ApplyError::InvalidTransaction(
+                    "Purchase order subworkflow does not have start state".to_string(),
+                )
+            })?,
             payload.workflow_state(),
         )
         .map_err(|err| {
@@ -872,30 +885,29 @@ fn create_version(
             "Desired workflow state has `draft` constraint, version is not a draft".to_string(),
         ));
     }
-    // Get the "create" state from the version subworkflow, to validate if we are able to
+    // Get the start state from the version subworkflow, to validate if we are able to
     // create this version
-    let create_workflow_state = get_workflow(&workflow_id)
+    let version_subworkflow = get_workflow(&workflow_id)
         .ok_or_else(|| {
             ApplyError::InvalidTransaction(format!("Workflow `{}` does not exist", &workflow_id))
         })?
         .subworkflow("version")
         .ok_or_else(|| {
             ApplyError::InvalidTransaction("Subworkflow `version` does not exist".to_string())
-        })?
-        .state("create")
-        .ok_or_else(|| {
-            ApplyError::InvalidTransaction(
-                "Workflow state `create` does not exist in `version` subworkflow".to_string(),
-            )
         })?;
+    let start_workflow_state = version_subworkflow.start_state().ok_or_else(|| {
+        ApplyError::InvalidTransaction(
+            "Workflow start state does not exist in `version` subworkflow".to_string(),
+        )
+    })?;
     // Validate the agent is able to create the purchase order version
     let perm_string = Permission::CanCreatePoVersion.to_string();
     let perm_result = perm_checker
-        .check_permission_within_workflow(
+        .check_permission_to_enter_workflow(
             &perm_string,
             signer,
             &agent_org_id,
-            &create_workflow_state,
+            start_workflow_state,
             &desired_workflow_state_string,
         )
         .map_err(|err| {
@@ -1562,7 +1574,7 @@ mod tests {
             .with_created_at(1)
             .with_buyer_org_id(ORG_ID_1.to_string())
             .with_seller_org_id(ORG_ID_2.to_string())
-            .with_workflow_state("create".to_string())
+            .with_workflow_state("issued".to_string())
             .with_workflow_id(POWorkflow::SystemOfRecord.to_string())
             .build()
             .expect("Unable to build CreatePurchaseOrderPayload");

--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -212,7 +212,7 @@ fn create_purchase_order(
                         ))
                     })?;
                 let perm_result = perm_checker
-                    .check_permission_with_workflow(
+                    .check_permission_within_workflow(
                         &perm_string,
                         signer,
                         agent.org_id(),
@@ -273,7 +273,7 @@ fn create_purchase_order(
 
     let perm_string = Permission::CanCreatePo.to_string();
     let perm_result = perm_checker
-        .check_permission_with_workflow(
+        .check_permission_within_workflow(
             &perm_string,
             signer,
             agent.org_id(),
@@ -459,7 +459,7 @@ fn update_purchase_order(
         })?
     };
     let perm_result = perm_checker
-        .check_permission_with_workflow(
+        .check_permission_within_workflow(
             &perm_string.to_string(),
             signer,
             agent.org_id(),
@@ -724,7 +724,7 @@ fn validate_version_update_permissions(
             .to_string()
     };
     let perm_result = perm_checker
-        .check_permission_with_workflow(
+        .check_permission_within_workflow(
             &perm_string,
             signer,
             agent_org_id,
@@ -891,7 +891,7 @@ fn create_version(
     // Validate the agent is able to create the purchase order version
     let perm_string = Permission::CanCreatePoVersion.to_string();
     let perm_result = perm_checker
-        .check_permission_with_workflow(
+        .check_permission_within_workflow(
             &perm_string,
             signer,
             &agent_org_id,
@@ -993,7 +993,7 @@ fn update_version(
     };
     // Validate the submitter is allowed to perform the action
     let perm_result = perm_checker
-        .check_permission_with_workflow(
+        .check_permission_within_workflow(
             &perm_string.to_string(),
             signer,
             agent.org_id(),

--- a/contracts/purchase_order/src/workflow.rs
+++ b/contracts/purchase_order/src/workflow.rs
@@ -15,7 +15,8 @@
 use std::fmt;
 
 use grid_sdk::workflow::{
-    PermissionAlias, SubWorkflow, SubWorkflowBuilder, Workflow, WorkflowStateBuilder,
+    PermissionAlias, StartWorkflowStateBuilder, SubWorkflow, SubWorkflowBuilder, Workflow,
+    WorkflowStateBuilder,
 };
 
 use crate::permissions::Permission;
@@ -52,7 +53,7 @@ fn collaborative_workflow() -> Workflow {
 }
 
 fn default_sub_workflow() -> SubWorkflow {
-    let create = {
+    let start_state = {
         let mut buyer = PermissionAlias::new("po::buyer");
         buyer.add_permission(&Permission::CanCreatePo.to_string());
         buyer.add_permission(&Permission::CanCreatePoVersion.to_string());
@@ -60,7 +61,6 @@ fn default_sub_workflow() -> SubWorkflow {
         buyer.add_transition("issued");
 
         let mut seller = PermissionAlias::new("po::seller");
-        seller.add_permission(&Permission::CanCreatePoVersion.to_string());
         seller.add_permission(&Permission::CanTransitionIssued.to_string());
         seller.add_transition("issued");
 
@@ -69,7 +69,7 @@ fn default_sub_workflow() -> SubWorkflow {
         partner.add_permission(&Permission::CanTransitionIssued.to_string());
         partner.add_transition("issued");
 
-        WorkflowStateBuilder::new("create")
+        StartWorkflowStateBuilder::default()
             .add_transition("issued")
             .add_permission_alias(buyer)
             .add_permission_alias(seller)
@@ -156,16 +156,15 @@ fn default_sub_workflow() -> SubWorkflow {
     };
 
     SubWorkflowBuilder::new("po")
-        .add_state(create)
+        .with_start_state(start_state)
         .add_state(issued)
         .add_state(confirmed)
         .add_state(closed)
-        .add_starting_state("create")
         .build()
 }
 
 fn system_of_record_sub_workflow() -> SubWorkflow {
-    let create = {
+    let start_state = {
         let mut buyer = PermissionAlias::new("po::buyer");
         buyer.add_permission(&Permission::CanCreatePoVersion.to_string());
         buyer.add_permission(&Permission::CanTransitionProposed.to_string());
@@ -178,7 +177,7 @@ fn system_of_record_sub_workflow() -> SubWorkflow {
         draft.add_permission(&Permission::CanTransitionEditable.to_string());
         draft.add_transition("editable");
 
-        WorkflowStateBuilder::new("create")
+        StartWorkflowStateBuilder::default()
             .add_transition("proposed")
             .add_transition("editable")
             .add_permission_alias(buyer)
@@ -363,7 +362,7 @@ fn system_of_record_sub_workflow() -> SubWorkflow {
     };
 
     SubWorkflowBuilder::new("version")
-        .add_state(create)
+        .with_start_state(start_state)
         .add_state(proposed)
         .add_state(obsolete)
         .add_state(rejected)
@@ -374,19 +373,17 @@ fn system_of_record_sub_workflow() -> SubWorkflow {
         .add_state(declined)
         .add_state(composed)
         .add_state(cancelled)
-        .add_starting_state("proposed")
-        .add_starting_state("editable")
         .build()
 }
 
 fn collaborative_sub_workflow() -> SubWorkflow {
-    let create = {
+    let start_state = {
         let mut partner = PermissionAlias::new("po::partner");
         partner.add_permission(&Permission::CanCreatePoVersion.to_string());
         partner.add_permission(&Permission::CanTransitionProposed.to_string());
         partner.add_transition("proposed");
 
-        WorkflowStateBuilder::new("create")
+        StartWorkflowStateBuilder::default()
             .add_transition("proposed")
             .add_permission_alias(partner)
             .build()
@@ -467,13 +464,12 @@ fn collaborative_sub_workflow() -> SubWorkflow {
     };
 
     SubWorkflowBuilder::new("version")
-        .add_state(create)
+        .with_start_state(start_state)
         .add_state(proposed)
         .add_state(obsolete)
         .add_state(rejected)
         .add_state(modified)
         .add_state(accepted)
-        .add_starting_state("create")
         .build()
 }
 

--- a/sdk/src/pike/permissions/mod.rs
+++ b/sdk/src/pike/permissions/mod.rs
@@ -1043,9 +1043,8 @@ mod tests {
             buyer.add_transition("issued");
 
             let mut seller = PermissionAlias::new("po::seller");
-            seller.add_permission("can-create-po-version");
-            buyer.add_permission("can-transition-issued");
-            buyer.add_transition("issued");
+            seller.add_permission("can-transition-issued");
+            seller.add_transition("issued");
 
             StartWorkflowStateBuilder::default()
                 .add_transition("issued")

--- a/sdk/src/pike/permissions/mod.rs
+++ b/sdk/src/pike/permissions/mod.rs
@@ -718,16 +718,16 @@ mod tests {
         let subworkflow = workflow
             .subworkflow("po")
             .expect("Unable to get po subworkflow");
-        let state = subworkflow
-            .state("create")
-            .expect("Unable to get create state from subworkflow");
+        let start_state = subworkflow
+            .start_state()
+            .expect("Unable to get start state from subworkflow");
         // Validate that the Agent has the correct permission
         let result = perm_checker
             .check_permission_to_enter_workflow(
                 PERM_CAN_CREATE_PO,
                 PUBLIC_KEY_ALPHA,
                 ORG_ID_ALPHA,
-                &state,
+                &start_state,
                 "issued",
             )
             .expect("Unable to check permission with workflow");
@@ -794,7 +794,7 @@ mod tests {
             .subworkflow("po")
             .expect("Unable to get po subworkflow");
         let state = subworkflow
-            .state("create")
+            .start_state()
             .expect("Unable to get create state from subworkflow");
         // Validate the Agent does not have the correct permission.
         let result = perm_checker
@@ -938,8 +938,8 @@ mod tests {
             .subworkflow("po")
             .expect("Unable to get po subworkflow");
         let state = subworkflow
-            .state("create")
-            .expect("Unable to get create state from subworkflow");
+            .start_state()
+            .expect("Unable to get start state from subworkflow");
         // Check that the agent is able to transition the state to "issued" and has the
         // "can-create-po" permission for the Alpha organization
         let result = perm_checker
@@ -1015,7 +1015,7 @@ mod tests {
             .subworkflow("po")
             .expect("Unable to get po subworkflow");
         let state = subworkflow
-            .state("create")
+            .start_state()
             .expect("Unable to get create state from subworkflow");
 
         let result = perm_checker
@@ -1047,7 +1047,7 @@ mod tests {
             buyer.add_permission("can-transition-issued");
             buyer.add_transition("issued");
 
-            WorkflowStateBuilder::new("create")
+            StartWorkflowStateBuilder::default()
                 .add_transition("issued")
                 .add_permission_alias(buyer)
                 .add_permission_alias(seller)
@@ -1105,11 +1105,10 @@ mod tests {
         };
 
         SubWorkflowBuilder::new("po")
-            .add_state(create)
+            .with_start_state(create)
             .add_state(issued)
             .add_state(confirmed)
             .add_state(closed)
-            .add_starting_state("create")
             .build()
     }
 }

--- a/sdk/src/workflow/mod.rs
+++ b/sdk/src/workflow/mod.rs
@@ -21,7 +21,10 @@
 mod state;
 mod subworkflow;
 
-pub use state::{PermissionAlias, WorkflowState, WorkflowStateBuilder};
+pub use state::{
+    PermissionAlias, StartWorkflowState, StartWorkflowStateBuilder, WorkflowState,
+    WorkflowStateBuilder,
+};
 pub use subworkflow::{SubWorkflow, SubWorkflowBuilder};
 
 /// A single workflow may involve multiple processes; these processes are defined by the list of

--- a/sdk/src/workflow/mod.rs
+++ b/sdk/src/workflow/mod.rs
@@ -116,20 +116,21 @@ mod tests {
             .add_constraint("active=None")
             .add_transition("issued")
             .add_transition("confirm")
+            .add_permission_alias(permission.clone())
+            .build();
+
+        let start_state = StartWorkflowStateBuilder::default()
             .add_permission_alias(permission)
+            .add_transition("issued")
             .build();
 
         let subworkflow = SubWorkflowBuilder::new("po")
+            .with_start_state(start_state.clone())
             .add_state(state)
-            .add_starting_state("issued")
-            .add_starting_state("proposed")
             .build();
 
         assert_eq!("po", subworkflow.name());
-        assert_eq!(
-            &["issued".to_string(), "proposed".to_string()],
-            subworkflow.starting_states()
-        );
+        assert!(subworkflow.start_state().is_some());
         assert!(subworkflow.state("issued").is_some());
     }
 
@@ -145,13 +146,17 @@ mod tests {
             .add_constraint("active=None")
             .add_transition("issued")
             .add_transition("confirm")
+            .add_permission_alias(permission.clone())
+            .build();
+
+        let start_state = StartWorkflowStateBuilder::default()
             .add_permission_alias(permission)
+            .add_transition("issued")
             .build();
 
         let subworkflow = SubWorkflowBuilder::new("po")
+            .with_start_state(start_state)
             .add_state(state)
-            .add_starting_state("issued")
-            .add_starting_state("proposed")
             .build();
 
         let workflow = Workflow::new(vec![subworkflow]);

--- a/sdk/src/workflow/subworkflow.rs
+++ b/sdk/src/workflow/subworkflow.rs
@@ -15,7 +15,7 @@
 //! An API for managing a subprocess within a workflow, which contains the list of states involved
 //! in this subprocess
 
-use super::state::WorkflowState;
+use super::state::{StartWorkflowState, WorkflowState};
 
 /// A smaller more specific version of a workflow used to define a more complicated business
 /// process within a workflow
@@ -24,8 +24,8 @@ pub struct SubWorkflow {
     name: String,
     /// The states an object may be in within this subworkflow
     states: Vec<WorkflowState>,
-    /// The states an object may begin at within this subworkflow
-    starting_states: Vec<String>,
+    /// The state an object begins at within this subworkflow
+    start_state: Option<StartWorkflowState>,
 }
 
 impl SubWorkflow {
@@ -45,9 +45,9 @@ impl SubWorkflow {
         None
     }
 
-    /// Return the workflow states an object must enter the subworkflow at
-    pub fn starting_states(&self) -> &[String] {
-        &self.starting_states
+    /// Return the workflow state an object must enter the subworkflow at
+    pub fn start_state(&self) -> Option<&StartWorkflowState> {
+        self.start_state.as_ref()
     }
 }
 
@@ -56,7 +56,7 @@ impl SubWorkflow {
 pub struct SubWorkflowBuilder {
     name: String,
     states: Vec<WorkflowState>,
-    starting_states: Vec<String>,
+    start_state: Option<StartWorkflowState>,
 }
 
 impl SubWorkflowBuilder {
@@ -74,8 +74,8 @@ impl SubWorkflowBuilder {
     }
 
     /// Add the name of a workflow state an object must enter this subworkflow at
-    pub fn add_starting_state(mut self, starting_state: &str) -> Self {
-        self.starting_states.push(starting_state.to_string());
+    pub fn with_start_state(mut self, start_state: StartWorkflowState) -> Self {
+        self.start_state = Some(start_state);
         self
     }
 
@@ -83,7 +83,7 @@ impl SubWorkflowBuilder {
         SubWorkflow {
             name: self.name,
             states: self.states,
-            starting_states: self.starting_states,
+            start_state: self.start_state,
         }
     }
 }


### PR DESCRIPTION
This adds a new struct to Workflow state, `StartWorkflowState`. This is specifically used to validate a user's permissions to create an object within a workflow.

Also updates the methods within the permission checker to better specify between checking a user's permission within a workflow and when entering a workflow. This updates the `check_permission_with_workflow` method to be `check_permission_within_workflow` and adds a new method, `check_permission_to_enter_workflow` which inspects a `StartWorkflowState` rather than a `WorkflowState`. 

This also updates the purchase order smart contract handler to use the correct permission checking method (the create_X actions now use the `check_permission_to_enter_workflow` method) and updates an affected test that was specifying the "create" workflow state which no longer exists in the built-in subworkflows as it was replaced by the 'start_state'