### PR TITLE
Add `download-xsd` CLI command

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,9 +50,15 @@ serde_yaml = "0.8"
 diesel_migrations = "1.4"
 whoami = "1"
 rand = { version = "0.7", optional = true }
+zip = { version = "0.5.13", optional = true }
+reqwest = { version = "0.11", features = ["blocking", "json"], optional = true }
+sha2 = { version = "0.10.1", optional = true }
+hex-literal = { version = "0.3.4", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"
+mockito = "0.30.0"
+pretty_assertions = "1.0.0"
 
 [features]
 default = [
@@ -77,6 +83,7 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "xsd-downloader"
 ]
 
 database = ["diesel"]
@@ -95,6 +102,7 @@ product = ["pike", "schema", "grid-sdk/product", "grid-sdk/product-gdsn"]
 purchase-order = ["chrono", "grid-sdk/purchase-order", "rand", "serde_json"]
 sawtooth = []
 schema = ["pike", "grid-sdk/schema"]
+xsd-downloader = ["zip", "reqwest", "sha2", "hex-literal"]
 
 [package.metadata.deb]
 maintainer = "The Hyperledger Grid Team"

--- a/cli/man/grid-download-xsd.1.md
+++ b/cli/man/grid-download-xsd.1.md
@@ -1,0 +1,79 @@
+% GRID-DOWNLOAD-XSD(1) Cargill, Incorporated | Grid
+
+<!--
+  Copyright 2022 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-download-xsd** - Downloads and extracts the XSDs necessary for Grid
+validation.
+
+SYNOPSIS
+========
+
+**grid download-xsd** \[**FLAGS**\] \[**OPTIONS**\] 
+
+DESCRIPTION
+===========
+
+This command downloads GS1 XSD files used by various Grid features. The
+downloaded artifacts are first copied into a cache directory. They are then
+expanded into Grid's state directory. If the desired artifacts are in the
+cache directory, Grid will not attempt to re-download them, and instead
+prefer the cache contents.
+
+To avoid downloading from the internet (for example, if a firewall rule
+would prevent access to the remote website), use the --copy-from and
+--no-download arguments.
+
+If --copy-from is used without --no-download, artfacts will be copied from
+the directory provided via --copy-from and any missing artifacts will be
+downloaded as usual.
+
+FLAGS
+=====
+
+`--no-download`
+: Do not download the XSD even if there is no artifact cached
+
+`--force`
+: Continue even if a checksum on the cached file is incorrect
+
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Do not display output.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Log verbosely.
+
+OPTIONS
+=======
+
+`--copy-from`
+: Replenish the cache from a directory resource and use that. The directory
+  should contain the following files:
+  /GS1\_XML\_3-4-1\_Publication.zip
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_CACHE_DIR`**
+: Specifies the local path to the directory containing GRID cache.
+  The default value is "/var/cache/grid".
+
+**`GRID_STATE_DIR`**
+: Specifies the local path to the directory containing GRID state.
+  The default value is "/var/lib/grid".
+
+SEE ALSO
+========
+| Grid documentation: https://grid.hyperledger.org/docs/0.3/

--- a/cli/man/grid-po-version-create.1.md
+++ b/cli/man/grid-po-version-create.1.md
@@ -121,10 +121,10 @@ ENVIRONMENT VARIABLES
 **`GRID_SERVICE_ID`**
 : Specifies a default value for `--service-id`
 
-**`GRID_ORDER_SCHEMA_DIR`**
-: Specifies the local path to the directory containing the `Order.xsd`
-  schema used to validate the purchase order. The default value is
-  "/usr/share/grid/xsd".
+**`GRID_STATE_DIR`**
+: Specifies the local path to the directory containing Grid state, which would
+  contain "xsd/po/gs1/ecom/Order.xsd" for validating purchase orders. The default
+  value is "/var/lib/grid".
 
 SEE ALSO
 ========

--- a/cli/man/grid-po-version-update.1.md
+++ b/cli/man/grid-po-version-update.1.md
@@ -117,10 +117,10 @@ ENVIRONMENT VARIABLES
 **`GRID_SERVICE_ID`**
 : Specifies a default value for `--service-id`
 
-**`GRID_ORDER_SCHEMA_DIR`**
-: Specifies the local path to the directory containing the `Order.xsd`
-  schema used to validate the purchase order. The default value is
-  "/usr/share/grid/xsd".
+**`GRID_STATE_DIR`**
+: Specifies the local path to the directory containing Grid state, which would
+  contain "xsd/po/gs1/ecom/Order.xsd" for validating purchase orders. The default
+  value is "/var/lib/grid".
 
 SEE ALSO
 ========

--- a/cli/man/grid-product-create.1.md
+++ b/cli/man/grid-product-create.1.md
@@ -275,10 +275,10 @@ ENVIRONMENT VARIABLES
 **`GRID_SERVICE_ID`**
 : Specifies a default value for `--service-id`.
 
-**`GRID_PRODUCT_SCHEMA_DIR`**
-: Specifies the local path to the directory containing the `GridTradeItems.xsd`
-  schema used to validate the product. The default value is
-  "/usr/share/grid/xsd".
+**`GRID_STATE_DIR`**
+: Specifies the local path to the directory containing Grid state, which would
+  contain "xsd/product/GridTradeItem.xsd" for validating product. The default
+  value is "/var/lib/grid".
 
 SEE ALSO
 ========

--- a/cli/man/grid-product-update.1.md
+++ b/cli/man/grid-product-update.1.md
@@ -268,10 +268,10 @@ ENVIRONMENT VARIABLES
 **`GRID_SERVICE_ID`**
 : Specifies a default value for `--service-id`.
 
-**`GRID_PRODUCT_SCHEMA_DIR`**
-: Specifies the local path to the directory containing the `GridTradeItems.xsd`
-  schema used to validate the product. The default value is
-  "/usr/share/grid/xsd".
+**`GRID_STATE_DIR`**
+: Specifies the local path to the directory containing Grid state, which would
+  contain "xsd/product/GridTradeItem.xsd" for validating product. The default
+  value is "/var/lib/grid".
 
 SEE ALSO
 ========

--- a/cli/src/actions/mod.rs
+++ b/cli/src/actions/mod.rs
@@ -15,8 +15,20 @@
  * -----------------------------------------------------------------------------
  */
 
+#[cfg(any(
+    feature = "purchase-order",
+    feature = "product",
+    feature = "xsd-downloader"
+))]
+use std::env;
 use std::ffi::CString;
 use std::path::Path;
+#[cfg(any(
+    feature = "purchase-order",
+    feature = "product",
+    feature = "xsd-downloader"
+))]
+use std::path::PathBuf;
 
 use super::error::CliError;
 
@@ -37,9 +49,22 @@ pub mod purchase_order;
 pub mod role;
 #[cfg(feature = "schema")]
 pub mod schema;
+#[cfg(feature = "xsd-downloader")]
+pub mod xsd_downloader;
 
-#[cfg(any(feature = "purchase-order", feature = "product"))]
-const DEFAULT_SCHEMA_DIR: &str = "/usr/share/grid/xsd";
+#[cfg(any(
+    feature = "purchase-order",
+    feature = "product",
+    feature = "xsd-downloader"
+))]
+const ENV_GRID_STATE_DIR: &str = "GRID_STATE_DIR";
+
+#[cfg(any(
+    feature = "purchase-order",
+    feature = "product",
+    feature = "xsd-downloader"
+))]
+const DEFAULT_GRID_STATE_DIR: &str = "/var/lib/grid";
 
 fn chown(path: &Path, uid: u32, gid: u32) -> Result<(), CliError> {
     let pathstr = path
@@ -54,4 +79,22 @@ fn chown(path: &Path, uid: u32, gid: u32) -> Result<(), CliError> {
             pathstr, code
         ))),
     }
+}
+
+#[cfg(any(
+    feature = "purchase-order",
+    feature = "product",
+    feature = "xsd-downloader"
+))]
+fn get_grid_state_dir() -> String {
+    env::var(ENV_GRID_STATE_DIR).unwrap_or_else(|_| DEFAULT_GRID_STATE_DIR.to_string())
+}
+
+#[cfg(any(
+    feature = "purchase-order",
+    feature = "product",
+    feature = "xsd-downloader"
+))]
+fn get_grid_xsd_dir() -> PathBuf {
+    PathBuf::from(get_grid_state_dir()).join("xsd")
 }

--- a/cli/src/actions/purchase_order.rs
+++ b/cli/src/actions/purchase_order.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::env;
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use grid_sdk::{
@@ -38,7 +38,7 @@ use rand::{distributions::Alphanumeric, Rng};
 use sawtooth_sdk::messages::batch::BatchList;
 use serde::Serialize;
 
-use super::DEFAULT_SCHEMA_DIR;
+use crate::actions;
 use crate::error::CliError;
 use crate::transaction::purchase_order_batch_builder;
 
@@ -1041,7 +1041,13 @@ pub fn get_purchase_order_version(
     }
 }
 
-pub fn get_order_schema_dir() -> String {
-    env::var("GRID_ORDER_SCHEMA_DIR")
-        .unwrap_or_else(|_| DEFAULT_SCHEMA_DIR.to_string() + "/po/gs1/ecom")
+pub fn get_order_schema_dir() -> PathBuf {
+    actions::get_grid_xsd_dir().join("po/gs1/ecom")
+}
+
+pub fn get_order_schema_dir_string() -> Result<String, CliError> {
+    get_order_schema_dir()
+        .into_os_string()
+        .into_string()
+        .map_err(|_| CliError::UserError("could not parse schema dir".to_string()))
 }

--- a/cli/src/actions/xsd_downloader/downloader.rs
+++ b/cli/src/actions/xsd_downloader/downloader.rs
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+use std::fs::{self, File};
+use std::io::{self, Cursor};
+use std::path::PathBuf;
+
+use reqwest::{blocking::Client, Url};
+
+use crate::error::CliError;
+
+/// Uses the Reqwest library to download a file
+pub fn download(url: &Url, file_name: &str) -> Result<(), CliError> {
+    let client = Client::new();
+    let res = client
+        .get(url.clone())
+        .send()
+        .map_err(|err| CliError::InternalError(err.to_string()))?;
+    if res.status().is_server_error() {
+        return Err(CliError::ActionError(format!(
+            "received server error {:?}",
+            res.status()
+        )));
+    }
+    let body = res
+        .bytes()
+        .map_err(|err| CliError::InternalError(err.to_string()))?;
+    let mut file =
+        File::create(file_name).map_err(|err| CliError::InternalError(err.to_string()))?;
+    let mut cursor = Cursor::new(body);
+    io::copy(&mut cursor, &mut file).map_err(|err| CliError::InternalError(err.to_string()))?;
+
+    Ok(())
+}
+
+/// Configuration for the caching downloader
+#[derive(Debug, PartialEq)]
+pub struct CachingDownloadConfig<Hash> {
+    pub url: Url,
+    pub file_path: PathBuf,
+    pub temp_file_path: PathBuf,
+    pub force_download: bool,
+    pub hash: Hash,
+}
+
+/// Cache a file
+///
+/// * `config` - The configuration for caching and downloading the file
+/// * `download` - The function to use to download the file
+/// * `validate_hash` - The function to use to validate the hash
+pub fn caching_download<T, Hash>(
+    config: CachingDownloadConfig<Hash>,
+    download: T,
+    validate_hash: impl FnOnce(&PathBuf, &Hash) -> Result<(), CliError>,
+) -> Result<(), CliError>
+where
+    T: FnOnce(&Url, &str) -> Result<(), CliError>,
+{
+    let cached = config.file_path.exists();
+
+    if cached {
+        debug!(
+            "file {file_path} is cached",
+            file_path = &fs::canonicalize(config.file_path.clone())
+                .unwrap_or_else(|_| config.file_path.clone())
+                .as_os_str()
+                .to_string_lossy()
+        );
+    }
+
+    if !cached || config.force_download {
+        if cached {
+            debug!("downloading anyway due to force download option",);
+        }
+
+        let temp_path_name: &str = &config.temp_file_path.as_os_str().to_string_lossy();
+
+        if config.temp_file_path.exists() {
+            return Err(CliError::ActionError(format!(
+                "cannot proceed, as temp file {temp_file_path} already exists. is a \
+                download already in progress? if not, please delete the temp file",
+                temp_file_path = &fs::canonicalize(config.temp_file_path.clone())
+                    .unwrap_or(config.temp_file_path)
+                    .as_os_str()
+                    .to_string_lossy()
+            )));
+        }
+
+        info!("downloading file from {url_name}", url_name = config.url);
+
+        let url = &config.url;
+        download(url, temp_path_name)?;
+
+        info!("download finished");
+
+        if let Err(result) = (validate_hash)(&config.temp_file_path, &config.hash) {
+            fs::remove_file(config.temp_file_path)
+                .map_err(|err| CliError::InternalError(err.to_string()))?;
+
+            return Err(result);
+        }
+
+        debug!("hash valid, moving to cache");
+
+        fs::rename(config.temp_file_path, config.file_path)
+            .map_err(|err| CliError::InternalError(err.to_string()))?;
+    } else {
+        debug!("using cache");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::{MockValidator, MockValidatorCall};
+    use super::*;
+
+    use mockito::mock;
+    use pretty_assertions::assert_eq;
+    use std::fs::File;
+    use std::io::Write;
+    use tempdir::TempDir;
+
+    const TEST_DATA: &str = "lagomorpha";
+    const TEST_HASH: &str = "9b44a9cb40096bf6767dec8e97bdc5a36ead7bc6200025cac801bf445307aba0";
+
+    #[derive(Debug, PartialEq)]
+    struct MockDownloaderCall {
+        pub url: Url,
+        pub file_name: String,
+    }
+
+    struct MockDownloader {
+        responses: Vec<Result<(), CliError>>,
+        calls: Vec<MockDownloaderCall>,
+    }
+
+    impl MockDownloader {
+        pub fn new(responses: Vec<Result<(), CliError>>) -> MockDownloader {
+            MockDownloader {
+                responses,
+                calls: vec![],
+            }
+        }
+
+        pub fn download(&mut self, url: &Url, file_name: &str) -> Result<(), CliError> {
+            self.calls.push(MockDownloaderCall {
+                url: url.clone(),
+                file_name: file_name.to_string(),
+            });
+
+            let mut output = File::create(file_name).expect("could not create file");
+            write!(output, "{}", TEST_DATA).expect("could not write file");
+
+            self.responses.pop().unwrap()
+        }
+
+        pub fn get_calls(&self) -> &[MockDownloaderCall] {
+            &self.calls
+        }
+    }
+
+    #[test]
+    // Test that ReqwestDownloader downloads from the given url to the given file
+    fn reqwest_downloader_downloads() {
+        let url = Url::parse(&mockito::server_url()).expect("could not parse url");
+        let url = url.join("some_file.zip").expect("could not create url");
+
+        let mock_endpoint = mock("GET", "/some_file.zip")
+            .with_status(201)
+            .with_header("content-type", "text/plain")
+            .with_body("world")
+            .create();
+
+        let tmp_dir = TempDir::new("example").expect("could not create tempdir");
+        let file_path = tmp_dir.path().join("some_file_location.txt");
+
+        assert!(!file_path.exists());
+
+        download(&url, &file_path.as_os_str().to_string_lossy()).expect("download failed");
+
+        assert!(file_path.exists());
+        mock_endpoint.assert();
+
+        let file = fs::read_to_string(file_path).expect("could not read file");
+        assert_eq!(file, "world");
+    }
+
+    #[test]
+    // Test that ReqwestDownloader downloads from the given url to the given file
+    fn reqwest_downloader_does_not_leave_file_on_failure() {
+        let url = Url::parse(&mockito::server_url()).expect("could not parse url");
+        let url = url.join("bad_file.zip").expect("could not create url");
+
+        let mock_endpoint = mock("GET", "/bad_file.zip").with_status(503).create();
+
+        let tmp_dir = TempDir::new("example").expect("could not create tempdir");
+        let file_path = tmp_dir.path().join("some_file_location.txt");
+
+        assert!(!file_path.exists());
+
+        let result = download(&url, &file_path.as_os_str().to_string_lossy());
+
+        assert_eq!(
+            format!("{:?}", result),
+            "Err(ActionError(\"received server error 503\"))"
+        );
+        assert!(!file_path.exists());
+        mock_endpoint.assert();
+    }
+
+    #[test]
+    // Test that CachingDownloader does not download when file is cached
+    fn caching_download_doesnot_download_cached_file() {
+        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let dest_dir = temp_dir.path();
+
+        let file_name = "gs1.zip";
+        let temp_file_name = "gs1-temp.zip";
+
+        let file_path = dest_dir.join(file_name);
+        let temp_file_path = dest_dir.join(temp_file_name);
+
+        // Create the temporary file
+        File::create(file_path.clone()).expect("could not create file");
+        assert!(file_path.exists());
+
+        let mut downloader = MockDownloader::new(vec![]);
+        let mut validator = MockValidator::new(vec![]);
+
+        let config = CachingDownloadConfig {
+            url: Url::parse("http://localhost/fake").expect("could not create url"),
+            file_path: file_path.to_path_buf(),
+            temp_file_path: temp_file_path.to_path_buf(),
+            force_download: false,
+            hash: TEST_HASH.to_string(),
+        };
+
+        // Run the test
+        let result = caching_download(
+            config,
+            |url: &Url, file_name: &str| downloader.download(url, file_name),
+            |path_buf: &PathBuf, hash: &String| validator.validate(path_buf, hash),
+        );
+
+        assert_eq!(validator.get_calls(), &[]);
+        assert!(result.is_ok());
+        assert_eq!(downloader.get_calls(), &[]);
+    }
+
+    #[test]
+    // Test that CachingDownloader downloads if file is not cached
+    fn caching_download_downloads_file() -> Result<(), CliError> {
+        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let dest_dir = temp_dir.path();
+
+        let file_name = "gs1.zip";
+        let temp_file_name = "gs1-temp.zip";
+
+        let file_path = dest_dir.join(file_name);
+        let temp_file_path = dest_dir.join(temp_file_name);
+
+        assert!(!file_path.exists());
+
+        let mut downloader = MockDownloader::new(vec![Ok(())]);
+        let mut validator = MockValidator::new(vec![Ok(())]);
+
+        let url = Url::parse("http://localhost/fake").expect("could not create url");
+
+        let config = CachingDownloadConfig {
+            url: url.clone(),
+            file_path: file_path.to_path_buf(),
+            temp_file_path: temp_file_path.to_path_buf(),
+            force_download: false,
+            hash: TEST_HASH.to_string(),
+        };
+
+        // Run the test
+        caching_download(
+            config,
+            |url: &Url, file_name: &str| downloader.download(url, file_name),
+            |path_buf: &PathBuf, hash: &String| validator.validate(path_buf, hash),
+        )?;
+
+        assert_eq!(
+            validator.get_calls(),
+            &[MockValidatorCall {
+                path_buf: temp_file_path.to_path_buf(),
+                hash: TEST_HASH.to_string(),
+            }]
+        );
+        assert_eq!(
+            downloader.get_calls(),
+            &[MockDownloaderCall {
+                url,
+                file_name: dest_dir.join(temp_file_name).to_string_lossy().to_string()
+            }]
+        );
+        assert!(file_path.exists());
+        assert!(!temp_file_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    // Test that CachingDownloader downloads if file is cached, but force_download is enabled
+    fn caching_download_downloads_cached_file_with_force_download() -> Result<(), CliError> {
+        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let dest_dir = temp_dir.path();
+
+        let file_name = "gs1.zip";
+        let temp_file_name = "gs1-temp.zip";
+
+        let file_path = dest_dir.join(file_name);
+        let temp_file_path = dest_dir.join(temp_file_name);
+
+        // Create the temporary file
+        File::create(file_path.clone()).expect("could not create file");
+        assert!(file_path.exists());
+
+        let mut downloader = MockDownloader::new(vec![Ok(())]);
+        let mut validator = MockValidator::new(vec![Ok(())]);
+
+        let url = Url::parse("http://localhost/fake").expect("could not create url");
+
+        let config = CachingDownloadConfig {
+            url: url.clone(),
+            file_path: file_path.to_path_buf(),
+            temp_file_path: temp_file_path.to_path_buf(),
+            force_download: true,
+            hash: TEST_HASH.to_string(),
+        };
+
+        // Run the test
+        caching_download(
+            config,
+            |url: &Url, file_name: &str| downloader.download(url, file_name),
+            |path_buf: &PathBuf, hash: &String| validator.validate(path_buf, hash),
+        )?;
+
+        assert_eq!(
+            validator.get_calls(),
+            &[MockValidatorCall {
+                path_buf: temp_file_path.to_path_buf(),
+                hash: TEST_HASH.to_string(),
+            }]
+        );
+        assert_eq!(
+            downloader.get_calls(),
+            &[MockDownloaderCall {
+                url,
+                file_name: dest_dir.join(temp_file_name).to_string_lossy().to_string()
+            }]
+        );
+        assert!(!temp_file_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    // Test that CachingDownloader fails if the temporary file already exists
+    fn caching_download_fails_if_temp_file_exists() {
+        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let dest_dir = temp_dir.path();
+
+        let file_name = "gs1.zip";
+        let temp_file_name = "gs1-temp.zip";
+
+        let file_path = dest_dir.join(file_name);
+        let temp_file_path = dest_dir.join(temp_file_name);
+
+        // Create the temporary file
+        File::create(temp_file_path.clone()).expect("could not create temp file");
+        assert!(temp_file_path.exists());
+
+        let mut downloader = MockDownloader::new(vec![]);
+        let mut validator = MockValidator::new(vec![]);
+
+        let config = CachingDownloadConfig {
+            url: Url::parse("http://localhost/fake").expect("could not create url"),
+            file_path: file_path.to_path_buf(),
+            temp_file_path: temp_file_path.to_path_buf(),
+            force_download: true,
+            hash: TEST_HASH.to_string(),
+        };
+
+        // Run the test
+        let result = caching_download(
+            config,
+            |url: &Url, file_name: &str| downloader.download(url, file_name),
+            |path_buf: &PathBuf, hash: &String| validator.validate(path_buf, hash),
+        );
+
+        assert_eq!(validator.get_calls(), &[]);
+        assert!(result.is_err());
+        assert_eq!(downloader.get_calls(), &[]);
+    }
+
+    #[test]
+    // Test that CachingDownloader fails if the temporary file already exists
+    fn caching_download_fails_if_hash_incorrect() -> Result<(), CliError> {
+        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let dest_dir = temp_dir.path();
+
+        let file_name = "gs1.zip";
+        let temp_file_name = "gs1-temp.zip";
+
+        let file_path = dest_dir.join(file_name);
+        let temp_file_path = dest_dir.join(temp_file_name);
+
+        assert!(!file_path.exists());
+
+        let mut downloader = MockDownloader::new(vec![Ok(())]);
+        let mut validator =
+            MockValidator::new(vec![Err(CliError::ActionError("hash failure".to_string()))]);
+
+        let url = Url::parse("http://localhost/fake").expect("could not create url");
+
+        let config = CachingDownloadConfig {
+            url: url.clone(),
+            file_path: file_path.to_path_buf(),
+            temp_file_path: temp_file_path.to_path_buf(),
+            force_download: false,
+            hash: TEST_HASH.to_string(),
+        };
+
+        // Run the test
+        let result = caching_download(
+            config,
+            |url: &Url, file_name: &str| downloader.download(url, file_name),
+            |path_buf: &PathBuf, hash: &String| validator.validate(path_buf, hash),
+        );
+
+        assert_eq!(
+            validator.get_calls(),
+            &[MockValidatorCall {
+                path_buf: temp_file_path.to_path_buf(),
+                hash: TEST_HASH.to_string(),
+            }]
+        );
+        assert!(result.is_err());
+        assert_eq!(
+            downloader.get_calls(),
+            &[MockDownloaderCall {
+                url,
+                file_name: dest_dir.join(temp_file_name).to_string_lossy().to_string()
+            }]
+        );
+        assert!(!temp_file_path.exists());
+        Ok(())
+    }
+}

--- a/cli/src/actions/xsd_downloader/extractor.rs
+++ b/cli/src/actions/xsd_downloader/extractor.rs
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+use std::fs::{self, File};
+use std::io::{self, Cursor, Read, Seek};
+use std::path::Path;
+use zip::{self, ZipArchive};
+
+use crate::error::CliError;
+
+/// Get a file from an archive
+///
+/// * `file` - Zip archive file
+/// * `prefix` - Prefix of the sought file
+fn get_file_from_archive(file: impl Read + Seek, prefix: &str) -> Result<Vec<u8>, CliError> {
+    let mut archive =
+        ZipArchive::new(file).map_err(|err| CliError::InternalError(err.to_string()))?;
+
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .map_err(|err| CliError::InternalError(err.to_string()))?;
+        let outpath = match file.enclosed_name() {
+            Some(path) => path.to_owned(),
+            None => continue,
+        };
+
+        debug!("found path: {:?}", outpath);
+        if outpath.to_string_lossy().starts_with(prefix) {
+            let mut zip = Vec::new();
+            io::copy(&mut file, &mut zip)
+                .map_err(|err| CliError::InternalError(err.to_string()))?;
+            return Ok(zip);
+        }
+    }
+
+    Err(CliError::ActionError(
+        "zip does not contain necessary files".to_string(),
+    ))
+}
+
+/// Copy schemas
+///
+/// * `file` - Zip archive file with schemas
+/// * `dest_path` - Path to copy the schemas to
+fn copy_schemas(file: impl Read + Seek, dest_path: &Path) -> Result<(), CliError> {
+    let mut archive =
+        ZipArchive::new(file).map_err(|err| CliError::InternalError(err.to_string()))?;
+
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .map_err(|err| CliError::InternalError(err.to_string()))?;
+        debug!("file {}", file.name());
+
+        // Ex: BMS_Package_Order_r3p4p1_d1_7Nov_2019/Schemas/gs1/ecom/eComCommon.xsd
+        let full_path = match file.enclosed_name() {
+            Some(path) => path,
+            None => continue,
+        };
+
+        // Ex: BMS_Package_Order_r3p4p1_d1_7Nov_2019/Schemas
+        let prefix = Path::new(
+            full_path
+                .iter()
+                .next()
+                .ok_or_else(|| CliError::ActionError("error parsing zip".to_string()))?,
+        )
+        .join("Schemas");
+
+        if full_path.starts_with(prefix.clone()) {
+            // Ex: gs1/ecom/eComCommon.xsd
+            let outpath = dest_path.join(
+                full_path
+                    .strip_prefix(prefix)
+                    .map_err(|err| CliError::InternalError(err.to_string()))?,
+            );
+
+            if let Some(p) = outpath.parent() {
+                if !p.exists() {
+                    fs::create_dir_all(&p)
+                        .map_err(|err| CliError::InternalError(err.to_string()))?;
+                }
+            }
+
+            debug!("extracting {outpath}", outpath = outpath.to_string_lossy());
+
+            if (&*file.name()).ends_with('/') {
+                debug!("File {} extracted to \"{}\"", i, outpath.display());
+                fs::create_dir_all(&outpath)
+                    .map_err(|err| CliError::InternalError(err.to_string()))?;
+            } else {
+                debug!(
+                    "File {} extracted to \"{}\" ({} bytes)",
+                    i,
+                    outpath.display(),
+                    file.size()
+                );
+                if let Some(p) = outpath.parent() {
+                    if !p.exists() {
+                        fs::create_dir_all(&p)
+                            .map_err(|err| CliError::InternalError(err.to_string()))?;
+                    }
+                }
+                let mut outfile = fs::File::create(&outpath)
+                    .map_err(|err| CliError::InternalError(err.to_string()))?;
+                io::copy(&mut file, &mut outfile)
+                    .map_err(|err| CliError::InternalError(err.to_string()))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Extract xsd files
+///
+/// * `zip_path` - Zip archive file path
+/// * `dest_path` - Path to copy the schemas to
+pub fn extract(zip_path: &Path, dest_path: &Path) -> Result<(), CliError> {
+    debug!("parsing root archive {}", zip_path.to_string_lossy());
+    let root_file = File::open(&zip_path).map_err(CliError::IoError)?;
+    let xml_zip = get_file_from_archive(root_file, "BMS Packages EDI XML")?;
+
+    debug!("parsing order archive");
+    let xml_cursor = Cursor::new(xml_zip);
+    let order_zip = get_file_from_archive(xml_cursor, "BMS_Package_Order_")?;
+
+    debug!("extracting order schemas");
+    let order_cursor = Cursor::new(order_zip);
+    copy_schemas(order_cursor, dest_path)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Write;
+    use tempdir::TempDir;
+    use zip::{result::ZipResult, ZipWriter};
+
+    fn dummy(zip: &mut ZipWriter<impl Write + Seek>, filename: &str) -> ZipResult<()> {
+        zip.start_file(filename, Default::default())?;
+        Ok(())
+    }
+
+    fn create_example_zip(path: &Path) -> ZipResult<()> {
+        let mut order_file: Vec<u8> = vec![];
+        let order_cursor = Cursor::new(&mut order_file);
+        let mut order = zip::ZipWriter::new(order_cursor);
+
+        order.add_directory("BMS_Package_Order_r0p0p0_d0_1Dec_2000/", Default::default())?;
+        order.add_directory(
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas",
+            Default::default(),
+        )?;
+        order.add_directory(
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/gs1",
+            Default::default(),
+        )?;
+        order.add_directory(
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/gs1/ecom",
+            Default::default(),
+        )?;
+        order.add_directory(
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/gs1/shared",
+            Default::default(),
+        )?;
+        order.add_directory(
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/sbdh",
+            Default::default(),
+        )?;
+
+        dummy(
+            &mut order,
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/gs1/ecom/eComCommon.xsd",
+        )?;
+        dummy(
+            &mut order,
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/gs1/ecom/Order.xsd",
+        )?;
+        dummy(
+            &mut order,
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/gs1/shared/SharedCommon.xsd",
+        )?;
+        dummy(
+            &mut order,
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/sbdh/BasicTypes.xsd",
+        )?;
+        dummy(
+            &mut order,
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/sbdh/BusinessScope.xsd",
+        )?;
+        dummy(
+            &mut order,
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/sbdh/DocumentIdentification.xsd",
+        )?;
+        dummy(
+            &mut order,
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/sbdh/Manifest.xsd",
+        )?;
+        dummy(
+            &mut order,
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/sbdh/Partner.xsd",
+        )?;
+        dummy(
+            &mut order,
+            "BMS_Package_Order_r0p0p0_d0_1Dec_2000/Schemas/sbdh/StandardBusinessDocumentHeader.xsd",
+        )?;
+        order.finish()?;
+        drop(order);
+
+        let mut xml_file: Vec<u8> = vec![];
+        let xml_cursor = Cursor::new(&mut xml_file);
+        let mut xml = zip::ZipWriter::new(xml_cursor);
+        dummy(&mut xml, "BMS_Package_ATest_r0p0p0_d0_1Dec_2000.zip")?;
+        dummy(&mut xml, "BMS_Package_Order_r0p0p0_d0_1Dec_2000.zip")?;
+        xml.write_all(&order_file)?;
+        dummy(
+            &mut xml,
+            "BMS_Package_Order_Response_r0p0p0_d0_1Dec_2000.zip",
+        )?;
+        dummy(&mut xml, "BMS_Package_ZTest_r0p0p0_d0_1Dec_2000.zip")?;
+        xml.finish()?;
+        drop(xml);
+
+        let file = std::fs::File::create(&path).unwrap();
+        let mut root = zip::ZipWriter::new(file);
+        dummy(&mut root, "BMS_eCom_Common_Library_r0p0p0_d0_1Jan_2000.pdf")?;
+        dummy(&mut root, "BMS EDI XML 0.0.0 PDF.zip")?;
+        dummy(&mut root, "BMS Packages EDI XML 0.0.0.zip")?;
+        root.write_all(&xml_file)?;
+        dummy(
+            &mut root,
+            "BMS_Shared_Common_Library_r0p0p0_d0_1Jan_2000.pdf",
+        )?;
+
+        root.finish()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn extract_works() {
+        let source_temp = TempDir::new("zipstuff").expect("could not create tempdir");
+        let source_path = source_temp.into_path().join("test.zip");
+
+        let dest_temp = TempDir::new("dest").expect("could not create tempdir");
+        let dest_path = dest_temp.into_path();
+
+        create_example_zip(&source_path).unwrap();
+        extract(&source_path, &dest_path).unwrap();
+        assert!(dest_path.join("gs1/ecom/eComCommon.xsd").exists());
+        assert!(dest_path.join("gs1/ecom/Order.xsd").exists());
+        assert!(dest_path.join("gs1/shared/SharedCommon.xsd").exists());
+        assert!(dest_path.join("sbdh/BasicTypes.xsd").exists());
+        assert!(dest_path.join("sbdh/BusinessScope.xsd").exists());
+        assert!(dest_path.join("sbdh/DocumentIdentification.xsd").exists());
+        assert!(dest_path.join("sbdh/Manifest.xsd").exists());
+        assert!(dest_path.join("sbdh/Partner.xsd").exists());
+        assert!(dest_path
+            .join("sbdh/StandardBusinessDocumentHeader.xsd")
+            .exists());
+    }
+}

--- a/cli/src/actions/xsd_downloader/mod.rs
+++ b/cli/src/actions/xsd_downloader/mod.rs
@@ -1,0 +1,713 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+mod downloader;
+mod extractor;
+mod validator;
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use hex_literal::hex;
+use reqwest::Url;
+
+use crate::actions;
+use crate::error::CliError;
+use downloader::CachingDownloadConfig;
+
+const ENV_GRID_CACHE_DIR: &str = "GRID_CACHE_DIR";
+const DEFAULT_GRID_CACHE_DIR: &str = "/var/cache/grid";
+
+#[derive(Clone, Debug, PartialEq)]
+struct UrlFile<Hash> {
+    url: &'static str,
+    hash: Hash,
+    artifact_name: &'static str,
+    extract_to: &'static str,
+}
+
+/// Files to be downloaded, and where they go
+const DOWNLOADS: &[UrlFile<[u8; 32]>] = &[UrlFile {
+    url: "https://www.gs1.org/docs/EDI/xml/3.4.1/GS1_XML_3-4-1_Publication.zip",
+    hash: hex!("4a10f96d32fd0f73b39b0d969cb7b822f49b1bd1e7c0782cfe3648b70dd77376"),
+    artifact_name: "GS1_XML_3-4-1_Publication.zip",
+    extract_to: "po",
+}];
+
+/// Defines how file downloads will be handled in a cached context
+#[derive(Clone, Debug, PartialEq)]
+pub enum DownloadConfig {
+    Always,
+    CacheOnly,
+    IfNotCached,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct FetchAndExtractConfig<Hash: 'static> {
+    download_config: DownloadConfig,
+    copy_from: Option<String>,
+    do_checksum: bool,
+    url_files: &'static [UrlFile<Hash>],
+    artifact_dir: PathBuf,
+    schema_dir: PathBuf,
+}
+
+/// Fetch xsds and extract them
+///
+/// * `config` - Behavior when downloading the file
+/// * `download` - Function to download the files
+/// * `validate_hash` - Function to validate file hashes
+/// * `extract` - Function to extract the files
+fn fetch_and_extract_with_callbacks<Hash: Clone>(
+    config: FetchAndExtractConfig<Hash>,
+    mut download: impl FnMut(CachingDownloadConfig<Hash>) -> Result<(), CliError>,
+    mut validate_hash: impl FnMut(&Path, &Hash) -> Result<(), CliError>,
+    mut extract: impl FnMut(&Path, &Path) -> Result<(), CliError>,
+) -> Result<(), CliError> {
+    let copy_path = if let Some(ref dir) = config.copy_from {
+        let path = Path::new(dir);
+        if !path.exists() {
+            return Err(CliError::ActionError(format!(
+                "could not copy from {dir}, as path does not exist"
+            )));
+        }
+
+        let metadata =
+            fs::metadata(path).map_err(|err| CliError::InternalError(err.to_string()))?;
+
+        if !metadata.is_dir() {
+            return Err(CliError::ActionError(format!(
+                "could not copy from {dir}, as the specified path is not a directory"
+            )));
+        }
+
+        Some(path)
+    } else {
+        None
+    };
+
+    fs::create_dir_all(&config.artifact_dir)?;
+
+    for file in config.url_files {
+        let filename = file.artifact_name;
+        let file_path = config.artifact_dir.join(filename);
+        let mut checksum_validated = false;
+
+        if let Some(ref dir) = config.copy_from {
+            let copy_path = copy_path.ok_or_else(|| {
+                CliError::InternalError("sanity check fail: path unavailable".to_string())
+            })?;
+
+            let copy_file_path = copy_path.join(filename);
+
+            if copy_file_path.exists() {
+                if config.do_checksum {
+                    // Do a validation of the file before copying to cache
+                    (validate_hash)(&copy_file_path, &file.hash)?;
+
+                    // Make sure we don't revalidate later
+                    // (hashing can take a non-trivial amount of time)
+                    checksum_validated = true;
+                } else {
+                    debug!("skipping checksum");
+                }
+
+                debug!("skipping download for {filename}, copying from {dir}");
+                fs::copy(copy_file_path, &file_path)
+                    .map_err(|err| CliError::InternalError(err.to_string()))?;
+            } else if config.download_config == DownloadConfig::CacheOnly {
+                // If we are copying and not downloading, we expect all
+                // necessary files to exist in the copy directory, regardless
+                // of whether they exist in cache
+                return Err(CliError::ActionError(format!(
+                    "expected to find \"{filename}\" \
+                in \"{copy_path}\", but the file does not exist",
+                    copy_path = copy_path.to_string_lossy(),
+                )));
+            } else {
+                info!("file \"{filename}\" doesn't exist in copy path");
+            }
+        }
+
+        match config.download_config {
+            DownloadConfig::Always | DownloadConfig::IfNotCached => {
+                let url =
+                    Url::parse(file.url).map_err(|err| CliError::InternalError(err.to_string()))?;
+
+                let config = CachingDownloadConfig {
+                    url,
+                    file_path: file_path.to_path_buf(),
+                    temp_file_path: config.artifact_dir.join(format!("{filename}.download")),
+                    force_download: config.download_config == DownloadConfig::Always,
+                    hash: file.hash.clone(),
+                };
+
+                (download)(config)?;
+
+                // Make sure we don't revalidate later
+                // (hashing can take a non-trivial amount of time)
+                checksum_validated = true;
+            }
+            DownloadConfig::CacheOnly => {
+                debug!("skipping download, using cache only");
+            }
+        }
+
+        if !file_path.exists() {
+            return Err(CliError::ActionError(format!(
+                "file \"{file_path}\" does not exist",
+                file_path = file_path.to_string_lossy(),
+            )));
+        }
+
+        if !checksum_validated && config.do_checksum {
+            // Do a validation of the final file
+            (validate_hash)(&file_path, &file.hash)?;
+        } else {
+            debug!("skipping checksum");
+        }
+
+        info!("extracting to schema directory");
+
+        let dest_dir = config.schema_dir.join(file.extract_to);
+        (extract)(&file_path, &dest_dir)?;
+    }
+
+    Ok(())
+}
+
+/// Fetch xsds and extract them
+///
+/// * `artifact_dir` - Location to store and retrieve artifacts from
+/// * `download_config` - Behavior when downloading the file
+/// * `do_checksum` - Whether to perform a checksum on the cached file
+pub fn fetch_and_extract_xsds(
+    artifact_dir: Option<&str>,
+    download_config: DownloadConfig,
+    do_checksum: bool,
+    copy_from: Option<String>,
+) -> Result<(), CliError> {
+    let artifact_dir = artifact_dir.map(PathBuf::from).unwrap_or_else(|| {
+        PathBuf::from(
+            env::var(ENV_GRID_CACHE_DIR).unwrap_or_else(|_| DEFAULT_GRID_CACHE_DIR.to_string()),
+        )
+        .join("xsd_artifact_cache")
+    });
+
+    debug!(
+        "using artifact directory of {}",
+        artifact_dir.to_string_lossy()
+    );
+
+    fetch_and_extract_with_callbacks(
+        FetchAndExtractConfig {
+            download_config,
+            copy_from,
+            do_checksum,
+            url_files: DOWNLOADS,
+            artifact_dir,
+            schema_dir: actions::get_grid_xsd_dir(),
+        },
+        |config| {
+            downloader::caching_download(
+                config,
+                downloader::download,
+                |path_buf: &PathBuf, hash: &[u8; 32]| validator::validate_hash(path_buf, hash),
+            )
+        },
+        validator::validate_hash,
+        extractor::extract,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+    use std::fs::{self, File};
+    use std::path::Path;
+    use tempdir::TempDir;
+
+    #[derive(Debug, PartialEq)]
+    struct MockCacheDownloaderCall {
+        pub config: CachingDownloadConfig<&'static str>,
+    }
+
+    struct MockCacheDownloader {
+        responses: Vec<Result<(), CliError>>,
+        calls: Vec<MockCacheDownloaderCall>,
+    }
+
+    impl MockCacheDownloader {
+        pub fn new(responses: Vec<Result<(), CliError>>) -> MockCacheDownloader {
+            MockCacheDownloader {
+                responses,
+                calls: vec![],
+            }
+        }
+
+        pub fn download(
+            &mut self,
+            config: CachingDownloadConfig<&'static str>,
+        ) -> Result<(), CliError> {
+            self.calls.push(MockCacheDownloaderCall { config });
+            self.responses.pop().unwrap()
+        }
+
+        pub fn get_calls(&self) -> &[MockCacheDownloaderCall] {
+            &self.calls
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    pub struct MockValidatorCall {
+        pub path_buf: PathBuf,
+        pub hash: String,
+    }
+
+    pub struct MockValidator {
+        responses: Vec<Result<(), CliError>>,
+        calls: Vec<MockValidatorCall>,
+    }
+
+    impl MockValidator {
+        pub fn new(responses: Vec<Result<(), CliError>>) -> MockValidator {
+            MockValidator {
+                responses,
+                calls: vec![],
+            }
+        }
+
+        pub fn validate(&mut self, path_buf: &Path, hash: &str) -> Result<(), CliError> {
+            self.calls.push(MockValidatorCall {
+                path_buf: path_buf.to_path_buf(),
+                hash: hash.to_string(),
+            });
+
+            self.responses.pop().unwrap()
+        }
+
+        pub fn get_calls(&self) -> &[MockValidatorCall] {
+            &self.calls
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    pub struct MockExtractorCall {
+        pub source: PathBuf,
+        pub dest: PathBuf,
+    }
+
+    pub struct MockExtractor {
+        responses: Vec<Result<(), CliError>>,
+        calls: Vec<MockExtractorCall>,
+    }
+
+    impl MockExtractor {
+        pub fn new(responses: Vec<Result<(), CliError>>) -> MockExtractor {
+            MockExtractor {
+                responses,
+                calls: Vec::new(),
+            }
+        }
+
+        pub fn extract(&mut self, source: &Path, dest: &Path) -> Result<(), CliError> {
+            self.calls.push(MockExtractorCall {
+                source: source.to_path_buf(),
+                dest: dest.to_path_buf(),
+            });
+
+            self.responses.pop().unwrap()
+        }
+
+        pub fn get_calls(&self) -> &[MockExtractorCall] {
+            &self.calls
+        }
+    }
+
+    #[test]
+    fn fae_default_configuration_downloads_and_extracts() {
+        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let path = temp_dir.into_path();
+        let artifact_dir = path.join("artifact");
+        let schema_dir = path.join("schema");
+
+        fs::create_dir(&artifact_dir).expect("could not create directory");
+        File::create(&artifact_dir.join("out.zip")).expect("could not create file");
+
+        let mut downloader = MockCacheDownloader::new(vec![Ok(())]);
+        let mut validator = MockValidator::new(vec![Ok(())]);
+        let mut extractor = MockExtractor::new(vec![Ok(())]);
+
+        let config = FetchAndExtractConfig {
+            download_config: DownloadConfig::Always,
+            copy_from: None,
+            do_checksum: true,
+            url_files: &[UrlFile {
+                url: "https://bismuth/zepplin.zip",
+                hash: "notarealhash",
+                artifact_name: "out.zip",
+                extract_to: "edgarallen",
+            }],
+            artifact_dir: artifact_dir.clone(),
+            schema_dir: schema_dir.clone(),
+        };
+
+        fetch_and_extract_with_callbacks(
+            config.clone(),
+            |config| downloader.download(config),
+            |path_buf, hash| validator.validate(path_buf, hash),
+            |source, dest| extractor.extract(source, dest),
+        )
+        .expect("failed to fetch and extract");
+
+        assert_eq!(
+            downloader.get_calls(),
+            &config
+                .url_files
+                .iter()
+                .map(|file| MockCacheDownloaderCall {
+                    config: CachingDownloadConfig {
+                        url: Url::parse(file.url).expect("could not parse url"),
+                        file_path: artifact_dir.join(file.artifact_name).to_path_buf(),
+                        temp_file_path: artifact_dir.join(format!(
+                            "{filename}.download",
+                            filename = file.artifact_name
+                        )),
+                        force_download: true,
+                        hash: file.hash,
+                    }
+                })
+                .collect::<Vec<MockCacheDownloaderCall>>()
+        );
+
+        assert_eq!(validator.get_calls(), &[]);
+
+        assert_eq!(
+            extractor.get_calls(),
+            &config
+                .url_files
+                .iter()
+                .map(|file| MockExtractorCall {
+                    source: artifact_dir.join(file.artifact_name).to_path_buf(),
+                    dest: schema_dir.join(file.extract_to),
+                })
+                .collect::<Vec<MockExtractorCall>>()
+        );
+    }
+
+    // Validate that files are copied if that download option is selected
+    #[test]
+    fn fae_files_copy_if_copy_option_enabled() {
+        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let path = temp_dir.into_path();
+        let artifact_dir = path.join("artifact");
+        let schema_dir = path.join("schema");
+
+        let copy_dir = path.join("copy_from");
+        fs::create_dir(&copy_dir).expect("could not create directory");
+        File::create(&copy_dir.join("out.zip")).expect("could not create file");
+
+        let mut downloader = MockCacheDownloader::new(vec![]);
+        let mut validator = MockValidator::new(vec![Ok(()), Ok(())]);
+        let mut extractor = MockExtractor::new(vec![Ok(())]);
+
+        let config = FetchAndExtractConfig {
+            download_config: DownloadConfig::CacheOnly,
+            copy_from: Some(copy_dir.to_string_lossy().to_string()),
+            do_checksum: true,
+            url_files: &[UrlFile {
+                url: "https://bismuth/zepplin.zip",
+                hash: "notarealhash",
+                artifact_name: "out.zip",
+                extract_to: "edgarallen",
+            }],
+            artifact_dir: artifact_dir.clone(),
+            schema_dir: schema_dir.clone(),
+        };
+
+        fetch_and_extract_with_callbacks(
+            config.clone(),
+            |config| downloader.download(config),
+            |path_buf, hash| validator.validate(path_buf, hash),
+            |source, dest| extractor.extract(source, dest),
+        )
+        .expect("failed to fetch and extract");
+
+        assert_eq!(downloader.get_calls(), &[],);
+
+        assert_eq!(
+            validator.get_calls(),
+            &config
+                .url_files
+                .iter()
+                .map(|file| MockValidatorCall {
+                    path_buf: copy_dir.join(file.artifact_name).to_path_buf(),
+                    hash: file.hash.to_string(),
+                })
+                .collect::<Vec<MockValidatorCall>>()
+        );
+
+        assert_eq!(
+            extractor.get_calls(),
+            &config
+                .url_files
+                .iter()
+                .map(|file| MockExtractorCall {
+                    source: artifact_dir.join(file.artifact_name).to_path_buf(),
+                    dest: schema_dir.join(file.extract_to),
+                })
+                .collect::<Vec<MockExtractorCall>>()
+        );
+    }
+
+    // Validate that hash checking is disabled if the option is not selected
+    #[test]
+    fn fae_files_validation_does_not_happen_if_disabled() {
+        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let path = temp_dir.into_path();
+        let artifact_dir = path.join("artifact");
+        let schema_dir = path.join("schema");
+
+        fs::create_dir(&artifact_dir).expect("could not create directory");
+        File::create(&artifact_dir.join("out.zip")).expect("could not create file");
+
+        let mut downloader = MockCacheDownloader::new(vec![Ok(())]);
+        let mut validator = MockValidator::new(vec![]);
+        let mut extractor = MockExtractor::new(vec![Ok(())]);
+
+        let config = FetchAndExtractConfig {
+            download_config: DownloadConfig::Always,
+            copy_from: None,
+            do_checksum: false,
+            url_files: &[UrlFile {
+                url: "https://bismuth/zepplin.zip",
+                hash: "notarealhash",
+                artifact_name: "out.zip",
+                extract_to: "edgarallen",
+            }],
+            artifact_dir: artifact_dir.clone(),
+            schema_dir: schema_dir.clone(),
+        };
+
+        fetch_and_extract_with_callbacks(
+            config.clone(),
+            |config| downloader.download(config),
+            |path_buf, hash| validator.validate(path_buf, hash),
+            |source, dest| extractor.extract(source, dest),
+        )
+        .expect("failed to fetch and extract");
+
+        assert_eq!(
+            downloader.get_calls(),
+            &config
+                .url_files
+                .iter()
+                .map(|file| MockCacheDownloaderCall {
+                    config: CachingDownloadConfig {
+                        url: Url::parse(file.url).expect("could not parse url"),
+                        file_path: artifact_dir.join(file.artifact_name).to_path_buf(),
+                        temp_file_path: artifact_dir.join(format!(
+                            "{filename}.download",
+                            filename = file.artifact_name
+                        )),
+                        force_download: true,
+                        hash: file.hash,
+                    }
+                })
+                .collect::<Vec<MockCacheDownloaderCall>>()
+        );
+
+        assert_eq!(validator.get_calls(), &[],);
+
+        assert_eq!(
+            extractor.get_calls(),
+            &config
+                .url_files
+                .iter()
+                .map(|file| MockExtractorCall {
+                    source: artifact_dir.join(file.artifact_name).to_path_buf(),
+                    dest: schema_dir.join(file.extract_to),
+                })
+                .collect::<Vec<MockExtractorCall>>()
+        );
+    }
+
+    #[test]
+    fn fae_cache_only_with_missing_artifact_fails() {
+        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let path = temp_dir.into_path();
+        let schema_dir = path.join("schema");
+
+        let mut downloader = MockCacheDownloader::new(vec![Ok(())]);
+        let mut validator = MockValidator::new(vec![Ok(())]);
+        let mut extractor = MockExtractor::new(vec![Ok(())]);
+
+        let config = FetchAndExtractConfig {
+            download_config: DownloadConfig::CacheOnly,
+            copy_from: None,
+            do_checksum: true,
+            url_files: &[UrlFile {
+                url: "https://bismuth/zepplin.zip",
+                hash: "notarealhash",
+                artifact_name: "out.zip",
+                extract_to: "edgarallen",
+            }],
+            artifact_dir: PathBuf::from("fakedir"),
+            schema_dir: schema_dir.clone(),
+        };
+
+        let result = fetch_and_extract_with_callbacks(
+            config.clone(),
+            |config| downloader.download(config),
+            |path_buf, hash| validator.validate(path_buf, hash),
+            |source, dest| extractor.extract(source, dest),
+        );
+
+        assert_eq!(
+            format!("{:?}", result),
+            "Err(ActionError(\"file \\\"fakedir/out.zip\\\" does not exist\"))"
+        );
+        assert_eq!(downloader.get_calls(), &[],);
+        assert_eq!(validator.get_calls(), &[],);
+        assert_eq!(extractor.get_calls(), &[],);
+    }
+
+    #[test]
+    fn fae_cache_only_copy_from_missing_file_fails() {
+        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let path = temp_dir.into_path();
+        let schema_dir = path.join("schema");
+
+        let mut downloader = MockCacheDownloader::new(vec![Ok(())]);
+        let mut validator = MockValidator::new(vec![Ok(())]);
+        let mut extractor = MockExtractor::new(vec![Ok(())]);
+
+        let copy_dir = path.join("copy_from");
+        let copy_dir_string = copy_dir.to_string_lossy().to_string();
+        fs::create_dir(&copy_dir).expect("could not create directory");
+
+        let config = FetchAndExtractConfig {
+            download_config: DownloadConfig::CacheOnly,
+            copy_from: Some(copy_dir.to_string_lossy().to_string()),
+            do_checksum: true,
+            url_files: &[UrlFile {
+                url: "https://bismuth/zepplin.zip",
+                hash: "notarealhash",
+                artifact_name: "out.zip",
+                extract_to: "edgarallen",
+            }],
+            artifact_dir: PathBuf::from("fakedir"),
+            schema_dir: schema_dir.clone(),
+        };
+
+        let result = fetch_and_extract_with_callbacks(
+            config.clone(),
+            |config| downloader.download(config),
+            |path_buf, hash| validator.validate(path_buf, hash),
+            |source, dest| extractor.extract(source, dest),
+        );
+
+        assert_eq!(
+            format!("{:?}", result),
+            format!(
+                "Err(ActionError(\"expected to find \\\"out.zip\\\" in \
+            \\\"{copy_dir_string}\\\", but the file does not exist\"))"
+            )
+        );
+        assert_eq!(downloader.get_calls(), &[],);
+        assert_eq!(validator.get_calls(), &[],);
+        assert_eq!(extractor.get_calls(), &[],);
+    }
+
+    #[test]
+    fn fae_if_not_cached_copy_from_missing_file_downloads() {
+        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let path = temp_dir.into_path();
+        let schema_dir = path.join("schema");
+        let artifact_dir = path.join("artifact");
+
+        fs::create_dir(&artifact_dir).expect("could not create directory");
+
+        let mut downloader = MockCacheDownloader::new(vec![Ok(())]);
+        let mut validator = MockValidator::new(vec![Ok(())]);
+        let mut extractor = MockExtractor::new(vec![Ok(())]);
+
+        let copy_dir = path.join("copy_from");
+        fs::create_dir(&copy_dir).expect("could not create directory");
+
+        let config = FetchAndExtractConfig {
+            download_config: DownloadConfig::IfNotCached,
+            copy_from: Some(copy_dir.to_string_lossy().to_string()),
+            do_checksum: true,
+            url_files: &[UrlFile {
+                url: "https://bismuth/zepplin.zip",
+                hash: "notarealhash",
+                artifact_name: "out.zip",
+                extract_to: "edgarallen",
+            }],
+            artifact_dir: artifact_dir.clone(),
+            schema_dir: schema_dir.clone(),
+        };
+
+        let result = fetch_and_extract_with_callbacks(
+            config.clone(),
+            |config| {
+                File::create(&artifact_dir.join(&config.file_path)).expect("could not create file");
+                downloader.download(config)
+            },
+            |path_buf, hash| validator.validate(path_buf, hash),
+            |source, dest| extractor.extract(source, dest),
+        );
+
+        assert_eq!(format!("{:?}", result), "Ok(())");
+        assert_eq!(
+            downloader.get_calls(),
+            &config
+                .url_files
+                .iter()
+                .map(|file| MockCacheDownloaderCall {
+                    config: CachingDownloadConfig {
+                        url: Url::parse(file.url).expect("could not parse url"),
+                        file_path: artifact_dir.join(file.artifact_name).to_path_buf(),
+                        temp_file_path: artifact_dir.join(format!(
+                            "{filename}.download",
+                            filename = file.artifact_name
+                        )),
+                        force_download: false,
+                        hash: file.hash,
+                    }
+                })
+                .collect::<Vec<MockCacheDownloaderCall>>()
+        );
+
+        assert_eq!(validator.get_calls(), &[],);
+
+        assert_eq!(
+            extractor.get_calls(),
+            &config
+                .url_files
+                .iter()
+                .map(|file| MockExtractorCall {
+                    source: artifact_dir.join(file.artifact_name).to_path_buf(),
+                    dest: schema_dir.join(file.extract_to),
+                })
+                .collect::<Vec<MockExtractorCall>>()
+        );
+    }
+}

--- a/cli/src/actions/xsd_downloader/validator.rs
+++ b/cli/src/actions/xsd_downloader/validator.rs
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+use std::fmt::Write;
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use crate::error::CliError;
+
+/// Validate the hash of a file an return a useful error message if the hash is invalid
+///
+/// * `file` - The file to check the hash of
+/// * `hash` - The expected sha256 hash
+pub fn validate_hash(file: &Path, hash: &[u8; 32]) -> Result<(), CliError> {
+    info!("validating hash of {file}", file = file.to_string_lossy());
+    if !file.exists() {
+        return Err(CliError::ActionError(format!(
+            "file \"{file}\" does not exist",
+            file = file.to_string_lossy()
+        )));
+    }
+
+    let mut hasher = Sha256::new();
+    let data = std::fs::read(file).map_err(|err| CliError::InternalError(err.to_string()))?;
+    hasher.update(data);
+    let sha256 = hasher.finalize();
+
+    if sha256.as_slice() != hash {
+        let mut expected = String::new();
+        for byte in hash {
+            write!(&mut expected, "{:02x}", byte)
+                .map_err(|err| CliError::InternalError(err.to_string()))?;
+        }
+
+        return Err(CliError::ActionError(format!(
+            "expected file to have hash of {expected}, but it was {got:x}",
+            got = sha256
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs::File;
+    use std::io::Write;
+
+    use hex_literal::hex;
+    use pretty_assertions::assert_eq;
+    use tempdir::TempDir;
+
+    const TEST_DATA: &str = "lagomorpha";
+    const TEST_HASH: [u8; 32] =
+        hex!("9b44a9cb40096bf6767dec8e97bdc5a36ead7bc6200025cac801bf445307aba0");
+
+    #[test]
+    fn validate_hash_succeeds_on_valid_hash() {
+        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let file_path = temp_dir.path().join("gs1.zip");
+
+        let mut output = File::create(&file_path).expect("could not create file");
+        write!(output, "{}", TEST_DATA).expect("could not write file");
+
+        assert_eq!(
+            format!("{:?}", validate_hash(&file_path, &TEST_HASH)),
+            "Ok(())"
+        );
+    }
+
+    #[test]
+    fn validate_hash_fails_on_invalid_hash() {
+        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let file_path = temp_dir.path().join("gs1.zip");
+
+        let mut output = File::create(&file_path).expect("could not create file");
+        write!(output, "deus ex machina").expect("could not write file");
+
+        assert_eq!(
+            format!("{:?}", validate_hash(&file_path, &TEST_HASH)), 
+            "Err(ActionError(\"expected file to have hash of 9b44a9cb40096bf6767dec8e97bdc5a36ead7bc6200025cac801bf445307aba0, but it was 79909d2507886e03b19dded20d453c048a9e2f05f2e3553e4a399926505df260\"))".to_string()
+            );
+    }
+
+    #[test]
+    fn validate_hash_returns_error_if_file_does_not_exist() {
+        let file_path = Path::new("fakefile.zip");
+        assert_eq!(
+            format!("{:?}", validate_hash(file_path, &TEST_HASH)),
+            "Err(ActionError(\"file \\\"fakefile.zip\\\" does not exist\"))".to_string()
+        );
+    }
+}

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -76,6 +76,7 @@ RUN apt-get update \
  && apt-get install -y -q \
     postgresql-client \
     libsqlite3-dev \
+    curl \
     man \
  && mandb \
  && dpkg --unpack /tmp/grid*.deb \


### PR DESCRIPTION
Add an XSD download CLI command, along with several utility methods for
downloading, extracting, and validating the files within the schema
archive.

Signed-off-by: Lee Bradley <bradley@bitwise.io>