### PR TITLE
Fix PO migrations

### DIFF
--- a/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -15,50 +15,40 @@
 
 CREATE TABLE purchase_order (
     id BIGSERIAL PRIMARY KEY,
-    purchase_order_uid TEXT NOT NULL,
-    workflow_state TEXT NOT NULL,
-    buyer_org_id VARCHAR(256) NOT NULL,
-    seller_org_id VARCHAR(256) NOT NULL,
+    uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    workflow_status TEXT NOT NULL,
     is_closed BOOLEAN NOT NULL,
-    accepted_version_id TEXT,
-    created_at BIGINT NOT NULL,
-    workflow_id TEXT NOT NULL,
-    start_commit_num BIGINT NOT NULL,
-    end_commit_num BIGINT NOT NULL,
+    accepted_version_id TEXT NOT NULL,
     service_id TEXT
-);
+) INHERITS (chain_record);
 
 CREATE TABLE purchase_order_version (
     id BIGSERIAL PRIMARY KEY,
-    purchase_order_uid TEXT NOT NULL,
+    purchase_order_uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
     version_id TEXT NOT NULL,
     is_draft BOOLEAN NOT NULL,
-    current_revision_id BIGINT NOT NULL,
-    workflow_state TEXT NOT NULL,
-    start_commit_num BIGINT NOT NULL,
-    end_commit_num BIGINT NOT NULL,
+    current_revision_id TEXT NOT NULL,
     service_id TEXT
-);
+) INHERITS (chain_record);
 
 CREATE TABLE purchase_order_version_revision (
     id BIGSERIAL PRIMARY KEY,
-    purchase_order_uid TEXT NOT NULL,
     version_id TEXT NOT NULL,
-    revision_id BIGINT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    revision_id TEXT NOT NULL,
     order_xml_v3_4 TEXT NOT NULL,
     submitter TEXT NOT NULL,
     created_at BIGINT NOT NULL,
-    start_commit_num BIGINT NOT NULL,
-    end_commit_num BIGINT NOT NULL,
     service_id TEXT
-);
+) INHERITS (chain_record);
 
 CREATE TABLE purchase_order_alternate_id (
     id BIGSERIAL PRIMARY KEY,
-    purchase_order_uid TEXT NOT NULL,
+    purchase_order_uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
     alternate_id_type TEXT NOT NULL,
     alternate_id TEXT NOT NULL,
-    start_commit_num BIGINT NOT NULL,
-    end_commit_num BIGINT NOT NULL,
     service_id TEXT
-);
+) INHERITS (chain_record);

--- a/sdk/src/migrations/diesel/postgres/migrations/2022-01-17-100000_purchase_order_tables_0_3/down.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2022-01-17-100000_purchase_order_tables_0_3/down.sql
@@ -1,0 +1,59 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE purchase_order
+RENAME COLUMN purchase_order_uid TO uuid;
+
+ALTER TABLE purchase_order
+RENAME COLUMN workflow_state TO workflow_status;
+
+ALTER TABLE purchase_order
+ALTER COLUMN accepted_version_id SET NOT NULL;
+
+ALTER TABLE purchase_order
+DROP COLUMN buyer_org_id,
+DROP COLUMN seller_org_id,
+DROP COLUMN workflow_id,
+DROP COLUMN created_at;
+
+ALTER TABLE purchase_order
+ADD COLUMN org_id VARCHAR(256) NOT NULL;
+
+ALTER TABLE purchase_order_version
+RENAME COLUMN purchase_order_uid TO purchase_order_uuid;
+
+ALTER TABLE purchase_order_version
+DROP COLUMN workflow_state;
+
+ALTER TABLE purchase_order_version
+ADD COLUMN org_id VARCHAR(256) NOT NULL;
+
+ALTER TABLE purchase_order_version
+ALTER COLUMN current_revision_id TYPE TEXT USING current_revision_id::TEXT;
+
+ALTER TABLE purchase_order_version_revision
+DROP COLUMN purchase_order_uid;
+
+ALTER TABLE purchase_order_version_revision
+ADD COLUMN org_id VARCHAR(256) NOT NULL;
+
+ALTER TABLE purchase_order_version_revision
+ALTER COLUMN revision_id TYPE TEXT USING revision_id::TEXT;
+
+ALTER TABLE purchase_order_alternate_id
+RENAME COLUMN purchase_order_uid TO purchase_order_uuid;
+
+ALTER TABLE purchase_order_alternate_id
+ADD COLUMN org_id VARCHAR(256) NOT NULL;

--- a/sdk/src/migrations/diesel/postgres/migrations/2022-01-17-100000_purchase_order_tables_0_3/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2022-01-17-100000_purchase_order_tables_0_3/up.sql
@@ -1,0 +1,109 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE purchase_order
+RENAME COLUMN uuid TO purchase_order_uid;
+
+ALTER TABLE purchase_order
+RENAME COLUMN workflow_status TO workflow_state;
+
+ALTER TABLE purchase_order
+ALTER COLUMN accepted_version_id DROP NOT NULL;
+
+ALTER TABLE purchase_order
+DROP COLUMN org_id;
+
+ALTER TABLE purchase_order
+ADD COLUMN buyer_org_id VARCHAR(256) NOT NULL,
+ADD COLUMN seller_org_id VARCHAR(256) NOT NULL,
+ADD COLUMN workflow_id VARCHAR(256) NOT NULL,
+ADD COLUMN created_at BIGINT NOT NULL;
+
+ALTER TABLE purchase_order_version
+RENAME COLUMN purchase_order_uuid TO purchase_order_uid;
+
+ALTER TABLE purchase_order_version
+DROP COLUMN org_id;
+
+ALTER TABLE purchase_order_version
+ADD COLUMN workflow_state TEXT NOT NULL;
+
+ALTER TABLE purchase_order_version
+ALTER COLUMN current_revision_id TYPE BIGINT USING current_revision_id::BIGINT;
+
+ALTER TABLE purchase_order_version_revision
+DROP COLUMN org_id;
+
+ALTER TABLE purchase_order_version_revision
+ALTER COLUMN revision_id TYPE BIGINT USING revision_id::BIGINT;
+
+ALTER TABLE purchase_order_version_revision
+ADD COLUMN purchase_order_uid TEXT NOT NULL;
+
+ALTER TABLE purchase_order_alternate_id
+RENAME COLUMN purchase_order_uuid TO purchase_order_uid;
+
+ALTER TABLE purchase_order_alternate_id
+DROP COLUMN org_id;
+
+-- CREATE TABLE purchase_order (
+--     id BIGSERIAL PRIMARY KEY,
+--     purchase_order_uid TEXT NOT NULL,
+--     workflow_state TEXT NOT NULL,
+--     buyer_org_id VARCHAR(256) NOT NULL,
+--     seller_org_id VARCHAR(256) NOT NULL,
+--     is_closed BOOLEAN NOT NULL,
+--     accepted_version_id TEXT,
+--     created_at BIGINT NOT NULL,
+--     workflow_id TEXT NOT NULL,
+--     start_commit_num BIGINT NOT NULL,
+--     end_commit_num BIGINT NOT NULL,
+--     service_id TEXT
+-- );
+
+-- CREATE TABLE purchase_order_version (
+--     id BIGSERIAL PRIMARY KEY,
+--     purchase_order_uid TEXT NOT NULL,
+--     version_id TEXT NOT NULL,
+--     is_draft BOOLEAN NOT NULL,
+--     current_revision_id BIGINT NOT NULL,
+--     workflow_state TEXT NOT NULL,
+--     start_commit_num BIGINT NOT NULL,
+--     end_commit_num BIGINT NOT NULL,
+--     service_id TEXT
+-- );
+
+-- CREATE TABLE purchase_order_version_revision (
+--     id BIGSERIAL PRIMARY KEY,
+--     purchase_order_uid TEXT NOT NULL,
+--     version_id TEXT NOT NULL,
+--     revision_id BIGINT NOT NULL,
+--     order_xml_v3_4 TEXT NOT NULL,
+--     submitter TEXT NOT NULL,
+--     created_at BIGINT NOT NULL,
+--     start_commit_num BIGINT NOT NULL,
+--     end_commit_num BIGINT NOT NULL,
+--     service_id TEXT
+-- );
+
+-- CREATE TABLE purchase_order_alternate_id (
+--     id BIGSERIAL PRIMARY KEY,
+--     purchase_order_uid TEXT NOT NULL,
+--     alternate_id_type TEXT NOT NULL,
+--     alternate_id TEXT NOT NULL,
+--     start_commit_num BIGINT NOT NULL,
+--     end_commit_num BIGINT NOT NULL,
+--     service_id TEXT
+-- );

--- a/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2021-03-24-130200_purchase_order_tables/up.sql
@@ -15,14 +15,11 @@
 
 CREATE TABLE purchase_order (
     id INTEGER PRIMARY KEY,
-    purchase_order_uid TEXT NOT NULL,
-    workflow_state TEXT NOT NULL,
-    buyer_org_id VARCHAR(256) NOT NULL,
-    seller_org_id VARCHAR(256) NOT NULL,
+    uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    workflow_status TEXT NOT NULL,
     is_closed BOOLEAN NOT NULL,
-    accepted_version_id TEXT,
-    created_at BIGINT NOT NULL,
-    workflow_id TEXT NOT NULL,
+    accepted_version_id TEXT NOT NULL,
     start_commit_num BIGINT NOT NULL,
     end_commit_num BIGINT NOT NULL,
     service_id TEXT
@@ -30,11 +27,11 @@ CREATE TABLE purchase_order (
 
 CREATE TABLE purchase_order_version (
     id INTEGER PRIMARY KEY,
-    purchase_order_uid TEXT NOT NULL,
+    purchase_order_uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
     version_id TEXT NOT NULL,
     is_draft BOOLEAN NOT NULL,
-    current_revision_id BIGINT NOT NULL,
-    workflow_state TEXT NOT NULL,
+    current_revision_id TEXT NOT NULL,
     start_commit_num BIGINT NOT NULL,
     end_commit_num BIGINT NOT NULL,
     service_id TEXT
@@ -42,9 +39,9 @@ CREATE TABLE purchase_order_version (
 
 CREATE TABLE purchase_order_version_revision (
     id INTEGER PRIMARY KEY,
-    purchase_order_uid TEXT NOT NULL,
     version_id TEXT NOT NULL,
-    revision_id BIGINT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    revision_id TEXT NOT NULL,
     order_xml_v3_4 TEXT NOT NULL,
     submitter TEXT NOT NULL,
     created_at BIGINT NOT NULL,
@@ -55,7 +52,8 @@ CREATE TABLE purchase_order_version_revision (
 
 CREATE TABLE purchase_order_alternate_id (
     id INTEGER PRIMARY KEY,
-    purchase_order_uid TEXT NOT NULL,
+    purchase_order_uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
     alternate_id_type TEXT NOT NULL,
     alternate_id TEXT NOT NULL,
     start_commit_num BIGINT NOT NULL,

--- a/sdk/src/migrations/diesel/sqlite/migrations/2022-01-17-100000_purchase_order_tables_0_3/down.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2022-01-17-100000_purchase_order_tables_0_3/down.sql
@@ -1,0 +1,158 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE purchase_order_temp(
+    id INTEGER PRIMARY KEY,
+    uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    workflow_status TEXT NOT NULL,
+    is_closed BOOLEAN NOT NULL,
+    accepted_version_id TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO purchase_order_temp(
+    id,
+    uuid,
+    workflow_status,
+    is_closed,
+    accepted_version_id,
+    start_commit_num,
+    end_commit_num,
+    service_id
+) SELECT
+id,
+purchase_order_uid,
+workflow_state,
+is_closed,
+accepted_version_id,
+start_commit_num,
+end_commit_num,
+service_id
+FROM purchase_order;
+
+DROP TABLE purchase_order;
+
+ALTER TABLE purchase_order_temp RENAME TO purchase_order;
+
+CREATE TABLE purchase_order_version_temp(
+    id INTEGER PRIMARY KEY,
+    purchase_order_uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    version_id TEXT NOT NULL,
+    is_draft BOOLEAN NOT NULL,
+    current_revision_id TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO purchase_order_version_temp(
+    id,
+    purchase_order_uuid,
+    version_id,
+    is_draft,
+    current_revision_id,
+    start_commit_num,
+    end_commit_num,
+    service_id
+) SELECT
+id,
+purchase_order_uid,
+version_id,
+is_draft,
+current_revision_id,
+start_commit_num,
+end_commit_num,
+service_id
+FROM purchase_order_version;
+
+DROP TABLE purchase_order_version;
+
+ALTER TABLE purchase_order_version_temp RENAME TO purchase_order_version;
+
+CREATE TABLE purchase_order_version_revision_temp(
+    id INTEGER PRIMARY KEY,
+    version_id TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    revision_id TEXT NOT NULL,
+    order_xml_v3_4 TEXT NOT NULL,
+    submitter TEXT NOT NULL,
+    created_at BIGINT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO purchase_order_version_revision_temp(
+    id,
+    version_id,
+    revision_id,
+    order_xml_v3_4,
+    submitter,
+    created_at,
+    start_commit_num,
+    end_commit_num,
+    service_id
+) SELECT
+id,
+version_id,
+revision_id,
+order_xml_v3_4,
+submitter,
+created_at,
+start_commit_num,
+end_commit_num,
+service_id
+FROM purchase_order_version_revision;
+
+DROP TABLE purchase_order_version_revision;
+
+ALTER TABLE purchase_order_version_revision_temp RENAME TO purchase_order_version_revision;
+
+CREATE TABLE purchase_order_alternate_id_temp(
+    id INTEGER PRIMARY KEY,
+    purchase_order_uuid TEXT NOT NULL,
+    org_id VARCHAR(256) NOT NULL,
+    alternate_id_type TEXT NOT NULL,
+    alternate_id TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO purchase_order_alternate_id_temp(
+    id,
+    purchase_order_uuid,
+    alternate_id_type,
+    alternate_id,
+    start_commit_num,
+    end_commit_num,
+    service_id
+) SELECT
+id,
+purchase_order_uid,
+alternate_id_type,
+alternate_id,
+start_commit_num,
+end_commit_num,
+service_id
+FROM purchase_order_alternate_id;
+
+DROP TABLE purchase_order_alternate_id;
+
+ALTER TABLE purchase_order_alternate_id_temp RENAME TO purchase_order_alternate_id;

--- a/sdk/src/migrations/diesel/sqlite/migrations/2022-01-17-100000_purchase_order_tables_0_3/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2022-01-17-100000_purchase_order_tables_0_3/up.sql
@@ -1,0 +1,210 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE purchase_order_temp(
+    id INTEGER PRIMARY KEY,
+    purchase_order_uid TEXT NOT NULL,
+    workflow_state TEXT NOT NULL,
+    buyer_org_id VARCHAR(256) NOT NULL,
+    seller_org_id VARCHAR(256) NOT NULL,
+    is_closed BOOLEAN NOT NULL,
+    accepted_version_id TEXT,
+    created_at BIGINT NOT NULL,
+    workflow_id TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO purchase_order_temp(
+    id,
+    purchase_order_uid,
+    workflow_state,
+    is_closed,
+    accepted_version_id,
+    start_commit_num,
+    end_commit_num,
+    service_id
+) SELECT
+id,
+uuid,
+workflow_status,
+is_closed,
+accepted_version_id,
+start_commit_num,
+end_commit_num,
+service_id
+FROM purchase_order;
+
+DROP TABLE purchase_order;
+
+ALTER TABLE purchase_order_temp RENAME TO purchase_order;
+
+CREATE TABLE purchase_order_version_temp(
+    id INTEGER PRIMARY KEY,
+    purchase_order_uid TEXT NOT NULL,
+    version_id TEXT NOT NULL,
+    is_draft BOOLEAN NOT NULL,
+    current_revision_id BIGINT NOT NULL,
+    workflow_state TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO purchase_order_version_temp(
+    id,
+    purchase_order_uid,
+    version_id,
+    is_draft,
+    current_revision_id,
+    start_commit_num,
+    end_commit_num,
+    service_id
+) SELECT
+id,
+purchase_order_uuid,
+version_id,
+is_draft,
+current_revision_id,
+start_commit_num,
+end_commit_num,
+service_id
+FROM purchase_order_version;
+
+DROP TABLE purchase_order_version;
+
+ALTER TABLE purchase_order_version_temp RENAME TO purchase_order_version;
+
+CREATE TABLE purchase_order_version_revision_temp(
+    id INTEGER PRIMARY KEY,
+    purchase_order_uid TEXT NOT NULL,
+    version_id TEXT NOT NULL,
+    revision_id BIGINT NOT NULL,
+    order_xml_v3_4 TEXT NOT NULL,
+    submitter TEXT NOT NULL,
+    created_at BIGINT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO purchase_order_version_revision_temp(
+    id,
+    version_id,
+    revision_id,
+    order_xml_v3_4,
+    submitter,
+    created_at,
+    start_commit_num,
+    end_commit_num,
+    service_id
+) SELECT
+id,
+version_id,
+revision_id,
+order_xml_v3_4,
+submitter,
+created_at,
+start_commit_num,
+end_commit_num,
+service_id
+FROM purchase_order_version_revision;
+
+DROP TABLE purchase_order_version_revision;
+
+ALTER TABLE purchase_order_version_revision_temp RENAME TO purchase_order_version_revision;
+
+CREATE TABLE purchase_order_alternate_id_temp(
+    id INTEGER PRIMARY KEY,
+    purchase_order_uid TEXT NOT NULL,
+    alternate_id_type TEXT NOT NULL,
+    alternate_id TEXT NOT NULL,
+    start_commit_num BIGINT NOT NULL,
+    end_commit_num BIGINT NOT NULL,
+    service_id TEXT
+);
+
+INSERT INTO purchase_order_alternate_id_temp(
+    id,
+    purchase_order_uid,
+    alternate_id_type,
+    alternate_id,
+    start_commit_num,
+    end_commit_num,
+    service_id
+) SELECT
+id,
+purchase_order_uuid,
+alternate_id_type,
+alternate_id,
+start_commit_num,
+end_commit_num,
+service_id
+FROM purchase_order_alternate_id;
+
+DROP TABLE purchase_order_alternate_id;
+
+ALTER TABLE purchase_order_alternate_id_temp RENAME TO purchase_order_alternate_id;
+
+-- CREATE TABLE purchase_order (
+--     id INTEGER PRIMARY KEY,
+--     purchase_order_uid TEXT NOT NULL,
+--     workflow_state TEXT NOT NULL,
+--     buyer_org_id VARCHAR(256) NOT NULL,
+--     seller_org_id VARCHAR(256) NOT NULL,
+--     is_closed BOOLEAN NOT NULL,
+--     accepted_version_id TEXT,
+--     created_at BIGINT NOT NULL,
+--     workflow_id TEXT NOT NULL,
+--     start_commit_num BIGINT NOT NULL,
+--     end_commit_num BIGINT NOT NULL,
+--     service_id TEXT
+-- );
+
+-- CREATE TABLE purchase_order_version (
+--     id INTEGER PRIMARY KEY,
+--     purchase_order_uid TEXT NOT NULL,
+--     version_id TEXT NOT NULL,
+--     is_draft BOOLEAN NOT NULL,
+--     current_revision_id BIGINT NOT NULL,
+--     workflow_state TEXT NOT NULL,
+--     start_commit_num BIGINT NOT NULL,
+--     end_commit_num BIGINT NOT NULL,
+--     service_id TEXT
+-- );
+
+-- CREATE TABLE purchase_order_version_revision (
+--     id INTEGER PRIMARY KEY,
+--     purchase_order_uid TEXT NOT NULL,
+--     version_id TEXT NOT NULL,
+--     revision_id BIGINT NOT NULL,
+--     order_xml_v3_4 TEXT NOT NULL,
+--     submitter TEXT NOT NULL,
+--     created_at BIGINT NOT NULL,
+--     start_commit_num BIGINT NOT NULL,
+--     end_commit_num BIGINT NOT NULL,
+--     service_id TEXT
+-- );
+
+-- CREATE TABLE purchase_order_alternate_id (
+--     id INTEGER PRIMARY KEY,
+--     purchase_order_uid TEXT NOT NULL,
+--     alternate_id_type TEXT NOT NULL,
+--     alternate_id TEXT NOT NULL,
+--     start_commit_num BIGINT NOT NULL,
+--     end_commit_num BIGINT NOT NULL,
+--     service_id TEXT
+-- );


### PR DESCRIPTION
This updates the PO migrations by adding a new migrations file for the
0.3 version of the tables and reverts the original file back to its
original 0.2 state.

Signed-off-by: Davey Newhall <newhall@bitwise.io>