### PR TITLE
Remove actix-web default features

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/main.rs"
 [dependencies]
 actix = "0.9"
 actix-rt = "1.0"
-actix-web = "3.0"
+actix-web = { version = "3", default-features = false }
 base64 = "0.13"
 byteorder = "1"
 cfg-if = "1"

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -9,7 +9,7 @@ description = "Grid integration component"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "3"
+actix-web = { version = "3", default-features = false }
 clap = "2.33.3"
 diesel = { version = "1.0", features = ["r2d2"], optional = true }
 flexi_logger = "0.17"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -28,7 +28,7 @@ license = "Apache-2.0"
 
 
 [dependencies]
-actix-web = { version = "3", optional = true }
+actix-web = { version = "3", optional = true, default-features = false }
 base64 = { version = "0.13", optional = true }
 cfg-if = { version = "1", optional = true }
 chrono = { version = "0.4", optional = true }


### PR DESCRIPTION
This change updates the actix-web dependencies used across Grid to
disable default features. As Grid's Splinter dependency uses another
version of actix-web, multiple versions of a default compression
feature were being pulled in which caused a build error pertaining to
multiple definitions of the same things across the different versions
of the brotli compression feature. As Grid does not currently use these
default compression features, it is safe to turn these features off.

Signed-off-by: Shannyn Telander <telander@bitwise.io>