### PR TITLE
Remove actix-web default features

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/main.rs"
 [dependencies]
 actix = "0.9"
 actix-rt = "1.0"
-actix-web = "3.0"
+actix-web = { version = "3.0", default-features = false }
 base64 = "0.13"
 byteorder = "1"
 cfg-if = "1"

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -9,7 +9,7 @@ description = "Grid integration component"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "3"
+actix-web = { version = "3", default-features = false }
 clap = "2.33.3"
 diesel = { version = "1.0", features = ["r2d2"], optional = true }
 flexi_logger = "0.17"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -28,7 +28,7 @@ license = "Apache-2.0"
 
 
 [dependencies]
-actix-web = { version = "3", optional = true }
+actix-web = { version = "3", optional = true, default-features = false }
 base64 = { version = "0.13", optional = true }
 cfg-if = { version = "1", optional = true }
 chrono = { version = "0.4", optional = true }


### PR DESCRIPTION
This change removes the default features from the actix-web dependency
which removes the transient dependency on brotli for compression (as well as gzip).

This fixes a compilation issue on linux systems where there is an impedence
mismatch between actix-http 2.x (pulled in by actix-web-3) and awc 0.2.x
 (pulled in by the splinter/events feature).

As compression is not used in any of the clients, it is acceptible to remove
these transient dependencies.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>