### PR TITLE
Add check if po doesn't have accepted version

### DIFF
--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -692,6 +692,23 @@ fn update_purchase_order(
                 accepted_version_number,
             )));
         }
+    } else {
+        // Check if we have removed a version as "accepted"
+        if let Some((vers_id, workflow_state)) =
+            updated_version_states
+                .into_iter()
+                .find(|(_vers_id, workflow_state)| {
+                    workflow_state.has_constraint(&WorkflowConstraint::Accepted.to_string())
+                })
+        {
+            return Err(ApplyError::InvalidTransaction(format!(
+                "Purchase order {} does not specify an accepted version, but version \
+                    {} workflow state {} has `accepted` constraint",
+                updated_po.uid(),
+                vers_id,
+                workflow_state.name(),
+            )));
+        }
     }
 
     /* ------------------- Persist updated state ----------------------------- */


### PR DESCRIPTION
This change adds a check if the purchase order does not have the
`accepted_version_number` set to validate the list of versions for that
purchase order do not contain versions that exist in an
`accepted`-constrained state.

This addresses this bug: https://github.com/hyperledger/grid/issues/1246