### PR TITLE
Add file checks to avoid "os error: file not found"

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2962,7 +2962,13 @@ fn run() -> Result<(), CliError> {
                     let signer = signing::load_signer(key)?;
                     let wait = value_t!(m, "wait", u64).unwrap_or(0);
 
-                    let order_xml_path = m.value_of("order_xml").unwrap();
+                    let order_xml_path = PathBuf::from(m.value_of("order_xml").unwrap());
+                    if !order_xml_path.exists() {
+                        return Err(CliError::UserError(format!(
+                            "The specified file {} does not exist.",
+                            order_xml_path.to_string_lossy()
+                        )));
+                    }
                     let data_validation_dir = purchase_order::get_order_schema_dir_string()?;
                     let mut xml_str = String::new();
                     std::fs::File::open(order_xml_path)?.read_to_string(&mut xml_str)?;

--- a/sdk/src/data_validation/xml/mod.rs
+++ b/sdk/src/data_validation/xml/mod.rs
@@ -92,6 +92,19 @@ fn load_schema(schema_type: Schema, schema_dir: &str) -> Result<XmlSchema, DataV
     let schema: Vec<u8> = match schema_type {
         Schema::OrderXmlV3_4 => {
             schema_dir_path.push("Order.xsd");
+            if !schema_dir_path.exists() {
+                return Err(DataValidationError::InvalidArgument(
+                    InvalidArgumentError::new(
+                        "xml validation".to_string(),
+                        format!(
+                            "Cannot validate XML file against XSD file: XSD file {} is \
+                                missing. Hint: You may need to use the Grid XSD download tool to \
+                                get this file, or the file may have an incorrect name.",
+                            schema_dir_path.to_string_lossy()
+                        ),
+                    ),
+                ));
+            }
             fs::read_to_string(schema_dir_path.as_path())
                 .map_err(|err| {
                     DataValidationError::Internal(InternalError::from_source(Box::new(err)))
@@ -100,6 +113,18 @@ fn load_schema(schema_type: Schema, schema_dir: &str) -> Result<XmlSchema, DataV
         }
         Schema::GdsnXmlV3_1 => {
             schema_dir_path.push("GridTradeItems.xsd");
+            if !schema_dir_path.exists() {
+                return Err(DataValidationError::InvalidArgument(
+                    InvalidArgumentError::new(
+                        "xml validation".to_string(),
+                        format!(
+                            "Cannot validate XML file against XSD file: XSD file {} is \
+                            missing.",
+                            schema_dir_path.to_string_lossy()
+                        ),
+                    ),
+                ));
+            }
             fs::read_to_string(schema_dir_path.as_path())
                 .map_err(|err| {
                     DataValidationError::Internal(InternalError::from_source(Box::new(err)))


### PR DESCRIPTION
Checks to see if XSD and user-provided po XML files exist before attempting to read. Previously, the user would get a generic os error message, as these errors weren't mapping to ours.

Resolves: #1169 