### PR TITLE
Check if version exists in create version command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2982,14 +2982,20 @@ fn run() -> Result<(), CliError> {
                         )?;
                     }
 
-                    let workflow_state = m.value_of("workflow_state").unwrap();
-
-                    let revision_id = purchase_order::get_latest_revision_id(
-                        &*purchase_order_client,
-                        &po,
-                        version_id,
+                    if let Ok(Some(vers)) = purchase_order_client.get_purchase_order_version(
+                        po.to_string(),
+                        version_id.to_string(),
                         service_id.as_deref(),
-                    )? + 1;
+                    ) {
+                        return Err(CliError::PayloadError(format!(
+                            "Purchase order {} version {} already exists",
+                            po, vers.version_id,
+                        )));
+                    }
+
+                    let workflow_state = m.value_of("workflow_state").unwrap();
+                    // As we are creating a version, the revision included will be the first
+                    let revision_id = 1;
 
                     let draft = !m.is_present("not_draft");
 


### PR DESCRIPTION
This change updates how the revision ID is fetched for a version being
created. As this version is being created, the revision ID should be '1'
rather than the most recent revision ID of the version. The most recent
revision ID should not exist, as a version being created should not
already exist.

Testing instructions:
1. Create a PO & a PO version
2. Attempt to create the same version made previously
3. You should receive an error that that version already exists. Previously, you would receive the error I pasted in a comment below.