### PR TITLE
Stabilize `xsd-downloader` feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,6 +71,7 @@ default = [
     "purchase-order",
     "schema",
     "sqlite",
+    "xsd-downloader"
 ]
 
 stable = [
@@ -83,7 +84,6 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
-    "xsd-downloader"
 ]
 
 database = ["diesel"]


### PR DESCRIPTION
This change stabilizes the `xsd-downloader` feature, which enables the
user to download XSDs using the `grid download-xsd` subcommand.

Signed-off-by: Lee Bradley <bradley@bitwise.io>