### PR TITLE
BACKPORT 0-2: Remove actix-web default features & 1.58.1 clippy fixes & update grid-cli Dockerfile to not be based on sabre-cli

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hyperledger/grid-dev:v5 as grid-cli-builder
+FROM hyperledger/grid-dev:v9 as grid-cli-builder
 
 # Install dependencies
 RUN apt-get update \
@@ -20,10 +20,6 @@ RUN apt-get update \
     libxml2-dev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-
-# Temporary workaround until sabre is updated to focal
-RUN USER=root cargo new --bin griddle
-RUN USER=root cargo new --bin contracts/purchase_order
 
 # Copy over Cargo.toml files
 COPY Cargo.toml /build/Cargo.toml
@@ -57,7 +53,9 @@ WORKDIR /tmp
 RUN git rev-parse HEAD > /commit-hash
 
 # -------------=== grid-cli docker build ===-------------
-FROM hyperledger/sawtooth-sabre-cli:0.5
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 ARG CARGO_ARGS
 RUN echo "CARGO_ARGS = '$CARGO_ARGS'" > CARGO_ARGS

--- a/cli/src/actions/schemas.rs
+++ b/cli/src/actions/schemas.rs
@@ -101,10 +101,9 @@ pub fn display_schemas_info(schemas: &[GridSchemaSlice]) {
         }
     });
     println!(
-        "{:<width_name$} {:<width_owner$} {}",
+        "{:<width_name$} {:<width_owner$} DESCRIPTION",
         "NAME",
         "OWNER",
-        "DESCRIPTION".to_string(),
         width_name = name_width,
         width_owner = owner_width,
     );

--- a/contracts/pike/src/handler.rs
+++ b/contracts/pike/src/handler.rs
@@ -619,7 +619,7 @@ fn create_org(
         Ok(Some(_)) => {
             return Err(ApplyError::InvalidTransaction(format!(
                 "Agent already exists: {}",
-                signer.to_string(),
+                signer,
             )))
         }
         Err(err) => {

--- a/contracts/track_and_trace/src/handler.rs
+++ b/contracts/track_and_trace/src/handler.rs
@@ -983,11 +983,7 @@ impl TrackAndTraceTransactionHandler {
 }
 
 fn map_builder_error_to_apply_error(err: BuilderError, protocol_name: &str) -> ApplyError {
-    ApplyError::InvalidTransaction(format!(
-        "Failed to build {}. {}",
-        protocol_name,
-        err.to_string()
-    ))
+    ApplyError::InvalidTransaction(format!("Failed to build {}. {}", protocol_name, err))
 }
 
 impl TransactionHandler for TrackAndTraceTransactionHandler {

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/main.rs"
 [dependencies]
 actix = "0.9"
 actix-rt = "1.0"
-actix-web = "3.0"
+actix-web = { version = "3", default-features = false }
 base64 = "0.13"
 byteorder = "1"
 cfg-if = "1"

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -9,7 +9,7 @@ description = "Grid integration component"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "3"
+actix-web = { version = "3", default-features = false }
 clap = "2.33.3"
 diesel = { version = "1.0", features = ["r2d2"], optional = true }
 flexi_logger = "0.17"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -28,7 +28,7 @@ license = "Apache-2.0"
 
 
 [dependencies]
-actix-web = { version = "3", optional = true }
+actix-web = { version = "3", optional = true, default-features = false }
 base64 = { version = "0.13", optional = true }
 cfg-if = { version = "1", optional = true }
 chrono = { version = "0.4", optional = true }

--- a/sdk/src/backend/sawtooth.rs
+++ b/sdk/src/backend/sawtooth.rs
@@ -126,7 +126,7 @@ pub fn query_validator<T: protobuf::Message, C: protobuf::Message, MS: MessageSe
     let content = protobuf::Message::write_to_bytes(message).map_err(|err| {
         BackendClientError::BadRequestError(format!(
             "Failed to serialize batch submit request. {}",
-            err.to_string()
+            err
         ))
     })?;
 
@@ -137,7 +137,7 @@ pub fn query_validator<T: protobuf::Message, C: protobuf::Message, MS: MessageSe
         .map_err(|err| {
             BackendClientError::ConnectionError(format!(
                 "Failed to send message to validator. {}",
-                err.to_string()
+                err
             ))
         })?;
 
@@ -150,7 +150,7 @@ pub fn query_validator<T: protobuf::Message, C: protobuf::Message, MS: MessageSe
     .map_err(|err| {
         BackendClientError::InternalError(format!(
             "Failed to parse validator response from bytes. {}",
-            err.to_string()
+            err
         ))
     })
 }

--- a/sdk/src/batch_processor/submitter/sawtooth.rs
+++ b/sdk/src/batch_processor/submitter/sawtooth.rs
@@ -115,7 +115,7 @@ pub fn query_validator<T: protobuf::Message, C: protobuf::Message, MS: MessageSe
     let content = protobuf::Message::write_to_bytes(message).map_err(|err| {
         BatchSubmitterError::BadRequestError(format!(
             "Failed to serialize batch submit request. {}",
-            err.to_string()
+            err
         ))
     })?;
 
@@ -126,7 +126,7 @@ pub fn query_validator<T: protobuf::Message, C: protobuf::Message, MS: MessageSe
         .map_err(|err| {
             BatchSubmitterError::ConnectionError(format!(
                 "Failed to send message to validator. {}",
-                err.to_string()
+                err
             ))
         })?;
 
@@ -139,7 +139,7 @@ pub fn query_validator<T: protobuf::Message, C: protobuf::Message, MS: MessageSe
     .map_err(|err| {
         BatchSubmitterError::InternalError(format!(
             "Failed to parse validator response from bytes. {}",
-            err.to_string()
+            err
         ))
     })
 }

--- a/sdk/src/rest_api/resources/batches/v1/handler.rs
+++ b/sdk/src/rest_api/resources/batches/v1/handler.rs
@@ -35,7 +35,7 @@ pub async fn submit_batches(
         Err(err) => {
             return Err(ErrorResponse::new(
                 400,
-                &format!("Protobuf message was badly formatted. {}", err.to_string()),
+                &format!("Protobuf message was badly formatted. {}", err),
             ));
         }
     };


### PR DESCRIPTION
This change updates the actix-web dependencies used across Grid to
disable default features. As Grid's Splinter dependency uses another
version of actix-web, multiple versions of a default compression
feature were being pulled in which caused a build error pertaining to
multiple definitions of the same things across the different versions
of the brotli compression feature. As Grid does not currently use these
default compression features, it is safe to turn these features off.

Signed-off-by: Shannyn Telander <telander@bitwise.io>