### PR TITLE
BACKPORT 0-2: Set dotenv-load to true in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set dotenv-load := true
+
 crates := '\
     sdk \
     daemon \


### PR DESCRIPTION
Starting with version 0.11.0, just ignores .env files by default. This
breaks some recipes because we read docker environment variables from
the .env file.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>