### PR TITLE
Add `BatchBuilder` struct

### DIFF
--- a/sdk/src/batches/store/error.rs
+++ b/sdk/src/batches/store/error.rs
@@ -87,3 +87,34 @@ impl From<PoolError> for BatchStoreError {
         )
     }
 }
+
+/// Represents BatchBuilder errors
+#[derive(Debug)]
+pub enum BatchBuilderError {
+    /// Returned when a required field was not set
+    MissingRequiredField(String),
+    /// Returned when an error occurs building the Batch
+    BuildError(Box<dyn Error>),
+}
+
+impl Error for BatchBuilderError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            BatchBuilderError::MissingRequiredField(_) => None,
+            BatchBuilderError::BuildError(err) => Some(&**err),
+        }
+    }
+}
+
+impl fmt::Display for BatchBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BatchBuilderError::MissingRequiredField(ref s) => {
+                write!(f, "Missing required field: {}", s)
+            }
+            BatchBuilderError::BuildError(ref s) => {
+                write!(f, "Failed to build batch object: {}", s)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a `BatchBuilder` struct and implementation to mirror the Grid
structs in other modules. This also updates the `Batch` struct's fields
to be private with public accessor methods, also to mirror other
modules.

Signed-off-by: Davey Newhall <newhall@bitwise.io>