### PR TITLE
Add migrations for new batch tracking tables

### DIFF
--- a/sdk/src/migrations/diesel/postgres/migrations/2022-02-09-212341_add_batch_tracking_tables/down.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2022-02-09-212341_add_batch_tracking_tables/down.sql
@@ -1,0 +1,55 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE batches;
+DROP TABLE transactions;
+DROP TABLE transaction_receipts;
+DROP TABLE submissions;
+DROP TABLE batch_statuses;
+
+CREATE TABLE batches (
+    header_signature TEXT PRIMARY KEY,
+    data_change_id TEXT,
+    signer_public_key TEXT NOT NULL,
+    trace BOOLEAN NOT NULL,
+    serialized_batch TEXT NOT NULL,
+    submitted BOOLEAN NOT NULL,
+    submission_error VARCHAR(16),
+    submission_error_message TEXT,
+    dlt_status VARCHAR(16),
+    claim_expires TIMESTAMP,
+    created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    service_id TEXT
+);
+
+CREATE TABLE transactions (
+    header_signature TEXT PRIMARY KEY,
+    batch_id TEXT NOT NULL,
+    family_name TEXT NOT NULL,
+    family_version TEXT NOT NULL,
+    signer_public_key TEXT NOT NULL,
+    FOREIGN KEY (batch_id) REFERENCES batches(header_signature) ON DELETE CASCADE
+);
+
+CREATE TABLE transaction_receipts (
+    id BIGSERIAL PRIMARY KEY,
+    transaction_id TEXT UNIQUE,
+    result_valid BOOLEAN NOT NULL,
+    error_message TEXT,
+    error_data TEXT,
+    serialized_receipt TEXT NOT NULL,
+    external_status VARCHAR(16),
+    external_error_message TEXT
+);

--- a/sdk/src/migrations/diesel/postgres/migrations/2022-02-09-212341_add_batch_tracking_tables/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2022-02-09-212341_add_batch_tracking_tables/up.sql
@@ -1,0 +1,85 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE batches CASCADE;
+DROP TABLE transactions;
+DROP TABLE transaction_receipts;
+
+CREATE TABLE batches
+  (
+     service_id        VARCHAR(17) NOT NULL,
+     batch_id          VARCHAR(128) NOT NULL,
+     data_change_id    VARCHAR(256),
+     signer_public_key VARCHAR(70) NOT NULL,
+     trace             BOOLEAN NOT NULL,
+     serialized_batch  BYTEA NOT NULL,
+     submitted         BOOLEAN NOT NULL,
+     created_at        TIMESTAMP NOT NULL,
+     PRIMARY KEY (service_id, batch_id)
+  );
+
+CREATE TABLE transactions
+  (
+     service_id        VARCHAR(17) NOT NULL,
+     transaction_id    VARCHAR(128) NOT NULL,
+     batch_id          VARCHAR(128) NOT NULL,
+     batch_service_id  VARCHAR(17) NOT NULL,
+     payload           BYTEA NOT NULL,
+     family_name       VARCHAR(128) NOT NULL,
+     family_version    VARCHAR(16) NOT NULL,
+     signer_public_key VARCHAR(70) NOT NULL,
+     FOREIGN KEY (batch_service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE,
+     PRIMARY KEY (service_id, transaction_id)
+  );
+
+CREATE TABLE transaction_receipts
+  (
+     service_id             VARCHAR(17) NOT NULL,
+     transaction_id         VARCHAR(70) NOT NULL,
+     result_valid           BOOLEAN NOT NULL,
+     error_message          TEXT,
+     error_data             BYTEA,
+     serialized_receipt     BYTEA NOT NULL,
+     external_status        VARCHAR(16),
+     external_error_message TEXT,
+     PRIMARY KEY (service_id, transaction_id)
+  );
+
+CREATE TABLE submissions
+  (
+     service_id            VARCHAR(17) NOT NULL,
+     batch_id              VARCHAR(128) NOT NULL,
+     batch_service_id      VARCHAR(17) NOT NULL,
+     last_checked          TIMESTAMP,
+     times_checked         VARCHAR(32),
+     error_type            VARCHAR(64),
+     error_message         TEXT,
+     created_at            TIMESTAMP NOT NULL,
+     updated_at            TIMESTAMP NOT NULL,
+     FOREIGN KEY (batch_service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE,
+     PRIMARY KEY (service_id, batch_id)
+  );
+
+CREATE TABLE batch_statuses
+  (
+     service_id        VARCHAR(17) NOT NULL,
+     batch_id          VARCHAR(128) NOT NULL,
+     batch_service_id  VARCHAR(17) NOT NULL,
+     dlt_status        VARCHAR(16) NOT NULL,
+     created_at        TIMESTAMP NOT NULL,
+     updated_at        TIMESTAMP NOT NULL,
+     FOREIGN KEY (batch_service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE,
+     PRIMARY KEY (service_id, batch_id)
+  );

--- a/sdk/src/migrations/diesel/sqlite/migrations/2022-02-09-212341_add_batch_tracking_tables/down.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2022-02-09-212341_add_batch_tracking_tables/down.sql
@@ -1,0 +1,55 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE batches;
+DROP TABLE transactions;
+DROP TABLE transaction_receipts;
+DROP TABLE submissions;
+DROP TABLE batch_statuses;
+
+CREATE TABLE batches (
+    header_signature TEXT PRIMARY KEY,
+    data_change_id TEXT,
+    signer_public_key TEXT NOT NULL,
+    trace BOOLEAN NOT NULL,
+    serialized_batch TEXT NOT NULL,
+    submitted BOOLEAN NOT NULL,
+    submission_error VARCHAR(16),
+    submission_error_message TEXT,
+    dlt_status VARCHAR(16),
+    claim_expires DATETIME,
+    created DATETIME DEFAULT CURRENT_TIMESTAMP,
+    service_id TEXT
+);
+
+CREATE TABLE transactions (
+    header_signature TEXT PRIMARY KEY,
+    batch_id TEXT NOT NULL,
+    family_name TEXT NOT NULL,
+    family_version TEXT NOT NULL,
+    signer_public_key TEXT NOT NULL,
+    FOREIGN KEY (batch_id) REFERENCES batches(header_signature) ON DELETE CASCADE
+);
+
+CREATE TABLE transaction_receipts (
+    id INTEGER PRIMARY KEY,
+    transaction_id TEXT UNIQUE,
+    result_valid BOOLEAN NOT NULL,
+    error_message TEXT,
+    error_data TEXT,
+    serialized_receipt TEXT NOT NULL,
+    external_status VARCHAR(16),
+    external_error_message TEXT
+);

--- a/sdk/src/migrations/diesel/sqlite/migrations/2022-02-09-212341_add_batch_tracking_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2022-02-09-212341_add_batch_tracking_tables/up.sql
@@ -1,0 +1,85 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE batches;
+DROP TABLE transactions;
+DROP TABLE transaction_receipts;
+
+CREATE TABLE batches
+  (
+     service_id        VARCHAR(17) NOT NULL,
+     batch_id          VARCHAR(128) NOT NULL,
+     data_change_id    VARCHAR(256),
+     signer_public_key VARCHAR(70) NOT NULL,
+     trace             BOOLEAN NOT NULL,
+     serialized_batch  BLOB NOT NULL,
+     submitted         BOOLEAN NOT NULL,
+     created_at        TIMESTAMP NOT NULL,
+     PRIMARY KEY (service_id, batch_id)
+  );
+
+CREATE TABLE transactions
+  (
+     service_id        VARCHAR(17) NOT NULL,
+     transaction_id    VARCHAR(128) NOT NULL,
+     batch_id          VARCHAR(128) NOT NULL,
+     batch_service_id  VARCHAR(17) NOT NULL,
+     payload           BLOB NOT NULL,
+     family_name       VARCHAR(128) NOT NULL,
+     family_version    VARCHAR(16) NOT NULL,
+     signer_public_key VARCHAR(70) NOT NULL,
+     FOREIGN KEY (batch_service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE,
+     PRIMARY KEY (service_id, transaction_id)
+  );
+
+CREATE TABLE transaction_receipts
+  (
+     service_id             VARCHAR(17) NOT NULL,
+     transaction_id         VARCHAR(70) NOT NULL,
+     result_valid           BOOLEAN NOT NULL,
+     error_message          TEXT,
+     error_data             BLOB,
+     serialized_receipt     BLOB NOT NULL,
+     external_status        VARCHAR(16),
+     external_error_message TEXT,
+     PRIMARY KEY (service_id, transaction_id)
+  );
+
+CREATE TABLE submissions
+  (
+     service_id            VARCHAR(17) NOT NULL,
+     batch_id              VARCHAR(128) NOT NULL,
+     batch_service_id      VARCHAR(17) NOT NULL,
+     last_checked          TIMESTAMP,
+     times_checked         VARCHAR(32),
+     error_type            VARCHAR(64),
+     error_message         TEXT,
+     created_at            TIMESTAMP NOT NULL,
+     updated_at            TIMESTAMP NOT NULL,
+     FOREIGN KEY (batch_service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE,
+     PRIMARY KEY (service_id, batch_id)
+  );
+
+CREATE TABLE batch_statuses
+  (
+     service_id        VARCHAR(17) NOT NULL,
+     batch_id          VARCHAR(128) NOT NULL,
+     batch_service_id  VARCHAR(17) NOT NULL,
+     dlt_status        VARCHAR(16) NOT NULL,
+     created_at        TIMESTAMP NOT NULL,
+     updated_at        TIMESTAMP NOT NULL,
+     FOREIGN KEY (batch_service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE,
+     PRIMARY KEY (service_id, batch_id)
+  );


### PR DESCRIPTION
This adds postgres and sqlite migrations for updated batch tracking
tables. These migrations remove the unused and outdated tables of the
same name and add updated ones.

Signed-off-by: Davey Newhall <newhall@bitwise.io>