### PR TITLE
Fix grid-ui build on M1

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -36,7 +36,7 @@ RUN git rev-parse HEAD > /commit-hash
 # Sapling build stage
 FROM node:14.18.1-alpine3.11 as sapling-build-stage
 
-RUN apk update && apk add git
+RUN apk update && apk add python g++ git make && rm -rf /var/cache/apk/*
 
 RUN npm config set unsafe-perm true
 


### PR DESCRIPTION
Without this change, the sapling stage fails with an error about
missing python.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>