### PR TITLE
Fix 1.59 clippy errors

### DIFF
--- a/cli/src/actions/purchase_order.rs
+++ b/cli/src/actions/purchase_order.rs
@@ -316,7 +316,7 @@ fn generate_random_base62_string(len: usize) -> String {
 }
 
 pub fn make_alternate_id_from_str(uid: &str, id: &str) -> Result<AlternateId, CliError> {
-    validate_alt_id_format(&id.to_string())?;
+    validate_alt_id_format(id)?;
 
     let split: Vec<&str> = id.split(':').collect();
 

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -176,7 +176,7 @@ impl std::fmt::Display for CliError {
                 feature = "purchase-order",
                 feature = "schema",
             ))]
-            CliError::DaemonError(ref err) => write!(f, "{}", err.replace("\"", "")),
+            CliError::DaemonError(ref err) => write!(f, "{}", err.replace('\"', "")),
             #[cfg(any(
                 feature = "location",
                 feature = "pike",
@@ -184,7 +184,7 @@ impl std::fmt::Display for CliError {
                 feature = "purchase-order",
                 feature = "schema",
             ))]
-            CliError::InternalError(ref err) => write!(f, "{}", err.replace("\"", "")),
+            CliError::InternalError(ref err) => write!(f, "{}", err.replace('\"', "")),
         }
     }
 }

--- a/contracts/location/src/main.rs
+++ b/contracts/location/src/main.rs
@@ -53,13 +53,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LogLevelFilter::Warn,
-        1 => console_log_level = LogLevelFilter::Info,
-        2 => console_log_level = LogLevelFilter::Debug,
-        _ => console_log_level = LogLevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LogLevelFilter::Warn,
+        1 => LogLevelFilter::Info,
+        2 => LogLevelFilter::Debug,
+        _ => LogLevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(

--- a/contracts/product/src/main.rs
+++ b/contracts/product/src/main.rs
@@ -56,13 +56,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LogLevelFilter::Warn,
-        1 => console_log_level = LogLevelFilter::Info,
-        2 => console_log_level = LogLevelFilter::Debug,
-        _ => console_log_level = LogLevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LogLevelFilter::Warn,
+        1 => LogLevelFilter::Info,
+        2 => LogLevelFilter::Debug,
+        _ => LogLevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(

--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -404,7 +404,7 @@ fn update_purchase_order(
         ))),
     }?;
     // Collect the versions from this purchase order
-    let mut existing_versions = purchase_order.versions().to_vec().into_iter();
+    let mut existing_versions = purchase_order.versions().iter().cloned();
     // Lists existing versions if there is also an update payload for the version
     let mut version_updates = payload
         .version_updates()
@@ -523,8 +523,8 @@ fn update_purchase_order(
     // Meld version updates to those into this purchase order's existing versions
     let versions = purchase_order
         .versions()
-        .to_vec()
-        .into_iter()
+        .iter()
+        .cloned()
         .map(|vers| {
             if let Some(updated_vers) = updated_versions.remove(vers.version_id()) {
                 Ok(updated_vers)
@@ -798,7 +798,7 @@ fn convert_update_to_version(
         })?;
     // Check if a new revision is included in the update
     let (current_revision_id, rev_addition): (u64, Option<PurchaseOrderRevision>) =
-        match existing_version.revisions().to_vec().into_iter().last() {
+        match existing_version.revisions().iter().cloned().last() {
             Some(last_rev) => {
                 if last_rev == new_revision {
                     (last_rev.revision_id(), None)

--- a/contracts/purchase_order/src/main.rs
+++ b/contracts/purchase_order/src/main.rs
@@ -55,13 +55,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LogLevelFilter::Warn,
-        1 => console_log_level = LogLevelFilter::Info,
-        2 => console_log_level = LogLevelFilter::Debug,
-        _ => console_log_level = LogLevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LogLevelFilter::Warn,
+        1 => LogLevelFilter::Info,
+        2 => LogLevelFilter::Debug,
+        _ => LogLevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(

--- a/contracts/schema/src/main.rs
+++ b/contracts/schema/src/main.rs
@@ -53,13 +53,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LogLevelFilter::Warn,
-        1 => console_log_level = LogLevelFilter::Info,
-        2 => console_log_level = LogLevelFilter::Debug,
-        _ => console_log_level = LogLevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LogLevelFilter::Warn,
+        1 => LogLevelFilter::Info,
+        2 => LogLevelFilter::Debug,
+        _ => LogLevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(

--- a/contracts/track_and_trace/src/main.rs
+++ b/contracts/track_and_trace/src/main.rs
@@ -53,13 +53,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LogLevelFilter::Warn,
-        1 => console_log_level = LogLevelFilter::Info,
-        2 => console_log_level = LogLevelFilter::Debug,
-        _ => console_log_level = LogLevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LogLevelFilter::Warn,
+        1 => LogLevelFilter::Info,
+        2 => LogLevelFilter::Debug,
+        _ => LogLevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(

--- a/sdk/src/protocol/location/payload.rs
+++ b/sdk/src/protocol/location/payload.rs
@@ -268,8 +268,8 @@ impl FromProto<location_payload::LocationCreateAction> for LocationCreateAction 
             owner: proto.get_owner().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -285,8 +285,8 @@ impl FromNative<LocationCreateAction> for location_payload::LocationCreateAction
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -404,8 +404,8 @@ impl FromProto<protos::location_payload::LocationUpdateAction> for LocationUpdat
             location_id: proto.get_location_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -420,8 +420,8 @@ impl FromNative<LocationUpdateAction> for protos::location_payload::LocationUpda
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,

--- a/sdk/src/protocol/location/state.rs
+++ b/sdk/src/protocol/location/state.rs
@@ -115,8 +115,8 @@ impl FromProto<protos::location_state::Location> for Location {
             owner: location.get_owner().to_string(),
             properties: location
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -132,8 +132,8 @@ impl FromNative<Location> for protos::location_state::Location {
         proto.set_properties(RepeatedField::from_vec(
             location
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<schema_state::PropertyValue>, ProtoConversionError>>()?,
         ));
@@ -273,8 +273,8 @@ impl FromProto<protos::location_state::LocationList> for LocationList {
         Ok(LocationList {
             locations: location_list
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Location::from_proto)
                 .collect::<Result<Vec<Location>, ProtoConversionError>>()?,
         })
@@ -288,8 +288,8 @@ impl FromNative<LocationList> for protos::location_state::LocationList {
         location_list_proto.set_entries(RepeatedField::from_vec(
             location_list
                 .locations()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Location::into_proto)
                 .collect::<Result<Vec<protos::location_state::Location>, ProtoConversionError>>()?,
         ));

--- a/sdk/src/protocol/pike/payload.rs
+++ b/sdk/src/protocol/pike/payload.rs
@@ -82,8 +82,8 @@ impl FromProto<protos::pike_payload::CreateAgentAction> for CreateAgentAction {
             roles: create_agent.get_roles().to_vec(),
             metadata: create_agent
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -102,8 +102,8 @@ impl FromNative<CreateAgentAction> for protos::pike_payload::CreateAgentAction {
         proto_create_agent.set_metadata(RepeatedField::from_vec(
             create_agent
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -275,8 +275,8 @@ impl FromProto<protos::pike_payload::UpdateAgentAction> for UpdateAgentAction {
             roles: update_agent.get_roles().to_vec(),
             metadata: update_agent
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -295,8 +295,8 @@ impl FromNative<UpdateAgentAction> for protos::pike_payload::UpdateAgentAction {
         proto_update_agent.set_metadata(RepeatedField::from_vec(
             update_agent
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -527,14 +527,14 @@ impl FromProto<protos::pike_payload::CreateOrganizationAction> for CreateOrganiz
             name: create_org.get_name().to_string(),
             alternate_ids: create_org
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::from_proto)
                 .collect::<Result<Vec<AlternateId>, ProtoConversionError>>()?,
             metadata: create_org
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -550,16 +550,16 @@ impl FromNative<CreateOrganizationAction> for protos::pike_payload::CreateOrgani
         proto_create_org.set_alternate_ids(RepeatedField::from_vec(
             create_org
                 .alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateId>, ProtoConversionError>>()?,
         ));
         proto_create_org.set_metadata(RepeatedField::from_vec(
             create_org
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -733,14 +733,14 @@ impl FromProto<protos::pike_payload::UpdateOrganizationAction> for UpdateOrganiz
             locations: create_org.get_locations().to_vec(),
             alternate_ids: create_org
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::from_proto)
                 .collect::<Result<Vec<AlternateId>, ProtoConversionError>>()?,
             metadata: create_org
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -757,16 +757,16 @@ impl FromNative<UpdateOrganizationAction> for protos::pike_payload::UpdateOrgani
         proto_update_org.set_alternate_ids(RepeatedField::from_vec(
             update_org
                 .alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateId>, ProtoConversionError>>()?,
         ));
         proto_update_org.set_metadata(RepeatedField::from_vec(
             update_org
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,

--- a/sdk/src/protocol/pike/state.rs
+++ b/sdk/src/protocol/pike/state.rs
@@ -383,8 +383,8 @@ impl FromProto<protos::pike_state::RoleList> for RoleList {
         Ok(RoleList {
             roles: role_list
                 .get_roles()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Role::from_proto)
                 .collect::<Result<Vec<Role>, ProtoConversionError>>()?,
         })
@@ -398,8 +398,8 @@ impl FromNative<RoleList> for protos::pike_state::RoleList {
         role_list_proto.set_roles(RepeatedField::from_vec(
             role_list
                 .roles()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Role::into_proto)
                 .collect::<Result<Vec<protos::pike_state::Role>, ProtoConversionError>>()?,
         ));
@@ -676,8 +676,8 @@ impl FromProto<protos::pike_state::AlternateIdIndexEntryList> for AlternateIdInd
         Ok(AlternateIdIndexEntryList {
             entries: entry_list
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateIdIndexEntry::from_proto)
                 .collect::<Result<Vec<AlternateIdIndexEntry>, ProtoConversionError>>()?,
         })
@@ -691,8 +691,8 @@ impl FromNative<AlternateIdIndexEntryList> for protos::pike_state::AlternateIdIn
         entry_list_proto.set_entries(RepeatedField::from_vec(
             entry_list
                 .entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateIdIndexEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateIdIndexEntry>, ProtoConversionError>>()?,
         ));
@@ -969,8 +969,8 @@ impl FromProto<protos::pike_state::Agent> for Agent {
             roles: agent.get_roles().to_vec(),
             metadata: agent
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -989,8 +989,8 @@ impl FromNative<Agent> for protos::pike_state::Agent {
         agent_proto.set_metadata(RepeatedField::from_vec(
             agent
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -1131,8 +1131,8 @@ impl FromProto<protos::pike_state::AgentList> for AgentList {
         Ok(AgentList {
             agents: agent_list
                 .get_agents()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Agent::from_proto)
                 .collect::<Result<Vec<Agent>, ProtoConversionError>>()?,
         })
@@ -1146,8 +1146,8 @@ impl FromNative<AgentList> for protos::pike_state::AgentList {
         agent_list_proto.set_agents(RepeatedField::from_vec(
             agent_list
                 .agents()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Agent::into_proto)
                 .collect::<Result<Vec<protos::pike_state::Agent>, ProtoConversionError>>()?,
         ));
@@ -1286,14 +1286,14 @@ impl FromProto<protos::pike_state::Organization> for Organization {
             locations: org.get_locations().to_vec(),
             alternate_ids: org
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::from_proto)
                 .collect::<Result<Vec<AlternateId>, ProtoConversionError>>()?,
             metadata: org
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -1309,15 +1309,15 @@ impl FromNative<Organization> for protos::pike_state::Organization {
         org_proto.set_locations(RepeatedField::from_vec(org.locations().to_vec()));
         org_proto.set_alternate_ids(RepeatedField::from_vec(
             org.alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateId>, ProtoConversionError>>()?,
         ));
         org_proto.set_metadata(RepeatedField::from_vec(
             org.metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -1467,8 +1467,8 @@ impl FromProto<protos::pike_state::OrganizationList> for OrganizationList {
         Ok(OrganizationList {
             organizations: organization_list
                 .get_organizations()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Organization::from_proto)
                 .collect::<Result<Vec<Organization>, ProtoConversionError>>()?,
         })
@@ -1482,8 +1482,8 @@ impl FromNative<OrganizationList> for protos::pike_state::OrganizationList {
         org_list_proto.set_organizations(RepeatedField::from_vec(
             org_list
                 .organizations()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Organization::into_proto)
                 .collect::<Result<Vec<protos::pike_state::Organization>, ProtoConversionError>>()?,
         ));

--- a/sdk/src/protocol/product/payload.rs
+++ b/sdk/src/protocol/product/payload.rs
@@ -227,8 +227,8 @@ impl FromProto<product_payload::ProductCreateAction> for ProductCreateAction {
             owner: proto.get_owner().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -244,8 +244,8 @@ impl FromNative<ProductCreateAction> for product_payload::ProductCreateAction {
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -363,8 +363,8 @@ impl FromProto<protos::product_payload::ProductUpdateAction> for ProductUpdateAc
             product_id: proto.get_product_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -379,8 +379,8 @@ impl FromNative<ProductUpdateAction> for protos::product_payload::ProductUpdateA
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,

--- a/sdk/src/protocol/product/state.rs
+++ b/sdk/src/protocol/product/state.rs
@@ -112,8 +112,8 @@ impl FromProto<protos::product_state::Product> for Product {
             owner: product.get_owner().to_string(),
             properties: product
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -129,8 +129,8 @@ impl FromNative<Product> for protos::product_state::Product {
         proto.set_properties(RepeatedField::from_vec(
             product
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<schema_state::PropertyValue>, ProtoConversionError>>()?,
         ));
@@ -280,8 +280,8 @@ impl FromProto<protos::product_state::ProductList> for ProductList {
         Ok(ProductList {
             products: product_list
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Product::from_proto)
                 .collect::<Result<Vec<Product>, ProtoConversionError>>()?,
         })
@@ -295,8 +295,8 @@ impl FromNative<ProductList> for protos::product_state::ProductList {
         product_list_proto.set_entries(RepeatedField::from_vec(
             product_list
                 .products()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Product::into_proto)
                 .collect::<Result<Vec<protos::product_state::Product>, ProtoConversionError>>()?,
         ));

--- a/sdk/src/protocol/purchase_order/payload.rs
+++ b/sdk/src/protocol/purchase_order/payload.rs
@@ -249,8 +249,8 @@ impl FromProto<purchase_order_payload::CreatePurchaseOrderPayload> for CreatePur
             workflow_state: proto.take_workflow_state(),
             alternate_ids: proto
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PurchaseOrderAlternateId::from_proto)
                 .collect::<Result<Vec<PurchaseOrderAlternateId>, ProtoConversionError>>()?,
             create_version_payload,
@@ -269,8 +269,8 @@ impl FromNative<CreatePurchaseOrderPayload> for purchase_order_payload::CreatePu
         proto.set_alternate_ids(RepeatedField::from_vec(
             native
                 .alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PurchaseOrderAlternateId::into_proto)
                 .collect::<Result<
                     Vec<protos::purchase_order_state::PurchaseOrderAlternateId>,
@@ -468,14 +468,14 @@ impl FromProto<purchase_order_payload::UpdatePurchaseOrderPayload> for UpdatePur
             },
             alternate_ids: proto
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PurchaseOrderAlternateId::from_proto)
                 .collect::<Result<Vec<PurchaseOrderAlternateId>, ProtoConversionError>>()?,
             version_updates: proto
                 .get_version_updates()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(UpdateVersionPayload::from_proto)
                 .collect::<Result<Vec<UpdateVersionPayload>, ProtoConversionError>>()?,
         })
@@ -494,8 +494,8 @@ impl FromNative<UpdatePurchaseOrderPayload> for purchase_order_payload::UpdatePu
         proto.set_alternate_ids(RepeatedField::from_vec(
             native
                 .alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PurchaseOrderAlternateId::into_proto)
                 .collect::<Result<
                     Vec<protos::purchase_order_state::PurchaseOrderAlternateId>,
@@ -505,8 +505,8 @@ impl FromNative<UpdatePurchaseOrderPayload> for purchase_order_payload::UpdatePu
         proto.set_version_updates(RepeatedField::from_vec(
             native
                 .version_updates()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(UpdateVersionPayload::into_proto)
                 .collect::<Result<
                     Vec<protos::purchase_order_payload::UpdateVersionPayload>,

--- a/sdk/src/protocol/purchase_order/state.rs
+++ b/sdk/src/protocol/purchase_order/state.rs
@@ -267,8 +267,8 @@ impl FromNative<PurchaseOrderVersion> for purchase_order_state::PurchaseOrderVer
         proto.set_revisions(RepeatedField::from_vec(
             version
                 .revisions()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(|revision| revision.into_proto())
                 .collect::<Result<_, _>>()?,
         ));
@@ -518,8 +518,8 @@ impl FromNative<PurchaseOrder> for purchase_order_state::PurchaseOrder {
         proto.set_versions(RepeatedField::from_vec(
             order
                 .versions()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(|version| version.into_proto())
                 .collect::<Result<_, _>>()?,
         ));
@@ -530,8 +530,8 @@ impl FromNative<PurchaseOrder> for purchase_order_state::PurchaseOrder {
         proto.set_alternate_ids(RepeatedField::from_vec(
             order
                 .alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(|id| id.into_proto())
                 .collect::<Result<_, _>>()?,
         ));
@@ -731,8 +731,8 @@ impl FromProto<purchase_order_state::PurchaseOrderList> for PurchaseOrderList {
         Ok(PurchaseOrderList {
             purchase_orders: order_list
                 .get_purchase_orders()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PurchaseOrder::from_proto)
                 .collect::<Result<Vec<PurchaseOrder>, ProtoConversionError>>()?,
         })
@@ -746,8 +746,8 @@ impl FromNative<PurchaseOrderList> for purchase_order_state::PurchaseOrderList {
         order_list_proto.set_purchase_orders(RepeatedField::from_vec(
             order_list
                 .purchase_orders()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PurchaseOrder::into_proto)
                 .collect::<Result<Vec<purchase_order_state::PurchaseOrder>, ProtoConversionError>>(
                 )?,
@@ -1009,8 +1009,8 @@ impl FromProto<purchase_order_state::PurchaseOrderAlternateIdList>
         Ok(PurchaseOrderAlternateIdList {
             alternate_ids: id_list
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PurchaseOrderAlternateId::from_proto)
                 .collect::<Result<Vec<PurchaseOrderAlternateId>, ProtoConversionError>>()?,
         })
@@ -1027,8 +1027,8 @@ impl FromNative<PurchaseOrderAlternateIdList>
             RepeatedField::from_vec(
                 id_list
                     .alternate_ids()
-                    .to_vec()
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .map(PurchaseOrderAlternateId::into_proto)
                     .collect::<Result<
                         Vec<purchase_order_state::PurchaseOrderAlternateId>,

--- a/sdk/src/protocol/schema/payload.rs
+++ b/sdk/src/protocol/schema/payload.rs
@@ -201,8 +201,8 @@ impl FromProto<protos::schema_payload::SchemaCreateAction> for SchemaCreateActio
             description: schema_create.get_description().to_string(),
             properties: schema_create
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -218,7 +218,7 @@ impl FromNative<SchemaCreateAction> for protos::schema_payload::SchemaCreateActi
         proto_schema_create.set_description(schema_create.description().to_string());
         proto_schema_create.set_properties(
             RepeatedField::from_vec(
-            schema_create.properties().to_vec().into_iter()
+            schema_create.properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
 
@@ -377,8 +377,8 @@ impl FromProto<protos::schema_payload::SchemaUpdateAction> for SchemaUpdateActio
             owner: schema_update.get_owner().to_string(),
             properties: schema_update
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -393,7 +393,7 @@ impl FromNative<SchemaUpdateAction> for protos::schema_payload::SchemaUpdateActi
         proto_schema_update.set_owner(schema_update.owner().to_string());
         proto_schema_update.set_properties(
             RepeatedField::from_vec(
-            schema_update.properties().to_vec().into_iter()
+            schema_update.properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
 

--- a/sdk/src/protocol/schema/state.rs
+++ b/sdk/src/protocol/schema/state.rs
@@ -237,8 +237,8 @@ impl FromProto<protos::schema_state::PropertyDefinition> for PropertyDefinition 
             enum_options: property_definition.get_enum_options().to_vec(),
             struct_properties: property_definition
                 .get_struct_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -259,7 +259,7 @@ impl FromNative<PropertyDefinition> for protos::schema_state::PropertyDefinition
         ));
         proto_property_definition.set_struct_properties(
             RepeatedField::from_vec(
-            property_definition.struct_properties().to_vec().into_iter()
+            property_definition.struct_properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
         Ok(proto_property_definition)
@@ -482,8 +482,8 @@ impl FromProto<protos::schema_state::Schema> for Schema {
             owner: schema.get_owner().to_string(),
             properties: schema
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -499,8 +499,8 @@ impl FromNative<Schema> for protos::schema_state::Schema {
         proto_schema.set_properties(RepeatedField::from_vec(
             schema
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,
         ));
@@ -644,8 +644,8 @@ impl FromProto<protos::schema_state::SchemaList> for SchemaList {
         Ok(SchemaList {
             schemas: schema_list
                 .get_schemas()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Schema::from_proto)
                 .collect::<Result<Vec<Schema>, ProtoConversionError>>()?,
         })
@@ -659,8 +659,8 @@ impl FromNative<SchemaList> for protos::schema_state::SchemaList {
         schema_list_proto.set_schemas(RepeatedField::from_vec(
             schema_list
                 .schemas()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Schema::into_proto)
                 .collect::<Result<Vec<protos::schema_state::Schema>, ProtoConversionError>>()?,
         ));
@@ -824,8 +824,8 @@ impl FromProto<protos::schema_state::PropertyValue> for PropertyValue {
             enum_value: property_value.get_enum_value(),
             struct_values: property_value
                 .get_struct_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
             lat_long_value: property_value.get_lat_long_value().clone().into_native()?,
@@ -846,8 +846,8 @@ impl FromNative<PropertyValue> for protos::schema_state::PropertyValue {
         proto_property_value.set_struct_values(RepeatedField::from_vec(
             property_value
                 .struct_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,

--- a/sdk/src/protocol/track_and_trace/payload.rs
+++ b/sdk/src/protocol/track_and_trace/payload.rs
@@ -100,8 +100,8 @@ impl FromProto<track_and_trace_payload::CreateRecordAction> for CreateRecordActi
             schema: proto.get_schema().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -116,8 +116,8 @@ impl FromNative<CreateRecordAction> for track_and_trace_payload::CreateRecordAct
         proto.set_properties(RepeatedField::from_vec(
             create_record_action
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -286,8 +286,8 @@ impl FromProto<track_and_trace_payload::UpdatePropertiesAction> for UpdateProper
             record_id: proto.get_record_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -301,8 +301,8 @@ impl FromNative<UpdatePropertiesAction> for track_and_trace_payload::UpdatePrope
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -434,8 +434,8 @@ impl FromProto<track_and_trace_payload::CreateProposalAction> for CreateProposal
             role: Role::from_proto(proto.get_role())?,
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(String::from)
                 .collect(),
             terms: proto.get_terms().to_string(),
@@ -718,8 +718,8 @@ impl FromProto<track_and_trace_payload::RevokeReporterAction> for RevokeReporter
             reporter_id: proto.get_reporter_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(String::from)
                 .collect(),
         })

--- a/sdk/src/protocol/track_and_trace/state.rs
+++ b/sdk/src/protocol/track_and_trace/state.rs
@@ -262,8 +262,8 @@ impl FromProto<track_and_trace_state::Property> for Property {
             )?,
             reporters: proto
                 .get_reporters()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Reporter::from_proto)
                 .collect::<Result<Vec<Reporter>, ProtoConversionError>>()?,
             current_page: proto.get_current_page(),
@@ -280,8 +280,8 @@ impl FromNative<Property> for track_and_trace_state::Property {
         proto.set_property_definition(native.property_definition().clone().into_proto()?);
         proto.set_reporters(RepeatedField::from_vec(
             native.reporters()
-            .to_vec()
-            .into_iter()
+            .iter()
+            .cloned()
             .map(Reporter::into_proto)
             .collect::<Result<Vec<track_and_trace_state::Property_Reporter>, ProtoConversionError>>()?));
         proto.set_current_page(*native.current_page());
@@ -357,8 +357,8 @@ impl FromProto<track_and_trace_state::PropertyList> for PropertyList {
         Ok(PropertyList {
             properties: proto
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Property::from_proto)
                 .collect::<Result<Vec<Property>, ProtoConversionError>>()?,
         })
@@ -371,8 +371,8 @@ impl FromNative<PropertyList> for track_and_trace_state::PropertyList {
         proto.set_entries(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Property::into_proto)
                 .collect::<Result<Vec<track_and_trace_state::Property>, ProtoConversionError>>()?,
         ));
@@ -604,8 +604,8 @@ impl FromProto<track_and_trace_state::PropertyPage> for PropertyPage {
             record_id: proto.get_record_id().to_string(),
             reported_values: proto
                 .get_reported_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(ReportedValue::from_proto)
                 .collect::<Result<Vec<ReportedValue>, ProtoConversionError>>()?,
         })
@@ -620,8 +620,8 @@ impl FromNative<PropertyPage> for track_and_trace_state::PropertyPage {
         proto.set_reported_values(RepeatedField::from_vec(
             native
                 .reported_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(ReportedValue::into_proto)
                 .collect::<Result<
                     Vec<track_and_trace_state::PropertyPage_ReportedValue>,
@@ -703,8 +703,8 @@ impl FromProto<track_and_trace_state::PropertyPageList> for PropertyPageList {
         Ok(PropertyPageList {
             property_pages: proto
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyPage::from_proto)
                 .collect::<Result<Vec<PropertyPage>, ProtoConversionError>>()?,
         })
@@ -717,8 +717,8 @@ impl FromNative<PropertyPageList> for track_and_trace_state::PropertyPageList {
         proto.set_entries(RepeatedField::from_vec(
             native
                 .property_pages()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyPage::into_proto)
                 .collect::<Result<Vec<track_and_trace_state::PropertyPage>, ProtoConversionError>>(
                 )?,
@@ -985,8 +985,8 @@ impl FromProto<track_and_trace_state::Proposal> for Proposal {
             role: Role::from_proto(proto.get_role())?,
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(String::from)
                 .collect(),
             status: Status::from_proto(proto.get_status())?,
@@ -1079,8 +1079,8 @@ impl FromProto<track_and_trace_state::ProposalList> for ProposalList {
         Ok(ProposalList {
             proposals: proto
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Proposal::from_proto)
                 .collect::<Result<Vec<Proposal>, ProtoConversionError>>()?,
         })
@@ -1093,8 +1093,8 @@ impl FromNative<ProposalList> for track_and_trace_state::ProposalList {
         proto.set_entries(RepeatedField::from_vec(
             native
                 .proposals()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Proposal::into_proto)
                 .collect::<Result<Vec<track_and_trace_state::Proposal>, ProtoConversionError>>()?,
         ));
@@ -1338,14 +1338,14 @@ impl FromProto<track_and_trace_state::Record> for Record {
             schema: proto.get_schema().to_string(),
             owners: proto
                 .get_owners()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AssociatedAgent::from_proto)
                 .collect::<Result<Vec<AssociatedAgent>, ProtoConversionError>>()?,
             custodians: proto
                 .get_custodians()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AssociatedAgent::from_proto)
                 .collect::<Result<Vec<AssociatedAgent>, ProtoConversionError>>()?,
             field_final: proto.get_field_final(),
@@ -1362,8 +1362,8 @@ impl FromNative<Record> for track_and_trace_state::Record {
             RepeatedField::from_vec(
                 native
                     .owners()
-                    .to_vec()
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .map(AssociatedAgent::into_proto)
                     .collect::<Result<
                         Vec<track_and_trace_state::Record_AssociatedAgent>,
@@ -1375,8 +1375,8 @@ impl FromNative<Record> for track_and_trace_state::Record {
             RepeatedField::from_vec(
                 native
                     .custodians()
-                    .to_vec()
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .map(AssociatedAgent::into_proto)
                     .collect::<Result<
                         Vec<track_and_trace_state::Record_AssociatedAgent>,
@@ -1454,8 +1454,8 @@ impl FromProto<track_and_trace_state::RecordList> for RecordList {
         Ok(RecordList {
             records: proto
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Record::from_proto)
                 .collect::<Result<Vec<Record>, ProtoConversionError>>()?,
         })
@@ -1468,8 +1468,8 @@ impl FromNative<RecordList> for track_and_trace_state::RecordList {
         proto.set_entries(RepeatedField::from_vec(
             native
                 .records()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Record::into_proto)
                 .collect::<Result<Vec<track_and_trace_state::Record>, ProtoConversionError>>()?,
         ));

--- a/sdk/src/rest_api/resources/submit/v1/payloads/location.rs
+++ b/sdk/src/rest_api/resources/submit/v1/payloads/location.rs
@@ -200,8 +200,8 @@ impl FromProto<location_payload::LocationCreateAction> for LocationCreateAction 
             owner: proto.get_owner().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -217,8 +217,8 @@ impl FromNative<LocationCreateAction> for location_payload::LocationCreateAction
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -334,8 +334,8 @@ impl FromProto<protos::location_payload::LocationUpdateAction> for LocationUpdat
             location_id: proto.get_location_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -350,8 +350,8 @@ impl FromNative<LocationUpdateAction> for protos::location_payload::LocationUpda
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,

--- a/sdk/src/rest_api/resources/submit/v1/payloads/pike.rs
+++ b/sdk/src/rest_api/resources/submit/v1/payloads/pike.rs
@@ -80,8 +80,8 @@ impl FromProto<protos::pike_payload::CreateAgentAction> for CreateAgentAction {
             roles: create_agent.get_roles().to_vec(),
             metadata: create_agent
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -100,8 +100,8 @@ impl FromNative<CreateAgentAction> for protos::pike_payload::CreateAgentAction {
         proto_create_agent.set_metadata(RepeatedField::from_vec(
             create_agent
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -244,8 +244,8 @@ impl FromProto<protos::pike_payload::UpdateAgentAction> for UpdateAgentAction {
             roles: update_agent.get_roles().to_vec(),
             metadata: update_agent
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -264,8 +264,8 @@ impl FromNative<UpdateAgentAction> for protos::pike_payload::UpdateAgentAction {
         proto_update_agent.set_metadata(RepeatedField::from_vec(
             update_agent
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -499,14 +499,14 @@ impl FromProto<protos::pike_payload::CreateOrganizationAction> for CreateOrganiz
             name: create_org.get_name().to_string(),
             alternate_ids: create_org
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::from_proto)
                 .collect::<Result<Vec<AlternateId>, ProtoConversionError>>()?,
             metadata: create_org
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -522,16 +522,16 @@ impl FromNative<CreateOrganizationAction> for protos::pike_payload::CreateOrgani
         proto_create_org.set_alternate_ids(RepeatedField::from_vec(
             create_org
                 .alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateId>, ProtoConversionError>>()?,
         ));
         proto_create_org.set_metadata(RepeatedField::from_vec(
             create_org
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -670,15 +670,15 @@ impl FromProto<protos::pike_payload::UpdateOrganizationAction> for UpdateOrganiz
             name: update_org.get_name().to_string(),
             alternate_ids: update_org
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::from_proto)
                 .collect::<Result<Vec<AlternateId>, ProtoConversionError>>()?,
             locations: update_org.get_locations().to_vec(),
             metadata: update_org
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -694,8 +694,8 @@ impl FromNative<UpdateOrganizationAction> for protos::pike_payload::UpdateOrgani
         proto_update_org.set_alternate_ids(RepeatedField::from_vec(
             update_org
                 .alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateId>, ProtoConversionError>>()?,
         ));
@@ -703,8 +703,8 @@ impl FromNative<UpdateOrganizationAction> for protos::pike_payload::UpdateOrgani
         proto_update_org.set_metadata(RepeatedField::from_vec(
             update_org
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,

--- a/sdk/src/rest_api/resources/submit/v1/payloads/product.rs
+++ b/sdk/src/rest_api/resources/submit/v1/payloads/product.rs
@@ -203,8 +203,8 @@ impl FromProto<product_payload::ProductCreateAction> for ProductCreateAction {
             owner: proto.get_owner().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -220,8 +220,8 @@ impl FromNative<ProductCreateAction> for product_payload::ProductCreateAction {
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -337,8 +337,8 @@ impl FromProto<protos::product_payload::ProductUpdateAction> for ProductUpdateAc
             product_id: proto.get_product_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -353,8 +353,8 @@ impl FromNative<ProductUpdateAction> for protos::product_payload::ProductUpdateA
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,

--- a/sdk/src/rest_api/resources/submit/v1/payloads/schema.rs
+++ b/sdk/src/rest_api/resources/submit/v1/payloads/schema.rs
@@ -147,8 +147,8 @@ impl FromProto<protos::schema_payload::SchemaCreateAction> for SchemaCreateActio
             description: schema_create.get_description().to_string(),
             properties: schema_create
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -163,7 +163,7 @@ impl FromNative<SchemaCreateAction> for protos::schema_payload::SchemaCreateActi
         proto_schema_create.set_description(schema_create.description().to_string());
         proto_schema_create.set_properties(
             RepeatedField::from_vec(
-            schema_create.properties().to_vec().into_iter()
+            schema_create.properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
 
@@ -274,8 +274,8 @@ impl FromProto<protos::schema_payload::SchemaUpdateAction> for SchemaUpdateActio
             schema_name: schema_update.get_schema_name().to_string(),
             properties: schema_update
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -289,7 +289,7 @@ impl FromNative<SchemaUpdateAction> for protos::schema_payload::SchemaUpdateActi
         proto_schema_update.set_schema_name(schema_update.schema_name().to_string());
         proto_schema_update.set_properties(
             RepeatedField::from_vec(
-            schema_update.properties().to_vec().into_iter()
+            schema_update.properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
 
@@ -421,8 +421,8 @@ impl FromProto<protos::schema_state::PropertyDefinition> for PropertyDefinition 
             enum_options: property_definition.get_enum_options().to_vec(),
             struct_properties: property_definition
                 .get_struct_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -443,7 +443,7 @@ impl FromNative<PropertyDefinition> for protos::schema_state::PropertyDefinition
         ));
         proto_property_definition.set_struct_properties(
             RepeatedField::from_vec(
-            property_definition.struct_properties().to_vec().into_iter()
+            property_definition.struct_properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
         Ok(proto_property_definition)
@@ -658,8 +658,8 @@ impl FromProto<protos::schema_state::PropertyValue> for PropertyValue {
             enum_value: property_value.get_enum_value(),
             struct_values: property_value
                 .get_struct_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
             lat_long_value: property_value.get_lat_long_value().clone().into_native()?,
@@ -680,8 +680,8 @@ impl FromNative<PropertyValue> for protos::schema_state::PropertyValue {
         proto_property_value.set_struct_values(RepeatedField::from_vec(
             property_value
                 .struct_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,


### PR DESCRIPTION
This fixes the clippy formatting errors introduced with Rust v1.59

Signed-off-by: Davey Newhall <newhall@bitwise.io>