### PR TITLE
Backport 0-2: Fix 1.59 clippy errors

### DIFF
--- a/cli/src/actions/schemas.rs
+++ b/cli/src/actions/schemas.rs
@@ -529,9 +529,9 @@ mod test {
         run_test(|test_yaml_file_path| {
             let mut file =
                 File::create(test_yaml_file_path).expect("Error creating test schema yaml file.");
-            file.write(LIGHTBULB_YAML_EXAMPLE)
+            file.write_all(LIGHTBULB_YAML_EXAMPLE)
                 .expect("Error writting example schema.");
-            file.write(PHONE_YAML_EXAMPLE)
+            file.write_all(PHONE_YAML_EXAMPLE)
                 .expect("Error writting example schema.");
 
             let payload = parse_yaml(
@@ -577,9 +577,9 @@ mod test {
         run_test(|test_yaml_file_path| {
             let mut file =
                 File::create(test_yaml_file_path).expect("Error creating test schema yaml file.");
-            file.write(LIGHTBULB_YAML_EXAMPLE)
+            file.write_all(LIGHTBULB_YAML_EXAMPLE)
                 .expect("Error writting example schema.");
-            file.write(PHONE_YAML_EXAMPLE)
+            file.write_all(PHONE_YAML_EXAMPLE)
                 .expect("Error writting example schema.");
 
             let payload = parse_yaml(
@@ -748,9 +748,9 @@ mod test {
             .unwrap()
     }
 
-    fn run_test<T>(test: T) -> ()
+    fn run_test<T>(test: T)
     where
-        T: FnOnce(&str) -> () + panic::UnwindSafe,
+        T: FnOnce(&str) + panic::UnwindSafe,
     {
         let test_yaml_file = temp_yaml_file_path();
 

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -127,7 +127,7 @@ impl std::fmt::Display for CliError {
                 feature = "product",
                 feature = "schema",
             ))]
-            CliError::DaemonError(ref err) => write!(f, "{}", err.replace("\"", "")),
+            CliError::DaemonError(ref err) => write!(f, "{}", err.replace('\"', "")),
         }
     }
 }

--- a/cli/src/yaml_parser.rs
+++ b/cli/src/yaml_parser.rs
@@ -236,7 +236,7 @@ mod test {
         );
         assert_eq!(
             parse_value_as_string(&property_valid, &key).unwrap(),
-            Some(string_value.clone())
+            Some(string_value)
         );
 
         // Check method returns an error when key is found but value cannot be parsed into a
@@ -262,10 +262,10 @@ mod test {
 
         // Check method can properly parse a boolean value
         let mut property_valid = Mapping::new();
-        property_valid.insert(Value::String(key.clone()), Value::Bool(bool_value.clone()));
+        property_valid.insert(Value::String(key.clone()), Value::Bool(bool_value));
         assert_eq!(
             parse_value_as_boolean(&property_valid, &key).unwrap(),
-            Some(bool_value.clone())
+            Some(bool_value)
         );
 
         // Check method returns an error when key is found but value cannot be parsed into a
@@ -293,11 +293,11 @@ mod test {
         let mut property_valid = Mapping::new();
         property_valid.insert(
             Value::String(key.clone()),
-            Value::Number(number_value.clone().into()),
+            Value::Number(number_value.into()),
         );
         assert_eq!(
             parse_value_as_i32(&property_valid, &key).unwrap(),
-            Some(number_value.clone())
+            Some(number_value)
         );
 
         // Check method returns an error when key is found but value overflows an i32 capacity.
@@ -336,7 +336,7 @@ mod test {
         property_valid.insert(Value::String(key.clone()), Value::Sequence(sequence_value));
         assert_eq!(
             parse_value_as_vec_string(&property_valid, &key).unwrap(),
-            Some(vec![string_value.clone()])
+            Some(vec![string_value])
         );
 
         // Check method returns an error when key is found but values inside the sequence cannot

--- a/cli/tests/product.rs
+++ b/cli/tests/product.rs
@@ -48,14 +48,15 @@ mod integration {
     #[test]
     fn test_product_create() {
         get_setup();
-        let url = env::var("INTEGRATION_TEST_URL").unwrap_or("http://gridd:8080".to_string());
+        let url =
+            env::var("INTEGRATION_TEST_URL").unwrap_or_else(|_| "http://gridd:8080".to_string());
         //run `grid product create`
         let mut cmd_product_create = make_grid_command();
         cmd_product_create
             .arg("product")
             .args(&["--url", &url])
             .arg("create")
-            .args(&["--file", &PRODUCT_CREATE_FILE])
+            .args(&["--file", PRODUCT_CREATE_FILE])
             .args(&["--wait", "300000"]);
         cmd_product_create.assert().success();
     }
@@ -69,14 +70,15 @@ mod integration {
     #[test]
     fn test_product_update() {
         get_setup();
-        let url = env::var("INTEGRATION_TEST_URL").unwrap_or("http://gridd:8080".to_string());
+        let url =
+            env::var("INTEGRATION_TEST_URL").unwrap_or_else(|_| "http://gridd:8080".to_string());
         //run `grid product create`
         let mut cmd_product_create = make_grid_command();
         cmd_product_create
             .arg("product")
             .args(&["--url", &url])
             .arg("create")
-            .args(&["--file", &PRODUCT_CREATE_FILE])
+            .args(&["--file", PRODUCT_CREATE_FILE])
             .args(&["--wait", "300000"]);
         cmd_product_create.assert().success();
 
@@ -86,7 +88,7 @@ mod integration {
             .arg("product")
             .args(&["--url", &url])
             .arg("update")
-            .args(&["--file", &PRODUCT_UPDATE_FILE])
+            .args(&["--file", PRODUCT_UPDATE_FILE])
             .args(&["--wait", "300000"]);
         cmd_product_update.assert().success();
     }
@@ -100,14 +102,15 @@ mod integration {
     #[test]
     fn test_product_delete() {
         get_setup();
-        let url = env::var("INTEGRATION_TEST_URL").unwrap_or("http://gridd:8080".to_string());
+        let url =
+            env::var("INTEGRATION_TEST_URL").unwrap_or_else(|_| "http://gridd:8080".to_string());
         //run `grid product create`
         let mut cmd_product_create = make_grid_command();
         cmd_product_create
             .arg("product")
             .args(&["--url", &url])
             .arg("create")
-            .args(&["--file", &PRODUCT_CREATE_FILE])
+            .args(&["--file", PRODUCT_CREATE_FILE])
             .args(&["--wait", "300000"]);
         cmd_product_create.assert().success();
 
@@ -128,7 +131,8 @@ mod integration {
     ///     Necessary to run product commands
     ///
     fn setup() {
-        let url = env::var("INTEGRATION_TEST_URL").unwrap_or("http://gridd:8080".to_string());
+        let url =
+            env::var("INTEGRATION_TEST_URL").unwrap_or_else(|_| "http://gridd:8080".to_string());
         //run `grid keygen`
         let key_name: String = get_current_username().unwrap().into_string().unwrap();
         println!("key name: {}", &key_name);
@@ -172,7 +176,7 @@ mod integration {
             .arg(&ORG_ID)
             .arg("test")
             .args(&["-d", "Schema/product perms"])
-            .args(&["--permissions", &permissions])
+            .args(&["--permissions", permissions])
             .arg("--active")
             .args(&["--wait", "300000"]);
         cmd_role_create.assert().success();
@@ -211,7 +215,7 @@ mod integration {
     fn make_grid_command() -> Command {
         let mut cmd = Command::cargo_bin("grid").unwrap();
         cmd.arg("-vv");
-        return cmd;
+        cmd
     }
 
     /// Gets a memoized setup

--- a/contracts/location/src/main.rs
+++ b/contracts/location/src/main.rs
@@ -53,13 +53,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LogLevelFilter::Warn,
-        1 => console_log_level = LogLevelFilter::Info,
-        2 => console_log_level = LogLevelFilter::Debug,
-        _ => console_log_level = LogLevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LogLevelFilter::Warn,
+        1 => LogLevelFilter::Info,
+        2 => LogLevelFilter::Debug,
+        _ => LogLevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(

--- a/contracts/product/src/main.rs
+++ b/contracts/product/src/main.rs
@@ -56,13 +56,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LogLevelFilter::Warn,
-        1 => console_log_level = LogLevelFilter::Info,
-        2 => console_log_level = LogLevelFilter::Debug,
-        _ => console_log_level = LogLevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LogLevelFilter::Warn,
+        1 => LogLevelFilter::Info,
+        2 => LogLevelFilter::Debug,
+        _ => LogLevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(

--- a/contracts/purchase_order/src/main.rs
+++ b/contracts/purchase_order/src/main.rs
@@ -53,13 +53,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LogLevelFilter::Warn,
-        1 => console_log_level = LogLevelFilter::Info,
-        2 => console_log_level = LogLevelFilter::Debug,
-        _ => console_log_level = LogLevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LogLevelFilter::Warn,
+        1 => LogLevelFilter::Info,
+        2 => LogLevelFilter::Debug,
+        _ => LogLevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(

--- a/contracts/schema/src/main.rs
+++ b/contracts/schema/src/main.rs
@@ -53,13 +53,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LogLevelFilter::Warn,
-        1 => console_log_level = LogLevelFilter::Info,
-        2 => console_log_level = LogLevelFilter::Debug,
-        _ => console_log_level = LogLevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LogLevelFilter::Warn,
+        1 => LogLevelFilter::Info,
+        2 => LogLevelFilter::Debug,
+        _ => LogLevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(

--- a/contracts/track_and_trace/src/main.rs
+++ b/contracts/track_and_trace/src/main.rs
@@ -53,13 +53,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LogLevelFilter::Warn,
-        1 => console_log_level = LogLevelFilter::Info,
-        2 => console_log_level = LogLevelFilter::Debug,
-        _ => console_log_level = LogLevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LogLevelFilter::Warn,
+        1 => LogLevelFilter::Info,
+        2 => LogLevelFilter::Debug,
+        _ => LogLevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(

--- a/daemon/src/rest_api/mod.rs
+++ b/daemon/src/rest_api/mod.rs
@@ -161,7 +161,6 @@ mod test {
     use diesel::r2d2::{ConnectionManager, Pool};
     use diesel::SqliteConnection;
     use futures::prelude::*;
-    use serde_json;
 
     use grid_sdk::backend::BackendClientError;
     use grid_sdk::backend::{
@@ -288,7 +287,7 @@ mod test {
                             .collect::<Vec<_>>()
                             .join(",");
 
-                        let mut response_url = msg.response_url.clone();
+                        let mut response_url = msg.response_url;
                         response_url.set_query(Some(&format!("id={}", batch_query)));
 
                         Ok(BatchStatusLink {
@@ -1191,7 +1190,7 @@ mod test {
         let mut response = srv
             .request(
                 http::Method::GET,
-                srv.url(&format!("/schema/{}", "TestGridSchema".to_string())),
+                srv.url(&format!("/schema/{}", "TestGridSchema")),
             )
             .send()
             .await
@@ -1420,7 +1419,7 @@ mod test {
         let mut response = srv
             .request(
                 http::Method::GET,
-                srv.url(&format!("/product/{}", "041205707820".to_string())),
+                srv.url(&format!("/product/{}", "041205707820")),
             )
             .send()
             .await
@@ -1449,7 +1448,7 @@ mod test {
         let mut response = srv
             .request(
                 http::Method::GET,
-                srv.url(&format!("/location/{}", "0653114000000".to_string())),
+                srv.url(&format!("/location/{}", "0653114000000")),
             )
             .send()
             .await
@@ -2889,7 +2888,7 @@ mod test {
             .with_end_commit_num(i64::MAX);
 
         if let Some(service_id) = service_id {
-            agent = agent.with_service_id(service_id.to_string())
+            agent = agent.with_service_id(service_id)
         }
 
         vec![agent.build().expect("Unable to build Pike Agent")]
@@ -2945,7 +2944,7 @@ mod test {
                 .with_start_commit_num(1)
                 .with_end_commit_num(i64::MAX);
             if let Some(id) = service_id {
-                builder = builder.with_service_id(id.to_string());
+                builder = builder.with_service_id(id);
             }
             builder.build().expect("Unable to build organization")
         };
@@ -3483,7 +3482,7 @@ mod test {
                 number_exponent: 0,
                 enum_options: vec![],
                 struct_properties: vec![],
-                service_id: service_id,
+                service_id,
             },
         ]
     }
@@ -3602,7 +3601,7 @@ mod test {
                 .with_lat_long_value(None)
                 .with_start_commit_number(0)
                 .with_end_commit_number(i64::MAX)
-                .with_service_id(service_id.clone())
+                .with_service_id(service_id)
                 .build()
                 .unwrap(),
         ]

--- a/daemon/src/sawtooth/event.rs
+++ b/daemon/src/sawtooth/event.rs
@@ -471,7 +471,7 @@ mod tests {
 
     fn create_state_change(address: String, value: Option<Vec<u8>>) -> SawtoothStateChange {
         let mut state_change = SawtoothStateChange::new();
-        state_change.set_address(address.clone());
+        state_change.set_address(address);
 
         match value {
             Some(value) => {

--- a/sdk/src/pike/permissions/mod.rs
+++ b/sdk/src/pike/permissions/mod.rs
@@ -283,14 +283,14 @@ mod tests {
 
     fn agent_to_bytes(agent: Agent) -> Vec<u8> {
         let builder = AgentListBuilder::new();
-        let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
-        return agent_list.into_bytes().unwrap();
+        let agent_list = builder.with_agents(vec![agent]).build().unwrap();
+        agent_list.into_bytes().unwrap()
     }
 
     fn role_to_bytes(role: Role) -> Vec<u8> {
         let builder = RoleListBuilder::new();
-        let role_list = builder.with_roles(vec![role.clone()]).build().unwrap();
-        return role_list.into_bytes().unwrap();
+        let role_list = builder.with_roles(vec![role]).build().unwrap();
+        role_list.into_bytes().unwrap()
     }
 
     /// These tests are based on the example in the Grid Identity RFC.
@@ -542,7 +542,7 @@ mod tests {
             .build()
             .unwrap();
         let builder = AgentListBuilder::new();
-        let agent_list = builder.with_agents(vec![agent.clone()]).build().unwrap();
+        let agent_list = builder.with_agents(vec![agent]).build().unwrap();
         let agent_bytes = agent_list.into_bytes().unwrap();
         let agent_address = compute_agent_address(PUBLIC_KEY);
         context.set_state_entry(agent_address, agent_bytes).unwrap();

--- a/sdk/src/product/gdsn/mod.rs
+++ b/sdk/src/product/gdsn/mod.rs
@@ -232,12 +232,10 @@ mod tests {
         let mut payload_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         payload_path.push(path);
 
-        let payload = read_to_string(payload_path)
+        read_to_string(payload_path)
             .unwrap()
             .replace("    ", "")
-            .replace("\n", "");
-
-        payload
+            .replace('\n', "")
     }
 
     /// Test that a well-formed and valid XML file with a gridTradeItems element

--- a/sdk/src/protocol/location/payload.rs
+++ b/sdk/src/protocol/location/payload.rs
@@ -257,8 +257,8 @@ impl FromProto<location_payload::LocationCreateAction> for LocationCreateAction 
             owner: proto.get_owner().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -274,8 +274,8 @@ impl FromNative<LocationCreateAction> for location_payload::LocationCreateAction
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -391,8 +391,8 @@ impl FromProto<protos::location_payload::LocationUpdateAction> for LocationUpdat
             location_id: proto.get_location_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -407,8 +407,8 @@ impl FromNative<LocationUpdateAction> for protos::location_payload::LocationUpda
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,

--- a/sdk/src/protocol/location/state.rs
+++ b/sdk/src/protocol/location/state.rs
@@ -106,8 +106,8 @@ impl FromProto<protos::location_state::Location> for Location {
             owner: location.get_owner().to_string(),
             properties: location
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -123,8 +123,8 @@ impl FromNative<Location> for protos::location_state::Location {
         proto.set_properties(RepeatedField::from_vec(
             location
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<schema_state::PropertyValue>, ProtoConversionError>>()?,
         ));
@@ -260,8 +260,8 @@ impl FromProto<protos::location_state::LocationList> for LocationList {
         Ok(LocationList {
             locations: location_list
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Location::from_proto)
                 .collect::<Result<Vec<Location>, ProtoConversionError>>()?,
         })
@@ -275,8 +275,8 @@ impl FromNative<LocationList> for protos::location_state::LocationList {
         location_list_proto.set_entries(RepeatedField::from_vec(
             location_list
                 .locations()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Location::into_proto)
                 .collect::<Result<Vec<protos::location_state::Location>, ProtoConversionError>>()?,
         ));

--- a/sdk/src/protocol/pike/payload.rs
+++ b/sdk/src/protocol/pike/payload.rs
@@ -80,8 +80,8 @@ impl FromProto<protos::pike_payload::CreateAgentAction> for CreateAgentAction {
             roles: create_agent.get_roles().to_vec(),
             metadata: create_agent
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -100,8 +100,8 @@ impl FromNative<CreateAgentAction> for protos::pike_payload::CreateAgentAction {
         proto_create_agent.set_metadata(RepeatedField::from_vec(
             create_agent
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -271,8 +271,8 @@ impl FromProto<protos::pike_payload::UpdateAgentAction> for UpdateAgentAction {
             roles: update_agent.get_roles().to_vec(),
             metadata: update_agent
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -291,8 +291,8 @@ impl FromNative<UpdateAgentAction> for protos::pike_payload::UpdateAgentAction {
         proto_update_agent.set_metadata(RepeatedField::from_vec(
             update_agent
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -521,14 +521,14 @@ impl FromProto<protos::pike_payload::CreateOrganizationAction> for CreateOrganiz
             name: create_org.get_name().to_string(),
             alternate_ids: create_org
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::from_proto)
                 .collect::<Result<Vec<AlternateId>, ProtoConversionError>>()?,
             metadata: create_org
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -544,16 +544,16 @@ impl FromNative<CreateOrganizationAction> for protos::pike_payload::CreateOrgani
         proto_create_org.set_alternate_ids(RepeatedField::from_vec(
             create_org
                 .alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateId>, ProtoConversionError>>()?,
         ));
         proto_create_org.set_metadata(RepeatedField::from_vec(
             create_org
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -725,14 +725,14 @@ impl FromProto<protos::pike_payload::UpdateOrganizationAction> for UpdateOrganiz
             locations: create_org.get_locations().to_vec(),
             alternate_ids: create_org
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::from_proto)
                 .collect::<Result<Vec<AlternateId>, ProtoConversionError>>()?,
             metadata: create_org
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -749,16 +749,16 @@ impl FromNative<UpdateOrganizationAction> for protos::pike_payload::UpdateOrgani
         proto_update_org.set_alternate_ids(RepeatedField::from_vec(
             update_org
                 .alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateId>, ProtoConversionError>>()?,
         ));
         proto_update_org.set_metadata(RepeatedField::from_vec(
             update_org
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -1836,7 +1836,7 @@ mod tests {
             .with_public_key("public_key".to_string())
             .with_active(true)
             .with_roles(vec!["Role".to_string()])
-            .with_metadata(vec![key_value.clone()])
+            .with_metadata(vec![key_value])
             .build()
             .unwrap();
 
@@ -1888,7 +1888,7 @@ mod tests {
             .with_public_key("public_key".to_string())
             .with_active(true)
             .with_roles(vec!["Role".to_string()])
-            .with_metadata(vec![key_value.clone()])
+            .with_metadata(vec![key_value])
             .build()
             .unwrap();
 
@@ -1934,7 +1934,7 @@ mod tests {
         let original = builder
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
-            .with_metadata(vec![key_value.clone()])
+            .with_metadata(vec![key_value])
             .build()
             .unwrap();
 
@@ -1991,7 +1991,7 @@ mod tests {
             .with_public_key("public_key".to_string())
             .with_active(true)
             .with_roles(vec!["Role".to_string()])
-            .with_metadata(vec![key_value.clone()])
+            .with_metadata(vec![key_value])
             .build()
             .unwrap();
 
@@ -2026,7 +2026,7 @@ mod tests {
             .with_public_key("public_key".to_string())
             .with_active(true)
             .with_roles(vec!["Role".to_string()])
-            .with_metadata(vec![key_value.clone()])
+            .with_metadata(vec![key_value])
             .build()
             .unwrap();
 

--- a/sdk/src/protocol/pike/state.rs
+++ b/sdk/src/protocol/pike/state.rs
@@ -371,8 +371,8 @@ impl FromProto<protos::pike_state::RoleList> for RoleList {
         Ok(RoleList {
             roles: role_list
                 .get_roles()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Role::from_proto)
                 .collect::<Result<Vec<Role>, ProtoConversionError>>()?,
         })
@@ -386,8 +386,8 @@ impl FromNative<RoleList> for protos::pike_state::RoleList {
         role_list_proto.set_roles(RepeatedField::from_vec(
             role_list
                 .roles()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Role::into_proto)
                 .collect::<Result<Vec<protos::pike_state::Role>, ProtoConversionError>>()?,
         ));
@@ -657,8 +657,8 @@ impl FromProto<protos::pike_state::AlternateIdIndexEntryList> for AlternateIdInd
         Ok(AlternateIdIndexEntryList {
             entries: entry_list
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateIdIndexEntry::from_proto)
                 .collect::<Result<Vec<AlternateIdIndexEntry>, ProtoConversionError>>()?,
         })
@@ -672,8 +672,8 @@ impl FromNative<AlternateIdIndexEntryList> for protos::pike_state::AlternateIdIn
         entry_list_proto.set_entries(RepeatedField::from_vec(
             entry_list
                 .entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateIdIndexEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateIdIndexEntry>, ProtoConversionError>>()?,
         ));
@@ -940,8 +940,8 @@ impl FromProto<protos::pike_state::Agent> for Agent {
             roles: agent.get_roles().to_vec(),
             metadata: agent
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -960,8 +960,8 @@ impl FromNative<Agent> for protos::pike_state::Agent {
         agent_proto.set_metadata(RepeatedField::from_vec(
             agent
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -1100,8 +1100,8 @@ impl FromProto<protos::pike_state::AgentList> for AgentList {
         Ok(AgentList {
             agents: agent_list
                 .get_agents()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Agent::from_proto)
                 .collect::<Result<Vec<Agent>, ProtoConversionError>>()?,
         })
@@ -1115,8 +1115,8 @@ impl FromNative<AgentList> for protos::pike_state::AgentList {
         agent_list_proto.set_agents(RepeatedField::from_vec(
             agent_list
                 .agents()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Agent::into_proto)
                 .collect::<Result<Vec<protos::pike_state::Agent>, ProtoConversionError>>()?,
         ));
@@ -1250,14 +1250,14 @@ impl FromProto<protos::pike_state::Organization> for Organization {
             locations: org.get_locations().to_vec(),
             alternate_ids: org
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::from_proto)
                 .collect::<Result<Vec<AlternateId>, ProtoConversionError>>()?,
             metadata: org
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -1273,15 +1273,15 @@ impl FromNative<Organization> for protos::pike_state::Organization {
         org_proto.set_locations(RepeatedField::from_vec(org.locations().to_vec()));
         org_proto.set_alternate_ids(RepeatedField::from_vec(
             org.alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateId>, ProtoConversionError>>()?,
         ));
         org_proto.set_metadata(RepeatedField::from_vec(
             org.metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -1429,8 +1429,8 @@ impl FromProto<protos::pike_state::OrganizationList> for OrganizationList {
         Ok(OrganizationList {
             organizations: organization_list
                 .get_organizations()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Organization::from_proto)
                 .collect::<Result<Vec<Organization>, ProtoConversionError>>()?,
         })
@@ -1444,8 +1444,8 @@ impl FromNative<OrganizationList> for protos::pike_state::OrganizationList {
         org_list_proto.set_organizations(RepeatedField::from_vec(
             org_list
                 .organizations()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Organization::into_proto)
                 .collect::<Result<Vec<protos::pike_state::Organization>, ProtoConversionError>>()?,
         ));
@@ -1618,7 +1618,7 @@ mod tests {
             .with_public_key("public_key".to_string())
             .with_active(true)
             .with_roles(vec!["Role".to_string()])
-            .with_metadata(vec![key_value.clone()])
+            .with_metadata(vec![key_value])
             .build()
             .unwrap();
 
@@ -1643,7 +1643,7 @@ mod tests {
             .with_public_key("public_key".to_string())
             .with_active(true)
             .with_roles(vec!["Role".to_string()])
-            .with_metadata(vec![key_value.clone()])
+            .with_metadata(vec![key_value])
             .build()
             .unwrap();
 
@@ -1669,12 +1669,12 @@ mod tests {
             .with_public_key("public_key".to_string())
             .with_active(true)
             .with_roles(vec!["Role".to_string()])
-            .with_metadata(vec![key_value.clone()])
+            .with_metadata(vec![key_value])
             .build()
             .unwrap();
 
         let builder = AgentListBuilder::new();
-        let original = builder.with_agents(vec![agent.clone()]).build().unwrap();
+        let original = builder.with_agents(vec![agent]).build().unwrap();
 
         let bytes = original.clone().into_bytes().unwrap();
         let agent_list = AgentList::from_bytes(&bytes).unwrap();
@@ -1721,7 +1721,7 @@ mod tests {
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
             .with_locations(vec!["locations".to_string()])
-            .with_metadata(vec![key_value.clone()])
+            .with_metadata(vec![key_value])
             .build()
             .unwrap();
 
@@ -1745,7 +1745,7 @@ mod tests {
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
             .with_locations(vec!["location".to_string()])
-            .with_metadata(vec![key_value.clone()])
+            .with_metadata(vec![key_value])
             .build()
             .unwrap();
 
@@ -1773,13 +1773,13 @@ mod tests {
             .with_org_id("organization".to_string())
             .with_name("name".to_string())
             .with_locations(vec!["locations".to_string()])
-            .with_metadata(vec![key_value.clone()])
+            .with_metadata(vec![key_value])
             .build()
             .unwrap();
 
         let builder = OrganizationListBuilder::new();
         let original = builder
-            .with_organizations(vec![organization.clone()])
+            .with_organizations(vec![organization])
             .build()
             .unwrap();
 

--- a/sdk/src/protocol/product/payload.rs
+++ b/sdk/src/protocol/product/payload.rs
@@ -223,8 +223,8 @@ impl FromProto<product_payload::ProductCreateAction> for ProductCreateAction {
             owner: proto.get_owner().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -240,8 +240,8 @@ impl FromNative<ProductCreateAction> for product_payload::ProductCreateAction {
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -358,8 +358,8 @@ impl FromProto<protos::product_payload::ProductUpdateAction> for ProductUpdateAc
             product_id: proto.get_product_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -374,8 +374,8 @@ impl FromNative<ProductUpdateAction> for protos::product_payload::ProductUpdateA
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -708,7 +708,7 @@ mod tests {
             .unwrap();
 
         let payload = ProductPayloadBuilder::new()
-            .with_action(Action::ProductCreate(action.clone()))
+            .with_action(Action::ProductCreate(action))
             .with_timestamp(0)
             .build()
             .unwrap();
@@ -730,10 +730,7 @@ mod tests {
             .build()
             .unwrap();
 
-        vec![
-            property_value_description.clone(),
-            property_value_price.clone(),
-        ]
+        vec![property_value_description, property_value_price]
     }
 
     fn test_from_bytes<T: FromBytes<T> + Clone + PartialEq + IntoBytes + Debug, F>(

--- a/sdk/src/protocol/product/state.rs
+++ b/sdk/src/protocol/product/state.rs
@@ -106,8 +106,8 @@ impl FromProto<protos::product_state::Product> for Product {
             owner: product.get_owner().to_string(),
             properties: product
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -123,8 +123,8 @@ impl FromNative<Product> for protos::product_state::Product {
         proto.set_properties(RepeatedField::from_vec(
             product
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<schema_state::PropertyValue>, ProtoConversionError>>()?,
         ));
@@ -272,8 +272,8 @@ impl FromProto<protos::product_state::ProductList> for ProductList {
         Ok(ProductList {
             products: product_list
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Product::from_proto)
                 .collect::<Result<Vec<Product>, ProtoConversionError>>()?,
         })
@@ -287,8 +287,8 @@ impl FromNative<ProductList> for protos::product_state::ProductList {
         product_list_proto.set_entries(RepeatedField::from_vec(
             product_list
                 .products()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Product::into_proto)
                 .collect::<Result<Vec<protos::product_state::Product>, ProtoConversionError>>()?,
         ));
@@ -543,10 +543,7 @@ mod tests {
             .build()
             .unwrap();
 
-        vec![
-            property_value_description.clone(),
-            property_value_price.clone(),
-        ]
+        vec![property_value_description, property_value_price]
     }
 
     fn build_product_list() -> ProductList {

--- a/sdk/src/protocol/purchase_order/state.rs
+++ b/sdk/src/protocol/purchase_order/state.rs
@@ -444,8 +444,8 @@ impl FromNative<PurchaseOrder> for purchase_order_state::PurchaseOrder {
         proto.set_versions(RepeatedField::from_vec(
             order
                 .versions()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(|version| version.into_proto())
                 .collect::<Result<_, _>>()?,
         ));
@@ -602,8 +602,8 @@ impl FromProto<purchase_order_state::PurchaseOrderList> for PurchaseOrderList {
         Ok(PurchaseOrderList {
             purchase_orders: order_list
                 .get_purchase_orders()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PurchaseOrder::from_proto)
                 .collect::<Result<Vec<PurchaseOrder>, ProtoConversionError>>()?,
         })
@@ -617,8 +617,8 @@ impl FromNative<PurchaseOrderList> for purchase_order_state::PurchaseOrderList {
         order_list_proto.set_purchase_orders(RepeatedField::from_vec(
             order_list
                 .purchase_orders()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PurchaseOrder::into_proto)
                 .collect::<Result<Vec<purchase_order_state::PurchaseOrder>, ProtoConversionError>>(
                 )?,
@@ -862,8 +862,8 @@ impl FromProto<purchase_order_state::PurchaseOrderAlternateIdList>
         Ok(PurchaseOrderAlternateIdList {
             alternate_ids: id_list
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PurchaseOrderAlternateId::from_proto)
                 .collect::<Result<Vec<PurchaseOrderAlternateId>, ProtoConversionError>>()?,
         })
@@ -880,8 +880,8 @@ impl FromNative<PurchaseOrderAlternateIdList>
             RepeatedField::from_vec(
                 id_list
                     .alternate_ids()
-                    .to_vec()
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .map(PurchaseOrderAlternateId::into_proto)
                     .collect::<Result<
                         Vec<purchase_order_state::PurchaseOrderAlternateId>,

--- a/sdk/src/protocol/schema/payload.rs
+++ b/sdk/src/protocol/schema/payload.rs
@@ -197,8 +197,8 @@ impl FromProto<protos::schema_payload::SchemaCreateAction> for SchemaCreateActio
             description: schema_create.get_description().to_string(),
             properties: schema_create
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -214,7 +214,7 @@ impl FromNative<SchemaCreateAction> for protos::schema_payload::SchemaCreateActi
         proto_schema_create.set_description(schema_create.description().to_string());
         proto_schema_create.set_properties(
             RepeatedField::from_vec(
-            schema_create.properties().to_vec().into_iter()
+            schema_create.properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
 
@@ -371,8 +371,8 @@ impl FromProto<protos::schema_payload::SchemaUpdateAction> for SchemaUpdateActio
             owner: schema_update.get_owner().to_string(),
             properties: schema_update
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -387,7 +387,7 @@ impl FromNative<SchemaUpdateAction> for protos::schema_payload::SchemaUpdateActi
         proto_schema_update.set_owner(schema_update.owner().to_string());
         proto_schema_update.set_properties(
             RepeatedField::from_vec(
-            schema_update.properties().to_vec().into_iter()
+            schema_update.properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
 
@@ -550,7 +550,7 @@ mod tests {
             .with_schema_name("TestSchema".to_string())
             .with_owner("test_org".to_string())
             .with_description("Test Schema".to_string())
-            .with_properties(vec![property_definition.clone()])
+            .with_properties(vec![property_definition])
             .build()
             .unwrap();
 
@@ -598,7 +598,7 @@ mod tests {
         let original = builder
             .with_schema_name("TestSchema".to_string())
             .with_owner("test_org".to_string())
-            .with_properties(vec![property_definition.clone()])
+            .with_properties(vec![property_definition])
             .build()
             .unwrap();
 
@@ -624,7 +624,7 @@ mod tests {
             .with_schema_name("TestSchema".to_string())
             .with_owner("test_org".to_string())
             .with_description("Test Schema".to_string())
-            .with_properties(vec![property_definition.clone()])
+            .with_properties(vec![property_definition])
             .build()
             .unwrap();
 
@@ -652,7 +652,7 @@ mod tests {
         let action = builder
             .with_schema_name("TestSchema".to_string())
             .with_owner("test_org".to_string())
-            .with_properties(vec![property_definition.clone()])
+            .with_properties(vec![property_definition])
             .build()
             .unwrap();
 
@@ -680,7 +680,7 @@ mod tests {
         let action = builder
             .with_schema_name("TestSchema".to_string())
             .with_owner("test_org".to_string())
-            .with_properties(vec![property_definition.clone()])
+            .with_properties(vec![property_definition])
             .build()
             .unwrap();
 

--- a/sdk/src/protocol/schema/state.rs
+++ b/sdk/src/protocol/schema/state.rs
@@ -226,8 +226,8 @@ impl FromProto<protos::schema_state::PropertyDefinition> for PropertyDefinition 
             enum_options: property_definition.get_enum_options().to_vec(),
             struct_properties: property_definition
                 .get_struct_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -248,7 +248,7 @@ impl FromNative<PropertyDefinition> for protos::schema_state::PropertyDefinition
         ));
         proto_property_definition.set_struct_properties(
             RepeatedField::from_vec(
-            property_definition.struct_properties().to_vec().into_iter()
+            property_definition.struct_properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
         Ok(proto_property_definition)
@@ -467,8 +467,8 @@ impl FromProto<protos::schema_state::Schema> for Schema {
             owner: schema.get_owner().to_string(),
             properties: schema
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -484,8 +484,8 @@ impl FromNative<Schema> for protos::schema_state::Schema {
         proto_schema.set_properties(RepeatedField::from_vec(
             schema
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,
         ));
@@ -627,8 +627,8 @@ impl FromProto<protos::schema_state::SchemaList> for SchemaList {
         Ok(SchemaList {
             schemas: schema_list
                 .get_schemas()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Schema::from_proto)
                 .collect::<Result<Vec<Schema>, ProtoConversionError>>()?,
         })
@@ -642,8 +642,8 @@ impl FromNative<SchemaList> for protos::schema_state::SchemaList {
         schema_list_proto.set_schemas(RepeatedField::from_vec(
             schema_list
                 .schemas()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Schema::into_proto)
                 .collect::<Result<Vec<protos::schema_state::Schema>, ProtoConversionError>>()?,
         ));
@@ -803,8 +803,8 @@ impl FromProto<protos::schema_state::PropertyValue> for PropertyValue {
             enum_value: property_value.get_enum_value(),
             struct_values: property_value
                 .get_struct_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
             lat_long_value: property_value.get_lat_long_value().clone().into_native()?,
@@ -825,8 +825,8 @@ impl FromNative<PropertyValue> for protos::schema_state::PropertyValue {
         proto_property_value.set_struct_values(RepeatedField::from_vec(
             property_value
                 .struct_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -1212,7 +1212,7 @@ mod tests {
             .with_name("TestSchema".to_string())
             .with_description("Test Schema".to_string())
             .with_owner("owner".to_string())
-            .with_properties(vec![property_definition.clone()])
+            .with_properties(vec![property_definition])
             .build()
             .unwrap();
 

--- a/sdk/src/protocol/track_and_trace/payload.rs
+++ b/sdk/src/protocol/track_and_trace/payload.rs
@@ -96,8 +96,8 @@ impl FromProto<track_and_trace_payload::CreateRecordAction> for CreateRecordActi
             schema: proto.get_schema().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -112,8 +112,8 @@ impl FromNative<CreateRecordAction> for track_and_trace_payload::CreateRecordAct
         proto.set_properties(RepeatedField::from_vec(
             create_record_action
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -278,8 +278,8 @@ impl FromProto<track_and_trace_payload::UpdatePropertiesAction> for UpdateProper
             record_id: proto.get_record_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -293,8 +293,8 @@ impl FromNative<UpdatePropertiesAction> for track_and_trace_payload::UpdatePrope
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -424,8 +424,8 @@ impl FromProto<track_and_trace_payload::CreateProposalAction> for CreateProposal
             role: Role::from_proto(proto.get_role())?,
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(String::from)
                 .collect(),
             terms: proto.get_terms().to_string(),
@@ -700,8 +700,8 @@ impl FromProto<track_and_trace_payload::RevokeReporterAction> for RevokeReporter
             reporter_id: proto.get_reporter_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(String::from)
                 .collect(),
         })
@@ -947,7 +947,7 @@ mod tests {
         let action = CreateRecordActionBuilder::new()
             .with_record_id("32".into())
             .with_schema("schema".into())
-            .with_properties(vec![property_value.clone()])
+            .with_properties(vec![property_value])
             .build()
             .unwrap();
 
@@ -1004,7 +1004,7 @@ mod tests {
 
         let action = UpdatePropertiesActionBuilder::new()
             .with_record_id("32".into())
-            .with_properties(vec![property_value.clone()])
+            .with_properties(vec![property_value])
             .build()
             .unwrap();
 
@@ -1127,7 +1127,7 @@ mod tests {
             .unwrap();
 
         let payload = TrackAndTracePayloadBuilder::new()
-            .with_action(Action::RevokeReporter(action.clone()))
+            .with_action(Action::RevokeReporter(action))
             .with_timestamp(0)
             .build()
             .unwrap();

--- a/sdk/src/protocol/track_and_trace/state.rs
+++ b/sdk/src/protocol/track_and_trace/state.rs
@@ -250,8 +250,8 @@ impl FromProto<track_and_trace_state::Property> for Property {
             )?,
             reporters: proto
                 .get_reporters()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Reporter::from_proto)
                 .collect::<Result<Vec<Reporter>, ProtoConversionError>>()?,
             current_page: proto.get_current_page(),
@@ -268,8 +268,8 @@ impl FromNative<Property> for track_and_trace_state::Property {
         proto.set_property_definition(native.property_definition().clone().into_proto()?);
         proto.set_reporters(RepeatedField::from_vec(
             native.reporters()
-            .to_vec()
-            .into_iter()
+            .iter()
+            .cloned()
             .map(Reporter::into_proto)
             .collect::<Result<Vec<track_and_trace_state::Property_Reporter>, ProtoConversionError>>()?));
         proto.set_current_page(*native.current_page());
@@ -343,8 +343,8 @@ impl FromProto<track_and_trace_state::PropertyList> for PropertyList {
         Ok(PropertyList {
             properties: proto
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Property::from_proto)
                 .collect::<Result<Vec<Property>, ProtoConversionError>>()?,
         })
@@ -357,8 +357,8 @@ impl FromNative<PropertyList> for track_and_trace_state::PropertyList {
         proto.set_entries(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Property::into_proto)
                 .collect::<Result<Vec<track_and_trace_state::Property>, ProtoConversionError>>()?,
         ));
@@ -580,8 +580,8 @@ impl FromProto<track_and_trace_state::PropertyPage> for PropertyPage {
             record_id: proto.get_record_id().to_string(),
             reported_values: proto
                 .get_reported_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(ReportedValue::from_proto)
                 .collect::<Result<Vec<ReportedValue>, ProtoConversionError>>()?,
         })
@@ -596,8 +596,8 @@ impl FromNative<PropertyPage> for track_and_trace_state::PropertyPage {
         proto.set_reported_values(RepeatedField::from_vec(
             native
                 .reported_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(ReportedValue::into_proto)
                 .collect::<Result<
                     Vec<track_and_trace_state::PropertyPage_ReportedValue>,
@@ -677,8 +677,8 @@ impl FromProto<track_and_trace_state::PropertyPageList> for PropertyPageList {
         Ok(PropertyPageList {
             property_pages: proto
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyPage::from_proto)
                 .collect::<Result<Vec<PropertyPage>, ProtoConversionError>>()?,
         })
@@ -691,8 +691,8 @@ impl FromNative<PropertyPageList> for track_and_trace_state::PropertyPageList {
         proto.set_entries(RepeatedField::from_vec(
             native
                 .property_pages()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyPage::into_proto)
                 .collect::<Result<Vec<track_and_trace_state::PropertyPage>, ProtoConversionError>>(
                 )?,
@@ -952,8 +952,8 @@ impl FromProto<track_and_trace_state::Proposal> for Proposal {
             role: Role::from_proto(proto.get_role())?,
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(String::from)
                 .collect(),
             status: Status::from_proto(proto.get_status())?,
@@ -1044,8 +1044,8 @@ impl FromProto<track_and_trace_state::ProposalList> for ProposalList {
         Ok(ProposalList {
             proposals: proto
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Proposal::from_proto)
                 .collect::<Result<Vec<Proposal>, ProtoConversionError>>()?,
         })
@@ -1058,8 +1058,8 @@ impl FromNative<ProposalList> for track_and_trace_state::ProposalList {
         proto.set_entries(RepeatedField::from_vec(
             native
                 .proposals()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Proposal::into_proto)
                 .collect::<Result<Vec<track_and_trace_state::Proposal>, ProtoConversionError>>()?,
         ));
@@ -1294,14 +1294,14 @@ impl FromProto<track_and_trace_state::Record> for Record {
             schema: proto.get_schema().to_string(),
             owners: proto
                 .get_owners()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AssociatedAgent::from_proto)
                 .collect::<Result<Vec<AssociatedAgent>, ProtoConversionError>>()?,
             custodians: proto
                 .get_custodians()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AssociatedAgent::from_proto)
                 .collect::<Result<Vec<AssociatedAgent>, ProtoConversionError>>()?,
             field_final: proto.get_field_final(),
@@ -1318,8 +1318,8 @@ impl FromNative<Record> for track_and_trace_state::Record {
             RepeatedField::from_vec(
                 native
                     .owners()
-                    .to_vec()
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .map(AssociatedAgent::into_proto)
                     .collect::<Result<
                         Vec<track_and_trace_state::Record_AssociatedAgent>,
@@ -1331,8 +1331,8 @@ impl FromNative<Record> for track_and_trace_state::Record {
             RepeatedField::from_vec(
                 native
                     .custodians()
-                    .to_vec()
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .map(AssociatedAgent::into_proto)
                     .collect::<Result<
                         Vec<track_and_trace_state::Record_AssociatedAgent>,
@@ -1408,8 +1408,8 @@ impl FromProto<track_and_trace_state::RecordList> for RecordList {
         Ok(RecordList {
             records: proto
                 .get_entries()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Record::from_proto)
                 .collect::<Result<Vec<Record>, ProtoConversionError>>()?,
         })
@@ -1422,8 +1422,8 @@ impl FromNative<RecordList> for track_and_trace_state::RecordList {
         proto.set_entries(RepeatedField::from_vec(
             native
                 .records()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Record::into_proto)
                 .collect::<Result<Vec<track_and_trace_state::Record>, ProtoConversionError>>()?,
         ));
@@ -1484,7 +1484,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(reporter.public_key(), "1234");
-        assert_eq!(*reporter.authorized(), true);
+        assert!(*reporter.authorized(), "{}", true);
         assert_eq!(*reporter.index(), 0);
     }
 
@@ -1549,7 +1549,7 @@ mod tests {
         assert_eq!(*property.property_definition(), property_definition);
         assert!(property.reporters().iter().any(|x| *x == reporter));
         assert_eq!(*property.current_page(), 0);
-        assert_eq!(*property.wrapped(), true);
+        assert!(*property.wrapped(), "{}", true);
     }
 
     #[test]
@@ -1609,8 +1609,8 @@ mod tests {
         let property = PropertyBuilder::new()
             .with_name("taco".into())
             .with_record_id("taco1234".into())
-            .with_property_definition(property_definition.clone())
-            .with_reporters(vec![reporter.clone()])
+            .with_property_definition(property_definition)
+            .with_reporters(vec![reporter])
             .with_current_page(0)
             .with_wrapped(true)
             .build()
@@ -1639,8 +1639,8 @@ mod tests {
         let property = PropertyBuilder::new()
             .with_name("taco".into())
             .with_record_id("taco1234".into())
-            .with_property_definition(property_definition.clone())
-            .with_reporters(vec![reporter.clone()])
+            .with_property_definition(property_definition)
+            .with_reporters(vec![reporter])
             .with_current_page(0)
             .with_wrapped(true)
             .build()
@@ -1674,8 +1674,8 @@ mod tests {
         let property = PropertyBuilder::new()
             .with_name("taco".into())
             .with_record_id("taco1234".into())
-            .with_property_definition(property_definition.clone())
-            .with_reporters(vec![reporter.clone()])
+            .with_property_definition(property_definition)
+            .with_reporters(vec![reporter])
             .with_current_page(0)
             .with_wrapped(true)
             .build()
@@ -1711,8 +1711,8 @@ mod tests {
         let property = PropertyBuilder::new()
             .with_name("taco".into())
             .with_record_id("taco1234".into())
-            .with_property_definition(property_definition.clone())
-            .with_reporters(vec![reporter.clone()])
+            .with_property_definition(property_definition)
+            .with_reporters(vec![reporter])
             .with_current_page(0)
             .with_wrapped(true)
             .build()
@@ -1806,7 +1806,7 @@ mod tests {
         let property_page = PropertyPageBuilder::new()
             .with_name("egg".into())
             .with_record_id("egg1234".into())
-            .with_reported_values(vec![reported_value.clone()])
+            .with_reported_values(vec![reported_value])
             .build()
             .unwrap();
 
@@ -1832,7 +1832,7 @@ mod tests {
         let property_page = PropertyPageBuilder::new()
             .with_name("egg".into())
             .with_record_id("egg1234".into())
-            .with_reported_values(vec![reported_value.clone()])
+            .with_reported_values(vec![reported_value])
             .build()
             .unwrap();
 
@@ -1866,7 +1866,7 @@ mod tests {
         let property_page = PropertyPageBuilder::new()
             .with_name("egg".into())
             .with_record_id("egg1234".into())
-            .with_reported_values(vec![reported_value.clone()])
+            .with_reported_values(vec![reported_value])
             .build()
             .unwrap();
 
@@ -1899,12 +1899,12 @@ mod tests {
         let property_page = PropertyPageBuilder::new()
             .with_name("egg".into())
             .with_record_id("egg1234".into())
-            .with_reported_values(vec![reported_value.clone()])
+            .with_reported_values(vec![reported_value])
             .build()
             .unwrap();
 
         let property_page_list = PropertyPageListBuilder::new()
-            .with_property_pages(vec![property_page.clone()])
+            .with_property_pages(vec![property_page])
             .build()
             .unwrap();
 
@@ -2039,7 +2039,7 @@ mod tests {
             .unwrap();
 
         let proposal_list = ProposalListBuilder::new()
-            .with_proposals(vec![proposal.clone()])
+            .with_proposals(vec![proposal])
             .build()
             .unwrap();
 
@@ -2092,7 +2092,7 @@ mod tests {
         assert_eq!(builder.record_id, Some("egg1234".to_string()));
         assert_eq!(builder.schema, Some("egg".to_string()));
         assert_eq!(builder.owners, Some(vec![associated_agent.clone()]));
-        assert_eq!(builder.custodians, Some(vec![associated_agent.clone()]));
+        assert_eq!(builder.custodians, Some(vec![associated_agent]));
         assert_eq!(builder.field_final, Some(false));
     }
 
@@ -2108,7 +2108,7 @@ mod tests {
             .with_record_id("egg1234".into())
             .with_schema("egg".into())
             .with_owners(vec![associated_agent.clone()])
-            .with_custodians(vec![associated_agent.clone()])
+            .with_custodians(vec![associated_agent])
             .with_field_final(false)
             .build()
             .unwrap();
@@ -2128,7 +2128,7 @@ mod tests {
             .with_record_id("egg1234".into())
             .with_schema("egg".into())
             .with_owners(vec![associated_agent.clone()])
-            .with_custodians(vec![associated_agent.clone()])
+            .with_custodians(vec![associated_agent])
             .with_field_final(false)
             .build()
             .unwrap();
@@ -2153,7 +2153,7 @@ mod tests {
             .with_record_id("egg1234".into())
             .with_schema("egg".into())
             .with_owners(vec![associated_agent.clone()])
-            .with_custodians(vec![associated_agent.clone()])
+            .with_custodians(vec![associated_agent])
             .with_field_final(false)
             .build()
             .unwrap();
@@ -2180,13 +2180,13 @@ mod tests {
             .with_record_id("egg1234".into())
             .with_schema("egg".into())
             .with_owners(vec![associated_agent.clone()])
-            .with_custodians(vec![associated_agent.clone()])
+            .with_custodians(vec![associated_agent])
             .with_field_final(false)
             .build()
             .unwrap();
 
         let record_list = RecordListBuilder::new()
-            .with_records(vec![record.clone()])
+            .with_records(vec![record])
             .build()
             .unwrap();
 

--- a/sdk/src/rest_api/resources/submit/v1/payloads/location.rs
+++ b/sdk/src/rest_api/resources/submit/v1/payloads/location.rs
@@ -200,8 +200,8 @@ impl FromProto<location_payload::LocationCreateAction> for LocationCreateAction 
             owner: proto.get_owner().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -217,8 +217,8 @@ impl FromNative<LocationCreateAction> for location_payload::LocationCreateAction
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -334,8 +334,8 @@ impl FromProto<protos::location_payload::LocationUpdateAction> for LocationUpdat
             location_id: proto.get_location_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -350,8 +350,8 @@ impl FromNative<LocationUpdateAction> for protos::location_payload::LocationUpda
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,

--- a/sdk/src/rest_api/resources/submit/v1/payloads/pike.rs
+++ b/sdk/src/rest_api/resources/submit/v1/payloads/pike.rs
@@ -80,8 +80,8 @@ impl FromProto<protos::pike_payload::CreateAgentAction> for CreateAgentAction {
             roles: create_agent.get_roles().to_vec(),
             metadata: create_agent
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -100,8 +100,8 @@ impl FromNative<CreateAgentAction> for protos::pike_payload::CreateAgentAction {
         proto_create_agent.set_metadata(RepeatedField::from_vec(
             create_agent
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -244,8 +244,8 @@ impl FromProto<protos::pike_payload::UpdateAgentAction> for UpdateAgentAction {
             roles: update_agent.get_roles().to_vec(),
             metadata: update_agent
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -264,8 +264,8 @@ impl FromNative<UpdateAgentAction> for protos::pike_payload::UpdateAgentAction {
         proto_update_agent.set_metadata(RepeatedField::from_vec(
             update_agent
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -499,14 +499,14 @@ impl FromProto<protos::pike_payload::CreateOrganizationAction> for CreateOrganiz
             name: create_org.get_name().to_string(),
             alternate_ids: create_org
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::from_proto)
                 .collect::<Result<Vec<AlternateId>, ProtoConversionError>>()?,
             metadata: create_org
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -522,16 +522,16 @@ impl FromNative<CreateOrganizationAction> for protos::pike_payload::CreateOrgani
         proto_create_org.set_alternate_ids(RepeatedField::from_vec(
             create_org
                 .alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateId>, ProtoConversionError>>()?,
         ));
         proto_create_org.set_metadata(RepeatedField::from_vec(
             create_org
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,
@@ -670,15 +670,15 @@ impl FromProto<protos::pike_payload::UpdateOrganizationAction> for UpdateOrganiz
             name: update_org.get_name().to_string(),
             alternate_ids: update_org
                 .get_alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::from_proto)
                 .collect::<Result<Vec<AlternateId>, ProtoConversionError>>()?,
             locations: update_org.get_locations().to_vec(),
             metadata: update_org
                 .get_metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::from_proto)
                 .collect::<Result<Vec<KeyValueEntry>, ProtoConversionError>>()?,
         })
@@ -694,8 +694,8 @@ impl FromNative<UpdateOrganizationAction> for protos::pike_payload::UpdateOrgani
         proto_update_org.set_alternate_ids(RepeatedField::from_vec(
             update_org
                 .alternate_ids()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(AlternateId::into_proto)
                 .collect::<Result<Vec<protos::pike_state::AlternateId>, ProtoConversionError>>()?,
         ));
@@ -703,8 +703,8 @@ impl FromNative<UpdateOrganizationAction> for protos::pike_payload::UpdateOrgani
         proto_update_org.set_metadata(RepeatedField::from_vec(
             update_org
                 .metadata()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(KeyValueEntry::into_proto)
                 .collect::<Result<Vec<protos::pike_state::KeyValueEntry>, ProtoConversionError>>(
                 )?,

--- a/sdk/src/rest_api/resources/submit/v1/payloads/product.rs
+++ b/sdk/src/rest_api/resources/submit/v1/payloads/product.rs
@@ -203,8 +203,8 @@ impl FromProto<product_payload::ProductCreateAction> for ProductCreateAction {
             owner: proto.get_owner().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -220,8 +220,8 @@ impl FromNative<ProductCreateAction> for product_payload::ProductCreateAction {
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,
@@ -337,8 +337,8 @@ impl FromProto<protos::product_payload::ProductUpdateAction> for ProductUpdateAc
             product_id: proto.get_product_id().to_string(),
             properties: proto
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
         })
@@ -353,8 +353,8 @@ impl FromNative<ProductUpdateAction> for protos::product_payload::ProductUpdateA
         proto.set_properties(RepeatedField::from_vec(
             native
                 .properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,

--- a/sdk/src/rest_api/resources/submit/v1/payloads/schema.rs
+++ b/sdk/src/rest_api/resources/submit/v1/payloads/schema.rs
@@ -147,8 +147,8 @@ impl FromProto<protos::schema_payload::SchemaCreateAction> for SchemaCreateActio
             description: schema_create.get_description().to_string(),
             properties: schema_create
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -163,7 +163,7 @@ impl FromNative<SchemaCreateAction> for protos::schema_payload::SchemaCreateActi
         proto_schema_create.set_description(schema_create.description().to_string());
         proto_schema_create.set_properties(
             RepeatedField::from_vec(
-            schema_create.properties().to_vec().into_iter()
+            schema_create.properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
 
@@ -274,8 +274,8 @@ impl FromProto<protos::schema_payload::SchemaUpdateAction> for SchemaUpdateActio
             schema_name: schema_update.get_schema_name().to_string(),
             properties: schema_update
                 .get_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -289,7 +289,7 @@ impl FromNative<SchemaUpdateAction> for protos::schema_payload::SchemaUpdateActi
         proto_schema_update.set_schema_name(schema_update.schema_name().to_string());
         proto_schema_update.set_properties(
             RepeatedField::from_vec(
-            schema_update.properties().to_vec().into_iter()
+            schema_update.properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
 
@@ -421,8 +421,8 @@ impl FromProto<protos::schema_state::PropertyDefinition> for PropertyDefinition 
             enum_options: property_definition.get_enum_options().to_vec(),
             struct_properties: property_definition
                 .get_struct_properties()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyDefinition::from_proto)
                 .collect::<Result<Vec<PropertyDefinition>, ProtoConversionError>>()?,
         })
@@ -443,7 +443,7 @@ impl FromNative<PropertyDefinition> for protos::schema_state::PropertyDefinition
         ));
         proto_property_definition.set_struct_properties(
             RepeatedField::from_vec(
-            property_definition.struct_properties().to_vec().into_iter()
+            property_definition.struct_properties().iter().cloned()
             .map(PropertyDefinition::into_proto)
             .collect::<Result<Vec<protos::schema_state::PropertyDefinition>, ProtoConversionError>>()?,));
         Ok(proto_property_definition)
@@ -658,8 +658,8 @@ impl FromProto<protos::schema_state::PropertyValue> for PropertyValue {
             enum_value: property_value.get_enum_value(),
             struct_values: property_value
                 .get_struct_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::from_proto)
                 .collect::<Result<Vec<PropertyValue>, ProtoConversionError>>()?,
             lat_long_value: property_value.get_lat_long_value().clone().into_native()?,
@@ -680,8 +680,8 @@ impl FromNative<PropertyValue> for protos::schema_state::PropertyValue {
         proto_property_value.set_struct_values(RepeatedField::from_vec(
             property_value
                 .struct_values()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(PropertyValue::into_proto)
                 .collect::<Result<Vec<protos::schema_state::PropertyValue>, ProtoConversionError>>(
                 )?,


### PR DESCRIPTION
This fixes the clippy formatting errors introduced with Rust v1.59

Signed-off-by: Davey Newhall <newhall@bitwise.io>