### PR TITLE
Replace tempdir library with tempfile

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -57,7 +57,7 @@ zip = { version = "0.5", optional = true }
 [dev-dependencies]
 mockito = "0.30"
 pretty_assertions = "1"
-tempdir = "0.3"
+tempfile = "3"
 
 [features]
 default = [

--- a/cli/src/actions/keygen.rs
+++ b/cli/src/actions/keygen.rs
@@ -200,12 +200,12 @@ pub fn generate_keys(
 mod tests {
     use super::*;
     use std::fs::File;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     /// Validate that create_key_pair skips when the keypairs already exist
     #[test]
     fn create_keypair_mode_skip_skips_existing_keypairs() {
-        let temp_dir = TempDir::new("test_files_exist").expect("Failed to create temp dir");
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
         let public_key_path = temp_dir.path().join("public_key");
         let private_key_path = temp_dir.path().join("private_key");
@@ -242,7 +242,7 @@ mod tests {
     /// missing
     #[test]
     fn create_keypair_mode_skip_fails_missing_private_key() {
-        let temp_dir = TempDir::new("test_files_exist").expect("Failed to create temp dir");
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
         let public_key_path = temp_dir.path().join("public_key");
         let private_key_path = temp_dir.path().join("private_key");
@@ -283,7 +283,7 @@ mod tests {
     /// missing
     #[test]
     fn create_keypair_mode_skip_fails_missing_public_key() {
-        let temp_dir = TempDir::new("test_files_exist").expect("Failed to create temp dir");
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
         let public_key_path = temp_dir.path().join("public_key");
         let private_key_path = temp_dir.path().join("private_key");
@@ -323,7 +323,7 @@ mod tests {
     /// Validate that create_key_pair writes new keys successfully on a success condition
     #[test]
     fn create_keypair_mode_skip_successfully_writes_new_keys() {
-        let temp_dir = TempDir::new("test_files_exist").expect("Failed to create temp dir");
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
         let public_key_path = temp_dir.path().join("public_key");
         let private_key_path = temp_dir.path().join("private_key");
@@ -344,7 +344,7 @@ mod tests {
     /// Validate that create_key_pair force option will overwrite an existing pubkey
     #[test]
     fn create_keypair_mode_force_returns_different_pubkey() {
-        let temp_dir = TempDir::new("test_files_exist").expect("Failed to create temp dir");
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
         let public_key_path = temp_dir.path().join("public_key");
         let private_key_path = temp_dir.path().join("private_key");
@@ -385,7 +385,7 @@ mod tests {
     /// Validate that create_key_pair force successfully creates both a private and public key
     #[test]
     fn create_keypair_mode_force_successfully_writes_new_keys() {
-        let temp_dir = TempDir::new("test_files_exist").expect("Failed to create temp dir");
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
         let public_key_path = temp_dir.path().join("public_key");
         let private_key_path = temp_dir.path().join("private_key");
@@ -406,7 +406,7 @@ mod tests {
     /// Validate that create_key_pair Error fails on existing keypairs
     #[test]
     fn create_keypair_mode_fail_fails_on_existing_keypairs() {
-        let temp_dir = TempDir::new("test_files_exist").expect("Failed to create temp dir");
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
         let public_key_path = temp_dir.path().join("public_key");
         let private_key_path = temp_dir.path().join("private_key");
@@ -457,7 +457,7 @@ mod tests {
     /// Validate that create_key_pair Error succeeds if there are no existing keypairs
     #[test]
     fn create_keypair_mode_fail_successfully_writes_new_keys() {
-        let temp_dir = TempDir::new("test_files_exist").expect("Failed to create temp dir");
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
         let public_key_path = temp_dir.path().join("public_key");
         let private_key_path = temp_dir.path().join("private_key");
@@ -479,7 +479,7 @@ mod tests {
     /// path
     #[test]
     fn generate_keys_succeeds() {
-        let temp_dir = TempDir::new("test_files_exist").expect("Failed to create temp dir");
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
         let public_key_path = temp_dir.path().join("grid_key.pub");
         let private_key_path = temp_dir.path().join("grid_key.priv");

--- a/cli/src/actions/xsd_downloader/downloader.rs
+++ b/cli/src/actions/xsd_downloader/downloader.rs
@@ -147,7 +147,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use std::fs::File;
     use std::io::Write;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     const TEST_DATA: &str = "lagomorpha";
     const TEST_HASH: &str = "9b44a9cb40096bf6767dec8e97bdc5a36ead7bc6200025cac801bf445307aba0";
@@ -200,7 +200,7 @@ mod tests {
             .with_body("world")
             .create();
 
-        let tmp_dir = TempDir::new("example").expect("could not create tempdir");
+        let tmp_dir = TempDir::new().expect("could not create tempdir");
         let file_path = tmp_dir.path().join("some_file_location.txt");
 
         assert!(!file_path.exists());
@@ -222,7 +222,7 @@ mod tests {
 
         let mock_endpoint = mock("GET", "/bad_file.zip").with_status(503).create();
 
-        let tmp_dir = TempDir::new("example").expect("could not create tempdir");
+        let tmp_dir = TempDir::new().expect("could not create tempdir");
         let file_path = tmp_dir.path().join("some_file_location.txt");
 
         assert!(!file_path.exists());
@@ -243,7 +243,7 @@ mod tests {
     #[test]
     // Test that CachingDownloader does not download when file is cached
     fn caching_download_doesnot_download_cached_file() {
-        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let dest_dir = temp_dir.path();
 
         let file_name = "gs1.zip";
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     // Test that CachingDownloader downloads if file is not cached
     fn caching_download_downloads_file() -> Result<(), CliError> {
-        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let dest_dir = temp_dir.path();
 
         let file_name = "gs1.zip";
@@ -338,7 +338,7 @@ mod tests {
     #[cfg(feature = "xsd-downloader-force-download")]
     // Test that CachingDownloader downloads if file is cached, but force_download is enabled
     fn caching_download_downloads_cached_file_with_force_download() -> Result<(), CliError> {
-        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let dest_dir = temp_dir.path();
 
         let file_name = "gs1.zip";
@@ -393,7 +393,7 @@ mod tests {
     #[cfg(feature = "xsd-downloader-force-download")]
     // Test that CachingDownloader fails if the temporary file already exists
     fn caching_download_fails_if_temp_file_exists() {
-        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let dest_dir = temp_dir.path();
 
         let file_name = "gs1.zip";
@@ -432,7 +432,7 @@ mod tests {
     #[test]
     // Test that CachingDownloader fails if the temporary file already exists
     fn caching_download_fails_if_hash_incorrect() -> Result<(), CliError> {
-        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let dest_dir = temp_dir.path();
 
         let file_name = "gs1.zip";

--- a/cli/src/actions/xsd_downloader/extractor.rs
+++ b/cli/src/actions/xsd_downloader/extractor.rs
@@ -156,7 +156,7 @@ mod tests {
     use super::*;
 
     use std::io::Write;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     use zip::{result::ZipResult, ZipWriter};
 
     fn dummy(zip: &mut ZipWriter<impl Write + Seek>, filename: &str) -> ZipResult<()> {
@@ -265,10 +265,10 @@ mod tests {
     // Validate that extract() will extract a zip file in the expected zipception format
     // without failure, and that the resulting files are in the expected locations.
     fn extract_works() {
-        let source_temp = TempDir::new("zipstuff").expect("could not create tempdir");
+        let source_temp = TempDir::new().expect("could not create tempdir");
         let source_path = source_temp.into_path().join("test.zip");
 
-        let dest_temp = TempDir::new("dest").expect("could not create tempdir");
+        let dest_temp = TempDir::new().expect("could not create tempdir");
         let dest_path = dest_temp.into_path();
 
         create_example_zip(&source_path).unwrap();

--- a/cli/src/actions/xsd_downloader/mod.rs
+++ b/cli/src/actions/xsd_downloader/mod.rs
@@ -359,7 +359,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use std::fs::{self, File};
     use std::path::Path;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     #[derive(Debug, PartialEq)]
     struct MockCacheDownloaderCall {
@@ -462,7 +462,7 @@ mod tests {
     // The downloader, validator, and extractor are mocked as successful, and
     // the calls to them are each compared against expected calls.
     fn fae_default_configuration_downloads_and_extracts() {
-        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let path = temp_dir.into_path();
         let artifact_dir = path.join("artifact");
         let schema_dir = path.join("schema");
@@ -541,7 +541,7 @@ mod tests {
     //
     // The downloader expects zero calls.
     fn fae_files_copy_if_copy_option_enabled() {
-        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let path = temp_dir.into_path();
         let artifact_dir = path.join("artifact");
         fs::create_dir(&artifact_dir).expect("could not create directory");
@@ -614,7 +614,7 @@ mod tests {
     //
     // The validator expects zero calls.
     fn fae_files_validation_does_not_happen_if_disabled() {
-        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let path = temp_dir.into_path();
         let artifact_dir = path.join("artifact");
         let schema_dir = path.join("schema");
@@ -690,7 +690,7 @@ mod tests {
     //
     // The downloader, validator, and extractor expect zero calls.
     fn fae_cache_only_with_missing_artifact_fails() {
-        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let path = temp_dir.into_path();
         let schema_dir = path.join("schema");
 
@@ -734,7 +734,7 @@ mod tests {
     //
     // The downloader, validator, and extractor expect zero calls.
     fn fae_cache_only_copy_from_missing_file_fails() {
-        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let path = temp_dir.into_path();
         let schema_dir = path.join("schema");
 
@@ -786,7 +786,7 @@ mod tests {
     // The downloader, validator, and extractor are mocked as successful, and
     // the calls to them are each compared against expected calls.
     fn fae_if_not_cached_copy_from_missing_file_downloads() {
-        let temp_dir = TempDir::new("fae_xsds").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let path = temp_dir.into_path();
         let schema_dir = path.join("schema");
         let artifact_dir = path.join("artifact");
@@ -863,7 +863,7 @@ mod tests {
 
     #[test]
     fn test_directory_writable_succeeds_if_writable() {
-        let temp_dir = TempDir::new("writable").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let path = temp_dir.into_path();
 
         test_directory_writable("test", &path).expect("could not write to directory");

--- a/cli/src/actions/xsd_downloader/validator.rs
+++ b/cli/src/actions/xsd_downloader/validator.rs
@@ -72,14 +72,14 @@ mod tests {
     use std::io::Write;
 
     use pretty_assertions::assert_eq;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     const TEST_DATA: &str = "lagomorpha";
     const TEST_HASH: &str = "9b44a9cb40096bf6767dec8e97bdc5a36ead7bc6200025cac801bf445307aba0";
 
     #[test]
     fn validate_hash_succeeds_on_valid_hash() {
-        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let file_path = temp_dir.path().join("gs1.zip");
 
         let mut output = File::create(&file_path).expect("could not create file");
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn validate_hash_fails_on_invalid_hash() {
-        let temp_dir = TempDir::new("example").expect("could not create tempdir");
+        let temp_dir = TempDir::new().expect("could not create tempdir");
         let file_path = temp_dir.path().join("gs1.zip");
 
         let mut output = File::create(&file_path).expect("could not create file");


### PR DESCRIPTION
Replace tempdir library with tempfile:3 because tempdir is no longer
maintained. See advisory: https://rustsec.org/advisories/RUSTSEC-2018-0017

Signed-off-by: Lee Bradley <bradley@bitwise.io>