### PR TITLE
Bump `mockito` from 0.30 -> 0.31

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,7 +55,7 @@ whoami = "1"
 zip = { version = "0.5", optional = true }
 
 [dev-dependencies]
-mockito = "0.30"
+mockito = "0.31"
 pretty_assertions = "1"
 tempdir = "0.3"
 


### PR DESCRIPTION
Latest version of mockito replaces unmaintained difference library with
similar.

Signed-off-by: Lee Bradley <bradley@bitwise.io>