### PR TITLE
Add initial setup for the Batch Tracking Store

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -45,6 +45,7 @@ sawtooth-sdk = { version = "0.4", features = ["transact-compat"], optional = tru
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = { version = "1.0" }
 serde_json = { version = "1.0", optional = true }
+transact = { version = "0.2", optional = true }
 url = { version = "2.1", optional = true, features = ["serde"] }
 uuid = { version = "0.8", features = ["v4"], optional = true }
 
@@ -116,6 +117,7 @@ experimental = [
     "stable",
     # The following features are experimental:
     "batch-processor",
+    "batch-tracking",
     "batch-store",
     "rest-api-actix-web-3",
     "rest-api-actix-web-3-run",
@@ -139,6 +141,7 @@ purchase-order = ["pike", "regex"]
 product = ["pike", "schema"]
 schema = ["pike"]
 track-and-trace = ["base64"]
+batch-tracking = ["transact"]
 batch-processor = ["batch-store", "backend", "log", "reqwest", "uuid"]
 batch-store = ["chrono"]
 

--- a/sdk/src/batch_tracking/mod.rs
+++ b/sdk/src/batch_tracking/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod store;

--- a/sdk/src/batch_tracking/store/diesel/mod.rs
+++ b/sdk/src/batch_tracking/store/diesel/mod.rs
@@ -12,4 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod models;
 pub(in crate) mod schema;
+
+use super::{
+    BatchStatus, InvalidTransaction, SubmissionError, TrackingBatch, TrackingTransaction,
+    TransactionReceipt, ValidTransaction,
+};

--- a/sdk/src/batch_tracking/store/diesel/mod.rs
+++ b/sdk/src/batch_tracking/store/diesel/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(in crate) mod schema;

--- a/sdk/src/batch_tracking/store/diesel/models.rs
+++ b/sdk/src/batch_tracking/store/diesel/models.rs
@@ -1,0 +1,279 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::convert::TryFrom;
+
+use crate::batch_tracking::store::diesel::schema::*;
+use crate::error::InternalError;
+use chrono::NaiveDateTime;
+
+use super::{
+    BatchStatus, InvalidTransaction, SubmissionError, TrackingBatch, TrackingTransaction,
+    TransactionReceipt, ValidTransaction,
+};
+use crate::batch_tracking::store::error::BatchTrackingStoreError;
+
+#[derive(Insertable, Queryable, PartialEq, Debug)]
+#[table_name = "batches"]
+pub struct BatchModel {
+    pub service_id: String,
+    pub batch_id: String,
+    pub data_change_id: Option<String>,
+    pub signer_public_key: String,
+    pub trace: bool,
+    pub serialized_batch: Vec<u8>,
+    pub submitted: bool,
+    pub created_at: NaiveDateTime,
+}
+
+#[derive(Insertable, Queryable, PartialEq, Debug)]
+#[table_name = "transactions"]
+pub struct TransactionModel {
+    pub service_id: String,
+    pub transaction_id: String,
+    pub batch_id: String,
+    pub batch_service_id: String,
+    pub payload: Vec<u8>,
+    pub family_name: String,
+    pub family_version: String,
+    pub signer_public_key: String,
+}
+
+#[derive(Insertable, PartialEq, Debug)]
+#[table_name = "transaction_receipts"]
+pub struct TransactionReceiptModel {
+    pub service_id: String,
+    pub transaction_id: String,
+    pub result_valid: bool,
+    pub error_message: Option<String>,
+    pub error_data: Option<Vec<u8>>,
+    pub serialized_receipt: Vec<u8>,
+    pub external_status: Option<String>,
+    pub external_error_message: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Debug)]
+#[table_name = "batch_statuses"]
+pub struct BatchStatusModel {
+    pub service_id: String,
+    pub batch_id: String,
+    pub batch_service_id: String,
+    pub dlt_status: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Insertable, PartialEq, Debug)]
+#[table_name = "submissions"]
+pub struct SubmissionModel {
+    pub service_id: String,
+    pub batch_id: String,
+    pub batch_service_id: String,
+    pub last_checked: Option<NaiveDateTime>,
+    pub times_checked: Option<String>,
+    pub error_type: Option<String>,
+    pub error_message: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+impl
+    From<(
+        BatchModel,
+        Vec<TrackingTransaction>,
+        Option<BatchStatus>,
+        Option<SubmissionError>,
+    )> for TrackingBatch
+{
+    fn from(
+        (batch, transactions, batch_status, submission_error): (
+            BatchModel,
+            Vec<TrackingTransaction>,
+            Option<BatchStatus>,
+            Option<SubmissionError>,
+        ),
+    ) -> Self {
+        Self {
+            service_id: batch.service_id.to_string(),
+            batch_header: batch.batch_id.to_string(),
+            data_change_id: batch.data_change_id.clone(),
+            signer_public_key: batch.signer_public_key.to_string(),
+            trace: batch.trace,
+            serialized_batch: batch.serialized_batch.to_vec(),
+            submitted: batch.submitted,
+            created_at: batch.created_at.timestamp(),
+            transactions,
+            batch_status,
+            submission_error,
+        }
+    }
+}
+
+impl From<TransactionModel> for TrackingTransaction {
+    fn from(transaction: TransactionModel) -> Self {
+        Self {
+            family_name: transaction.family_name.to_string(),
+            family_version: transaction.family_version.to_string(),
+            payload: transaction.payload.to_vec(),
+            signer_public_key: transaction.signer_public_key.to_string(),
+            service_id: transaction.service_id.clone(),
+        }
+    }
+}
+
+impl From<TransactionReceiptModel> for TransactionReceipt {
+    fn from(receipt: TransactionReceiptModel) -> Self {
+        Self {
+            transaction_id: receipt.transaction_id.to_string(),
+            result_valid: receipt.result_valid,
+            error_message: receipt.error_message,
+            error_data: receipt.error_data,
+            serialized_receipt: format!("{:?}", receipt.serialized_receipt),
+            external_status: receipt.external_status,
+            external_error_message: receipt.external_error_message,
+        }
+    }
+}
+
+impl
+    TryFrom<(
+        BatchStatusModel,
+        Option<Vec<InvalidTransaction>>,
+        Option<Vec<ValidTransaction>>,
+    )> for BatchStatus
+{
+    type Error = BatchTrackingStoreError;
+
+    fn try_from(
+        (batch_status, invalid_transactions, valid_transactions): (
+            BatchStatusModel,
+            Option<Vec<InvalidTransaction>>,
+            Option<Vec<ValidTransaction>>,
+        ),
+    ) -> Result<Self, Self::Error> {
+        match batch_status.dlt_status.as_str() {
+            "UNKNOWN" => Ok(BatchStatus::Unknown),
+            "PENDING" => Ok(BatchStatus::Pending),
+            "INVALID" => {
+                if invalid_transactions.is_none() {
+                    return Err(BatchTrackingStoreError::InternalError(
+                        InternalError::with_message(
+                            "Invalid batches must have invalid transactions".to_string(),
+                        ),
+                    ));
+                }
+
+                Ok(BatchStatus::Invalid(invalid_transactions.unwrap()))
+            }
+            "VALID" => {
+                if valid_transactions.is_none() {
+                    return Err(BatchTrackingStoreError::InternalError(
+                        InternalError::with_message(
+                            "Valid batches must have valid transactions".to_string(),
+                        ),
+                    ));
+                }
+
+                Ok(BatchStatus::Valid(valid_transactions.unwrap()))
+            }
+            "COMMITTED" => {
+                if valid_transactions.is_none() {
+                    return Err(BatchTrackingStoreError::InternalError(
+                        InternalError::with_message(
+                            "Committed batches must have valid transactions".to_string(),
+                        ),
+                    ));
+                }
+
+                Ok(BatchStatus::Committed(valid_transactions.unwrap()))
+            }
+            _ => Err(BatchTrackingStoreError::InternalError(
+                InternalError::with_message(format!(
+                    "{} is not a supported DLT status",
+                    batch_status.dlt_status
+                )),
+            )),
+        }
+    }
+}
+
+impl TryFrom<TransactionReceipt> for InvalidTransaction {
+    type Error = BatchTrackingStoreError;
+
+    fn try_from(receipt: TransactionReceipt) -> Result<Self, Self::Error> {
+        if receipt.error_message.is_none() {
+            return Err(BatchTrackingStoreError::InternalError(
+                InternalError::with_message(
+                    "Invalid transaction receipts must have an error message".to_string(),
+                ),
+            ));
+        }
+        let error_message = receipt.error_message.unwrap();
+
+        if receipt.error_data.is_none() {
+            return Err(BatchTrackingStoreError::InternalError(
+                InternalError::with_message(
+                    "Invalid transaction receipts must have error data".to_string(),
+                ),
+            ));
+        }
+        let error_data = receipt.error_data.unwrap();
+
+        Ok(Self {
+            transaction_id: receipt.transaction_id,
+            error_message,
+            error_data,
+        })
+    }
+}
+
+impl TryFrom<TransactionReceipt> for ValidTransaction {
+    type Error = BatchTrackingStoreError;
+
+    fn try_from(receipt: TransactionReceipt) -> Result<Self, Self::Error> {
+        if receipt.error_message.is_some() {
+            return Err(BatchTrackingStoreError::InternalError(
+                InternalError::with_message(
+                    "Valid transaction receipts must not have an error message".to_string(),
+                ),
+            ));
+        }
+        if receipt.error_data.is_some() {
+            return Err(BatchTrackingStoreError::InternalError(
+                InternalError::with_message(
+                    "Valid transaction receipts must not have error data".to_string(),
+                ),
+            ));
+        }
+        if receipt.external_status.is_some() {
+            return Err(BatchTrackingStoreError::InternalError(
+                InternalError::with_message(
+                    "Valid transaction receipts must not have an external error status".to_string(),
+                ),
+            ));
+        }
+        if receipt.external_error_message.is_some() {
+            return Err(BatchTrackingStoreError::InternalError(
+                InternalError::with_message(
+                    "Valid transaction receipts must not have an external error message"
+                        .to_string(),
+                ),
+            ));
+        }
+
+        Ok(Self {
+            transaction_id: receipt.transaction_id,
+        })
+    }
+}

--- a/sdk/src/batch_tracking/store/diesel/schema.rs
+++ b/sdk/src/batch_tracking/store/diesel/schema.rs
@@ -1,0 +1,85 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+table! {
+    batch_statuses (service_id, batch_id) {
+        service_id -> Text,
+        batch_id -> Text,
+        batch_service_id -> Text,
+        dlt_status -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
+    batches (service_id, batch_id) {
+        service_id -> Text,
+        batch_id -> Text,
+        data_change_id -> Nullable<Text>,
+        signer_public_key -> Text,
+        trace -> Bool,
+        serialized_batch -> Binary,
+        submitted -> Bool,
+        created_at -> Timestamp,
+    }
+}
+
+table! {
+    submissions (service_id, batch_id) {
+        service_id -> Text,
+        batch_id -> Text,
+        batch_service_id -> Text,
+        last_checked -> Nullable<Timestamp>,
+        times_checked -> Nullable<Text>,
+        error_type -> Nullable<Text>,
+        error_message -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
+    transaction_receipts (service_id, transaction_id) {
+        service_id -> Text,
+        transaction_id -> Text,
+        result_valid -> Bool,
+        error_message -> Nullable<Text>,
+        error_data -> Nullable<Binary>,
+        serialized_receipt -> Binary,
+        external_status -> Nullable<Text>,
+        external_error_message -> Nullable<Text>,
+    }
+}
+
+table! {
+    transactions (service_id, transaction_id) {
+        service_id -> Text,
+        transaction_id -> Text,
+        batch_id -> Text,
+        batch_service_id -> Text,
+        payload -> Binary,
+        family_name -> Text,
+        family_version -> Text,
+        signer_public_key -> Text,
+    }
+}
+
+allow_tables_to_appear_in_same_query!(
+    batch_statuses,
+    batches,
+    submissions,
+    transaction_receipts,
+    transactions,
+);

--- a/sdk/src/batch_tracking/store/error.rs
+++ b/sdk/src/batch_tracking/store/error.rs
@@ -1,0 +1,118 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+#[cfg(feature = "diesel")]
+use crate::error::ConstraintViolationType;
+use crate::error::{ConstraintViolationError, InternalError, ResourceTemporarilyUnavailableError};
+
+/// Represents Store errors
+#[derive(Debug)]
+pub enum BatchTrackingStoreError {
+    InternalError(InternalError),
+    ConstraintViolationError(ConstraintViolationError),
+    ResourceTemporarilyUnavailableError(ResourceTemporarilyUnavailableError),
+    NotFoundError(String),
+}
+
+impl Error for BatchTrackingStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            BatchTrackingStoreError::InternalError(err) => Some(err),
+            BatchTrackingStoreError::ConstraintViolationError(err) => Some(err),
+            BatchTrackingStoreError::ResourceTemporarilyUnavailableError(err) => Some(err),
+            BatchTrackingStoreError::NotFoundError(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for BatchTrackingStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            BatchTrackingStoreError::InternalError(err) => err.fmt(f),
+            BatchTrackingStoreError::ConstraintViolationError(err) => err.fmt(f),
+            BatchTrackingStoreError::ResourceTemporarilyUnavailableError(err) => err.fmt(f),
+            BatchTrackingStoreError::NotFoundError(ref s) => write!(f, "Element not found: {}", s),
+        }
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<diesel::result::Error> for BatchTrackingStoreError {
+    fn from(err: diesel::result::Error) -> Self {
+        match err {
+            diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::UniqueViolation,
+                _,
+            ) => BatchTrackingStoreError::ConstraintViolationError(
+                ConstraintViolationError::from_source_with_violation_type(
+                    ConstraintViolationType::Unique,
+                    Box::new(err),
+                ),
+            ),
+            diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::ForeignKeyViolation,
+                _,
+            ) => BatchTrackingStoreError::ConstraintViolationError(
+                ConstraintViolationError::from_source_with_violation_type(
+                    ConstraintViolationType::ForeignKey,
+                    Box::new(err),
+                ),
+            ),
+            _ => BatchTrackingStoreError::InternalError(InternalError::from_source(Box::new(err))),
+        }
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<diesel::r2d2::PoolError> for BatchTrackingStoreError {
+    fn from(err: diesel::r2d2::PoolError) -> BatchTrackingStoreError {
+        BatchTrackingStoreError::ResourceTemporarilyUnavailableError(
+            ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+        )
+    }
+}
+
+/// Represents BatchBuilder errors
+#[derive(Debug)]
+pub enum BatchBuilderError {
+    /// Returned when a required field was not set
+    MissingRequiredField(String),
+    /// Returned when an error occurs building the PO
+    BuildError(Box<dyn Error>),
+}
+
+impl Error for BatchBuilderError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            BatchBuilderError::MissingRequiredField(_) => None,
+            BatchBuilderError::BuildError(err) => Some(&**err),
+        }
+    }
+}
+
+impl fmt::Display for BatchBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BatchBuilderError::MissingRequiredField(ref s) => {
+                write!(f, "Missing required field: {}", s)
+            }
+            BatchBuilderError::BuildError(ref s) => {
+                write!(f, "Failed to build purchase order object: {}", s)
+            }
+        }
+    }
+}

--- a/sdk/src/batch_tracking/store/mod.rs
+++ b/sdk/src/batch_tracking/store/mod.rs
@@ -607,3 +607,158 @@ impl TransactionReceiptBuilder {
         self
     }
 }
+
+pub trait BatchTrackingStore {
+    /// Gets the status of a batch from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `id` - The ID or data change ID of the batch with the status to
+    ///    fetch
+    ///  * `service_id` - The service ID
+    fn get_batch_status(
+        &self,
+        id: &str,
+        service_id: Option<&str>,
+    ) -> Result<BatchStatus, BatchTrackingStoreError>;
+
+    /// Updates the status of a batch in the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `id` - The ID or data change ID of the batch with the status to
+    ///    update
+    ///  * `service_id` - The service ID
+    ///  * `status` - The new status for the batch
+    ///  * `errors` - Any errors encountered while attempting to submit the
+    ///    batch
+    fn update_batch_status(
+        &self,
+        id: String,
+        service_id: Option<&str>,
+        status: BatchStatus,
+        errors: Vec<SubmissionError>,
+    ) -> Result<(), BatchTrackingStoreError>;
+
+    /// Adds batches to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `batches` - The batches to be added
+    fn add_batches(&self, batches: Vec<TrackingBatch>) -> Result<(), BatchTrackingStoreError>;
+
+    /// Updates a batch's status to a submitted state
+    ///
+    /// # Arguments
+    ///
+    ///  * `batch_id` - The ID or data change ID of the batch to update
+    ///  * `service_id` - The service ID
+    fn change_batch_to_submitted(
+        &self,
+        batch_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<(), BatchTrackingStoreError>;
+
+    /// Gets a batch from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `id` - The ID or data change ID of the batch to fetch
+    fn get_batch(
+        &self,
+        id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Option<TrackingBatch>, BatchTrackingStoreError>;
+
+    /// Lists batches with a given status from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `status` - The status to fetch batches for
+    fn list_batches_by_status(
+        &self,
+        status: BatchStatus,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError>;
+
+    /// Removes records for batches and batch submissions before a given time
+    ///
+    /// # Arguments
+    ///
+    ///  * `submitted_by` - The timestamp for which to delete records submitted before
+    fn clean_stale_records(
+        &self,
+        submitted_by: &str,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError>;
+
+    /// Gets batches that have not yet been submitted from the underlying storage
+    fn get_unsubmitted_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError>;
+
+    /// Gets batches that failed either due to validation or submission errors
+    /// from the underlying storage
+    fn get_failed_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError>;
+}
+
+impl<BS> BatchTrackingStore for Box<BS>
+where
+    BS: BatchTrackingStore + ?Sized,
+{
+    fn get_batch_status(
+        &self,
+        _id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<BatchStatus, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn update_batch_status(
+        &self,
+        _id: String,
+        _service_id: Option<&str>,
+        _status: BatchStatus,
+        _errors: Vec<SubmissionError>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn add_batches(&self, _batches: Vec<TrackingBatch>) -> Result<(), BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn change_batch_to_submitted(
+        &self,
+        _batch_id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_batch(
+        &self,
+        _id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<Option<TrackingBatch>, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn list_batches_by_status(
+        &self,
+        _status: BatchStatus,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn clean_stale_records(
+        &self,
+        _submitted_by: &str,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_unsubmitted_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_failed_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+}

--- a/sdk/src/batch_tracking/store/mod.rs
+++ b/sdk/src/batch_tracking/store/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod error;

--- a/sdk/src/batch_tracking/store/mod.rs
+++ b/sdk/src/batch_tracking/store/mod.rs
@@ -12,4 +12,598 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::error::InternalError;
+use transact::protocol::{
+    batch::Batch,
+    transaction::{Transaction, TransactionHeader},
+};
+use transact::protos::FromBytes;
+
+#[cfg(feature = "diesel")]
+pub(in crate) mod diesel;
 mod error;
+
+pub use error::{BatchBuilderError, BatchTrackingStoreError};
+
+const NON_SPLINTER_SERVICE_ID_DEFAULT: &str = "----";
+
+#[derive(Clone)]
+pub enum BatchStatus {
+    Unknown,
+    Pending,
+    Invalid(Vec<InvalidTransaction>),
+    Valid(Vec<ValidTransaction>),
+    Committed(Vec<ValidTransaction>),
+}
+
+#[derive(Clone)]
+pub struct InvalidTransaction {
+    transaction_id: String,
+    error_message: String,
+    error_data: Vec<u8>,
+}
+
+impl InvalidTransaction {
+    pub fn transaction_id(&self) -> &str {
+        &self.transaction_id
+    }
+
+    pub fn error_message(&self) -> &str {
+        &self.error_message
+    }
+
+    pub fn error_data(&self) -> &[u8] {
+        &self.error_data
+    }
+}
+
+pub struct InvalidTransactionBuilder {
+    transaction_id: String,
+    error_message: String,
+    error_data: Vec<u8>,
+}
+
+impl InvalidTransactionBuilder {
+    pub fn with_transaction_id(mut self, transaction_id: String) -> Self {
+        self.transaction_id = transaction_id;
+        self
+    }
+
+    pub fn with_error_message(mut self, error_message: String) -> Self {
+        self.error_message = error_message;
+        self
+    }
+
+    pub fn error_data(mut self, error_data: Vec<u8>) -> Self {
+        self.error_data = error_data;
+        self
+    }
+
+    pub fn build(self) -> Result<InvalidTransaction, BatchBuilderError> {
+        let InvalidTransactionBuilder {
+            transaction_id,
+            error_message,
+            error_data,
+        } = self;
+
+        if transaction_id.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "transaction_id".to_string(),
+            ));
+        };
+
+        if error_message.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "error_message".to_string(),
+            ));
+        };
+
+        if error_data.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "error_data".to_string(),
+            ));
+        };
+
+        Ok(InvalidTransaction {
+            transaction_id,
+            error_message,
+            error_data,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct ValidTransaction {
+    transaction_id: String,
+}
+
+impl ValidTransaction {
+    pub fn transaction_id(&self) -> &str {
+        &self.transaction_id
+    }
+}
+
+pub struct ValidTransactionBuilder {
+    transaction_id: String,
+}
+
+impl ValidTransactionBuilder {
+    pub fn with_transaction_id(mut self, transaction_id: String) -> Self {
+        self.transaction_id = transaction_id;
+        self
+    }
+
+    pub fn build(self) -> Result<ValidTransaction, BatchBuilderError> {
+        let ValidTransactionBuilder { transaction_id } = self;
+
+        if transaction_id.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "transaction_id".to_string(),
+            ));
+        };
+
+        Ok(ValidTransaction { transaction_id })
+    }
+}
+
+#[derive(Clone)]
+pub struct SubmissionError {
+    error_type: String,
+    error_message: String,
+}
+
+impl SubmissionError {
+    pub fn error_type(&self) -> &str {
+        &self.error_type
+    }
+
+    pub fn error_message(&self) -> &str {
+        &self.error_message
+    }
+}
+
+pub struct SubmissionErrorBuilder {
+    error_type: String,
+    error_message: String,
+}
+
+impl SubmissionErrorBuilder {
+    pub fn with_error_type(mut self, error_type: String) -> Self {
+        self.error_type = error_type;
+        self
+    }
+
+    pub fn with_error_message(mut self, error_message: String) -> Self {
+        self.error_message = error_message;
+        self
+    }
+
+    pub fn build(self) -> Result<SubmissionError, BatchBuilderError> {
+        let SubmissionErrorBuilder {
+            error_type,
+            error_message,
+        } = self;
+
+        if error_type.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "error_type".to_string(),
+            ));
+        };
+
+        if error_message.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "error_message".to_string(),
+            ));
+        };
+
+        Ok(SubmissionError {
+            error_type,
+            error_message,
+        })
+    }
+}
+
+pub struct TrackingBatch {
+    service_id: String,
+    batch_header: String,
+    data_change_id: Option<String>,
+    signer_public_key: String,
+    trace: bool,
+    serialized_batch: Vec<u8>,
+    submitted: bool,
+    created_at: i64,
+    transactions: Vec<TrackingTransaction>,
+    batch_status: Option<BatchStatus>,
+    submission_error: Option<SubmissionError>,
+}
+
+impl TrackingBatch {
+    pub fn service_id(&self) -> &str {
+        &self.service_id
+    }
+
+    pub fn batch_header(&self) -> &str {
+        &self.batch_header
+    }
+
+    pub fn data_change_id(&self) -> Option<&str> {
+        self.data_change_id.as_deref()
+    }
+
+    pub fn signer_public_key(&self) -> &str {
+        &self.signer_public_key
+    }
+
+    pub fn trace(&self) -> bool {
+        self.trace
+    }
+
+    pub fn serialized_batch(&self) -> &[u8] {
+        &self.serialized_batch
+    }
+
+    pub fn submitted(&self) -> bool {
+        self.submitted
+    }
+
+    pub fn created_at(&self) -> i64 {
+        self.created_at
+    }
+
+    pub fn transactions(&self) -> &[TrackingTransaction] {
+        &self.transactions
+    }
+
+    pub fn batch_status(&self) -> Option<&BatchStatus> {
+        self.batch_status.as_ref()
+    }
+
+    pub fn submission_error(&self) -> Option<&SubmissionError> {
+        self.submission_error.as_ref()
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct TrackingBatchBuilder {
+    service_id: String,
+    batch: Option<Batch>,
+    data_change_id: Option<String>,
+    signer_public_key: String,
+    submitted: bool,
+    created_at: i64,
+    batch_status: Option<BatchStatus>,
+    submission_error: Option<SubmissionError>,
+}
+
+impl TrackingBatchBuilder {
+    pub fn with_batch(mut self, batch: Batch) -> Self {
+        self.batch = Some(batch);
+        self
+    }
+
+    pub fn with_service_id(mut self, service_id: String) -> Self {
+        self.service_id = service_id;
+        self
+    }
+
+    pub fn with_data_change_id(mut self, data_change_id: String) -> Self {
+        self.data_change_id = Some(data_change_id);
+        self
+    }
+
+    pub fn with_signer_public_key(mut self, signer_public_key: String) -> Self {
+        self.signer_public_key = signer_public_key;
+        self
+    }
+
+    pub fn with_submitted(mut self, submitted: bool) -> Self {
+        self.submitted = submitted;
+        self
+    }
+
+    pub fn with_batch_status(mut self, status: BatchStatus) -> Self {
+        self.batch_status = Some(status);
+        self
+    }
+
+    pub fn with_submission_error(mut self, submission_error: SubmissionError) -> Self {
+        self.submission_error = Some(submission_error);
+        self
+    }
+
+    pub fn build(self) -> Result<TrackingBatch, BatchBuilderError> {
+        let TrackingBatchBuilder {
+            service_id,
+            batch,
+            data_change_id,
+            signer_public_key,
+            submitted,
+            created_at,
+            batch_status,
+            submission_error,
+        } = self;
+
+        if batch.is_none() {
+            return Err(BatchBuilderError::MissingRequiredField("batch".to_string()));
+        };
+
+        let transact_batch = batch.unwrap();
+
+        if transact_batch.header_signature().is_empty()
+            || transact_batch.header().is_empty()
+            || transact_batch.transactions().is_empty()
+        {
+            return Err(BatchBuilderError::MissingRequiredField("batch".to_string()));
+        };
+
+        let mut serv_id = service_id.to_string();
+
+        if service_id.is_empty() {
+            serv_id = NON_SPLINTER_SERVICE_ID_DEFAULT.to_string();
+        };
+
+        let batch_header = transact_batch.header_signature().to_string();
+        let serialized_batch = transact_batch.header().to_vec();
+        let trace = transact_batch.trace();
+
+        let transactions: Vec<TrackingTransaction> = transact_batch
+            .transactions()
+            .iter()
+            .map(|t| {
+                TrackingTransactionBuilder::default()
+                    .with_transaction(t.clone())
+                    .with_service_id(serv_id.clone())
+                    .build()
+            })
+            .collect::<Result<Vec<TrackingTransaction>, _>>()?;
+
+        if batch_header.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "batch_header".to_string(),
+            ));
+        };
+
+        if signer_public_key.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "signer_public_key".to_string(),
+            ));
+        };
+
+        if serialized_batch.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "serialized_batch".to_string(),
+            ));
+        };
+
+        if created_at <= 0 {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "created_at".to_string(),
+            ));
+        };
+
+        if transactions.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "transactions".to_string(),
+            ));
+        };
+
+        Ok(TrackingBatch {
+            service_id: serv_id,
+            batch_header,
+            data_change_id,
+            signer_public_key,
+            trace,
+            serialized_batch,
+            submitted,
+            created_at,
+            transactions,
+            batch_status,
+            submission_error,
+        })
+    }
+}
+
+pub struct TrackingBatchList {
+    pub batches: Vec<TrackingBatch>,
+}
+
+pub struct TrackingTransaction {
+    family_name: String,
+    family_version: String,
+    payload: Vec<u8>,
+    signer_public_key: String,
+    service_id: String,
+}
+
+impl TrackingTransaction {
+    pub fn family_name(&self) -> &str {
+        &self.family_name
+    }
+
+    pub fn family_version(&self) -> &str {
+        &self.family_version
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    pub fn signer_public_key(&self) -> &str {
+        &self.signer_public_key
+    }
+
+    pub fn service_id(&self) -> &str {
+        &self.service_id
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct TrackingTransactionBuilder {
+    transaction: Option<Transaction>,
+    service_id: String,
+}
+
+impl TrackingTransactionBuilder {
+    pub fn with_transaction(mut self, transaction: Transaction) -> Self {
+        self.transaction = Some(transaction);
+        self
+    }
+
+    pub fn with_service_id(mut self, service_id: String) -> Self {
+        self.service_id = service_id;
+        self
+    }
+
+    pub fn build(self) -> Result<TrackingTransaction, BatchBuilderError> {
+        let TrackingTransactionBuilder {
+            transaction,
+            service_id,
+        } = self;
+
+        if transaction.is_none() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "transaction".to_string(),
+            ));
+        }
+
+        let transact_transaction = transaction.unwrap();
+
+        let mut serv_id = service_id.to_string();
+
+        if service_id.is_empty() {
+            serv_id = NON_SPLINTER_SERVICE_ID_DEFAULT.to_string();
+        };
+
+        let txn_header =
+            TransactionHeader::from_bytes(transact_transaction.header()).map_err(|err| {
+                BatchBuilderError::BuildError(Box::new(InternalError::with_message(format!(
+                    "Could not convert transaction header from bytes: {}",
+                    err
+                ))))
+            })?;
+
+        let family_name = txn_header.family_name().to_string();
+        let family_version = txn_header.family_version().to_string();
+        let signer_public_key = format!("{:?}", txn_header.signer_public_key());
+        let payload = transact_transaction.payload().to_vec();
+
+        if family_name.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "family_name".to_string(),
+            ));
+        }
+
+        if family_version.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "family_version".to_string(),
+            ));
+        }
+
+        if payload.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "payload".to_string(),
+            ));
+        }
+
+        if signer_public_key.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "signer_public_key".to_string(),
+            ));
+        }
+
+        Ok(TrackingTransaction {
+            family_name,
+            family_version,
+            payload,
+            signer_public_key,
+            service_id: serv_id,
+        })
+    }
+}
+
+pub struct TransactionReceipt {
+    transaction_id: String,
+    result_valid: bool,
+    error_message: Option<String>,
+    error_data: Option<Vec<u8>>,
+    serialized_receipt: String,
+    external_status: Option<String>,
+    external_error_message: Option<String>,
+}
+
+impl TransactionReceipt {
+    pub fn transaction_id(&self) -> &str {
+        &self.transaction_id
+    }
+
+    pub fn result_valid(&self) -> bool {
+        self.result_valid
+    }
+
+    pub fn error_message(&self) -> Option<&str> {
+        self.error_message.as_deref()
+    }
+
+    pub fn error_data(&self) -> Option<&[u8]> {
+        self.error_data.as_deref()
+    }
+
+    pub fn serialized_receipt(&self) -> &str {
+        &self.serialized_receipt
+    }
+
+    pub fn external_status(&self) -> Option<&str> {
+        self.external_status.as_deref()
+    }
+
+    pub fn external_error_message(&self) -> Option<&str> {
+        self.external_error_message.as_deref()
+    }
+}
+
+pub struct TransactionReceiptBuilder {
+    transaction_id: String,
+    result_valid: bool,
+    error_message: Option<String>,
+    error_data: Option<Vec<u8>>,
+    serialized_receipt: String,
+    external_status: Option<String>,
+    external_error_message: Option<String>,
+}
+
+impl TransactionReceiptBuilder {
+    pub fn with_transaction_id(mut self, id: String) -> Self {
+        self.transaction_id = id;
+        self
+    }
+
+    pub fn with_result_valid(mut self, result_valid: bool) -> Self {
+        self.result_valid = result_valid;
+        self
+    }
+
+    pub fn with_error_message(mut self, error_message: String) -> Self {
+        self.error_message = Some(error_message);
+        self
+    }
+
+    pub fn with_error_data(mut self, data: Vec<u8>) -> Self {
+        self.error_data = Some(data);
+        self
+    }
+
+    pub fn with_serialized_receipt(mut self, receipt: String) -> Self {
+        self.serialized_receipt = receipt;
+        self
+    }
+
+    pub fn with_external_status(mut self, status: String) -> Self {
+        self.external_status = Some(status);
+        self
+    }
+
+    pub fn with_external_error_message(mut self, message: String) -> Self {
+        self.external_error_message = Some(message);
+        self
+    }
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -35,6 +35,8 @@ extern crate log;
 pub mod backend;
 #[cfg(feature = "batch-processor")]
 pub mod batch_processor;
+#[cfg(feature = "batch-tracking")]
+pub mod batch_tracking;
 #[cfg(feature = "batch-store")]
 pub mod batches;
 #[cfg(feature = "client")]


### PR DESCRIPTION
This PR adds several things: a diesel DB schema file for the Batch Tracking store db, DB struct models and their associated Rust struct representations along with conversion methods, and the initial BatchTrackingStore trait and several associated methods.