### PR TITLE
Bump flexi_logger from 0.17 -> 0.22

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,7 @@ cylinder = { version = "0.2.2", features = ["key-load"] }
 diesel = { version = "1.0", features = ["postgres"], optional = true }
 diesel_migrations = "1.4"
 dirs = "4"
-flexi_logger = "0.17"
+flexi_logger = "0.22"
 grid-sdk = { path = "../sdk", features = ["client", "client-reqwest", "data-validation"] }
 libc = "0.2"
 log = "0.4"

--- a/contracts/pike/Cargo.toml
+++ b/contracts/pike/Cargo.toml
@@ -30,7 +30,7 @@ sabre-sdk = "0.5"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 sawtooth-sdk = "0.4"
 log = "0.4"
-flexi_logger = "0.17"
+flexi_logger = "0.22"
 clap = "2"
 rust-crypto = "0.2.36"
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -40,7 +40,7 @@ ctrlc = "3.0"
 cylinder = { version = "0.2.2", features = ["jwt"], optional = true }
 diesel = { version = "1.0.0", features = ["r2d2", "serde_json"] }
 diesel_migrations = "1.4"
-flexi_logger = "0.17"
+flexi_logger = "0.22"
 futures = "0.3"
 
 grid-sdk = { path = "../sdk"}

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -12,7 +12,7 @@ description = "Grid integration component"
 actix-web = { version = "3", default-features = false }
 clap = "2.33.3"
 diesel = { version = "1.0", features = ["r2d2"], optional = true }
-flexi_logger = "0.17"
+flexi_logger = "0.22"
 grid-sdk = { path = "../sdk", features = ["rest-api-actix-web-3", "rest-api-actix-web-3-run", "batch-processor"] }
 log = "0.4"
 users = "0.11"


### PR DESCRIPTION
The latest version of flexi_logger includes a number of API improvements
and fixes over 0.17.

Signed-off-by: Lee Bradley <bradley@bitwise.io>