### PR TITLE
Bump dirs library from 0.3 -> 0.4

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,7 +35,7 @@ clap = "2"
 cylinder = { version = "0.2.2", features = ["key-load"] }
 diesel = { version = "1.0", features = ["postgres"], optional = true }
 diesel_migrations = "1.4"
-dirs = "3"
+dirs = "4"
 flexi_logger = "0.17"
 grid-sdk = { path = "../sdk", features = ["client", "client-reqwest", "data-validation"] }
 libc = "0.2"


### PR DESCRIPTION
Latest version of dirs adds support for XDG_DATA_HOME.

Signed-off-by: Lee Bradley <bradley@bitwise.io>