### PR TITLE
Add `add_batches` Batch Tracking store operation

### DIFF
--- a/sdk/src/batch_tracking/store/diesel/mod.rs
+++ b/sdk/src/batch_tracking/store/diesel/mod.rs
@@ -13,9 +13,319 @@
 // limitations under the License.
 
 pub mod models;
+mod operations;
 pub(in crate) mod schema;
 
+use diesel::connection::AnsiTransactionManager;
+use diesel::r2d2::{ConnectionManager, Pool};
+
 use super::{
-    BatchStatus, InvalidTransaction, SubmissionError, TrackingBatch, TrackingTransaction,
-    TransactionReceipt, ValidTransaction,
+    BatchStatus, BatchTrackingStore, BatchTrackingStoreError, InvalidTransaction, SubmissionError,
+    TrackingBatch, TrackingBatchList, TrackingTransaction, TransactionReceipt, ValidTransaction,
 };
+
+use crate::error::ResourceTemporarilyUnavailableError;
+
+use operations::add_batches::BatchTrackingStoreAddBatchesOperation as _;
+use operations::BatchTrackingStoreOperations;
+
+/// Manages batches in the database
+#[derive(Clone)]
+pub struct DieselBatchTrackingStore<C: diesel::Connection + 'static> {
+    connection_pool: Pool<ConnectionManager<C>>,
+}
+
+impl<C: diesel::Connection> DieselBatchTrackingStore<C> {
+    /// Creates a new DieselBatchTrackingStore
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool to the database
+    #[allow(dead_code)]
+    pub fn new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        DieselBatchTrackingStore { connection_pool }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl BatchTrackingStore for DieselBatchTrackingStore<diesel::pg::PgConnection> {
+    fn get_batch_status(
+        &self,
+        _id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<BatchStatus, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn update_batch_status(
+        &self,
+        _id: String,
+        _service_id: Option<&str>,
+        _status: BatchStatus,
+        _errors: Vec<SubmissionError>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn add_batches(&self, batches: Vec<TrackingBatch>) -> Result<(), BatchTrackingStoreError> {
+        BatchTrackingStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            BatchTrackingStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .add_batches(batches)
+    }
+
+    fn change_batch_to_submitted(
+        &self,
+        _batch_id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_batch(
+        &self,
+        _id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<Option<TrackingBatch>, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn list_batches_by_status(
+        &self,
+        _status: BatchStatus,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn clean_stale_records(
+        &self,
+        _submitted_by: &str,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_unsubmitted_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_failed_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl BatchTrackingStore for DieselBatchTrackingStore<diesel::sqlite::SqliteConnection> {
+    fn get_batch_status(
+        &self,
+        _id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<BatchStatus, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn update_batch_status(
+        &self,
+        _id: String,
+        _service_id: Option<&str>,
+        _status: BatchStatus,
+        _errors: Vec<SubmissionError>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn add_batches(&self, batches: Vec<TrackingBatch>) -> Result<(), BatchTrackingStoreError> {
+        BatchTrackingStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            BatchTrackingStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .add_batches(batches)
+    }
+
+    fn change_batch_to_submitted(
+        &self,
+        _batch_id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_batch(
+        &self,
+        _id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<Option<TrackingBatch>, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn list_batches_by_status(
+        &self,
+        _status: BatchStatus,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn clean_stale_records(
+        &self,
+        _submitted_by: &str,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_unsubmitted_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_failed_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+}
+
+pub struct DieselConnectionBatchTrackingStore<'a, C>
+where
+    C: diesel::Connection<TransactionManager = AnsiTransactionManager> + 'static,
+    C::Backend: diesel::backend::UsesAnsiSavepointSyntax,
+{
+    connection: &'a C,
+}
+
+impl<'a, C> DieselConnectionBatchTrackingStore<'a, C>
+where
+    C: diesel::Connection<TransactionManager = AnsiTransactionManager> + 'static,
+    C::Backend: diesel::backend::UsesAnsiSavepointSyntax,
+{
+    #[allow(dead_code)]
+    pub fn new(connection: &'a C) -> Self {
+        DieselConnectionBatchTrackingStore { connection }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> BatchTrackingStore for DieselConnectionBatchTrackingStore<'a, diesel::pg::PgConnection> {
+    fn get_batch_status(
+        &self,
+        _id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<BatchStatus, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn update_batch_status(
+        &self,
+        _id: String,
+        _service_id: Option<&str>,
+        _status: BatchStatus,
+        _errors: Vec<SubmissionError>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn add_batches(&self, batches: Vec<TrackingBatch>) -> Result<(), BatchTrackingStoreError> {
+        BatchTrackingStoreOperations::new(self.connection).add_batches(batches)
+    }
+
+    fn change_batch_to_submitted(
+        &self,
+        _batch_id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_batch(
+        &self,
+        _id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<Option<TrackingBatch>, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn list_batches_by_status(
+        &self,
+        _status: BatchStatus,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn clean_stale_records(
+        &self,
+        _submitted_by: &str,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_unsubmitted_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_failed_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> BatchTrackingStore
+    for DieselConnectionBatchTrackingStore<'a, diesel::sqlite::SqliteConnection>
+{
+    fn get_batch_status(
+        &self,
+        _id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<BatchStatus, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn update_batch_status(
+        &self,
+        _id: String,
+        _service_id: Option<&str>,
+        _status: BatchStatus,
+        _errors: Vec<SubmissionError>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn add_batches(&self, batches: Vec<TrackingBatch>) -> Result<(), BatchTrackingStoreError> {
+        BatchTrackingStoreOperations::new(self.connection).add_batches(batches)
+    }
+
+    fn change_batch_to_submitted(
+        &self,
+        _batch_id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_batch(
+        &self,
+        _id: &str,
+        _service_id: Option<&str>,
+    ) -> Result<Option<TrackingBatch>, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn list_batches_by_status(
+        &self,
+        _status: BatchStatus,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn clean_stale_records(
+        &self,
+        _submitted_by: &str,
+    ) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_unsubmitted_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+
+    fn get_failed_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+        unimplemented!();
+    }
+}

--- a/sdk/src/batch_tracking/store/diesel/models.rs
+++ b/sdk/src/batch_tracking/store/diesel/models.rs
@@ -125,6 +125,7 @@ impl From<TransactionModel> for TrackingTransaction {
         Self {
             family_name: transaction.family_name.to_string(),
             family_version: transaction.family_version.to_string(),
+            transaction_id: transaction.transaction_id.to_string(),
             payload: transaction.payload.to_vec(),
             signer_public_key: transaction.signer_public_key.to_string(),
             service_id: transaction.service_id.clone(),
@@ -276,4 +277,46 @@ impl TryFrom<TransactionReceipt> for ValidTransaction {
             transaction_id: receipt.transaction_id,
         })
     }
+}
+
+pub fn make_batch_models(batches: &[TrackingBatch]) -> Vec<BatchModel> {
+    let mut models = Vec::new();
+    for batch in batches {
+        let model = BatchModel {
+            service_id: batch.service_id().to_string(),
+            batch_id: batch.batch_header().to_string(),
+            data_change_id: batch.data_change_id().map(String::from),
+            signer_public_key: batch.signer_public_key().to_string(),
+            trace: batch.trace(),
+            serialized_batch: batch.serialized_batch().to_vec(),
+            submitted: batch.submitted(),
+            created_at: NaiveDateTime::from_timestamp(batch.created_at(), 0),
+        };
+
+        models.push(model)
+    }
+
+    models
+}
+
+pub fn make_transaction_models(batches: &[TrackingBatch]) -> Vec<TransactionModel> {
+    let mut models = Vec::new();
+    for batch in batches {
+        for transaction in batch.transactions() {
+            let model = TransactionModel {
+                service_id: transaction.service_id().to_string(),
+                transaction_id: transaction.transaction_id().to_string(),
+                batch_id: batch.batch_header().to_string(),
+                batch_service_id: batch.service_id().to_string(),
+                payload: transaction.payload().to_vec(),
+                family_name: transaction.family_name().to_string(),
+                family_version: transaction.family_version().to_string(),
+                signer_public_key: transaction.signer_public_key().to_string(),
+            };
+
+            models.push(model)
+        }
+    }
+
+    models
 }

--- a/sdk/src/batch_tracking/store/diesel/operations/add_batches.rs
+++ b/sdk/src/batch_tracking/store/diesel/operations/add_batches.rs
@@ -1,0 +1,78 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::BatchTrackingStoreOperations;
+use crate::batch_tracking::store::{
+    diesel::{
+        models::{make_batch_models, make_transaction_models},
+        schema::{batches, transactions},
+    },
+    BatchTrackingStoreError, TrackingBatch,
+};
+
+use diesel::{dsl::insert_into, prelude::*};
+
+pub(in crate::batch_tracking::store::diesel) trait BatchTrackingStoreAddBatchesOperation {
+    fn add_batches(&self, batches: Vec<TrackingBatch>) -> Result<(), BatchTrackingStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> BatchTrackingStoreAddBatchesOperation
+    for BatchTrackingStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_batches(&self, batches: Vec<TrackingBatch>) -> Result<(), BatchTrackingStoreError> {
+        let batch_models = make_batch_models(&batches);
+        let transaction_models = make_transaction_models(&batches);
+        self.conn.transaction::<_, BatchTrackingStoreError, _>(|| {
+            insert_into(batches::table)
+                .values(batch_models)
+                .execute(&*self.conn)
+                .map(|_| ())
+                .map_err(BatchTrackingStoreError::from)?;
+
+            insert_into(transactions::table)
+                .values(transaction_models)
+                .execute(&*self.conn)
+                .map(|_| ())
+                .map_err(BatchTrackingStoreError::from)?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> BatchTrackingStoreAddBatchesOperation
+    for BatchTrackingStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_batches(&self, batches: Vec<TrackingBatch>) -> Result<(), BatchTrackingStoreError> {
+        let batch_models = make_batch_models(&batches);
+        let transaction_models = make_transaction_models(&batches);
+        self.conn.transaction::<_, BatchTrackingStoreError, _>(|| {
+            insert_into(batches::table)
+                .values(batch_models)
+                .execute(&*self.conn)
+                .map(|_| ())
+                .map_err(BatchTrackingStoreError::from)?;
+
+            insert_into(transactions::table)
+                .values(transaction_models)
+                .execute(&*self.conn)
+                .map(|_| ())
+                .map_err(BatchTrackingStoreError::from)?;
+
+            Ok(())
+        })
+    }
+}

--- a/sdk/src/batch_tracking/store/diesel/operations/mod.rs
+++ b/sdk/src/batch_tracking/store/diesel/operations/mod.rs
@@ -1,0 +1,28 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) mod add_batches;
+
+pub(super) struct BatchTrackingStoreOperations<'a, C> {
+    conn: &'a C,
+}
+
+impl<'a, C> BatchTrackingStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    pub fn new(conn: &'a C) -> Self {
+        BatchTrackingStoreOperations { conn }
+    }
+}

--- a/sdk/src/batch_tracking/store/mod.rs
+++ b/sdk/src/batch_tracking/store/mod.rs
@@ -410,6 +410,7 @@ pub struct TrackingBatchList {
 pub struct TrackingTransaction {
     family_name: String,
     family_version: String,
+    transaction_id: String,
     payload: Vec<u8>,
     signer_public_key: String,
     service_id: String,
@@ -422,6 +423,10 @@ impl TrackingTransaction {
 
     pub fn family_version(&self) -> &str {
         &self.family_version
+    }
+
+    pub fn transaction_id(&self) -> &str {
+        &self.transaction_id
     }
 
     pub fn payload(&self) -> &[u8] {
@@ -485,6 +490,7 @@ impl TrackingTransactionBuilder {
         let family_name = txn_header.family_name().to_string();
         let family_version = txn_header.family_version().to_string();
         let signer_public_key = format!("{:?}", txn_header.signer_public_key());
+        let transaction_id = transact_transaction.header_signature().to_string();
         let payload = transact_transaction.payload().to_vec();
 
         if family_name.is_empty() {
@@ -496,6 +502,12 @@ impl TrackingTransactionBuilder {
         if family_version.is_empty() {
             return Err(BatchBuilderError::MissingRequiredField(
                 "family_version".to_string(),
+            ));
+        }
+
+        if transaction_id.is_empty() {
+            return Err(BatchBuilderError::MissingRequiredField(
+                "transaction_id".to_string(),
             ));
         }
 
@@ -514,6 +526,7 @@ impl TrackingTransactionBuilder {
         Ok(TrackingTransaction {
             family_name,
             family_version,
+            transaction_id,
             payload,
             signer_public_key,
             service_id: serv_id,


### PR DESCRIPTION
This implements the `add_batches` operation for the Batch Tracking
store. As this is the first operation implemented for this store, some
additional initial setup is included as well.

Signed-off-by: Davey Newhall <newhall@bitwise.io>