### PR TITLE
Add `get_batch_status` db operation

### DIFF
--- a/sdk/src/batch_tracking/store/diesel/mod.rs
+++ b/sdk/src/batch_tracking/store/diesel/mod.rs
@@ -28,6 +28,7 @@ use crate::error::ResourceTemporarilyUnavailableError;
 
 use operations::add_batches::BatchTrackingStoreAddBatchesOperation as _;
 use operations::get_batch::BatchTrackingStoreGetBatchOperation as _;
+use operations::get_batch_status::BatchTrackingStoreGetBatchStatusOperation as _;
 use operations::BatchTrackingStoreOperations;
 
 /// Manages batches in the database
@@ -52,10 +53,15 @@ impl<C: diesel::Connection> DieselBatchTrackingStore<C> {
 impl BatchTrackingStore for DieselBatchTrackingStore<diesel::pg::PgConnection> {
     fn get_batch_status(
         &self,
-        _id: &str,
-        _service_id: Option<&str>,
-    ) -> Result<BatchStatus, BatchTrackingStoreError> {
-        unimplemented!();
+        id: &str,
+        service_id: &str,
+    ) -> Result<Option<BatchStatus>, BatchTrackingStoreError> {
+        BatchTrackingStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            BatchTrackingStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .get_batch_status(id, service_id)
     }
 
     fn update_batch_status(
@@ -125,10 +131,15 @@ impl BatchTrackingStore for DieselBatchTrackingStore<diesel::pg::PgConnection> {
 impl BatchTrackingStore for DieselBatchTrackingStore<diesel::sqlite::SqliteConnection> {
     fn get_batch_status(
         &self,
-        _id: &str,
-        _service_id: Option<&str>,
-    ) -> Result<BatchStatus, BatchTrackingStoreError> {
-        unimplemented!();
+        id: &str,
+        service_id: &str,
+    ) -> Result<Option<BatchStatus>, BatchTrackingStoreError> {
+        BatchTrackingStoreOperations::new(&*self.connection_pool.get().map_err(|err| {
+            BatchTrackingStoreError::ResourceTemporarilyUnavailableError(
+                ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+            )
+        })?)
+        .get_batch_status(id, service_id)
     }
 
     fn update_batch_status(
@@ -217,10 +228,10 @@ where
 impl<'a> BatchTrackingStore for DieselConnectionBatchTrackingStore<'a, diesel::pg::PgConnection> {
     fn get_batch_status(
         &self,
-        _id: &str,
-        _service_id: Option<&str>,
-    ) -> Result<BatchStatus, BatchTrackingStoreError> {
-        unimplemented!();
+        id: &str,
+        service_id: &str,
+    ) -> Result<Option<BatchStatus>, BatchTrackingStoreError> {
+        BatchTrackingStoreOperations::new(self.connection).get_batch_status(id, service_id)
     }
 
     fn update_batch_status(
@@ -282,10 +293,10 @@ impl<'a> BatchTrackingStore
 {
     fn get_batch_status(
         &self,
-        _id: &str,
-        _service_id: Option<&str>,
-    ) -> Result<BatchStatus, BatchTrackingStoreError> {
-        unimplemented!();
+        id: &str,
+        service_id: &str,
+    ) -> Result<Option<BatchStatus>, BatchTrackingStoreError> {
+        BatchTrackingStoreOperations::new(self.connection).get_batch_status(id, service_id)
     }
 
     fn update_batch_status(

--- a/sdk/src/batch_tracking/store/diesel/operations/get_batch.rs
+++ b/sdk/src/batch_tracking/store/diesel/operations/get_batch.rs
@@ -162,8 +162,7 @@ impl<'a> BatchTrackingStoreGetBatchOperation
                     };
 
                     let status = if let Some(s) = stat {
-                        let grid_status =
-                            BatchStatus::try_from((s, Some(invalid_txns), Some(valid_txns)))?;
+                        let grid_status = BatchStatus::try_from((s, invalid_txns, valid_txns))?;
                         Some(grid_status)
                     } else {
                         None
@@ -304,8 +303,7 @@ impl<'a> BatchTrackingStoreGetBatchOperation
                     };
 
                     let status = if let Some(s) = stat {
-                        let grid_status =
-                            BatchStatus::try_from((s, Some(invalid_txns), Some(valid_txns)))?;
+                        let grid_status = BatchStatus::try_from((s, invalid_txns, valid_txns))?;
                         Some(grid_status)
                     } else {
                         None

--- a/sdk/src/batch_tracking/store/diesel/operations/get_batch_status.rs
+++ b/sdk/src/batch_tracking/store/diesel/operations/get_batch_status.rs
@@ -1,0 +1,226 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::BatchTrackingStoreOperations;
+use crate::error::InternalError;
+
+use crate::batch_tracking::store::diesel::{
+    models::{BatchStatusModel, TransactionReceiptModel},
+    schema::{batch_statuses, transaction_receipts, transactions},
+    BatchStatus, InvalidTransaction, TransactionReceipt, ValidTransaction,
+};
+
+use crate::batch_tracking::store::BatchTrackingStoreError;
+use diesel::prelude::*;
+use std::convert::TryFrom;
+
+pub(in crate::batch_tracking::store::diesel) trait BatchTrackingStoreGetBatchStatusOperation {
+    fn get_batch_status(
+        &self,
+        id: &str,
+        service_id: &str,
+    ) -> Result<Option<BatchStatus>, BatchTrackingStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> BatchTrackingStoreGetBatchStatusOperation
+    for BatchTrackingStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn get_batch_status(
+        &self,
+        id: &str,
+        service_id: &str,
+    ) -> Result<Option<BatchStatus>, BatchTrackingStoreError> {
+        self.conn.transaction::<_, BatchTrackingStoreError, _>(|| {
+            // This query fetches the batch status for the batch with the given
+            // batch ID and service ID
+            let batch_status_query = batch_statuses::table
+                .into_boxed()
+                .select(batch_statuses::all_columns)
+                .filter(
+                    batch_statuses::batch_id
+                        .eq(id)
+                        .and(batch_statuses::batch_service_id.eq(service_id)),
+                );
+
+            let batch_status_model: Option<BatchStatusModel> = batch_status_query
+                .first::<BatchStatusModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    BatchTrackingStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            if batch_status_model.is_none() {
+                return Ok(None);
+            }
+
+            // This query fetches the transactions and any associated receipts
+            // for the given batch ID and service ID
+            let txn_query = transactions::table
+                .into_boxed()
+                .left_join(
+                    transaction_receipts::table
+                        .on(transaction_receipts::transaction_id.eq(transactions::transaction_id)),
+                )
+                .filter(
+                    transactions::batch_id
+                        .eq(id)
+                        .and(transactions::batch_service_id.eq(service_id)),
+                )
+                .select((
+                    transactions::transaction_id,
+                    transaction_receipts::all_columns.nullable(),
+                ));
+
+            let txn_query_result: Vec<(String, Option<TransactionReceiptModel>)> = txn_query
+                .load::<(String, Option<TransactionReceiptModel>)>(self.conn)
+                .map_err(|err| {
+                    BatchTrackingStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            let mut invalid_txns = Vec::new();
+            let mut valid_txns = Vec::new();
+
+            for (_, rcpt) in &txn_query_result {
+                if let Some(r) = rcpt {
+                    if r.result_valid {
+                        valid_txns.push(
+                            ValidTransaction::try_from(TransactionReceipt::from(r.clone()))
+                                .map_err(|err| {
+                                    BatchTrackingStoreError::InternalError(
+                                        InternalError::from_source(Box::new(err)),
+                                    )
+                                })?,
+                        );
+                    } else {
+                        invalid_txns.push(
+                            InvalidTransaction::try_from(TransactionReceipt::from(r.clone()))
+                                .map_err(|err| {
+                                    BatchTrackingStoreError::InternalError(
+                                        InternalError::from_source(Box::new(err)),
+                                    )
+                                })?,
+                        );
+                    }
+                }
+            }
+
+            let batch_status = batch_status_model.unwrap();
+
+            let status = BatchStatus::try_from((batch_status, invalid_txns, valid_txns))?;
+
+            Ok(Some(status))
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> BatchTrackingStoreGetBatchStatusOperation
+    for BatchTrackingStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn get_batch_status(
+        &self,
+        id: &str,
+        service_id: &str,
+    ) -> Result<Option<BatchStatus>, BatchTrackingStoreError> {
+        self.conn.transaction::<_, BatchTrackingStoreError, _>(|| {
+            // This query fetches the batch status for the batch with the given
+            // batch ID and service ID
+            let batch_status_query = batch_statuses::table
+                .into_boxed()
+                .select(batch_statuses::all_columns)
+                .filter(
+                    batch_statuses::batch_id
+                        .eq(id)
+                        .and(batch_statuses::batch_service_id.eq(service_id)),
+                );
+
+            let batch_status_model: Option<BatchStatusModel> = batch_status_query
+                .first::<BatchStatusModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    BatchTrackingStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            if batch_status_model.is_none() {
+                return Ok(None);
+            }
+
+            // This query fetches the transactions and any associated receipts
+            // for the given batch ID and service ID
+            let txn_query = transactions::table
+                .into_boxed()
+                .left_join(
+                    transaction_receipts::table
+                        .on(transaction_receipts::transaction_id.eq(transactions::transaction_id)),
+                )
+                .filter(
+                    transactions::batch_id
+                        .eq(id)
+                        .and(transactions::batch_service_id.eq(service_id)),
+                )
+                .select((
+                    transactions::transaction_id,
+                    transaction_receipts::all_columns.nullable(),
+                ));
+
+            let txn_query_result: Vec<(String, Option<TransactionReceiptModel>)> = txn_query
+                .load::<(String, Option<TransactionReceiptModel>)>(self.conn)
+                .map_err(|err| {
+                    BatchTrackingStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    )))
+                })?;
+
+            let mut invalid_txns = Vec::new();
+            let mut valid_txns = Vec::new();
+
+            for (_, rcpt) in &txn_query_result {
+                if let Some(r) = rcpt {
+                    if r.result_valid {
+                        valid_txns.push(
+                            ValidTransaction::try_from(TransactionReceipt::from(r.clone()))
+                                .map_err(|err| {
+                                    BatchTrackingStoreError::InternalError(
+                                        InternalError::from_source(Box::new(err)),
+                                    )
+                                })?,
+                        );
+                    } else {
+                        invalid_txns.push(
+                            InvalidTransaction::try_from(TransactionReceipt::from(r.clone()))
+                                .map_err(|err| {
+                                    BatchTrackingStoreError::InternalError(
+                                        InternalError::from_source(Box::new(err)),
+                                    )
+                                })?,
+                        );
+                    }
+                }
+            }
+
+            let batch_status = batch_status_model.unwrap();
+
+            let status = BatchStatus::try_from((batch_status, invalid_txns, valid_txns))?;
+
+            Ok(Some(status))
+        })
+    }
+}

--- a/sdk/src/batch_tracking/store/diesel/operations/mod.rs
+++ b/sdk/src/batch_tracking/store/diesel/operations/mod.rs
@@ -14,6 +14,7 @@
 
 pub(super) mod add_batches;
 pub(super) mod get_batch;
+pub(super) mod get_batch_status;
 
 pub(super) struct BatchTrackingStoreOperations<'a, C> {
     conn: &'a C,


### PR DESCRIPTION
This implements the `get_batch_status` operation for the Batch Tracking
    store. This operation returns the current batch status for a batch with
    a given ID and service ID. This PR also contains several other small but
    necessary updates to the models to make this work.
    
    Signed-off-by: Davey Newhall <newhall@bitwise.io>
