### PR TITLE
Add `DELAYED` batch status type

### DIFF
--- a/sdk/src/batch_tracking/store/diesel/models.rs
+++ b/sdk/src/batch_tracking/store/diesel/models.rs
@@ -179,6 +179,7 @@ impl
         match batch_status.dlt_status.as_str() {
             "UNKNOWN" => Ok(BatchStatus::Unknown),
             "PENDING" => Ok(BatchStatus::Pending),
+            "DELAYED" => Ok(BatchStatus::Delayed),
             "INVALID" => {
                 if invalid_transactions.is_empty() {
                     return Err(BatchTrackingStoreError::InternalError(

--- a/sdk/src/batch_tracking/store/mod.rs
+++ b/sdk/src/batch_tracking/store/mod.rs
@@ -31,6 +31,7 @@ const NON_SPLINTER_SERVICE_ID_DEFAULT: &str = "----";
 pub enum BatchStatus {
     Unknown,
     Pending,
+    Delayed,
     Invalid(Vec<InvalidTransaction>),
     Valid(Vec<ValidTransaction>),
     Committed(Vec<ValidTransaction>),


### PR DESCRIPTION
This adds a batch status variant: `DELAYED` to the `BatchStatus` enum.
    This type will be used when a batch cannot be resubmitted quite yet but
    should be queued to do so once any prerequisites are met.