### PR TITLE
BACKPORT 0.3: Add prerequisites to readme build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,32 @@ discussion](https://grid.hyperledger.org/community/join_the_discussion.html).
 
 ## Building Grid
 
-To build Grid, run `cargo build` from the root directory. This command
-builds all of the Grid components, including `gridd` (the grid daemon),
-the CLI, and all of the smart contracts in the `contracts` directory.
+Grid is built using latest stable [rust](https://www.rust-lang.org/), which
+you should install via [rustup](https://rustup.rs/).
+
+To install the remaining dependencies using a package manager, run one of the
+following commands.
+
+Homebrew (OS X):
+```bash
+brew install openssl zeromq pkg-config protobuf postgresql
+```
+
+APT (Ubuntu):
+```bash
+apt install libssl-dev libzmq3-dev pkg-config libprotobuf-dev postgresql
+```
+
+Once you have the prerequisites installed, run `cargo build` from the root
+directory. This command builds all of the Grid components, including `gridd`
+(the grid daemon), the CLI, and all of the smart contracts in the `contracts`
+directory.
 
 To build individual components, run `cargo build` in the component directories.
 For example, to build only the grid-cli, navigate to `cli`, then run
 `cargo build`.
+
+### Building with Docker
 
 To build Grid using Docker, run `docker-compose build` from the root directory.
 This command builds Docker images for all of the Grid components, including


### PR DESCRIPTION
There are a number of libraries unlikely to be present on reader's
systems that must be installed before `cargo build` will successfully
build the project. These changes clarify prerequisites so that readers
following the README build instuctions can successfully build the
project without hitting roadblocks or guessing Grid's dependencies.

Signed-off-by: Lee Bradley <bradley@bitwise.io>