### PR TITLE
BACKPORT 0.3: Add handling for Splinter error responses

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -64,6 +64,11 @@ tempfile = "3"
 protoc-rust = "2.14"
 glob = "0.3"
 
+[dev-dependencies]
+mockito = "0.30"
+pretty_assertions = "1"
+tokio = { version = "0.2", features = ["macros"] }
+
 [features]
 default = []
 


### PR DESCRIPTION
This change updates the SplinterBackendClient to so that it will
pass on error messages from Splinter error responses, and not
incorrectly mark them as internal errors.

It also adds a number of tests to verify the output in various
scenarios.

Signed-off-by: Lee Bradley <bradley@bitwise.io>