### PR TITLE
BACKPORT 0.3: Update grid integration test cache dirs

### DIFF
--- a/cli/tests/data_validation.rs
+++ b/cli/tests/data_validation.rs
@@ -29,14 +29,17 @@ use std::sync::Once;
 use grid_sdk::data_validation::validate_order_xml_3_4;
 use grid_sdk::error::InvalidArgumentError;
 
-static KEY_DIR: &str = "tmp/keys";
-static CACHE_DIR: &str = "tmp/cache";
-static STATE_DIR: &str = "tmp/state";
+const CACHE_DIR_ENV: &str = "GRID_TEST_CACHE_DIR";
+
+static KEY_DIR: &str = "keys";
+static CACHE_DIR: &str = "cache";
+static STATE_DIR: &str = "state";
 
 static INIT: Once = Once::new();
 
 struct Config {
     schema_dir: String,
+    manifest_path: PathBuf,
 }
 
 #[cfg(feature = "xsd-downloader")]
@@ -44,14 +47,12 @@ struct Config {
 fn test_validate_order_xml_3_4() {
     let config = get_setup().expect("Unable to get setup");
 
-    let mut test_gdsn_xml_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    test_gdsn_xml_path.push("tests/data_validation/xml/order.xml");
+    let test_gdsn_xml_path = config
+        .manifest_path
+        .join("tests/data_validation/xml/order.xml");
 
-    let path_str = test_gdsn_xml_path
-        .to_str()
-        .expect("Could not convert GDSN path to string");
     let mut data = String::new();
-    std::fs::File::open(path_str)
+    std::fs::File::open(test_gdsn_xml_path)
         .expect("Could not open file")
         .read_to_string(&mut data)
         .expect("Could not convert GDSN path to string");
@@ -66,8 +67,9 @@ fn test_validate_order_xml_3_4() {
 fn test_validate_order_xml_3_4_path() {
     let config = get_setup().expect("Unable to get setup");
 
-    let mut test_gdsn_xml_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    test_gdsn_xml_path.push("tests/data_validation/xml/order.xml");
+    let test_gdsn_xml_path = config
+        .manifest_path
+        .join("tests/data_validation/xml/order.xml");
 
     let path_str = test_gdsn_xml_path
         .to_str()
@@ -83,14 +85,12 @@ fn test_validate_order_xml_3_4_path() {
 fn test_validate_order_xml_3_4_invalid() {
     let config = get_setup().expect("Unable to get setup");
 
-    let mut test_gdsn_xml_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    test_gdsn_xml_path.push("tests/data_validation/xml/order_invalid.xml");
+    let test_gdsn_xml_path = config
+        .manifest_path
+        .join("tests/data_validation/xml/order_invalid.xml");
 
-    let path_str = test_gdsn_xml_path
-        .to_str()
-        .expect("Could not convert GDSN path to string");
     let mut data = String::new();
-    std::fs::File::open(path_str)
+    std::fs::File::open(test_gdsn_xml_path)
         .expect("Could not open file")
         .read_to_string(&mut data)
         .expect("Could not convert GDSN path to string");
@@ -109,8 +109,9 @@ fn test_validate_order_xml_3_4_invalid() {
 fn test_validate_order_xml_3_4_path_invalid() {
     let config = get_setup().expect("Unable to get setup");
 
-    let mut test_gdsn_xml_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    test_gdsn_xml_path.push("tests/data_validation/xml/order_invalid.xml");
+    let test_gdsn_xml_path = config
+        .manifest_path
+        .join("tests/data_validation/xml/order_invalid.xml");
 
     let path_str = test_gdsn_xml_path
         .to_str()
@@ -132,75 +133,77 @@ fn test_validate_order_xml_3_4_path_invalid() {
 ///     Necessary to run purchase order commands
 ///
 fn get_setup() -> std::io::Result<Config> {
-    let mut cache_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    cache_dir.push(format!("{}", CACHE_DIR));
-    let cache_dir_str = cache_dir
-        .clone()
-        .into_os_string()
-        .into_string()
-        .expect("Unable to convert cache dir to string");
-    fs::create_dir_all(&cache_dir_str)?;
+    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    let mut state_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    state_dir.push(STATE_DIR);
-    let state_dir_str = state_dir
-        .clone()
-        .into_os_string()
-        .into_string()
-        .expect("Unable to convert state dir to string");
-    fs::create_dir_all(&state_dir_str)?;
+    let temp_path = env::temp_dir().join("grid-integration-tests");
+    fs::create_dir_all(&temp_path).expect("could not create temp path");
+
+    let cache_path = match env::var(CACHE_DIR_ENV) {
+        Ok(value) => PathBuf::from(value),
+        Err(_) => {
+            let path = temp_path.join(CACHE_DIR);
+            fs::create_dir_all(&path).expect("could not create cache path");
+            path
+        }
+    };
+
+    let state_dir = temp_path.join(STATE_DIR);
+    fs::create_dir_all(&state_dir)?;
 
     let key_name: String = "test_key".to_string();
-    let mut key_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    key_dir.push(format!("{}", KEY_DIR));
-    key_dir.push(".grid");
-    key_dir.push("keys");
-    fs::create_dir_all(
-        key_dir
-            .clone()
-            .into_os_string()
-            .into_string()
-            .expect("Unable to convert key dir to string"),
-    )?;
+    let key_dir = temp_path.join(KEY_DIR).join(".grid").join("keys");
+    fs::create_dir_all(&key_dir)?;
+
     let mut public_key_path = key_dir.clone();
     public_key_path.push(&key_name);
     public_key_path.set_extension("pub");
+
     let mut private_key_path = key_dir.clone();
     private_key_path.push(&key_name);
     private_key_path.set_extension("priv");
 
     INIT.call_once(|| {
-        let mut cmd_key = Command::cargo_bin("grid").unwrap();
-        cmd_key.arg("-vv");
-        cmd_key.arg("keygen").arg(&key_name).arg("--force");
         let key_dir_str = key_dir
             .into_os_string()
             .into_string()
             .expect("Unable to convert key dir to string");
-        cmd_key.args(&["--key-dir", &key_dir_str]);
-        cmd_key.assert().success();
+
+        Command::cargo_bin("grid")
+            .unwrap()
+            .arg("-vv")
+            .arg("keygen")
+            .arg(&key_name)
+            .arg("--force")
+            .args(&["--key-dir", &key_dir_str])
+            .assert()
+            .success();
+
         assert!(public_key_path.exists());
         assert!(private_key_path.exists());
 
-        let mut cmd_download_xsd = Command::cargo_bin("grid").unwrap();
-        cmd_download_xsd.arg("-vv");
-        cmd_download_xsd
+        let cmd_download_xsd = Command::cargo_bin("grid")
+            .unwrap()
+            .arg("-vv")
             .arg("download-xsd")
-            .env("GRID_CACHE_DIR", &cache_dir_str)
-            .env("GRID_STATE_DIR", &state_dir_str)
+            .env("GRID_CACHE_DIR", &cache_path)
+            .env("GRID_STATE_DIR", &state_dir)
             .output()
             .expect("Error downloading XSD files");
+
         println!("{:?}", cmd_download_xsd);
         cmd_download_xsd.assert().success();
     });
-    assert_eq!(INIT.is_completed(), true);
-    let mut schema_dir = state_dir.clone();
-    schema_dir.push("xsd/po/gs1/ecom");
-    let schema_dir_str = schema_dir
+
+    assert!(INIT.is_completed());
+
+    let schema_dir_str = state_dir
+        .join("xsd/po/gs1/ecom")
         .into_os_string()
         .into_string()
         .expect("Unable to convert po schema dir to string");
+
     Ok(Config {
         schema_dir: schema_dir_str,
+        manifest_path,
     })
 }

--- a/docker/compose/grid-tests.yaml
+++ b/docker/compose/grid-tests.yaml
@@ -25,6 +25,9 @@ services:
         - https_proxy
         - no_proxy
     image: grid:tests
+    volumes:
+        - ../../cache:/var/cache/grid/
     environment:
         - TEST_ARGS=-- --test-threads=1
+        - GRID_TEST_CACHE_DIR=/var/cache/grid
     command: bash -c "just test"


### PR DESCRIPTION
Previously the tests used $CARGO_MANIFEST/tmp as a temporary directory
by default. This change updates the tests to instead create and use a
dir grid-integration-tests/ in the standard Rust environment temp
directory.

This change also updates the tests to optionally use an environment
variable for the cache directory, and updates the test dockerfile to set
the variable to /var/cache/grid. This should allow CI to persist the
cache from a stable and standard location between runs.

Signed-off-by: Lee Bradley <bradley@bitwise.io>

Backport of: https://github.com/hyperledger/grid/pull/1305