### PR TITLE
Tag images nightly instead of main

### DIFF
--- a/.github/workflows/publish-docker-branch.yaml
+++ b/.github/workflows/publish-docker-branch.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish main images to dockerhub
-        run: docker buildx ls && ./ci/publish-docker main
+        run: docker buildx ls && ./ci/publish-docker nightly
         env:
           NAMESPACE: ${{ secrets.DOCKER_HUB_NAMESPACE }}/
           VERSION: AUTO_STRICT


### PR DESCRIPTION
These images are published on a nightly schedule and not on every merge
so `main` tag is incorrect.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>