### PR TITLE
Add `update_batch_status` operation

### DIFF
--- a/sdk/src/batch_tracking/store/diesel/models.rs
+++ b/sdk/src/batch_tracking/store/diesel/models.rs
@@ -50,7 +50,7 @@ pub struct TransactionModel {
     pub signer_public_key: String,
 }
 
-#[derive(Identifiable, Insertable, Queryable, PartialEq, Debug, AsChangeset)]
+#[derive(Identifiable, Insertable, Queryable, PartialEq, Debug, AsChangeset, Clone)]
 #[table_name = "transaction_receipts"]
 #[primary_key(service_id, transaction_id)]
 #[changeset_options(treat_none_as_null = "true")]
@@ -357,6 +357,19 @@ impl TryFrom<TransactionReceipt> for ValidTransaction {
         Ok(Self {
             transaction_id: receipt.transaction_id,
         })
+    }
+}
+
+impl From<(SubmissionError, &str, &str)> for NewSubmissionModel {
+    fn from(
+        (error, batch_header, service_id): (SubmissionError, &str, &str),
+    ) -> NewSubmissionModel {
+        NewSubmissionModel {
+            batch_id: batch_header.to_string(),
+            service_id: service_id.to_string(),
+            error_type: Some(error.error_type().to_string()),
+            error_message: Some(error.error_message().to_string()),
+        }
     }
 }
 

--- a/sdk/src/batch_tracking/store/diesel/operations/mod.rs
+++ b/sdk/src/batch_tracking/store/diesel/operations/mod.rs
@@ -16,6 +16,7 @@ pub(super) mod add_batches;
 pub(super) mod change_batch_to_submitted;
 pub(super) mod get_batch;
 pub(super) mod get_batch_status;
+pub(super) mod update_batch_status;
 
 pub(super) struct BatchTrackingStoreOperations<'a, C> {
     conn: &'a C,

--- a/sdk/src/batch_tracking/store/diesel/operations/update_batch_status.rs
+++ b/sdk/src/batch_tracking/store/diesel/operations/update_batch_status.rs
@@ -1,0 +1,328 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::BatchTrackingStoreOperations;
+
+use crate::batch_tracking::store::{
+    diesel::{
+        models::{NewBatchStatusModel, NewSubmissionModel, TransactionReceiptModel},
+        schema::{batch_statuses, batches, submissions, transaction_receipts},
+    },
+    BatchStatusName, BatchTrackingStoreError,
+};
+
+use diesel::{
+    dsl::{exists, insert_into, update},
+    prelude::*,
+    select,
+};
+
+pub(in crate::batch_tracking::store::diesel) trait BatchTrackingStoreUpdateBatchStatusOperation {
+    fn update_batch_status(
+        &self,
+        id: &str,
+        service_id: &str,
+        status: Option<&str>,
+        txn_receipts: Vec<TransactionReceiptModel>,
+        submission_error: Option<NewSubmissionModel>,
+    ) -> Result<(), BatchTrackingStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> BatchTrackingStoreUpdateBatchStatusOperation
+    for BatchTrackingStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn update_batch_status(
+        &self,
+        id: &str,
+        service_id: &str,
+        status: Option<&str>,
+        txn_receipts: Vec<TransactionReceiptModel>,
+        submission_error: Option<NewSubmissionModel>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        self.conn.transaction::<_, BatchTrackingStoreError, _>(|| {
+            if let Some(batch_status) = status {
+                let status_string = BatchStatusName::try_from_string(batch_status)?;
+                match status_string {
+                    BatchStatusName::Pending
+                    | BatchStatusName::Invalid
+                    | BatchStatusName::Valid
+                    | BatchStatusName::Committed => {
+                        update(batches::table)
+                            .filter(
+                                batches::batch_id
+                                    .eq(&id)
+                                    .and(batches::service_id.eq(&service_id)),
+                            )
+                            .set(batches::submitted.eq(true))
+                            .execute(self.conn)?;
+                    }
+                    BatchStatusName::Delayed | BatchStatusName::Unknown => {
+                        update(batches::table)
+                            .filter(
+                                batches::batch_id
+                                    .eq(&id)
+                                    .and(batches::service_id.eq(&service_id)),
+                            )
+                            .set(batches::submitted.eq(false))
+                            .execute(self.conn)?;
+                    }
+                }
+
+                let status_exists: bool = select(exists(
+                    batch_statuses::table.filter(
+                        batch_statuses::batch_id
+                            .eq(&id)
+                            .and(batch_statuses::service_id.eq(&service_id)),
+                    ),
+                ))
+                .get_result(self.conn)?;
+
+                if status_exists {
+                    update(batch_statuses::table)
+                        .filter(
+                            batch_statuses::batch_id
+                                .eq(&id)
+                                .and(batch_statuses::service_id.eq(&service_id)),
+                        )
+                        .set(batch_statuses::dlt_status.eq(&batch_status))
+                        .execute(self.conn)?;
+                } else {
+                    let model = NewBatchStatusModel {
+                        batch_id: id.to_string(),
+                        service_id: service_id.to_string(),
+                        dlt_status: batch_status.to_string(),
+                    };
+
+                    insert_into(batch_statuses::table)
+                        .values(model)
+                        .execute(self.conn)?;
+                };
+            } else {
+                update(batches::table)
+                    .filter(
+                        batches::batch_id
+                            .eq(&id)
+                            .and(batches::service_id.eq(&service_id)),
+                    )
+                    .set(batches::submitted.eq(true))
+                    .execute(self.conn)?;
+            }
+
+            let rcpt_ids = txn_receipts
+                .iter()
+                .map(|t| t.transaction_id.to_string())
+                .collect::<Vec<String>>();
+
+            let existing_rcpts: Vec<String> = transaction_receipts::table
+                .into_boxed()
+                .select(transaction_receipts::transaction_id)
+                .filter(
+                    transaction_receipts::transaction_id
+                        .eq_any(rcpt_ids)
+                        .and(transaction_receipts::service_id.eq(&service_id)),
+                )
+                .load(self.conn)?;
+
+            for r in txn_receipts {
+                if existing_rcpts.contains(&r.transaction_id) {
+                    update(transaction_receipts::table)
+                        .filter(
+                            transaction_receipts::transaction_id
+                                .eq(&r.transaction_id)
+                                .and(transaction_receipts::service_id.eq(&service_id)),
+                        )
+                        .set(r.clone())
+                        .execute(self.conn)?;
+                } else {
+                    insert_into(transaction_receipts::table)
+                        .values(r.clone())
+                        .execute(self.conn)?;
+                }
+            }
+
+            if let Some(s) = submission_error {
+                let submission_exists = select(exists(
+                    submissions::table.filter(
+                        submissions::batch_id
+                            .eq(&s.batch_id)
+                            .and(submissions::service_id.eq(&s.service_id)),
+                    ),
+                ))
+                .get_result(self.conn)?;
+
+                if submission_exists {
+                    update(submissions::table)
+                        .filter(
+                            submissions::batch_id
+                                .eq(&s.batch_id)
+                                .and(submissions::service_id.eq(&s.service_id)),
+                        )
+                        .set(&s)
+                        .execute(self.conn)?;
+                } else {
+                    insert_into(submissions::table)
+                        .values(&s)
+                        .execute(self.conn)?;
+                }
+            }
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> BatchTrackingStoreUpdateBatchStatusOperation
+    for BatchTrackingStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn update_batch_status(
+        &self,
+        id: &str,
+        service_id: &str,
+        status: Option<&str>,
+        txn_receipts: Vec<TransactionReceiptModel>,
+        submission_error: Option<NewSubmissionModel>,
+    ) -> Result<(), BatchTrackingStoreError> {
+        self.conn.transaction::<_, BatchTrackingStoreError, _>(|| {
+            if let Some(batch_status) = status {
+                let status_string = BatchStatusName::try_from_string(batch_status)?;
+                match status_string {
+                    BatchStatusName::Pending
+                    | BatchStatusName::Invalid
+                    | BatchStatusName::Valid
+                    | BatchStatusName::Committed => {
+                        update(batches::table)
+                            .filter(
+                                batches::batch_id
+                                    .eq(&id)
+                                    .and(batches::service_id.eq(&service_id)),
+                            )
+                            .set(batches::submitted.eq(true))
+                            .execute(self.conn)?;
+                    }
+                    BatchStatusName::Delayed | BatchStatusName::Unknown => {
+                        update(batches::table)
+                            .filter(
+                                batches::batch_id
+                                    .eq(&id)
+                                    .and(batches::service_id.eq(&service_id)),
+                            )
+                            .set(batches::submitted.eq(false))
+                            .execute(self.conn)?;
+                    }
+                }
+
+                let status_exists: bool = select(exists(
+                    batch_statuses::table.filter(
+                        batch_statuses::batch_id
+                            .eq(&id)
+                            .and(batch_statuses::service_id.eq(&service_id)),
+                    ),
+                ))
+                .get_result(self.conn)?;
+
+                if status_exists {
+                    update(batch_statuses::table)
+                        .filter(
+                            batch_statuses::batch_id
+                                .eq(&id)
+                                .and(batch_statuses::service_id.eq(&service_id)),
+                        )
+                        .set(batch_statuses::dlt_status.eq(&batch_status))
+                        .execute(self.conn)?;
+                } else {
+                    let model = NewBatchStatusModel {
+                        batch_id: id.to_string(),
+                        service_id: service_id.to_string(),
+                        dlt_status: batch_status.to_string(),
+                    };
+
+                    insert_into(batch_statuses::table)
+                        .values(model)
+                        .execute(self.conn)?;
+                };
+            } else {
+                update(batches::table)
+                    .filter(
+                        batches::batch_id
+                            .eq(&id)
+                            .and(batches::service_id.eq(&service_id)),
+                    )
+                    .set(batches::submitted.eq(true))
+                    .execute(self.conn)?;
+            }
+
+            let rcpt_ids = txn_receipts
+                .iter()
+                .map(|t| t.transaction_id.to_string())
+                .collect::<Vec<String>>();
+
+            let existing_rcpts: Vec<String> = transaction_receipts::table
+                .into_boxed()
+                .select(transaction_receipts::transaction_id)
+                .filter(
+                    transaction_receipts::transaction_id
+                        .eq_any(rcpt_ids)
+                        .and(transaction_receipts::service_id.eq(&service_id)),
+                )
+                .load(self.conn)?;
+
+            for r in txn_receipts {
+                if existing_rcpts.contains(&r.transaction_id) {
+                    update(transaction_receipts::table)
+                        .filter(
+                            transaction_receipts::transaction_id
+                                .eq(&r.transaction_id)
+                                .and(transaction_receipts::service_id.eq(&service_id)),
+                        )
+                        .set(r.clone())
+                        .execute(self.conn)?;
+                } else {
+                    insert_into(transaction_receipts::table)
+                        .values(r.clone())
+                        .execute(self.conn)?;
+                }
+            }
+
+            if let Some(s) = submission_error {
+                let submission_exists = select(exists(
+                    submissions::table.filter(
+                        submissions::batch_id
+                            .eq(&s.batch_id)
+                            .and(submissions::service_id.eq(&s.service_id)),
+                    ),
+                ))
+                .get_result(self.conn)?;
+
+                if submission_exists {
+                    update(submissions::table)
+                        .filter(
+                            submissions::batch_id
+                                .eq(&s.batch_id)
+                                .and(submissions::service_id.eq(&s.service_id)),
+                        )
+                        .set(&s)
+                        .execute(self.conn)?;
+                } else {
+                    insert_into(submissions::table)
+                        .values(&s)
+                        .execute(self.conn)?;
+                }
+            }
+
+            Ok(())
+        })
+    }
+}

--- a/sdk/src/batch_tracking/store/mod.rs
+++ b/sdk/src/batch_tracking/store/mod.rs
@@ -111,6 +111,7 @@ impl InvalidTransaction {
     }
 }
 
+#[derive(Default)]
 pub struct InvalidTransactionBuilder {
     transaction_id: String,
     error_message: Option<String>,
@@ -130,7 +131,7 @@ impl InvalidTransactionBuilder {
         self
     }
 
-    pub fn error_data(mut self, error_data: Vec<u8>) -> Self {
+    pub fn with_error_data(mut self, error_data: Vec<u8>) -> Self {
         self.error_data = Some(error_data);
         self
     }
@@ -768,14 +769,13 @@ pub trait BatchTrackingStore {
     ///    update
     ///  * `service_id` - The service ID
     ///  * `status` - The new status for the batch
-    ///  * `errors` - Any errors encountered while attempting to submit the
-    ///    batch
     fn update_batch_status(
         &self,
-        id: String,
-        service_id: Option<&str>,
-        status: BatchStatus,
-        errors: Vec<SubmissionError>,
+        id: &str,
+        service_id: &str,
+        status: Option<BatchStatus>,
+        transaction_receipts: Vec<TransactionReceipt>,
+        submission_error: Option<SubmissionError>,
     ) -> Result<(), BatchTrackingStoreError>;
 
     /// Adds batches to the underlying storage
@@ -854,10 +854,11 @@ where
 
     fn update_batch_status(
         &self,
-        _id: String,
-        _service_id: Option<&str>,
-        _status: BatchStatus,
-        _errors: Vec<SubmissionError>,
+        _id: &str,
+        _service_id: &str,
+        _status: Option<BatchStatus>,
+        _transaction_receipts: Vec<TransactionReceipt>,
+        _submission_error: Option<SubmissionError>,
     ) -> Result<(), BatchTrackingStoreError> {
         unimplemented!();
     }


### PR DESCRIPTION
This adds an operation to update a batch's batch status. This operation updates the `batch_statuses` table as well as updating any associated transaction receipts. This also updates the batch tracking migrations to automatically generate timestamps which greatly simplifies this and other operations.