### PR TITLE
Fix over-eager clone

### DIFF
--- a/contracts/purchase_order/src/handler.rs
+++ b/contracts/purchase_order/src/handler.rs
@@ -798,7 +798,7 @@ fn convert_update_to_version(
         })?;
     // Check if a new revision is included in the update
     let (current_revision_id, rev_addition): (u64, Option<PurchaseOrderRevision>) =
-        match existing_version.revisions().iter().cloned().last() {
+        match existing_version.revisions().iter().last().cloned() {
             Some(last_rev) => {
                 if last_rev == new_revision {
                     (last_rev.revision_id(), None)


### PR DESCRIPTION
This change fixes a clippy warning from Rust 1.60. For more information
on this clippy lint, see:
https://rust-lang.github.io/rust-clippy/master/index.html#iter_overeager_cloned

Signed-off-by: Shannyn Telander <telander@bitwise.io>