### PR TITLE
Switch Publish Release GHA to run on self-hosted runner

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -32,7 +32,7 @@ jobs:
     needs: unit_test_grid
     if: >-
       github.repository_owner == 'hyperledger'
-    runs-on: ubuntu-latest
+    runs-on: macos-arm
     steps:
       - name: Display envvars
         run: env


### PR DESCRIPTION
Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>