### PR TITLE
Update batch tracking migrations

### DIFF
--- a/sdk/src/batch_tracking/store/diesel/mod.rs
+++ b/sdk/src/batch_tracking/store/diesel/mod.rs
@@ -26,6 +26,8 @@ use super::{
 
 use crate::error::ResourceTemporarilyUnavailableError;
 
+use models::make_database_id;
+
 use operations::add_batches::BatchTrackingStoreAddBatchesOperation as _;
 use operations::get_batch::BatchTrackingStoreGetBatchOperation as _;
 use operations::get_batch_status::BatchTrackingStoreGetBatchStatusOperation as _;
@@ -61,7 +63,7 @@ impl BatchTrackingStore for DieselBatchTrackingStore<diesel::pg::PgConnection> {
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .get_batch_status(id, service_id)
+        .get_batch_status(&make_database_id(id, service_id))
     }
 
     fn update_batch_status(
@@ -101,7 +103,7 @@ impl BatchTrackingStore for DieselBatchTrackingStore<diesel::pg::PgConnection> {
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .get_batch(id, service_id)
+        .get_batch(&make_database_id(id, service_id))
     }
 
     fn list_batches_by_status(
@@ -139,7 +141,7 @@ impl BatchTrackingStore for DieselBatchTrackingStore<diesel::sqlite::SqliteConne
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .get_batch_status(id, service_id)
+        .get_batch_status(&make_database_id(id, service_id))
     }
 
     fn update_batch_status(
@@ -179,7 +181,7 @@ impl BatchTrackingStore for DieselBatchTrackingStore<diesel::sqlite::SqliteConne
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .get_batch(id, service_id)
+        .get_batch(&make_database_id(id, service_id))
     }
 
     fn list_batches_by_status(
@@ -231,7 +233,8 @@ impl<'a> BatchTrackingStore for DieselConnectionBatchTrackingStore<'a, diesel::p
         id: &str,
         service_id: &str,
     ) -> Result<Option<BatchStatus>, BatchTrackingStoreError> {
-        BatchTrackingStoreOperations::new(self.connection).get_batch_status(id, service_id)
+        BatchTrackingStoreOperations::new(self.connection)
+            .get_batch_status(&make_database_id(id, service_id))
     }
 
     fn update_batch_status(
@@ -261,7 +264,8 @@ impl<'a> BatchTrackingStore for DieselConnectionBatchTrackingStore<'a, diesel::p
         id: &str,
         service_id: &str,
     ) -> Result<Option<TrackingBatch>, BatchTrackingStoreError> {
-        BatchTrackingStoreOperations::new(self.connection).get_batch(id, service_id)
+        BatchTrackingStoreOperations::new(self.connection)
+            .get_batch(&make_database_id(id, service_id))
     }
 
     fn list_batches_by_status(
@@ -296,7 +300,8 @@ impl<'a> BatchTrackingStore
         id: &str,
         service_id: &str,
     ) -> Result<Option<BatchStatus>, BatchTrackingStoreError> {
-        BatchTrackingStoreOperations::new(self.connection).get_batch_status(id, service_id)
+        BatchTrackingStoreOperations::new(self.connection)
+            .get_batch_status(&make_database_id(id, service_id))
     }
 
     fn update_batch_status(
@@ -326,7 +331,8 @@ impl<'a> BatchTrackingStore
         id: &str,
         service_id: &str,
     ) -> Result<Option<TrackingBatch>, BatchTrackingStoreError> {
-        BatchTrackingStoreOperations::new(self.connection).get_batch(id, service_id)
+        BatchTrackingStoreOperations::new(self.connection)
+            .get_batch(&make_database_id(id, service_id))
     }
 
     fn list_batches_by_status(

--- a/sdk/src/batch_tracking/store/diesel/models.rs
+++ b/sdk/src/batch_tracking/store/diesel/models.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use core::convert::TryFrom;
+use crypto::digest::Digest;
+use crypto::sha2::Sha512;
 
 use crate::batch_tracking::store::diesel::schema::*;
 use crate::error::InternalError;
-use chrono::NaiveDateTime;
 
 use super::{
     BatchStatus, InvalidTransaction, SubmissionError, TrackingBatch, TrackingTransaction,
@@ -24,37 +25,43 @@ use super::{
 };
 use crate::batch_tracking::store::error::BatchTrackingStoreError;
 
-#[derive(Insertable, Queryable, PartialEq, Debug)]
+#[derive(Identifiable, Insertable, Associations, Queryable, PartialEq, Debug)]
 #[table_name = "batches"]
+#[primary_key(batch_id)]
 pub struct BatchModel {
-    pub service_id: String,
     pub batch_id: String,
+    pub service_id: String,
+    pub batch_header: String,
     pub data_change_id: Option<String>,
     pub signer_public_key: String,
     pub trace: bool,
     pub serialized_batch: Vec<u8>,
     pub submitted: bool,
-    pub created_at: NaiveDateTime,
+    pub created_at: i64,
 }
 
-#[derive(Insertable, Queryable, PartialEq, Debug)]
+#[derive(Identifiable, Insertable, Associations, Queryable, PartialEq, Debug)]
 #[table_name = "transactions"]
+#[belongs_to(BatchModel, foreign_key = (batch_id))]
+#[primary_key(transaction_id)]
 pub struct TransactionModel {
-    pub service_id: String,
     pub transaction_id: String,
+    pub service_id: String,
+    pub transaction_header: String,
     pub batch_id: String,
-    pub batch_service_id: String,
     pub payload: Vec<u8>,
     pub family_name: String,
     pub family_version: String,
     pub signer_public_key: String,
 }
 
-#[derive(Insertable, Queryable, PartialEq, Debug, Clone)]
+#[derive(Identifiable, Insertable, Associations, Queryable, PartialEq, Debug)]
 #[table_name = "transaction_receipts"]
+#[belongs_to(TransactionModel, foreign_key = (transaction_id))]
+#[primary_key(transaction_id)]
 pub struct TransactionReceiptModel {
-    pub service_id: String,
     pub transaction_id: String,
+    pub service_id: String,
     pub result_valid: bool,
     pub error_message: Option<String>,
     pub error_data: Option<Vec<u8>>,
@@ -63,29 +70,50 @@ pub struct TransactionReceiptModel {
     pub external_error_message: Option<String>,
 }
 
-#[derive(Insertable, Queryable, PartialEq, Debug, Clone)]
+#[derive(Insertable, Debug)]
 #[table_name = "batch_statuses"]
-pub struct BatchStatusModel {
-    pub service_id: String,
+pub struct NewBatchStatusModel {
     pub batch_id: String,
-    pub batch_service_id: String,
+    pub service_id: String,
     pub dlt_status: String,
-    pub created_at: NaiveDateTime,
-    pub updated_at: NaiveDateTime,
 }
 
-#[derive(Insertable, Queryable, PartialEq, Debug)]
-#[table_name = "submissions"]
-pub struct SubmissionModel {
-    pub service_id: String,
+#[derive(Identifiable, Insertable, Associations, Queryable, PartialEq, Debug)]
+#[table_name = "batch_statuses"]
+#[belongs_to(BatchModel, foreign_key = (batch_id))]
+#[primary_key(batch_id)]
+pub struct BatchStatusModel {
     pub batch_id: String,
-    pub batch_service_id: String,
-    pub last_checked: Option<NaiveDateTime>,
+    pub service_id: String,
+    pub dlt_status: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Insertable, PartialEq, Queryable, Debug)]
+#[table_name = "submissions"]
+pub struct NewSubmissionModel {
+    pub batch_id: String,
+    pub service_id: String,
+    pub last_checked: Option<i64>,
     pub times_checked: Option<String>,
     pub error_type: Option<String>,
     pub error_message: Option<String>,
-    pub created_at: NaiveDateTime,
-    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Identifiable, Insertable, Associations, Queryable, PartialEq, Debug)]
+#[table_name = "submissions"]
+#[belongs_to(BatchModel, foreign_key = (batch_id))]
+#[primary_key(batch_id)]
+pub struct SubmissionModel {
+    pub batch_id: String,
+    pub service_id: String,
+    pub last_checked: Option<i64>,
+    pub times_checked: Option<String>,
+    pub error_type: Option<String>,
+    pub error_message: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
 }
 
 impl
@@ -106,13 +134,13 @@ impl
     ) -> Self {
         Self {
             service_id: batch.service_id.to_string(),
-            batch_header: batch.batch_id.to_string(),
+            batch_header: batch.batch_header.to_string(),
             data_change_id: batch.data_change_id.clone(),
             signer_public_key: batch.signer_public_key.to_string(),
             trace: batch.trace,
             serialized_batch: batch.serialized_batch.to_vec(),
             submitted: batch.submitted,
-            created_at: batch.created_at.timestamp(),
+            created_at: batch.created_at,
             transactions,
             batch_status,
             submission_error,
@@ -125,7 +153,7 @@ impl From<TransactionModel> for TrackingTransaction {
         Self {
             family_name: transaction.family_name.to_string(),
             family_version: transaction.family_version.to_string(),
-            transaction_id: transaction.transaction_id.to_string(),
+            transaction_header: transaction.transaction_header.to_string(),
             payload: transaction.payload.to_vec(),
             signer_public_key: transaction.signer_public_key.to_string(),
             service_id: transaction.service_id.clone(),
@@ -138,7 +166,7 @@ impl From<&TransactionModel> for TrackingTransaction {
         Self {
             family_name: transaction.family_name.to_string(),
             family_version: transaction.family_version.to_string(),
-            transaction_id: transaction.transaction_id.to_string(),
+            transaction_header: transaction.transaction_header.to_string(),
             payload: transaction.payload.to_vec(),
             signer_public_key: transaction.signer_public_key.to_string(),
             service_id: transaction.service_id.clone(),
@@ -156,6 +184,20 @@ impl From<TransactionReceiptModel> for TransactionReceipt {
             serialized_receipt: format!("{:?}", receipt.serialized_receipt),
             external_status: receipt.external_status,
             external_error_message: receipt.external_error_message,
+        }
+    }
+}
+
+impl From<&TransactionReceiptModel> for TransactionReceipt {
+    fn from(receipt: &TransactionReceiptModel) -> Self {
+        Self {
+            transaction_id: receipt.transaction_id.to_string(),
+            result_valid: receipt.result_valid,
+            error_message: receipt.error_message.clone(),
+            error_data: receipt.error_data.clone(),
+            serialized_receipt: format!("{:?}", receipt.serialized_receipt),
+            external_status: receipt.external_status.clone(),
+            external_error_message: receipt.external_error_message.clone(),
         }
     }
 }
@@ -344,14 +386,15 @@ pub fn make_batch_models(batches: &[TrackingBatch]) -> Vec<BatchModel> {
     let mut models = Vec::new();
     for batch in batches {
         let model = BatchModel {
+            batch_id: make_database_id(batch.batch_header(), batch.service_id()),
             service_id: batch.service_id().to_string(),
-            batch_id: batch.batch_header().to_string(),
+            batch_header: batch.batch_header().to_string(),
             data_change_id: batch.data_change_id().map(String::from),
             signer_public_key: batch.signer_public_key().to_string(),
             trace: batch.trace(),
             serialized_batch: batch.serialized_batch().to_vec(),
             submitted: batch.submitted(),
-            created_at: NaiveDateTime::from_timestamp(batch.created_at(), 0),
+            created_at: batch.created_at(),
         };
 
         models.push(model)
@@ -365,10 +408,13 @@ pub fn make_transaction_models(batches: &[TrackingBatch]) -> Vec<TransactionMode
     for batch in batches {
         for transaction in batch.transactions() {
             let model = TransactionModel {
+                transaction_id: make_database_id(
+                    transaction.transaction_header(),
+                    transaction.service_id(),
+                ),
                 service_id: transaction.service_id().to_string(),
-                transaction_id: transaction.transaction_id().to_string(),
-                batch_id: batch.batch_header().to_string(),
-                batch_service_id: batch.service_id().to_string(),
+                transaction_header: transaction.transaction_header().to_string(),
+                batch_id: make_database_id(batch.batch_header(), batch.service_id()),
                 payload: transaction.payload().to_vec(),
                 family_name: transaction.family_name().to_string(),
                 family_version: transaction.family_version().to_string(),
@@ -380,4 +426,12 @@ pub fn make_transaction_models(batches: &[TrackingBatch]) -> Vec<TransactionMode
     }
 
     models
+}
+
+pub fn make_database_id(id: &str, service_id: &str) -> String {
+    let mut sha = Sha512::new();
+    sha.input_str(&format!("{}{}", service_id, id));
+    let hash_result = sha.result_str();
+
+    hash_result[..70].to_string()
 }

--- a/sdk/src/batch_tracking/store/diesel/schema.rs
+++ b/sdk/src/batch_tracking/store/diesel/schema.rs
@@ -13,47 +13,46 @@
 // limitations under the License.
 
 table! {
-    batch_statuses (service_id, batch_id) {
-        service_id -> Text,
+    batch_statuses (batch_id) {
         batch_id -> Text,
-        batch_service_id -> Text,
+        service_id -> Text,
         dlt_status -> Text,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
+        created_at -> Int8,
+        updated_at -> Int8,
     }
 }
 
 table! {
-    batches (service_id, batch_id) {
-        service_id -> Text,
+    batches (batch_id) {
         batch_id -> Text,
+        service_id -> Text,
+        batch_header -> Text,
         data_change_id -> Nullable<Text>,
         signer_public_key -> Text,
         trace -> Bool,
         serialized_batch -> Binary,
         submitted -> Bool,
-        created_at -> Timestamp,
+        created_at -> Int8,
     }
 }
 
 table! {
-    submissions (service_id, batch_id) {
-        service_id -> Text,
+    submissions (batch_id) {
         batch_id -> Text,
-        batch_service_id -> Text,
-        last_checked -> Nullable<Timestamp>,
+        service_id -> Text,
+        last_checked -> Nullable<Int8>,
         times_checked -> Nullable<Text>,
         error_type -> Nullable<Text>,
         error_message -> Nullable<Text>,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
+        created_at -> Int8,
+        updated_at -> Int8,
     }
 }
 
 table! {
-    transaction_receipts (service_id, transaction_id) {
-        service_id -> Text,
+    transaction_receipts (transaction_id) {
         transaction_id -> Text,
+        service_id -> Text,
         result_valid -> Bool,
         error_message -> Nullable<Text>,
         error_data -> Nullable<Binary>,
@@ -64,17 +63,22 @@ table! {
 }
 
 table! {
-    transactions (service_id, transaction_id) {
-        service_id -> Text,
+    transactions (transaction_id) {
         transaction_id -> Text,
+        service_id -> Text,
+        transaction_header -> Text,
         batch_id -> Text,
-        batch_service_id -> Text,
         payload -> Binary,
         family_name -> Text,
         family_version -> Text,
         signer_public_key -> Text,
     }
 }
+
+joinable!(batch_statuses -> batches (batch_id));
+joinable!(submissions -> batches (batch_id));
+joinable!(transaction_receipts -> transactions (transaction_id));
+joinable!(transactions -> batches (batch_id));
 
 allow_tables_to_appear_in_same_query!(
     batch_statuses,

--- a/sdk/src/batch_tracking/store/mod.rs
+++ b/sdk/src/batch_tracking/store/mod.rs
@@ -459,7 +459,7 @@ pub struct TrackingBatchList {
 pub struct TrackingTransaction {
     family_name: String,
     family_version: String,
-    transaction_id: String,
+    transaction_header: String,
     payload: Vec<u8>,
     signer_public_key: String,
     service_id: String,
@@ -474,8 +474,8 @@ impl TrackingTransaction {
         &self.family_version
     }
 
-    pub fn transaction_id(&self) -> &str {
-        &self.transaction_id
+    pub fn transaction_header(&self) -> &str {
+        &self.transaction_header
     }
 
     pub fn payload(&self) -> &[u8] {
@@ -539,7 +539,7 @@ impl TrackingTransactionBuilder {
         let family_name = txn_header.family_name().to_string();
         let family_version = txn_header.family_version().to_string();
         let signer_public_key = format!("{:?}", txn_header.signer_public_key());
-        let transaction_id = transact_transaction.header_signature().to_string();
+        let transaction_header = transact_transaction.header_signature().to_string();
         let payload = transact_transaction.payload().to_vec();
 
         if family_name.is_empty() {
@@ -554,7 +554,7 @@ impl TrackingTransactionBuilder {
             ));
         }
 
-        if transaction_id.is_empty() {
+        if transaction_header.is_empty() {
             return Err(BatchBuilderError::MissingRequiredField(
                 "transaction_id".to_string(),
             ));
@@ -575,7 +575,7 @@ impl TrackingTransactionBuilder {
         Ok(TrackingTransaction {
             family_name,
             family_version,
-            transaction_id,
+            transaction_header,
             payload,
             signer_public_key,
             service_id: serv_id,

--- a/sdk/src/migrations/diesel/postgres/migrations/2022-04-14-215932_add_batch_tracking_tables_2/down.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2022-04-14-215932_add_batch_tracking_tables_2/down.sql
@@ -1,0 +1,61 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS set_batch_statuses_updated_at_timestamp;
+DROP TRIGGER IF EXISTS set_submissions_updated_at_timestamp;
+
+DROP FUNCTION utc_timestamp;
+DROP FUNCTION trigger_set_timestamp;
+
+DROP TABLE batches;
+DROP TABLE transactions;
+DROP TABLE transaction_receipts;
+DROP TABLE submissions;
+DROP TABLE batch_statuses;
+
+CREATE TABLE batches (
+    header_signature TEXT PRIMARY KEY,
+    data_change_id TEXT,
+    signer_public_key TEXT NOT NULL,
+    trace BOOLEAN NOT NULL,
+    serialized_batch TEXT NOT NULL,
+    submitted BOOLEAN NOT NULL,
+    submission_error VARCHAR(16),
+    submission_error_message TEXT,
+    dlt_status VARCHAR(16),
+    claim_expires TIMESTAMP,
+    created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    service_id TEXT
+);
+
+CREATE TABLE transactions (
+    header_signature TEXT PRIMARY KEY,
+    batch_id TEXT NOT NULL,
+    family_name TEXT NOT NULL,
+    family_version TEXT NOT NULL,
+    signer_public_key TEXT NOT NULL,
+    FOREIGN KEY (batch_id) REFERENCES batches(header_signature) ON DELETE CASCADE
+);
+
+CREATE TABLE transaction_receipts (
+    id BIGSERIAL PRIMARY KEY,
+    transaction_id TEXT UNIQUE,
+    result_valid BOOLEAN NOT NULL,
+    error_message TEXT,
+    error_data TEXT,
+    serialized_receipt TEXT NOT NULL,
+    external_status VARCHAR(16),
+    external_error_message TEXT
+);

--- a/sdk/src/migrations/diesel/postgres/migrations/2022-04-14-215932_add_batch_tracking_tables_2/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2022-04-14-215932_add_batch_tracking_tables_2/up.sql
@@ -1,0 +1,111 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE batches CASCADE;
+DROP TABLE transactions;
+DROP TABLE transaction_receipts;
+DROP TABLE batch_statuses;
+DROP TABLE submissions;
+
+CREATE OR REPLACE FUNCTION utc_timestamp()
+RETURNS INTEGER AS $$
+DECLARE
+	res INTEGER;
+BEGIN
+	SELECT extract(epoch from NOW())
+    INTO res;
+    RETURN res;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = utc_timestamp();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE batches
+  (
+     batch_id          VARCHAR(70) PRIMARY KEY,
+     service_id        VARCHAR(17) NOT NULL,
+     batch_header      VARCHAR(128) NOT NULL,
+     data_change_id    VARCHAR(256),
+     signer_public_key VARCHAR(70) NOT NULL,
+     trace             BOOLEAN NOT NULL,
+     serialized_batch  BYTEA NOT NULL,
+     submitted         BOOLEAN NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT utc_timestamp()
+  );
+
+CREATE TABLE transactions
+  (
+     transaction_id     VARCHAR(70) PRIMARY KEY,
+     service_id         VARCHAR(17) NOT NULL,
+     transaction_header VARCHAR(128) NOT NULL,
+     batch_id           VARCHAR(128) NOT NULL,
+     payload            BYTEA NOT NULL,
+     family_name        VARCHAR(128) NOT NULL,
+     family_version     VARCHAR(16) NOT NULL,
+     signer_public_key  VARCHAR(70) NOT NULL,
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE transaction_receipts
+  (
+     transaction_id         VARCHAR(70) PRIMARY KEY,
+     service_id             VARCHAR(17) NOT NULL,
+     result_valid           BOOLEAN NOT NULL,
+     error_message          TEXT,
+     error_data             BYTEA,
+     serialized_receipt     BYTEA NOT NULL,
+     external_status        VARCHAR(16),
+     external_error_message TEXT,
+     FOREIGN KEY (transaction_id) REFERENCES transactions(transaction_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE submissions
+  (
+     batch_id              VARCHAR(70) PRIMARY KEY,
+     service_id            VARCHAR(17) NOT NULL,
+     last_checked          INTEGER,
+     times_checked         VARCHAR(32),
+     error_type            VARCHAR(64),
+     error_message         TEXT,
+     created_at            INTEGER NOT NULL DEFAULT utc_timestamp(),
+     updated_at            INTEGER NOT NULL DEFAULT utc_timestamp(),
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE batch_statuses
+  (
+     batch_id          VARCHAR(70) PRIMARY KEY,
+     service_id        VARCHAR(17) NOT NULL,
+     dlt_status        VARCHAR(16) NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT utc_timestamp(),
+     updated_at        INTEGER NOT NULL DEFAULT utc_timestamp(),
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TRIGGER set_batch_statuses_updated_at_timestamp
+BEFORE UPDATE ON batch_statuses
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();
+
+CREATE TRIGGER set_submissions_updated_at_timestamp
+BEFORE UPDATE ON submissions
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();

--- a/sdk/src/migrations/diesel/sqlite/migrations/2022-04-14-215500_add_batch_tracking_tables_2/down.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2022-04-14-215500_add_batch_tracking_tables_2/down.sql
@@ -1,0 +1,58 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS set_batch_statuses_updated_at_timestamp;
+DROP TRIGGER IF EXISTS set_submissions_updated_at_timestamp;
+
+DROP TABLE batches;
+DROP TABLE transactions;
+DROP TABLE transaction_receipts;
+DROP TABLE submissions;
+DROP TABLE batch_statuses;
+
+CREATE TABLE batches (
+    header_signature TEXT PRIMARY KEY,
+    data_change_id TEXT,
+    signer_public_key TEXT NOT NULL,
+    trace BOOLEAN NOT NULL,
+    serialized_batch TEXT NOT NULL,
+    submitted BOOLEAN NOT NULL,
+    submission_error VARCHAR(16),
+    submission_error_message TEXT,
+    dlt_status VARCHAR(16),
+    claim_expires DATETIME,
+    created DATETIME DEFAULT CURRENT_TIMESTAMP,
+    service_id TEXT
+);
+
+CREATE TABLE transactions (
+    header_signature TEXT PRIMARY KEY,
+    batch_id TEXT NOT NULL,
+    family_name TEXT NOT NULL,
+    family_version TEXT NOT NULL,
+    signer_public_key TEXT NOT NULL,
+    FOREIGN KEY (batch_id) REFERENCES batches(header_signature) ON DELETE CASCADE
+);
+
+CREATE TABLE transaction_receipts (
+    id INTEGER PRIMARY KEY,
+    transaction_id TEXT UNIQUE,
+    result_valid BOOLEAN NOT NULL,
+    error_message TEXT,
+    error_data TEXT,
+    serialized_receipt TEXT NOT NULL,
+    external_status VARCHAR(16),
+    external_error_message TEXT
+);

--- a/sdk/src/migrations/diesel/sqlite/migrations/2022-04-14-215500_add_batch_tracking_tables_2/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2022-04-14-215500_add_batch_tracking_tables_2/up.sql
@@ -1,0 +1,100 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE batches;
+DROP TABLE batch_statuses;
+DROP TABLE submissions;
+DROP TABLE transactions;
+DROP TABLE transaction_receipts;
+
+CREATE TABLE batches
+  (
+     batch_id          VARCHAR(70) PRIMARY KEY,
+     service_id        VARCHAR(17) NOT NULL,
+     batch_header      VARCHAR(128) NOT NULL,
+     data_change_id    VARCHAR(256),
+     signer_public_key VARCHAR(70) NOT NULL,
+     trace             BOOLEAN NOT NULL,
+     serialized_batch  BLOB NOT NULL,
+     submitted         BOOLEAN NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int))
+  );
+
+CREATE TABLE transactions
+  (
+     transaction_id     VARCHAR(70) PRIMARY KEY,
+     service_id         VARCHAR(17) NOT NULL,
+     transaction_header VARCHAR(128) NOT NULL,
+     batch_id           VARCHAR(128) NOT NULL,
+     payload            BLOB NOT NULL,
+     family_name        VARCHAR(128) NOT NULL,
+     family_version     VARCHAR(16) NOT NULL,
+     signer_public_key  VARCHAR(70) NOT NULL,
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE transaction_receipts
+  (
+     transaction_id         VARCHAR(70) PRIMARY KEY,
+     service_id             VARCHAR(17) NOT NULL,
+     result_valid           BOOLEAN NOT NULL,
+     error_message          TEXT,
+     error_data             BLOB,
+     serialized_receipt     BLOB NOT NULL,
+     external_status        VARCHAR(16),
+     external_error_message TEXT,
+     FOREIGN KEY (transaction_id) REFERENCES transactions(transaction_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE submissions
+  (
+     batch_id              VARCHAR(70) PRIMARY KEY,
+     service_id            VARCHAR(17) NOT NULL,
+     last_checked          INTEGER,
+     times_checked         VARCHAR(32),
+     error_type            VARCHAR(64),
+     error_message         TEXT,
+     created_at            INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     updated_at            INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE batch_statuses
+  (
+     batch_id          VARCHAR(70) PRIMARY KEY,
+     service_id        VARCHAR(17) NOT NULL,
+     dlt_status        VARCHAR(16) NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     updated_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TRIGGER IF NOT EXISTS set_batch_statuses_updated_at_timestamp
+BEFORE UPDATE ON batch_statuses
+FOR EACH ROW
+BEGIN
+    UPDATE batch_statuses
+    SET updated_at = (cast(strftime('%s') as int))
+    WHERE rowid = NEW.rowid;
+END;
+
+CREATE TRIGGER IF NOT EXISTS set_submissions_updated_at_timestamp
+BEFORE UPDATE ON submissions
+FOR EACH ROW
+BEGIN
+    UPDATE submissions
+    SET updated_at = (cast(strftime('%s') as int))
+    WHERE rowid = NEW.rowid;
+END;


### PR DESCRIPTION
This updates the database schema for the batch tracking tables by
adding batch/transaction ID columns. These columns are intended to be
the primary keys for a table and consist of a hash of the batch/txn
header and the service ID. Columns for the service ID and batch/txn
headers are also included for deserialization sake. This is a necessary
change because diesel does not fully support composite keys.
Specifically, it does not implement the `BelongsToDsl` trait for
composite keys and they do not intend to implement this functionality,
as stated in https://github.com/diesel-rs/diesel/issues/1413.

Signed-off-by: Davey Newhall <newhall@bitwise.io>