### PR TITLE
Update batch tracking table timestamps

### DIFF
--- a/sdk/src/batch_tracking/store/diesel/schema.rs
+++ b/sdk/src/batch_tracking/store/diesel/schema.rs
@@ -18,8 +18,8 @@ table! {
         batch_id -> Text,
         batch_service_id -> Text,
         dlt_status -> Text,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
+        created_at -> Int8,
+        updated_at -> Int8,
     }
 }
 
@@ -32,7 +32,7 @@ table! {
         trace -> Bool,
         serialized_batch -> Binary,
         submitted -> Bool,
-        created_at -> Timestamp,
+        created_at -> Int8,
     }
 }
 
@@ -41,12 +41,12 @@ table! {
         service_id -> Text,
         batch_id -> Text,
         batch_service_id -> Text,
-        last_checked -> Nullable<Timestamp>,
+        last_checked -> Nullable<Int8>,
         times_checked -> Nullable<Text>,
         error_type -> Nullable<Text>,
         error_message -> Nullable<Text>,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
+        created_at -> Int8,
+        updated_at -> Int8,
     }
 }
 

--- a/sdk/src/migrations/diesel/postgres/migrations/2022-02-09-212341_add_batch_tracking_tables/down.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2022-02-09-212341_add_batch_tracking_tables/down.sql
@@ -13,6 +13,12 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
+DROP TRIGGER set_batch_statuses_updated_at_timestamp;
+DROP TRIGGER set_submissions_updated_at_timestamp;
+
+DROP FUNCTION utc_timestamp;
+DROP FUNCTION trigger_set_timestamp;
+
 DROP TABLE batches;
 DROP TABLE transactions;
 DROP TABLE transaction_receipts;

--- a/sdk/src/migrations/diesel/sqlite/migrations/2022-02-09-212341_add_batch_tracking_tables/down.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2022-02-09-212341_add_batch_tracking_tables/down.sql
@@ -13,6 +13,9 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
+DROP TRIGGER set_batch_statuses_updated_at_timestamp;
+DROP TRIGGER set_submissions_updated_at_timestamp;
+
 DROP TABLE batches;
 DROP TABLE transactions;
 DROP TABLE transaction_receipts;

--- a/sdk/src/migrations/diesel/sqlite/migrations/2022-02-09-212341_add_batch_tracking_tables/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2022-02-09-212341_add_batch_tracking_tables/up.sql
@@ -26,7 +26,7 @@ CREATE TABLE batches
      trace             BOOLEAN NOT NULL,
      serialized_batch  BLOB NOT NULL,
      submitted         BOOLEAN NOT NULL,
-     created_at        TIMESTAMP NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
      PRIMARY KEY (service_id, batch_id)
   );
 
@@ -62,12 +62,12 @@ CREATE TABLE submissions
      service_id            VARCHAR(17) NOT NULL,
      batch_id              VARCHAR(128) NOT NULL,
      batch_service_id      VARCHAR(17) NOT NULL,
-     last_checked          TIMESTAMP,
+     last_checked          INTEGER,
      times_checked         VARCHAR(32),
      error_type            VARCHAR(64),
      error_message         TEXT,
-     created_at            TIMESTAMP NOT NULL,
-     updated_at            TIMESTAMP NOT NULL,
+     created_at            INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     updated_at            INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
      FOREIGN KEY (batch_service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE,
      PRIMARY KEY (service_id, batch_id)
   );
@@ -78,8 +78,26 @@ CREATE TABLE batch_statuses
      batch_id          VARCHAR(128) NOT NULL,
      batch_service_id  VARCHAR(17) NOT NULL,
      dlt_status        VARCHAR(16) NOT NULL,
-     created_at        TIMESTAMP NOT NULL,
-     updated_at        TIMESTAMP NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     updated_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
      FOREIGN KEY (batch_service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE,
      PRIMARY KEY (service_id, batch_id)
   );
+
+CREATE TRIGGER IF NOT EXISTS set_batch_statuses_updated_at_timestamp
+BEFORE UPDATE ON batch_statuses
+FOR EACH ROW
+BEGIN
+    UPDATE batch_statuses
+    SET updated_at = (cast(strftime('%s') as int))
+    WHERE rowid = NEW.rowid;
+END;
+
+CREATE TRIGGER IF NOT EXISTS set_submissions_updated_at_timestamp
+BEFORE UPDATE ON submissions
+FOR EACH ROW
+BEGIN
+    UPDATE submissions
+    SET updated_at = (cast(strftime('%s') as int))
+    WHERE rowid = NEW.rowid;
+END;


### PR DESCRIPTION
This updates the migrations and associated schemas and models for the
Batch Tracking store to use auto-generated timestamps for `created_at`
and `updated_at` columns.

Signed-off-by: Davey Newhall <newhall@bitwise.io>