### PR TITLE
Undo batch_tracking migrations key changes

### DIFF
--- a/sdk/src/batch_tracking/store/diesel/mod.rs
+++ b/sdk/src/batch_tracking/store/diesel/mod.rs
@@ -26,8 +26,6 @@ use super::{
 
 use crate::error::ResourceTemporarilyUnavailableError;
 
-use models::make_database_id;
-
 use operations::add_batches::BatchTrackingStoreAddBatchesOperation as _;
 use operations::get_batch::BatchTrackingStoreGetBatchOperation as _;
 use operations::get_batch_status::BatchTrackingStoreGetBatchStatusOperation as _;
@@ -63,7 +61,7 @@ impl BatchTrackingStore for DieselBatchTrackingStore<diesel::pg::PgConnection> {
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .get_batch_status(&make_database_id(id, service_id))
+        .get_batch_status(id, service_id)
     }
 
     fn update_batch_status(
@@ -103,7 +101,7 @@ impl BatchTrackingStore for DieselBatchTrackingStore<diesel::pg::PgConnection> {
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .get_batch(&make_database_id(id, service_id))
+        .get_batch(id, service_id)
     }
 
     fn list_batches_by_status(
@@ -141,7 +139,7 @@ impl BatchTrackingStore for DieselBatchTrackingStore<diesel::sqlite::SqliteConne
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .get_batch_status(&make_database_id(id, service_id))
+        .get_batch_status(id, service_id)
     }
 
     fn update_batch_status(
@@ -181,7 +179,7 @@ impl BatchTrackingStore for DieselBatchTrackingStore<diesel::sqlite::SqliteConne
                 ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
             )
         })?)
-        .get_batch(&make_database_id(id, service_id))
+        .get_batch(id, service_id)
     }
 
     fn list_batches_by_status(
@@ -233,8 +231,7 @@ impl<'a> BatchTrackingStore for DieselConnectionBatchTrackingStore<'a, diesel::p
         id: &str,
         service_id: &str,
     ) -> Result<Option<BatchStatus>, BatchTrackingStoreError> {
-        BatchTrackingStoreOperations::new(self.connection)
-            .get_batch_status(&make_database_id(id, service_id))
+        BatchTrackingStoreOperations::new(self.connection).get_batch_status(id, service_id)
     }
 
     fn update_batch_status(
@@ -264,8 +261,7 @@ impl<'a> BatchTrackingStore for DieselConnectionBatchTrackingStore<'a, diesel::p
         id: &str,
         service_id: &str,
     ) -> Result<Option<TrackingBatch>, BatchTrackingStoreError> {
-        BatchTrackingStoreOperations::new(self.connection)
-            .get_batch(&make_database_id(id, service_id))
+        BatchTrackingStoreOperations::new(self.connection).get_batch(id, service_id)
     }
 
     fn list_batches_by_status(
@@ -300,8 +296,7 @@ impl<'a> BatchTrackingStore
         id: &str,
         service_id: &str,
     ) -> Result<Option<BatchStatus>, BatchTrackingStoreError> {
-        BatchTrackingStoreOperations::new(self.connection)
-            .get_batch_status(&make_database_id(id, service_id))
+        BatchTrackingStoreOperations::new(self.connection).get_batch_status(id, service_id)
     }
 
     fn update_batch_status(
@@ -331,8 +326,7 @@ impl<'a> BatchTrackingStore
         id: &str,
         service_id: &str,
     ) -> Result<Option<TrackingBatch>, BatchTrackingStoreError> {
-        BatchTrackingStoreOperations::new(self.connection)
-            .get_batch(&make_database_id(id, service_id))
+        BatchTrackingStoreOperations::new(self.connection).get_batch(id, service_id)
     }
 
     fn list_batches_by_status(

--- a/sdk/src/batch_tracking/store/diesel/schema.rs
+++ b/sdk/src/batch_tracking/store/diesel/schema.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 table! {
-    batch_statuses (batch_id) {
-        batch_id -> Text,
+    batch_statuses (service_id, batch_id) {
         service_id -> Text,
+        batch_id -> Text,
         dlt_status -> Text,
         created_at -> Int8,
         updated_at -> Int8,
@@ -23,10 +23,9 @@ table! {
 }
 
 table! {
-    batches (batch_id) {
-        batch_id -> Text,
+    batches (service_id, batch_id) {
         service_id -> Text,
-        batch_header -> Text,
+        batch_id -> Text,
         data_change_id -> Nullable<Text>,
         signer_public_key -> Text,
         trace -> Bool,
@@ -37,11 +36,11 @@ table! {
 }
 
 table! {
-    submissions (batch_id) {
-        batch_id -> Text,
+    submissions (service_id, batch_id) {
         service_id -> Text,
-        last_checked -> Nullable<Int8>,
-        times_checked -> Nullable<Text>,
+        batch_id -> Text,
+        last_checked -> Int8,
+        times_checked -> Int8,
         error_type -> Nullable<Text>,
         error_message -> Nullable<Text>,
         created_at -> Int8,
@@ -50,9 +49,9 @@ table! {
 }
 
 table! {
-    transaction_receipts (transaction_id) {
-        transaction_id -> Text,
+    transaction_receipts (service_id, transaction_id) {
         service_id -> Text,
+        transaction_id -> Text,
         result_valid -> Bool,
         error_message -> Nullable<Text>,
         error_data -> Nullable<Binary>,
@@ -63,10 +62,9 @@ table! {
 }
 
 table! {
-    transactions (transaction_id) {
-        transaction_id -> Text,
+    transactions (service_id, transaction_id) {
         service_id -> Text,
-        transaction_header -> Text,
+        transaction_id -> Text,
         batch_id -> Text,
         payload -> Binary,
         family_name -> Text,
@@ -74,11 +72,6 @@ table! {
         signer_public_key -> Text,
     }
 }
-
-joinable!(batch_statuses -> batches (batch_id));
-joinable!(submissions -> batches (batch_id));
-joinable!(transaction_receipts -> transactions (transaction_id));
-joinable!(transactions -> batches (batch_id));
 
 allow_tables_to_appear_in_same_query!(
     batch_statuses,

--- a/sdk/src/migrations/diesel/postgres/migrations/2022-04-19-160501_undo-batch-tracking-key-changes/down.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2022-04-19-160501_undo-batch-tracking-key-changes/down.sql
@@ -1,0 +1,115 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS set_update_submission ON submissions;
+
+DROP FUNCTION trigger_update_submission;
+
+DROP TABLE batches;
+DROP TABLE transactions;
+DROP TABLE transaction_receipts;
+DROP TABLE submissions;
+DROP TABLE batch_statuses;
+
+CREATE OR REPLACE FUNCTION utc_timestamp()
+RETURNS INTEGER AS $$
+DECLARE
+	res INTEGER;
+BEGIN
+	SELECT extract(epoch from NOW())
+    INTO res;
+    RETURN res;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = utc_timestamp();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE batches
+  (
+     batch_id          VARCHAR(70) PRIMARY KEY,
+     service_id        VARCHAR(17) NOT NULL,
+     batch_header      VARCHAR(128) NOT NULL,
+     data_change_id    VARCHAR(256),
+     signer_public_key VARCHAR(70) NOT NULL,
+     trace             BOOLEAN NOT NULL,
+     serialized_batch  BYTEA NOT NULL,
+     submitted         BOOLEAN NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT utc_timestamp()
+  );
+
+CREATE TABLE transactions
+  (
+     transaction_id     VARCHAR(70) PRIMARY KEY,
+     service_id         VARCHAR(17) NOT NULL,
+     transaction_header VARCHAR(128) NOT NULL,
+     batch_id           VARCHAR(128) NOT NULL,
+     payload            BYTEA NOT NULL,
+     family_name        VARCHAR(128) NOT NULL,
+     family_version     VARCHAR(16) NOT NULL,
+     signer_public_key  VARCHAR(70) NOT NULL,
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE transaction_receipts
+  (
+     transaction_id         VARCHAR(70) PRIMARY KEY,
+     service_id             VARCHAR(17) NOT NULL,
+     result_valid           BOOLEAN NOT NULL,
+     error_message          TEXT,
+     error_data             BYTEA,
+     serialized_receipt     BYTEA NOT NULL,
+     external_status        VARCHAR(16),
+     external_error_message TEXT,
+     FOREIGN KEY (transaction_id) REFERENCES transactions(transaction_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE submissions
+  (
+     batch_id              VARCHAR(70) PRIMARY KEY,
+     service_id            VARCHAR(17) NOT NULL,
+     last_checked          INTEGER,
+     times_checked         VARCHAR(32),
+     error_type            VARCHAR(64),
+     error_message         TEXT,
+     created_at            INTEGER NOT NULL DEFAULT utc_timestamp(),
+     updated_at            INTEGER NOT NULL DEFAULT utc_timestamp(),
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE batch_statuses
+  (
+     batch_id          VARCHAR(70) PRIMARY KEY,
+     service_id        VARCHAR(17) NOT NULL,
+     dlt_status        VARCHAR(16) NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT utc_timestamp(),
+     updated_at        INTEGER NOT NULL DEFAULT utc_timestamp(),
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TRIGGER set_batch_statuses_updated_at_timestamp
+BEFORE UPDATE ON batch_statuses
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();
+
+CREATE TRIGGER set_submissions_updated_at_timestamp
+BEFORE UPDATE ON submissions
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();

--- a/sdk/src/migrations/diesel/postgres/migrations/2022-04-19-160501_undo-batch-tracking-key-changes/up.sql
+++ b/sdk/src/migrations/diesel/postgres/migrations/2022-04-19-160501_undo-batch-tracking-key-changes/up.sql
@@ -1,0 +1,101 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS set_submissions_updated_at_timestamp ON submissions;
+
+DROP TABLE batches CASCADE;
+DROP TABLE transactions CASCADE;
+DROP TABLE transaction_receipts;
+DROP TABLE batch_statuses;
+DROP TABLE submissions;
+
+CREATE OR REPLACE FUNCTION trigger_update_submission()
+RETURNS TRIGGER AS $$
+BEGIN
+	NEW.updated_at = utc_timestamp();
+	NEW.last_checked = utc_timestamp();
+  	NEW.times_checked = OLD.times_checked + 1;
+  	RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE batches
+  (
+     service_id        VARCHAR(17) NOT NULL,
+     batch_id          VARCHAR(128) NOT NULL,
+     data_change_id    VARCHAR(256) UNIQUE,
+     signer_public_key VARCHAR(70) NOT NULL,
+     trace             BOOLEAN NOT NULL,
+     serialized_batch  BYTEA NOT NULL,
+     submitted         BOOLEAN NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT utc_timestamp(),
+     PRIMARY KEY (service_id, batch_id)
+  );
+
+CREATE TABLE transactions
+  (
+     service_id         VARCHAR(17) NOT NULL,
+     transaction_id     VARCHAR(128) NOT NULL,
+     batch_id           VARCHAR(128) NOT NULL,
+     payload            BYTEA NOT NULL,
+     family_name        VARCHAR(128) NOT NULL,
+     family_version     VARCHAR(16) NOT NULL,
+     signer_public_key  VARCHAR(70) NOT NULL,
+     PRIMARY KEY (service_id, transaction_id),
+     FOREIGN KEY (service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE transaction_receipts
+  (
+     service_id             VARCHAR(17) NOT NULL,
+     transaction_id         VARCHAR(128) NOT NULL,
+     result_valid           BOOLEAN NOT NULL,
+     error_message          TEXT,
+     error_data             BYTEA,
+     serialized_receipt     BYTEA NOT NULL,
+     external_status        VARCHAR(16),
+     external_error_message TEXT,
+     FOREIGN KEY (service_id, transaction_id) REFERENCES transactions(service_id, transaction_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE submissions
+  (
+     service_id            VARCHAR(17) NOT NULL,
+     batch_id              VARCHAR(128) NOT NULL,
+     last_checked          INTEGER NOT NULL DEFAULT utc_timestamp(),
+     times_checked         INTEGER NOT NULL DEFAULT 1,
+     error_type            VARCHAR(64),
+     error_message         TEXT,
+     created_at            INTEGER NOT NULL DEFAULT utc_timestamp(),
+     updated_at            INTEGER NOT NULL DEFAULT utc_timestamp(),
+     PRIMARY KEY (service_id, batch_id),
+     FOREIGN KEY (service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE batch_statuses
+  (
+     service_id        VARCHAR(17) NOT NULL,
+     batch_id          VARCHAR(70) NOT NULL,
+     dlt_status        VARCHAR(16) NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT utc_timestamp(),
+     updated_at        INTEGER NOT NULL DEFAULT utc_timestamp(),
+     PRIMARY KEY (service_id, batch_id),
+     FOREIGN KEY (service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE
+  );
+
+CREATE TRIGGER set_update_submission
+BEFORE UPDATE ON submissions
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_update_submission();

--- a/sdk/src/migrations/diesel/sqlite/migrations/2022-04-19-160454_undo-batch-tracking-key-changes/down.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2022-04-19-160454_undo-batch-tracking-key-changes/down.sql
@@ -1,0 +1,100 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE batches;
+DROP TABLE batch_statuses;
+DROP TABLE submissions;
+DROP TABLE transactions;
+DROP TABLE transaction_receipts;
+
+CREATE TABLE batches
+  (
+     batch_id          VARCHAR(70) PRIMARY KEY,
+     service_id        VARCHAR(17) NOT NULL,
+     batch_header      VARCHAR(128) NOT NULL,
+     data_change_id    VARCHAR(256),
+     signer_public_key VARCHAR(70) NOT NULL,
+     trace             BOOLEAN NOT NULL,
+     serialized_batch  BLOB NOT NULL,
+     submitted         BOOLEAN NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int))
+  );
+
+CREATE TABLE transactions
+  (
+     transaction_id     VARCHAR(70) PRIMARY KEY,
+     service_id         VARCHAR(17) NOT NULL,
+     transaction_header VARCHAR(128) NOT NULL,
+     batch_id           VARCHAR(128) NOT NULL,
+     payload            BLOB NOT NULL,
+     family_name        VARCHAR(128) NOT NULL,
+     family_version     VARCHAR(16) NOT NULL,
+     signer_public_key  VARCHAR(70) NOT NULL,
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE transaction_receipts
+  (
+     transaction_id         VARCHAR(70) PRIMARY KEY,
+     service_id             VARCHAR(17) NOT NULL,
+     result_valid           BOOLEAN NOT NULL,
+     error_message          TEXT,
+     error_data             BLOB,
+     serialized_receipt     BLOB NOT NULL,
+     external_status        VARCHAR(16),
+     external_error_message TEXT,
+     FOREIGN KEY (transaction_id) REFERENCES transactions(transaction_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE submissions
+  (
+     batch_id              VARCHAR(70) PRIMARY KEY,
+     service_id            VARCHAR(17) NOT NULL,
+     last_checked          INTEGER,
+     times_checked         VARCHAR(32),
+     error_type            VARCHAR(64),
+     error_message         TEXT,
+     created_at            INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     updated_at            INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TABLE batch_statuses
+  (
+     batch_id          VARCHAR(70) PRIMARY KEY,
+     service_id        VARCHAR(17) NOT NULL,
+     dlt_status        VARCHAR(16) NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     updated_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     FOREIGN KEY (batch_id) REFERENCES batches(batch_id) ON DELETE CASCADE
+  );
+
+CREATE TRIGGER IF NOT EXISTS set_batch_statuses_updated_at_timestamp
+BEFORE UPDATE ON batch_statuses
+FOR EACH ROW
+BEGIN
+    UPDATE batch_statuses
+    SET updated_at = (cast(strftime('%s') as int))
+    WHERE rowid = NEW.rowid;
+END;
+
+CREATE TRIGGER IF NOT EXISTS set_submissions_updated_at_timestamp
+BEFORE UPDATE ON submissions
+FOR EACH ROW
+BEGIN
+    UPDATE submissions
+    SET updated_at = (cast(strftime('%s') as int))
+    WHERE rowid = NEW.rowid;
+END;

--- a/sdk/src/migrations/diesel/sqlite/migrations/2022-04-19-160454_undo-batch-tracking-key-changes/up.sql
+++ b/sdk/src/migrations/diesel/sqlite/migrations/2022-04-19-160454_undo-batch-tracking-key-changes/up.sql
@@ -1,0 +1,98 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS set_submissions_updated_at_timestamp;
+
+DROP TABLE batches;
+DROP TABLE batch_statuses;
+DROP TABLE submissions;
+DROP TABLE transactions;
+DROP TABLE transaction_receipts;
+
+CREATE TABLE batches
+  (
+     service_id        VARCHAR(17) NOT NULL,
+     batch_id          VARCHAR(128) NOT NULL,
+     data_change_id    VARCHAR(256) UNIQUE,
+     signer_public_key VARCHAR(70) NOT NULL,
+     trace             BOOLEAN NOT NULL,
+     serialized_batch  BLOB NOT NULL,
+     submitted         BOOLEAN NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     PRIMARY KEY (service_id, batch_id)
+  );
+
+CREATE TABLE transactions
+  (
+     service_id         VARCHAR(17) NOT NULL,
+     transaction_id     VARCHAR(128) NOT NULL,
+     batch_id           VARCHAR(128) NOT NULL,
+     payload            BLOB NOT NULL,
+     family_name        VARCHAR(128) NOT NULL,
+     family_version     VARCHAR(16) NOT NULL,
+     signer_public_key  VARCHAR(70) NOT NULL,
+     FOREIGN KEY (service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE,
+     PRIMARY KEY (service_id, transaction_id)
+  );
+
+CREATE TABLE transaction_receipts
+  (
+     service_id             VARCHAR(17) NOT NULL,
+     transaction_id         VARCHAR(128) NOT NULL,
+     result_valid           BOOLEAN NOT NULL,
+     error_message          TEXT,
+     error_data             BLOB,
+     serialized_receipt     BLOB NOT NULL,
+     external_status        VARCHAR(16),
+     external_error_message TEXT,
+     FOREIGN KEY (service_id, transaction_id) REFERENCES transactions(service_id, transaction_id) ON DELETE CASCADE,
+     PRIMARY KEY (service_id, transaction_id)
+  );
+
+CREATE TABLE submissions
+  (
+     service_id            VARCHAR(17) NOT NULL,
+     batch_id              VARCHAR(128) NOT NULL,
+     last_checked          INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     times_checked         INTEGER NOT NULL DEFAULT 1,
+     error_type            VARCHAR(64),
+     error_message         TEXT,
+     created_at            INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     updated_at            INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     FOREIGN KEY (service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE,
+     PRIMARY KEY (service_id, batch_id)
+  );
+
+CREATE TABLE batch_statuses
+  (
+     service_id        VARCHAR(17) NOT NULL,
+     batch_id          VARCHAR(70) NOT NULL,
+     dlt_status        VARCHAR(16) NOT NULL,
+     created_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     updated_at        INTEGER NOT NULL DEFAULT (cast(strftime('%s') as int)),
+     FOREIGN KEY (service_id, batch_id) REFERENCES batches(service_id, batch_id) ON DELETE CASCADE,
+     PRIMARY KEY (service_id, batch_id)
+  );
+
+CREATE TRIGGER IF NOT EXISTS set_submissions_updated
+BEFORE UPDATE ON submissions
+FOR EACH ROW
+BEGIN
+    UPDATE submissions
+    SET updated_at = (cast(strftime('%s') as int)),
+        last_checked = (cast(strftime('%s') as int)),
+    	times_checked = times_checked + 1
+    WHERE rowid = NEW.rowid;
+END;


### PR DESCRIPTION
Previously, the migrations for the batch tracking tables were updated
to use a surrogate key composed of the id and service id due to Diesel's
incomplete support for composite foreign keys. This change switches the
primary key back to a composite primary key as well as the related
foreign keys and operations that need to filter based on those foreign
keys will use raw sql via the `sql_query` function.

Signed-off-by: Davey Newhall <newhall@bitwise.io>