### PR TITLE
Add JSON payload infrastructure

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -126,6 +126,7 @@ experimental = [
     "proxy-client",
     "rest-api-actix-web-3",
     "rest-api-actix-web-3-run",
+    "rest-api-resources-batch-tracking",
     "rest-api-endpoint-proxy",
     "rest-api-endpoint-record",
     "rest-api-endpoint-submit",
@@ -181,6 +182,7 @@ rest-api-endpoint-submit = ["batch-store", "rest-api-resources-submit"]
 rest-api-resources = ["rest-api"]
 rest-api-resources-agent = ["pike", "rest-api-resources", "serde_json"]
 rest-api-resources-batches = ["backend", "rest-api-resources"]
+rest-api-resources-batch-tracking = ["batch-tracking", "rest-api-resources"]
 rest-api-resources-location = ["location", "rest-api-resources"]
 rest-api-resources-organization = ["pike", "rest-api-resources"]
 rest-api-resources-product = ["product", "rest-api-resources"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -182,7 +182,11 @@ rest-api-endpoint-submit = ["batch-store", "rest-api-resources-submit"]
 rest-api-resources = ["rest-api"]
 rest-api-resources-agent = ["pike", "rest-api-resources", "serde_json"]
 rest-api-resources-batches = ["backend", "rest-api-resources"]
-rest-api-resources-batch-tracking = ["batch-tracking", "rest-api-resources"]
+rest-api-resources-batch-tracking = [
+    "batch-tracking",
+    "rest-api-resources",
+    "transact/protocol-sabre",
+]
 rest-api-resources-location = ["location", "rest-api-resources"]
 rest-api-resources-organization = ["pike", "rest-api-resources"]
 rest-api-resources-product = ["product", "rest-api-resources"]

--- a/sdk/src/rest_api/resources/mod.rs
+++ b/sdk/src/rest_api/resources/mod.rs
@@ -30,7 +30,10 @@ pub mod purchase_order;
 pub mod roles;
 #[cfg(feature = "rest-api-resources-schema")]
 pub mod schemas;
-#[cfg(feature = "rest-api-resources-submit")]
+#[cfg(any(
+    feature = "rest-api-resources-submit",
+    feature = "rest-api-resources-batch-tracking"
+))]
 pub mod submit;
 #[cfg(feature = "rest-api-resources-track-and-trace")]
 pub mod track_and_trace;

--- a/sdk/src/rest_api/resources/submit/v2/error.rs
+++ b/sdk/src/rest_api/resources/submit/v2/error.rs
@@ -1,0 +1,44 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides errors when building transaction payloads
+
+use serde_json::error;
+
+use crate::rest_api::resources::error::ErrorResponse;
+
+#[derive(Debug)]
+pub enum BuilderError {
+    MissingField(String),
+    EmptyVec(String),
+}
+
+impl std::fmt::Display for BuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            BuilderError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+            BuilderError::EmptyVec(ref s) => write!(f, "EmptyVec: {}", s),
+        }
+    }
+}
+
+impl From<error::Error> for ErrorResponse {
+    fn from(e: error::Error) -> Self {
+        if e.is_io() {
+            ErrorResponse::internal_error(Box::new(e))
+        } else {
+            ErrorResponse::new(400, &format!("Failed to convert JSON: {e}"))
+        }
+    }
+}

--- a/sdk/src/rest_api/resources/submit/v2/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 Cargill Incorporated
+// Copyright 2022 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod v1;
-#[cfg(feature = "rest-api-resources-batch-tracking")]
-#[allow(dead_code)]
-pub mod v2;
+pub mod error;
+pub mod payloads;

--- a/sdk/src/rest_api/resources/submit/v2/payloads/location.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/location.rs
@@ -1,0 +1,274 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::rest_api::resources::submit::v2::error::BuilderError;
+
+use super::{PropertyValue, TransactionPayload};
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+pub enum LocationNamespace {
+    #[serde(rename = "GS1")]
+    Gs1,
+}
+
+impl Default for LocationNamespace {
+    fn default() -> Self {
+        LocationNamespace::Gs1
+    }
+}
+
+// Allow the `LocationAction` enum variants to have the same `Location` postfix
+#[allow(clippy::enum_variant_names)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum LocationAction {
+    CreateLocation(CreateLocationAction),
+    UpdateLocation(UpdateLocationAction),
+    DeleteLocation(DeleteLocationAction),
+}
+
+impl LocationAction {
+    pub fn into_inner(self) -> Box<dyn TransactionPayload> {
+        unimplemented!();
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct LocationPayload {
+    #[serde(flatten)]
+    action: LocationAction,
+    timestamp: u64,
+}
+
+impl LocationPayload {
+    pub fn new(action: LocationAction, timestamp: u64) -> Self {
+        LocationPayload { action, timestamp }
+    }
+
+    pub fn action(&self) -> &LocationAction {
+        &self.action
+    }
+
+    pub fn timestamp(&self) -> &u64 {
+        &self.timestamp
+    }
+
+    pub fn into_transaction_payload(self) -> Box<dyn TransactionPayload> {
+        self.action.into_inner()
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct CreateLocationAction {
+    namespace: LocationNamespace,
+    location_id: String,
+    owner: String,
+    #[serde(default)]
+    properties: Vec<PropertyValue>,
+}
+
+impl CreateLocationAction {
+    pub fn namespace(&self) -> &LocationNamespace {
+        &self.namespace
+    }
+
+    pub fn location_id(&self) -> &str {
+        &self.location_id
+    }
+
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    pub fn properties(&self) -> &[PropertyValue] {
+        &self.properties
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct CreateLocationActionBuilder {
+    namespace: Option<LocationNamespace>,
+    location_id: Option<String>,
+    owner: Option<String>,
+    properties: Option<Vec<PropertyValue>>,
+}
+
+impl CreateLocationActionBuilder {
+    pub fn new() -> Self {
+        CreateLocationActionBuilder::default()
+    }
+    pub fn with_namespace(mut self, value: LocationNamespace) -> Self {
+        self.namespace = Some(value);
+        self
+    }
+    pub fn with_location_id(mut self, value: String) -> Self {
+        self.location_id = Some(value);
+        self
+    }
+    pub fn with_owner(mut self, value: String) -> Self {
+        self.owner = Some(value);
+        self
+    }
+    pub fn with_properties(mut self, value: Vec<PropertyValue>) -> Self {
+        self.properties = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<CreateLocationAction, BuilderError> {
+        let namespace = self.namespace.ok_or_else(|| {
+            BuilderError::MissingField("'namespace' field is required".to_string())
+        })?;
+        let location_id = self
+            .location_id
+            .ok_or_else(|| BuilderError::MissingField("'location_id' field is required".into()))?;
+        let owner = self
+            .owner
+            .ok_or_else(|| BuilderError::MissingField("'owner' field is required".into()))?;
+        let properties = self
+            .properties
+            .ok_or_else(|| BuilderError::MissingField("'properties' field is required".into()))?;
+        Ok(CreateLocationAction {
+            namespace,
+            location_id,
+            owner,
+            properties,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct UpdateLocationAction {
+    namespace: LocationNamespace,
+    location_id: String,
+    properties: Vec<PropertyValue>,
+}
+
+impl UpdateLocationAction {
+    pub fn namespace(&self) -> &LocationNamespace {
+        &self.namespace
+    }
+
+    pub fn location_id(&self) -> &str {
+        &self.location_id
+    }
+
+    pub fn properties(&self) -> &[PropertyValue] {
+        &self.properties
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct UpdateLocationActionBuilder {
+    namespace: Option<LocationNamespace>,
+    location_id: Option<String>,
+    properties: Vec<PropertyValue>,
+}
+
+impl UpdateLocationActionBuilder {
+    pub fn new() -> Self {
+        UpdateLocationActionBuilder::default()
+    }
+
+    pub fn with_namespace(mut self, namespace: LocationNamespace) -> Self {
+        self.namespace = Some(namespace);
+        self
+    }
+
+    pub fn with_location_id(mut self, location_id: String) -> Self {
+        self.location_id = Some(location_id);
+        self
+    }
+
+    pub fn with_properties(mut self, properties: Vec<PropertyValue>) -> Self {
+        self.properties = properties;
+        self
+    }
+
+    pub fn build(self) -> Result<UpdateLocationAction, BuilderError> {
+        let namespace = self.namespace.ok_or_else(|| {
+            BuilderError::MissingField("'namespace' field is required".to_string())
+        })?;
+
+        let location_id = self.location_id.ok_or_else(|| {
+            BuilderError::MissingField("'location_id' field is required".to_string())
+        })?;
+
+        let properties = {
+            if !self.properties.is_empty() {
+                self.properties
+            } else {
+                return Err(BuilderError::MissingField(
+                    "'properties' field is required".to_string(),
+                ));
+            }
+        };
+
+        Ok(UpdateLocationAction {
+            namespace,
+            location_id,
+            properties,
+        })
+    }
+}
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct DeleteLocationAction {
+    namespace: LocationNamespace,
+    location_id: String,
+}
+
+impl DeleteLocationAction {
+    pub fn namespace(&self) -> &LocationNamespace {
+        &self.namespace
+    }
+
+    pub fn location_id(&self) -> &str {
+        &self.location_id
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct DeleteLocationActionBuilder {
+    namespace: Option<LocationNamespace>,
+    location_id: Option<String>,
+}
+
+impl DeleteLocationActionBuilder {
+    pub fn new() -> Self {
+        DeleteLocationActionBuilder::default()
+    }
+
+    pub fn with_namespace(mut self, namespace: LocationNamespace) -> Self {
+        self.namespace = Some(namespace);
+        self
+    }
+
+    pub fn with_location_id(mut self, location_id: String) -> Self {
+        self.location_id = Some(location_id);
+        self
+    }
+
+    pub fn build(self) -> Result<DeleteLocationAction, BuilderError> {
+        let namespace = self.namespace.ok_or_else(|| {
+            BuilderError::MissingField("'namespace' field is required".to_string())
+        })?;
+
+        let location_id = self.location_id.ok_or_else(|| {
+            BuilderError::MissingField("'location_id' field is required".to_string())
+        })?;
+
+        Ok(DeleteLocationAction {
+            namespace,
+            location_id,
+        })
+    }
+}

--- a/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
@@ -16,10 +16,12 @@
 
 mod location;
 mod pike;
+mod product;
 mod schema;
 
 pub use location::LocationPayload;
 pub use pike::PikePayload;
+pub use product::ProductPayload;
 pub use schema::{PropertyValue, SchemaPayload};
 
 use cylinder::Signer;
@@ -34,6 +36,7 @@ pub enum Payload {
     Location(LocationPayload),
     Pike(PikePayload),
     Schema(SchemaPayload),
+    Product(ProductPayload),
 }
 
 impl Payload {
@@ -42,6 +45,7 @@ impl Payload {
             Payload::Location(payload) => payload.into_transaction_payload(),
             Payload::Pike(payload) => payload.into_transaction_payload(),
             Payload::Schema(payload) => payload.into_transaction_payload(),
+            Payload::Product(payload) => payload.into_transaction_payload(),
         }
     }
 }
@@ -155,6 +159,9 @@ mod tests {
                 assert_eq!(ex_payload.action(), test_payload.action())
             }
             (Payload::Schema(ex_payload), Payload::Schema(test_payload)) => {
+                assert_eq!(ex_payload.action(), test_payload.action())
+            }
+            (Payload::Product(ex_payload), Payload::Product(test_payload)) => {
                 assert_eq!(ex_payload.action(), test_payload.action())
             }
             (_, _) => {

--- a/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
@@ -17,11 +17,13 @@
 mod location;
 mod pike;
 mod product;
+mod purchase_order;
 mod schema;
 
 pub use location::LocationPayload;
 pub use pike::PikePayload;
 pub use product::ProductPayload;
+pub use purchase_order::PurchaseOrderPayload;
 pub use schema::{PropertyValue, SchemaPayload};
 
 use cylinder::Signer;
@@ -37,6 +39,7 @@ pub enum Payload {
     Pike(PikePayload),
     Schema(SchemaPayload),
     Product(ProductPayload),
+    PurchaseOrder(PurchaseOrderPayload),
 }
 
 impl Payload {
@@ -46,6 +49,7 @@ impl Payload {
             Payload::Pike(payload) => payload.into_transaction_payload(),
             Payload::Schema(payload) => payload.into_transaction_payload(),
             Payload::Product(payload) => payload.into_transaction_payload(),
+            Payload::PurchaseOrder(payload) => payload.into_transaction_payload(),
         }
     }
 }
@@ -162,6 +166,9 @@ mod tests {
                 assert_eq!(ex_payload.action(), test_payload.action())
             }
             (Payload::Product(ex_payload), Payload::Product(test_payload)) => {
+                assert_eq!(ex_payload.action(), test_payload.action())
+            }
+            (Payload::PurchaseOrder(ex_payload), Payload::PurchaseOrder(test_payload)) => {
                 assert_eq!(ex_payload.action(), test_payload.action())
             }
             (_, _) => {

--- a/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
@@ -14,8 +14,10 @@
 
 //! Provides native representations of smart contract actions used to deserialize from JSON
 
+mod location;
 mod schema;
 
+pub use location::LocationPayload;
 pub use schema::{PropertyValue, SchemaPayload};
 
 use cylinder::Signer;
@@ -27,12 +29,14 @@ use crate::rest_api::resources::error::ErrorResponse;
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum Payload {
+    Location(LocationPayload),
     Schema(SchemaPayload),
 }
 
 impl Payload {
     pub fn into_inner(self) -> Box<dyn TransactionPayload> {
         match self {
+            Payload::Location(payload) => payload.into_transaction_payload(),
             Payload::Schema(payload) => payload.into_transaction_payload(),
         }
     }

--- a/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
@@ -14,10 +14,29 @@
 
 //! Provides native representations of smart contract actions used to deserialize from JSON
 
+mod schema;
+
+pub use schema::{PropertyValue, SchemaPayload};
+
 use cylinder::Signer;
 use transact::protocol::transaction::Transaction;
 
 use crate::rest_api::resources::error::ErrorResponse;
+
+/// Represents all possible smart contract payloads able to be submitted
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum Payload {
+    Schema(SchemaPayload),
+}
+
+impl Payload {
+    pub fn into_inner(self) -> Box<dyn TransactionPayload> {
+        match self {
+            Payload::Schema(payload) => payload.into_transaction_payload(),
+        }
+    }
+}
 
 pub trait TransactionPayload {
     fn build_transaction(&self, signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse>;

--- a/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
@@ -15,9 +15,11 @@
 //! Provides native representations of smart contract actions used to deserialize from JSON
 
 mod location;
+mod pike;
 mod schema;
 
 pub use location::LocationPayload;
+pub use pike::PikePayload;
 pub use schema::{PropertyValue, SchemaPayload};
 
 use cylinder::Signer;
@@ -30,6 +32,7 @@ use crate::rest_api::resources::error::ErrorResponse;
 #[serde(untagged)]
 pub enum Payload {
     Location(LocationPayload),
+    Pike(PikePayload),
     Schema(SchemaPayload),
 }
 
@@ -37,6 +40,7 @@ impl Payload {
     pub fn into_inner(self) -> Box<dyn TransactionPayload> {
         match self {
             Payload::Location(payload) => payload.into_transaction_payload(),
+            Payload::Pike(payload) => payload.into_transaction_payload(),
             Payload::Schema(payload) => payload.into_transaction_payload(),
         }
     }
@@ -57,6 +61,7 @@ mod tests {
     use super::*;
 
     use super::location::{CreateLocationActionBuilder, LocationAction, LocationNamespace};
+    use super::pike::{CreateAgentActionBuilder, PikeAction, UpdateAgentActionBuilder};
     use super::Payload;
 
     use serde_json;
@@ -64,10 +69,36 @@ mod tests {
 
     const LOCATION: &str = "location";
     const ORG: &str = "myorg";
+    const ROLE: &str = "test_role";
+    const PUBLIC_KEY: &str = "PUBLIC_KEY";
+
+    const JSON_CREATE_AGENT_PAYLOAD: &str =
+        "{ \"org_id\": \"myorg\", \"public_key\": \"PUBLIC_KEY\", \"active\": true, \
+        \"target\": \"POST /agent\" }";
+    const JSON_UPDATE_AGENT_PAYLOAD: &str =
+        "{ \"org_id\": \"myorg\", \"public_key\": \"PUBLIC_KEY\", \"active\": true, \
+        \"target\": \"PUT /agent/PUBLIC_KEY\"}";
 
     const JSON_CREATE_LOCATION_PAYLOAD: &str =
         "{ \"namespace\": \"GS1\", \"location_id\": \"location\", \"owner\": \"myorg\", \
         \"target\": \"POST /location\" }";
+
+    #[test]
+    /// Test the process of deserializing a `CreateAgentAction` into a `Payload` enum.
+    /// The test follows this process:
+    ///
+    /// 1. Create a String representing a `CreateAgentAction` as JSON
+    /// 2. Deserialize this string using `serde_json` into a `Payload` enum variant
+    /// 3. Validate this variant is equivalent to `Payload::CreateAgent` and the inner struct
+    ///    is a `CreateAgentAction` with the expected values
+    fn test_deserialize_json_create_agent_payload() {
+        let example_payload = create_agent_payload();
+
+        let deserialized_payload: Payload = serde_json::from_str(JSON_CREATE_AGENT_PAYLOAD)
+            .expect("Unable to parse `create agent`");
+
+        assert_eq!(example_payload, deserialized_payload);
+    }
 
     #[test]
     /// Test the process of deserializing a `CreateLocationAction` into a `Payload` enum.
@@ -86,9 +117,41 @@ mod tests {
         assert_eq!(example_payload, deserialized_payload);
     }
 
+    #[test]
+    /// Test the process of deserializing a list of JSON strings into a list of `Payload` enums.
+    /// The test follows this process:
+    ///
+    /// 1. Create multiple Strings representing various contract actions as JSON
+    /// 2. Deserialize this list using `serde_json` into a list of `Payload` enum variants
+    /// 3. Validate these `Payload` variants match the native struct that is expected
+    fn test_deserialize_json_payload_list() {
+        let example_payload_list = vec![
+            create_location_payload(),
+            create_agent_payload(),
+            update_agent_payload(),
+        ];
+        // Test the deserializing of a list of these JSON payloads
+        let payload_list = vec![
+            JSON_CREATE_LOCATION_PAYLOAD,
+            JSON_CREATE_AGENT_PAYLOAD,
+            JSON_UPDATE_AGENT_PAYLOAD,
+        ];
+        let payloads: Vec<Payload> = payload_list
+            .iter()
+            .map(|e| serde_json::from_str(e).expect("Unable to parse action"))
+            .collect();
+        let assert_payloads = example_payload_list.iter().zip(payloads.iter());
+        for (example_payload, test_payload) in assert_payloads {
+            assert_payload_actions(example_payload, test_payload);
+        }
+    }
+
     fn assert_payload_actions(example: &Payload, test: &Payload) {
         match (example, test) {
             (Payload::Location(ex_payload), Payload::Location(test_payload)) => {
+                assert_eq!(ex_payload.action(), test_payload.action())
+            }
+            (Payload::Pike(ex_payload), Payload::Pike(test_payload)) => {
                 assert_eq!(ex_payload.action(), test_payload.action())
             }
             (Payload::Schema(ex_payload), Payload::Schema(test_payload)) => {
@@ -101,6 +164,40 @@ mod tests {
                 )
             }
         }
+    }
+
+    fn create_agent_payload() -> Payload {
+        let action = PikeAction::CreateAgent(
+            CreateAgentActionBuilder::default()
+                .with_org_id(ORG.to_string())
+                .with_public_key(PUBLIC_KEY.to_string())
+                .with_active(true)
+                .build()
+                .expect("Unable to build CreateAgentAction"),
+        );
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .expect("Unable to get current time as seconds");
+        Payload::Pike(PikePayload::new(action, timestamp))
+    }
+
+    fn update_agent_payload() -> Payload {
+        let action = PikeAction::UpdateAgent(
+            UpdateAgentActionBuilder::default()
+                .with_org_id(ORG.to_string())
+                .with_public_key(PUBLIC_KEY.to_string())
+                .with_active(true)
+                .with_roles(vec![])
+                .with_metadata(vec![])
+                .build()
+                .expect("Unable to build UpdateAgentAction"),
+        );
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .expect("Unable to get current time as seconds");
+        Payload::Pike(PikePayload::new(action, timestamp))
     }
 
     fn create_location_payload() -> Payload {

--- a/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
@@ -51,3 +51,73 @@ impl TransactionPayload for Box<dyn TransactionPayload> {
         (**self).build_transaction(signer)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use super::location::{CreateLocationActionBuilder, LocationAction, LocationNamespace};
+    use super::Payload;
+
+    use serde_json;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const LOCATION: &str = "location";
+    const ORG: &str = "myorg";
+
+    const JSON_CREATE_LOCATION_PAYLOAD: &str =
+        "{ \"namespace\": \"GS1\", \"location_id\": \"location\", \"owner\": \"myorg\", \
+        \"target\": \"POST /location\" }";
+
+    #[test]
+    /// Test the process of deserializing a `CreateLocationAction` into a `Payload` enum.
+    /// The test follows this process:
+    ///
+    /// 1. Create a String representing a `CreateLocationAction` as JSON
+    /// 2. Deserialize this string using `serde_json` into a `Payload` enum variant
+    /// 3. Validate this variant is equivalent to `Payload::CreateLocation` and the inner struct
+    ///    is a `CreateLocationAction` with the expected values
+    fn test_deserialize_json_create_location_payload() {
+        let example_payload = create_location_payload();
+
+        let deserialized_payload: Payload = serde_json::from_str(JSON_CREATE_LOCATION_PAYLOAD)
+            .expect("Unable to parse `create location`");
+
+        assert_eq!(example_payload, deserialized_payload);
+    }
+
+    fn assert_payload_actions(example: &Payload, test: &Payload) {
+        match (example, test) {
+            (Payload::Location(ex_payload), Payload::Location(test_payload)) => {
+                assert_eq!(ex_payload.action(), test_payload.action())
+            }
+            (Payload::Schema(ex_payload), Payload::Schema(test_payload)) => {
+                assert_eq!(ex_payload.action(), test_payload.action())
+            }
+            (_, _) => {
+                panic!(
+                    "Invalid `Payload` comparison, expected: {:?}, got: {:?}",
+                    example, test
+                )
+            }
+        }
+    }
+
+    fn create_location_payload() -> Payload {
+        let namespace = LocationNamespace::Gs1;
+        let action = LocationAction::CreateLocation(
+            CreateLocationActionBuilder::default()
+                .with_namespace(namespace)
+                .with_location_id(LOCATION.to_string())
+                .with_owner(ORG.to_string())
+                .with_properties(vec![])
+                .build()
+                .expect("Unable to build CreateLocationAction"),
+        );
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .expect("Unable to get current time as seconds");
+        Payload::Location(LocationPayload::new(action, timestamp))
+    }
+}

--- a/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
@@ -1,0 +1,30 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides native representations of smart contract actions used to deserialize from JSON
+
+use cylinder::Signer;
+use transact::protocol::transaction::Transaction;
+
+use crate::rest_api::resources::error::ErrorResponse;
+
+pub trait TransactionPayload {
+    fn build_transaction(&self, signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse>;
+}
+
+impl TransactionPayload for Box<dyn TransactionPayload> {
+    fn build_transaction(&self, signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse> {
+        (**self).build_transaction(signer)
+    }
+}

--- a/sdk/src/rest_api/resources/submit/v2/payloads/pike.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/pike.rs
@@ -1,0 +1,1089 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryFrom;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use cylinder::Signer;
+use transact::protocol::{sabre::ExecuteContractActionBuilder, transaction::Transaction};
+
+use crate::pike::addressing::GRID_PIKE_NAMESPACE;
+use crate::protocol::pike::{payload as payload_protocol, state as state_protocol};
+use crate::protos::IntoBytes;
+use crate::rest_api::resources::{
+    error::ErrorResponse, submit::v2::error::BuilderError, submit::v2::payloads::TransactionPayload,
+};
+
+pub(super) const GRID_PIKE_FAMILY_NAME: &str = "grid_pike";
+pub(super) const GRID_PIKE_FAMILY_VERSION: &str = "2";
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum PikeAction {
+    CreateAgent(CreateAgentAction),
+    UpdateAgent(UpdateAgentAction),
+    DeleteAgent(DeleteAgentAction),
+    CreateOrganization(CreateOrganizationAction),
+    UpdateOrganization(UpdateOrganizationAction),
+    DeleteOrganization(DeleteOrganizationAction),
+    CreateRole(CreateRoleAction),
+    UpdateRole(UpdateRoleAction),
+    DeleteRole(DeleteRoleAction),
+}
+
+impl PikeAction {
+    pub fn into_inner(self) -> Box<dyn TransactionPayload> {
+        match self {
+            PikeAction::CreateAgent(inner) => Box::new(inner),
+            PikeAction::UpdateAgent(inner) => Box::new(inner),
+            PikeAction::DeleteAgent(inner) => Box::new(inner),
+            PikeAction::CreateOrganization(inner) => Box::new(inner),
+            PikeAction::UpdateOrganization(inner) => Box::new(inner),
+            PikeAction::DeleteOrganization(inner) => Box::new(inner),
+            PikeAction::CreateRole(inner) => Box::new(inner),
+            PikeAction::UpdateRole(inner) => Box::new(inner),
+            PikeAction::DeleteRole(inner) => Box::new(inner),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+pub struct CreateAgentAction {
+    org_id: String,
+    public_key: String,
+    active: bool,
+    roles: Vec<String>,
+    metadata: Vec<KeyValueEntry>,
+}
+
+impl CreateAgentAction {
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    pub fn public_key(&self) -> &str {
+        &self.public_key
+    }
+
+    pub fn active(&self) -> &bool {
+        &self.active
+    }
+
+    pub fn roles(&self) -> &[String] {
+        &self.roles
+    }
+
+    pub fn metadata(&self) -> &[KeyValueEntry] {
+        &self.metadata
+    }
+}
+
+impl TryFrom<&CreateAgentAction> for payload_protocol::CreateAgentAction {
+    type Error = ErrorResponse;
+
+    fn try_from(action: &CreateAgentAction) -> Result<Self, Self::Error> {
+        let metadata = action
+            .metadata()
+            .iter()
+            .map(state_protocol::KeyValueEntry::try_from)
+            .collect::<Result<Vec<_>, ErrorResponse>>()?;
+        payload_protocol::CreateAgentActionBuilder::default()
+            .with_org_id(action.org_id().to_string())
+            .with_public_key(action.public_key().to_string())
+            .with_active(*action.active())
+            .with_roles(action.roles().to_vec())
+            .with_metadata(metadata)
+            .build()
+            .map_err(|err| {
+                ErrorResponse::new(
+                    400,
+                    &format!("Unable to build protocol CreateAgentAction: {err}"),
+                )
+            })
+    }
+}
+
+impl TransactionPayload for CreateAgentAction {
+    fn build_transaction(&self, signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse> {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+        let action = payload_protocol::CreateAgentAction::try_from(self)?;
+        let payload_bytes = payload_protocol::PikePayloadBuilder::default()
+            .with_action(payload_protocol::Action::CreateAgent(action))
+            .with_timestamp(timestamp)
+            .build()
+            .map_err(|err| {
+                ErrorResponse::new(
+                    400,
+                    &format!("Failed to build protocol Pike payload: {err}"),
+                )
+            })?
+            .into_bytes()
+            .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+        // Turn contract-specific action into Sabre `ExecuteContractActionBuilder`
+        let sabre_payload_builder = ExecuteContractActionBuilder::new()
+            .with_name(GRID_PIKE_FAMILY_NAME.to_string())
+            .with_version(GRID_PIKE_FAMILY_VERSION.to_string())
+            .with_inputs(vec![GRID_PIKE_NAMESPACE.to_string()])
+            .with_outputs(vec![GRID_PIKE_NAMESPACE.to_string()])
+            .with_payload(payload_bytes)
+            .into_payload_builder()
+            .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?;
+        // Turn the Sabre `ExecuteContractActionBuilder` into a `Transaction`
+        sabre_payload_builder
+            .into_transaction_builder()
+            .map_err(|err| ErrorResponse::internal_error(Box::new(err)))?
+            .build(&*signer)
+            .map_err(|err| ErrorResponse::internal_error(Box::new(err)))
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct CreateAgentActionBuilder {
+    pub org_id: Option<String>,
+    pub public_key: Option<String>,
+    pub active: Option<bool>,
+    pub roles: Vec<String>,
+    pub metadata: Vec<KeyValueEntry>,
+}
+
+impl CreateAgentActionBuilder {
+    pub fn new() -> Self {
+        CreateAgentActionBuilder::default()
+    }
+
+    pub fn with_org_id(mut self, org_id: String) -> CreateAgentActionBuilder {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    pub fn with_public_key(mut self, public_key: String) -> CreateAgentActionBuilder {
+        self.public_key = Some(public_key);
+        self
+    }
+
+    pub fn with_active(mut self, active: bool) -> CreateAgentActionBuilder {
+        self.active = Some(active);
+        self
+    }
+
+    pub fn with_roles(mut self, roles: Vec<String>) -> CreateAgentActionBuilder {
+        self.roles = roles;
+        self
+    }
+
+    pub fn with_metadata(mut self, metadata: Vec<KeyValueEntry>) -> CreateAgentActionBuilder {
+        self.metadata = metadata;
+        self
+    }
+
+    pub fn build(self) -> Result<CreateAgentAction, BuilderError> {
+        let org_id = self
+            .org_id
+            .ok_or_else(|| BuilderError::MissingField("'org_id' field is required".to_string()))?;
+
+        let public_key = self.public_key.ok_or_else(|| {
+            BuilderError::MissingField("'public_key' field is required".to_string())
+        })?;
+
+        let active = self.active.unwrap_or_default();
+        let roles = self.roles;
+        let metadata = self.metadata;
+
+        Ok(CreateAgentAction {
+            org_id,
+            public_key,
+            active,
+            roles,
+            metadata,
+        })
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+pub struct UpdateAgentAction {
+    org_id: String,
+    public_key: String,
+    active: bool,
+    #[serde(default)]
+    roles: Vec<String>,
+    #[serde(default)]
+    metadata: Vec<KeyValueEntry>,
+}
+
+impl UpdateAgentAction {
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    pub fn public_key(&self) -> &str {
+        &self.public_key
+    }
+
+    pub fn active(&self) -> &bool {
+        &self.active
+    }
+
+    pub fn roles(&self) -> &[String] {
+        &self.roles
+    }
+
+    pub fn metadata(&self) -> &[KeyValueEntry] {
+        &self.metadata
+    }
+}
+
+impl TransactionPayload for UpdateAgentAction {
+    fn build_transaction(&self, _signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse> {
+        unimplemented!();
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct UpdateAgentActionBuilder {
+    org_id: Option<String>,
+    public_key: Option<String>,
+    active: Option<bool>,
+    roles: Vec<String>,
+    metadata: Vec<KeyValueEntry>,
+}
+
+impl UpdateAgentActionBuilder {
+    pub fn new() -> Self {
+        UpdateAgentActionBuilder::default()
+    }
+
+    pub fn with_org_id(mut self, org_id: String) -> UpdateAgentActionBuilder {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    pub fn with_public_key(mut self, public_key: String) -> UpdateAgentActionBuilder {
+        self.public_key = Some(public_key);
+        self
+    }
+
+    pub fn with_active(mut self, active: bool) -> UpdateAgentActionBuilder {
+        self.active = Some(active);
+        self
+    }
+
+    pub fn with_roles(mut self, roles: Vec<String>) -> UpdateAgentActionBuilder {
+        self.roles = roles;
+        self
+    }
+
+    pub fn with_metadata(mut self, metadata: Vec<KeyValueEntry>) -> UpdateAgentActionBuilder {
+        self.metadata = metadata;
+        self
+    }
+
+    pub fn build(self) -> Result<UpdateAgentAction, BuilderError> {
+        let org_id = self
+            .org_id
+            .ok_or_else(|| BuilderError::MissingField("'org_id' field is required".to_string()))?;
+
+        let public_key = self.public_key.ok_or_else(|| {
+            BuilderError::MissingField("'public_key' field is required".to_string())
+        })?;
+
+        let active = self.active.unwrap_or_default();
+        let roles = self.roles;
+        let metadata = self.metadata;
+
+        Ok(UpdateAgentAction {
+            org_id,
+            public_key,
+            active,
+            roles,
+            metadata,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct DeleteAgentAction {
+    org_id: String,
+    public_key: String,
+}
+
+impl DeleteAgentAction {
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    pub fn public_key(&self) -> &str {
+        &self.public_key
+    }
+}
+
+impl TransactionPayload for DeleteAgentAction {
+    fn build_transaction(&self, _signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse> {
+        unimplemented!();
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct DeleteAgentActionBuilder {
+    pub org_id: Option<String>,
+    pub public_key: Option<String>,
+}
+
+impl DeleteAgentActionBuilder {
+    pub fn new() -> Self {
+        DeleteAgentActionBuilder::default()
+    }
+
+    pub fn with_org_id(mut self, org_id: String) -> DeleteAgentActionBuilder {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    pub fn with_public_key(mut self, public_key: String) -> DeleteAgentActionBuilder {
+        self.public_key = Some(public_key);
+        self
+    }
+
+    pub fn build(self) -> Result<DeleteAgentAction, BuilderError> {
+        let org_id = self
+            .org_id
+            .ok_or_else(|| BuilderError::MissingField("'org_id' field is required".to_string()))?;
+
+        let public_key = self.public_key.ok_or_else(|| {
+            BuilderError::MissingField("'public_key' field is required".to_string())
+        })?;
+
+        Ok(DeleteAgentAction { org_id, public_key })
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+pub struct CreateOrganizationAction {
+    id: String,
+    name: String,
+    #[serde(default)]
+    alternate_ids: Vec<AlternateId>,
+    #[serde(default)]
+    metadata: Vec<KeyValueEntry>,
+}
+
+impl CreateOrganizationAction {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn alternate_ids(&self) -> &[AlternateId] {
+        &self.alternate_ids
+    }
+
+    pub fn metadata(&self) -> &[KeyValueEntry] {
+        &self.metadata
+    }
+}
+
+impl TransactionPayload for CreateOrganizationAction {
+    fn build_transaction(&self, _signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse> {
+        unimplemented!();
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct CreateOrganizationActionBuilder {
+    id: Option<String>,
+    name: Option<String>,
+    alternate_ids: Vec<AlternateId>,
+    metadata: Vec<KeyValueEntry>,
+}
+
+impl CreateOrganizationActionBuilder {
+    pub fn new() -> Self {
+        CreateOrganizationActionBuilder::default()
+    }
+
+    pub fn with_id(mut self, id: String) -> CreateOrganizationActionBuilder {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn with_name(mut self, name: String) -> CreateOrganizationActionBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_alternate_ids(
+        mut self,
+        alternate_ids: Vec<AlternateId>,
+    ) -> CreateOrganizationActionBuilder {
+        self.alternate_ids = alternate_ids;
+        self
+    }
+
+    pub fn with_metadata(
+        mut self,
+        metadata: Vec<KeyValueEntry>,
+    ) -> CreateOrganizationActionBuilder {
+        self.metadata = metadata;
+        self
+    }
+
+    pub fn build(self) -> Result<CreateOrganizationAction, BuilderError> {
+        let id = self
+            .id
+            .ok_or_else(|| BuilderError::MissingField("'id' field is required".to_string()))?;
+
+        let name = self
+            .name
+            .ok_or_else(|| BuilderError::MissingField("'name' field is required".to_string()))?;
+
+        let alternate_ids = self.alternate_ids;
+
+        let metadata = self.metadata;
+
+        Ok(CreateOrganizationAction {
+            id,
+            name,
+            alternate_ids,
+            metadata,
+        })
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+pub struct UpdateOrganizationAction {
+    id: String,
+    name: String,
+    #[serde(default)]
+    alternate_ids: Vec<AlternateId>,
+    #[serde(default)]
+    locations: Vec<String>,
+    #[serde(default)]
+    metadata: Vec<KeyValueEntry>,
+}
+
+impl UpdateOrganizationAction {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn alternate_ids(&self) -> &[AlternateId] {
+        &self.alternate_ids
+    }
+
+    pub fn locations(&self) -> &[String] {
+        &self.locations
+    }
+
+    pub fn metadata(&self) -> &[KeyValueEntry] {
+        &self.metadata
+    }
+}
+
+impl TransactionPayload for UpdateOrganizationAction {
+    fn build_transaction(&self, _signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse> {
+        unimplemented!();
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct UpdateOrganizationActionBuilder {
+    id: Option<String>,
+    name: Option<String>,
+    alternate_ids: Vec<AlternateId>,
+    locations: Vec<String>,
+    metadata: Vec<KeyValueEntry>,
+}
+
+impl UpdateOrganizationActionBuilder {
+    pub fn new() -> Self {
+        UpdateOrganizationActionBuilder::default()
+    }
+
+    pub fn with_id(mut self, id: String) -> UpdateOrganizationActionBuilder {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn with_name(mut self, name: String) -> UpdateOrganizationActionBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn alternate_ids(
+        mut self,
+        alternate_ids: Vec<AlternateId>,
+    ) -> UpdateOrganizationActionBuilder {
+        self.alternate_ids = alternate_ids;
+        self
+    }
+
+    pub fn locations(mut self, locations: Vec<String>) -> UpdateOrganizationActionBuilder {
+        self.locations = locations;
+        self
+    }
+
+    pub fn with_metadata(
+        mut self,
+        metadata: Vec<KeyValueEntry>,
+    ) -> UpdateOrganizationActionBuilder {
+        self.metadata = metadata;
+        self
+    }
+
+    pub fn build(self) -> Result<UpdateOrganizationAction, BuilderError> {
+        let id = self
+            .id
+            .ok_or_else(|| BuilderError::MissingField("'id' field is required".to_string()))?;
+
+        let name = self.name.unwrap_or_default();
+
+        let locations = self.locations;
+
+        let alternate_ids = self.alternate_ids;
+
+        let metadata = self.metadata;
+
+        Ok(UpdateOrganizationAction {
+            id,
+            name,
+            alternate_ids,
+            locations,
+            metadata,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct DeleteOrganizationAction {
+    id: String,
+}
+
+impl DeleteOrganizationAction {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+impl TransactionPayload for DeleteOrganizationAction {
+    fn build_transaction(&self, _signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse> {
+        unimplemented!();
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct DeleteOrganizationActionBuilder {
+    pub id: Option<String>,
+}
+
+impl DeleteOrganizationActionBuilder {
+    pub fn new() -> Self {
+        DeleteOrganizationActionBuilder::default()
+    }
+
+    pub fn with_id(mut self, id: String) -> DeleteOrganizationActionBuilder {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn build(self) -> Result<DeleteOrganizationAction, BuilderError> {
+        let id = self
+            .id
+            .ok_or_else(|| BuilderError::MissingField("'id' field is required".to_string()))?;
+
+        Ok(DeleteOrganizationAction { id })
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+pub struct CreateRoleAction {
+    org_id: String,
+    name: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    permissions: Vec<String>,
+    #[serde(default)]
+    allowed_organizations: Vec<String>,
+    #[serde(default)]
+    inherit_from: Vec<String>,
+    active: bool,
+}
+
+impl CreateRoleAction {
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn permissions(&self) -> &[String] {
+        &self.permissions
+    }
+
+    pub fn allowed_organizations(&self) -> &[String] {
+        &self.allowed_organizations
+    }
+
+    pub fn inherit_from(&self) -> &[String] {
+        &self.inherit_from
+    }
+
+    pub fn active(&self) -> &bool {
+        &self.active
+    }
+}
+
+impl TransactionPayload for CreateRoleAction {
+    fn build_transaction(&self, _signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse> {
+        unimplemented!();
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct CreateRoleActionBuilder {
+    org_id: Option<String>,
+    name: Option<String>,
+    description: Option<String>,
+    permissions: Vec<String>,
+    allowed_organizations: Vec<String>,
+    inherit_from: Vec<String>,
+    active: bool,
+}
+
+impl CreateRoleActionBuilder {
+    pub fn new() -> Self {
+        CreateRoleActionBuilder::default()
+    }
+
+    pub fn with_org_id(mut self, org_id: String) -> CreateRoleActionBuilder {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    pub fn with_name(mut self, name: String) -> CreateRoleActionBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> CreateRoleActionBuilder {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_permissions(mut self, permissions: Vec<String>) -> CreateRoleActionBuilder {
+        self.permissions = permissions;
+        self
+    }
+
+    pub fn with_allowed_organizations(
+        mut self,
+        allowed_organizations: Vec<String>,
+    ) -> CreateRoleActionBuilder {
+        self.allowed_organizations = allowed_organizations;
+        self
+    }
+
+    pub fn with_inherit_from(mut self, inherit_from: Vec<String>) -> CreateRoleActionBuilder {
+        self.inherit_from = inherit_from;
+        self
+    }
+
+    pub fn with_active(mut self, active: bool) -> CreateRoleActionBuilder {
+        self.active = active;
+        self
+    }
+
+    pub fn build(self) -> Result<CreateRoleAction, BuilderError> {
+        let org_id = self
+            .org_id
+            .ok_or_else(|| BuilderError::MissingField("'org_id' field is required".to_string()))?;
+
+        let name = self
+            .name
+            .ok_or_else(|| BuilderError::MissingField("'name' field is required".to_string()))?;
+
+        let description = self.description.ok_or_else(|| {
+            BuilderError::MissingField("'description' field is required".to_string())
+        })?;
+
+        let permissions = self.permissions;
+
+        let allowed_organizations = self.allowed_organizations;
+
+        let inherit_from = self.inherit_from;
+
+        let active = self.active;
+
+        Ok(CreateRoleAction {
+            org_id,
+            name,
+            description,
+            permissions,
+            allowed_organizations,
+            inherit_from,
+            active,
+        })
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+pub struct UpdateRoleAction {
+    org_id: String,
+    name: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    permissions: Vec<String>,
+    #[serde(default)]
+    allowed_organizations: Vec<String>,
+    #[serde(default)]
+    inherit_from: Vec<String>,
+    active: bool,
+}
+
+impl UpdateRoleAction {
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn permissions(&self) -> &[String] {
+        &self.permissions
+    }
+
+    pub fn allowed_organizations(&self) -> &[String] {
+        &self.allowed_organizations
+    }
+
+    pub fn inherit_from(&self) -> &[String] {
+        &self.inherit_from
+    }
+
+    pub fn active(&self) -> &bool {
+        &self.active
+    }
+}
+
+impl TransactionPayload for UpdateRoleAction {
+    fn build_transaction(&self, _signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse> {
+        unimplemented!();
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct UpdateRoleActionBuilder {
+    org_id: Option<String>,
+    name: Option<String>,
+    description: Option<String>,
+    permissions: Vec<String>,
+    allowed_organizations: Vec<String>,
+    inherit_from: Vec<String>,
+    active: bool,
+}
+
+impl UpdateRoleActionBuilder {
+    pub fn new() -> Self {
+        UpdateRoleActionBuilder::default()
+    }
+
+    pub fn with_org_id(mut self, org_id: String) -> UpdateRoleActionBuilder {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    pub fn with_name(mut self, name: String) -> UpdateRoleActionBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> UpdateRoleActionBuilder {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_permissions(mut self, permissions: Vec<String>) -> UpdateRoleActionBuilder {
+        self.permissions = permissions;
+        self
+    }
+
+    pub fn with_allowed_organizations(
+        mut self,
+        allowed_organizations: Vec<String>,
+    ) -> UpdateRoleActionBuilder {
+        self.allowed_organizations = allowed_organizations;
+        self
+    }
+
+    pub fn with_inherit_from(mut self, inherit_from: Vec<String>) -> UpdateRoleActionBuilder {
+        self.inherit_from = inherit_from;
+        self
+    }
+
+    pub fn with_active(mut self, active: bool) -> UpdateRoleActionBuilder {
+        self.active = active;
+        self
+    }
+
+    pub fn build(self) -> Result<UpdateRoleAction, BuilderError> {
+        let org_id = self
+            .org_id
+            .ok_or_else(|| BuilderError::MissingField("'org_id' field is required".to_string()))?;
+
+        let name = self
+            .name
+            .ok_or_else(|| BuilderError::MissingField("'name' field is required".to_string()))?;
+
+        let description = self.description.ok_or_else(|| {
+            BuilderError::MissingField("'description' field is required".to_string())
+        })?;
+
+        let permissions = self.permissions;
+
+        let allowed_organizations = self.allowed_organizations;
+
+        let inherit_from = self.inherit_from;
+
+        let active = self.active;
+
+        Ok(UpdateRoleAction {
+            org_id,
+            name,
+            description,
+            permissions,
+            allowed_organizations,
+            inherit_from,
+            active,
+        })
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
+pub struct DeleteRoleAction {
+    org_id: String,
+    name: String,
+}
+
+impl DeleteRoleAction {
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl TransactionPayload for DeleteRoleAction {
+    fn build_transaction(&self, _signer: Box<dyn Signer>) -> Result<Transaction, ErrorResponse> {
+        unimplemented!();
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct DeleteRoleActionBuilder {
+    org_id: Option<String>,
+    name: Option<String>,
+}
+
+impl DeleteRoleActionBuilder {
+    pub fn new() -> Self {
+        DeleteRoleActionBuilder::default()
+    }
+
+    pub fn with_org_id(mut self, org_id: String) -> DeleteRoleActionBuilder {
+        self.org_id = Some(org_id);
+        self
+    }
+
+    pub fn with_name(mut self, name: String) -> DeleteRoleActionBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn build(self) -> Result<DeleteRoleAction, BuilderError> {
+        let org_id = self
+            .org_id
+            .ok_or_else(|| BuilderError::MissingField("'org_id' field is required".to_string()))?;
+
+        let name = self
+            .name
+            .ok_or_else(|| BuilderError::MissingField("'name' field is required".to_string()))?;
+
+        Ok(DeleteRoleAction { org_id, name })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct AlternateId {
+    id_type: String,
+    id: String,
+}
+
+impl AlternateId {
+    pub fn id_type(&self) -> &str {
+        &self.id_type
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct AlternateIdBuilder {
+    id_type: Option<String>,
+    id: Option<String>,
+}
+
+impl AlternateIdBuilder {
+    pub fn new() -> Self {
+        AlternateIdBuilder::default()
+    }
+
+    pub fn with_id_type(mut self, id_type: String) -> AlternateIdBuilder {
+        self.id_type = Some(id_type);
+        self
+    }
+
+    pub fn with_id(mut self, id: String) -> AlternateIdBuilder {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn build(self) -> Result<AlternateId, BuilderError> {
+        let id_type = self
+            .id_type
+            .ok_or_else(|| BuilderError::MissingField("'id_type' field is required".to_string()))?;
+
+        let id = self
+            .id
+            .ok_or_else(|| BuilderError::MissingField("'id' field is required".to_string()))?;
+
+        Ok(AlternateId { id_type, id })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct KeyValueEntry {
+    key: String,
+    value: String,
+}
+
+impl KeyValueEntry {
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+impl TryFrom<&KeyValueEntry> for state_protocol::KeyValueEntry {
+    type Error = ErrorResponse;
+
+    fn try_from(entry: &KeyValueEntry) -> Result<Self, Self::Error> {
+        state_protocol::KeyValueEntryBuilder::default()
+            .with_key(entry.key().to_string())
+            .with_value(entry.value().to_string())
+            .build()
+            .map_err(|err| {
+                ErrorResponse::new(
+                    400,
+                    &format!("Unable to build protocol KeyValueEntry: {err}"),
+                )
+            })
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct KeyValueEntryBuilder {
+    key: Option<String>,
+    value: Option<String>,
+}
+
+impl KeyValueEntryBuilder {
+    pub fn new() -> Self {
+        KeyValueEntryBuilder::default()
+    }
+
+    pub fn with_key(mut self, key: String) -> KeyValueEntryBuilder {
+        self.key = Some(key);
+        self
+    }
+
+    pub fn with_value(mut self, value: String) -> KeyValueEntryBuilder {
+        self.value = Some(value);
+        self
+    }
+
+    pub fn build(self) -> Result<KeyValueEntry, BuilderError> {
+        let key = self
+            .key
+            .ok_or_else(|| BuilderError::MissingField("'key' field is required".to_string()))?;
+
+        let value = self
+            .value
+            .ok_or_else(|| BuilderError::MissingField("'value' field is required".to_string()))?;
+
+        Ok(KeyValueEntry { key, value })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct PikePayload {
+    #[serde(flatten)]
+    action: PikeAction,
+    timestamp: u64,
+}
+
+impl PikePayload {
+    pub fn new(action: PikeAction, timestamp: u64) -> Self {
+        Self { action, timestamp }
+    }
+
+    pub fn action(&self) -> &PikeAction {
+        &self.action
+    }
+
+    pub fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    pub fn into_transaction_payload(self) -> Box<dyn TransactionPayload> {
+        self.action.into_inner()
+    }
+}

--- a/sdk/src/rest_api/resources/submit/v2/payloads/product.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/product.rs
@@ -1,0 +1,272 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::rest_api::resources::submit::v2::error::BuilderError;
+
+use super::{PropertyValue, TransactionPayload};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum ProductNamespace {
+    #[serde(rename = "GS1")]
+    Gs1,
+}
+
+impl Default for ProductNamespace {
+    fn default() -> Self {
+        ProductNamespace::Gs1
+    }
+}
+
+// Allow the enum variants to end in the same `Product` postfix
+#[allow(clippy::enum_variant_names)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum ProductAction {
+    CreateProduct(CreateProductAction),
+    UpdateProduct(UpdateProductAction),
+    DeleteProduct(DeleteProductAction),
+}
+
+impl ProductAction {
+    pub fn into_inner(self) -> Box<dyn TransactionPayload> {
+        unimplemented!();
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ProductPayload {
+    action: ProductAction,
+    timestamp: u64,
+}
+
+impl ProductPayload {
+    pub fn new(timestamp: u64, action: ProductAction) -> Self {
+        Self { action, timestamp }
+    }
+
+    pub fn action(&self) -> &ProductAction {
+        &self.action
+    }
+    pub fn timestamp(&self) -> &u64 {
+        &self.timestamp
+    }
+
+    pub fn into_transaction_payload(self) -> Box<dyn TransactionPayload> {
+        self.action.into_inner()
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct CreateProductAction {
+    product_namespace: ProductNamespace,
+    product_id: String,
+    owner: String,
+    properties: Vec<PropertyValue>,
+}
+
+impl CreateProductAction {
+    pub fn product_namespace(&self) -> &ProductNamespace {
+        &self.product_namespace
+    }
+
+    pub fn product_id(&self) -> &str {
+        &self.product_id
+    }
+
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    pub fn properties(&self) -> &[PropertyValue] {
+        &self.properties
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct CreateProductActionBuilder {
+    product_namespace: Option<ProductNamespace>,
+    product_id: Option<String>,
+    owner: Option<String>,
+    properties: Option<Vec<PropertyValue>>,
+}
+
+impl CreateProductActionBuilder {
+    pub fn new() -> Self {
+        CreateProductActionBuilder::default()
+    }
+    pub fn with_product_namespace(mut self, value: ProductNamespace) -> Self {
+        self.product_namespace = Some(value);
+        self
+    }
+    pub fn with_product_id(mut self, value: String) -> Self {
+        self.product_id = Some(value);
+        self
+    }
+    pub fn with_owner(mut self, value: String) -> Self {
+        self.owner = Some(value);
+        self
+    }
+    pub fn with_properties(mut self, value: Vec<PropertyValue>) -> Self {
+        self.properties = Some(value);
+        self
+    }
+    pub fn build(self) -> Result<CreateProductAction, BuilderError> {
+        let product_namespace = self.product_namespace.ok_or_else(|| {
+            BuilderError::MissingField("'product_namespace' field is required".to_string())
+        })?;
+        let product_id = self
+            .product_id
+            .ok_or_else(|| BuilderError::MissingField("'product_id' field is required".into()))?;
+        let owner = self
+            .owner
+            .ok_or_else(|| BuilderError::MissingField("'owner' field is required".into()))?;
+        let properties = self
+            .properties
+            .ok_or_else(|| BuilderError::MissingField("'properties' field is required".into()))?;
+        Ok(CreateProductAction {
+            product_namespace,
+            product_id,
+            owner,
+            properties,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct UpdateProductAction {
+    product_namespace: ProductNamespace,
+    product_id: String,
+    properties: Vec<PropertyValue>,
+}
+
+impl UpdateProductAction {
+    pub fn product_namespace(&self) -> &ProductNamespace {
+        &self.product_namespace
+    }
+
+    pub fn product_id(&self) -> &str {
+        &self.product_id
+    }
+
+    pub fn properties(&self) -> &[PropertyValue] {
+        &self.properties
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct UpdateProductActionBuilder {
+    product_namespace: Option<ProductNamespace>,
+    product_id: Option<String>,
+    properties: Vec<PropertyValue>,
+}
+
+impl UpdateProductActionBuilder {
+    pub fn new() -> Self {
+        UpdateProductActionBuilder::default()
+    }
+
+    pub fn with_product_namespace(mut self, product_namespace: ProductNamespace) -> Self {
+        self.product_namespace = Some(product_namespace);
+        self
+    }
+
+    pub fn with_product_id(mut self, product_id: String) -> Self {
+        self.product_id = Some(product_id);
+        self
+    }
+
+    pub fn with_properties(mut self, properties: Vec<PropertyValue>) -> Self {
+        self.properties = properties;
+        self
+    }
+
+    pub fn build(self) -> Result<UpdateProductAction, BuilderError> {
+        let product_namespace = self.product_namespace.ok_or_else(|| {
+            BuilderError::MissingField("'product_namespace' field is required".to_string())
+        })?;
+
+        let product_id = self.product_id.ok_or_else(|| {
+            BuilderError::MissingField("'product_id' field is required".to_string())
+        })?;
+
+        let properties = {
+            if !self.properties.is_empty() {
+                self.properties
+            } else {
+                return Err(BuilderError::MissingField(
+                    "'properties' field is required".to_string(),
+                ));
+            }
+        };
+
+        Ok(UpdateProductAction {
+            product_namespace,
+            product_id,
+            properties,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct DeleteProductAction {
+    product_namespace: ProductNamespace,
+    product_id: String,
+}
+
+impl DeleteProductAction {
+    pub fn product_namespace(&self) -> &ProductNamespace {
+        &self.product_namespace
+    }
+
+    pub fn product_id(&self) -> &str {
+        &self.product_id
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct DeleteProductActionBuilder {
+    product_namespace: Option<ProductNamespace>,
+    product_id: Option<String>,
+}
+
+impl DeleteProductActionBuilder {
+    pub fn new() -> Self {
+        DeleteProductActionBuilder::default()
+    }
+
+    pub fn with_product_namespace(mut self, product_namespace: ProductNamespace) -> Self {
+        self.product_namespace = Some(product_namespace);
+        self
+    }
+
+    pub fn with_product_id(mut self, product_id: String) -> Self {
+        self.product_id = Some(product_id);
+        self
+    }
+
+    pub fn build(self) -> Result<DeleteProductAction, BuilderError> {
+        let product_namespace = self.product_namespace.ok_or_else(|| {
+            BuilderError::MissingField("'product_namespace' field is required".to_string())
+        })?;
+
+        let product_id = self.product_id.ok_or_else(|| {
+            BuilderError::MissingField("'product_id' field is required".to_string())
+        })?;
+
+        Ok(DeleteProductAction {
+            product_namespace,
+            product_id,
+        })
+    }
+}

--- a/sdk/src/rest_api/resources/submit/v2/payloads/purchase_order.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/purchase_order.rs
@@ -1,0 +1,671 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::rest_api::resources::submit::v2::error::BuilderError;
+
+use super::TransactionPayload;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum PurchaseOrderAction {
+    CreatePo(CreatePurchaseOrderAction),
+    UpdatePo(UpdatePurchaseOrderAction),
+    CreateVersion(CreateVersionAction),
+    UpdateVersion(UpdateVersionAction),
+}
+
+impl PurchaseOrderAction {
+    pub fn into_inner(self) -> Box<dyn TransactionPayload> {
+        unimplemented!();
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct PurchaseOrderPayload {
+    #[serde(flatten)]
+    action: PurchaseOrderAction,
+    timestamp: u64,
+}
+
+impl PurchaseOrderPayload {
+    pub fn action(&self) -> &PurchaseOrderAction {
+        &self.action
+    }
+
+    pub fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    pub fn into_transaction_payload(self) -> Box<dyn TransactionPayload> {
+        self.action.into_inner()
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct CreatePurchaseOrderAction {
+    uid: String,
+    created_at: u64,
+    buyer_org_id: String,
+    seller_org_id: String,
+    workflow_state: String,
+    alternate_ids: Vec<PurchaseOrderAlternateId>,
+    create_version_payload: Option<CreateVersionAction>,
+    workflow_id: String,
+}
+
+impl CreatePurchaseOrderAction {
+    pub fn uid(&self) -> &str {
+        &self.uid
+    }
+
+    pub fn created_at(&self) -> u64 {
+        self.created_at
+    }
+
+    pub fn buyer_org_id(&self) -> &str {
+        &self.buyer_org_id
+    }
+
+    pub fn seller_org_id(&self) -> &str {
+        &self.seller_org_id
+    }
+
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
+    }
+
+    pub fn alternate_ids(&self) -> &[PurchaseOrderAlternateId] {
+        &self.alternate_ids
+    }
+
+    pub fn create_version_payload(&self) -> Option<CreateVersionAction> {
+        self.create_version_payload.clone()
+    }
+
+    pub fn workflow_id(&self) -> &str {
+        &self.workflow_id
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct CreatePurchaseOrderActionBuilder {
+    uid: Option<String>,
+    created_at: Option<u64>,
+    buyer_org_id: Option<String>,
+    seller_org_id: Option<String>,
+    workflow_state: Option<String>,
+    alternate_ids: Vec<PurchaseOrderAlternateId>,
+    create_version_payload: Option<CreateVersionAction>,
+    workflow_id: Option<String>,
+}
+
+impl CreatePurchaseOrderActionBuilder {
+    pub fn new() -> Self {
+        CreatePurchaseOrderActionBuilder::default()
+    }
+
+    pub fn with_uid(mut self, value: String) -> Self {
+        self.uid = Some(value);
+        self
+    }
+
+    pub fn with_created_at(mut self, value: u64) -> Self {
+        self.created_at = Some(value);
+        self
+    }
+
+    pub fn with_buyer_org_id(mut self, value: String) -> Self {
+        self.buyer_org_id = Some(value);
+        self
+    }
+
+    pub fn with_seller_org_id(mut self, value: String) -> Self {
+        self.seller_org_id = Some(value);
+        self
+    }
+
+    pub fn with_workflow_state(mut self, value: String) -> Self {
+        self.workflow_state = Some(value);
+        self
+    }
+
+    pub fn with_alternate_ids(mut self, alternate_ids: Vec<PurchaseOrderAlternateId>) -> Self {
+        self.alternate_ids = alternate_ids;
+        self
+    }
+
+    pub fn with_create_version_payload(mut self, payload: CreateVersionAction) -> Self {
+        self.create_version_payload = Some(payload);
+        self
+    }
+
+    pub fn with_workflow_id(mut self, value: String) -> Self {
+        self.workflow_id = Some(value);
+        self
+    }
+
+    pub fn build(self) -> Result<CreatePurchaseOrderAction, BuilderError> {
+        let uid = self
+            .uid
+            .ok_or_else(|| BuilderError::MissingField("'uid' field is required".to_string()))?;
+
+        let created_at = self.created_at.ok_or_else(|| {
+            BuilderError::MissingField("'created_at' field is required".to_string())
+        })?;
+
+        let buyer_org_id = self.buyer_org_id.ok_or_else(|| {
+            BuilderError::MissingField("'buyer_org_id' field is required".to_string())
+        })?;
+
+        let seller_org_id = self.seller_org_id.ok_or_else(|| {
+            BuilderError::MissingField("'seller_org_id' field is required".to_string())
+        })?;
+
+        let workflow_state = self.workflow_state.ok_or_else(|| {
+            BuilderError::MissingField("'workflow_state' field is required".to_string())
+        })?;
+
+        let alternate_ids = self.alternate_ids;
+
+        let create_version_payload = self.create_version_payload;
+
+        let workflow_id = self.workflow_id.ok_or_else(|| {
+            BuilderError::MissingField("'workflow_id' field is required".to_string())
+        })?;
+
+        Ok(CreatePurchaseOrderAction {
+            uid,
+            created_at,
+            buyer_org_id,
+            seller_org_id,
+            workflow_state,
+            alternate_ids,
+            create_version_payload,
+            workflow_id,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct UpdatePurchaseOrderAction {
+    uid: String,
+    workflow_state: String,
+    is_closed: bool,
+    accepted_version_number: Option<String>,
+    alternate_ids: Vec<PurchaseOrderAlternateId>,
+    version_updates: Vec<UpdateVersionAction>,
+}
+
+impl UpdatePurchaseOrderAction {
+    pub fn uid(&self) -> &str {
+        &self.uid
+    }
+
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.is_closed
+    }
+
+    pub fn accepted_version_number(&self) -> Option<&str> {
+        self.accepted_version_number.as_deref()
+    }
+
+    pub fn alternate_ids(&self) -> &[PurchaseOrderAlternateId] {
+        &self.alternate_ids
+    }
+
+    pub fn version_updates(&self) -> &[UpdateVersionAction] {
+        &self.version_updates
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct UpdatePurchaseOrderActionBuilder {
+    uid: Option<String>,
+    workflow_state: Option<String>,
+    is_closed: Option<bool>,
+    accepted_version_number: Option<String>,
+    alternate_ids: Vec<PurchaseOrderAlternateId>,
+    version_updates: Vec<UpdateVersionAction>,
+}
+
+impl UpdatePurchaseOrderActionBuilder {
+    pub fn new() -> Self {
+        UpdatePurchaseOrderActionBuilder::default()
+    }
+
+    pub fn with_uid(mut self, value: String) -> Self {
+        self.uid = Some(value);
+        self
+    }
+
+    pub fn with_workflow_state(mut self, value: String) -> Self {
+        self.workflow_state = Some(value);
+        self
+    }
+
+    pub fn with_is_closed(mut self, value: bool) -> Self {
+        self.is_closed = Some(value);
+        self
+    }
+
+    pub fn with_accepted_version_number(mut self, value: Option<String>) -> Self {
+        self.accepted_version_number = value;
+        self
+    }
+
+    pub fn with_alternate_ids(mut self, value: Vec<PurchaseOrderAlternateId>) -> Self {
+        self.alternate_ids = value;
+        self
+    }
+
+    pub fn with_version_updates(mut self, value: Vec<UpdateVersionAction>) -> Self {
+        self.version_updates = value;
+        self
+    }
+
+    pub fn build(self) -> Result<UpdatePurchaseOrderAction, BuilderError> {
+        let uid = self
+            .uid
+            .ok_or_else(|| BuilderError::MissingField("'uid' field is required".to_string()))?;
+
+        let workflow_state = self.workflow_state.ok_or_else(|| {
+            BuilderError::MissingField("'workflow_state' field is required".to_string())
+        })?;
+
+        let is_closed = self.is_closed.ok_or_else(|| {
+            BuilderError::MissingField("'is_closed' field is required".to_string())
+        })?;
+
+        let alternate_ids = self.alternate_ids;
+
+        let version_updates = self.version_updates;
+
+        Ok(UpdatePurchaseOrderAction {
+            uid,
+            workflow_state,
+            is_closed,
+            accepted_version_number: self.accepted_version_number,
+            alternate_ids,
+            version_updates,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct CreateVersionAction {
+    version_id: String,
+    po_uid: String,
+    is_draft: bool,
+    workflow_state: String,
+    revision: PayloadRevision,
+}
+
+impl CreateVersionAction {
+    pub fn version_id(&self) -> &str {
+        &self.version_id
+    }
+
+    pub fn po_uid(&self) -> &str {
+        &self.po_uid
+    }
+
+    pub fn is_draft(&self) -> bool {
+        self.is_draft
+    }
+
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
+    }
+
+    pub fn revision(&self) -> &PayloadRevision {
+        &self.revision
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct CreateVersionActionBuilder {
+    version_id: Option<String>,
+    po_uid: Option<String>,
+    is_draft: Option<bool>,
+    workflow_state: Option<String>,
+    revision: Option<PayloadRevision>,
+}
+
+impl CreateVersionActionBuilder {
+    pub fn new() -> Self {
+        CreateVersionActionBuilder::default()
+    }
+
+    pub fn with_version_id(mut self, value: String) -> Self {
+        self.version_id = Some(value);
+        self
+    }
+
+    pub fn with_po_uid(mut self, value: String) -> Self {
+        self.po_uid = Some(value);
+        self
+    }
+
+    pub fn with_is_draft(mut self, value: bool) -> Self {
+        self.is_draft = Some(value);
+        self
+    }
+
+    pub fn with_workflow_state(mut self, value: String) -> Self {
+        self.workflow_state = Some(value);
+        self
+    }
+
+    pub fn with_revision(mut self, value: PayloadRevision) -> Self {
+        self.revision = Some(value);
+        self
+    }
+
+    pub fn build(self) -> Result<CreateVersionAction, BuilderError> {
+        let version_id = self.version_id.ok_or_else(|| {
+            BuilderError::MissingField("'version_id' field is required".to_string())
+        })?;
+
+        let po_uid = self
+            .po_uid
+            .ok_or_else(|| BuilderError::MissingField("'po_uid' field is required".to_string()))?;
+
+        let is_draft = self.is_draft.ok_or_else(|| {
+            BuilderError::MissingField("'is_draft' field is required".to_string())
+        })?;
+
+        let workflow_state = self.workflow_state.ok_or_else(|| {
+            BuilderError::MissingField("'workflow_state' field is required".to_string())
+        })?;
+
+        let revision = self.revision.ok_or_else(|| {
+            BuilderError::MissingField("'revision' field is required".to_string())
+        })?;
+
+        Ok(CreateVersionAction {
+            version_id,
+            po_uid,
+            is_draft,
+            workflow_state,
+            revision,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct UpdateVersionAction {
+    version_id: String,
+    po_uid: String,
+    workflow_state: String,
+    is_draft: bool,
+    revision: PayloadRevision,
+}
+
+impl UpdateVersionAction {
+    pub fn version_id(&self) -> &str {
+        &self.version_id
+    }
+
+    pub fn po_uid(&self) -> &str {
+        &self.po_uid
+    }
+
+    pub fn workflow_state(&self) -> &str {
+        &self.workflow_state
+    }
+
+    pub fn is_draft(&self) -> bool {
+        self.is_draft
+    }
+
+    pub fn revision(&self) -> &PayloadRevision {
+        &self.revision
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct UpdateVersionActionBuilder {
+    version_id: Option<String>,
+    po_uid: Option<String>,
+    workflow_state: Option<String>,
+    is_draft: Option<bool>,
+    revision: Option<PayloadRevision>,
+}
+
+impl UpdateVersionActionBuilder {
+    pub fn new() -> Self {
+        UpdateVersionActionBuilder::default()
+    }
+
+    pub fn with_version_id(mut self, value: String) -> Self {
+        self.version_id = Some(value);
+        self
+    }
+
+    pub fn with_po_uid(mut self, value: String) -> Self {
+        self.po_uid = Some(value);
+        self
+    }
+
+    pub fn with_workflow_state(mut self, value: String) -> Self {
+        self.workflow_state = Some(value);
+        self
+    }
+
+    pub fn with_is_draft(mut self, value: bool) -> Self {
+        self.is_draft = Some(value);
+        self
+    }
+
+    pub fn with_revision(mut self, value: PayloadRevision) -> Self {
+        self.revision = Some(value);
+        self
+    }
+
+    pub fn build(self) -> Result<UpdateVersionAction, BuilderError> {
+        let version_id = self.version_id.ok_or_else(|| {
+            BuilderError::MissingField("'version_id' field is required".to_string())
+        })?;
+
+        let po_uid = self
+            .po_uid
+            .ok_or_else(|| BuilderError::MissingField("'po_uid' field is required".to_string()))?;
+
+        let workflow_state = self.workflow_state.ok_or_else(|| {
+            BuilderError::MissingField("'workflow_state' field is required".to_string())
+        })?;
+
+        let is_draft = self.is_draft.ok_or_else(|| {
+            BuilderError::MissingField("'is_draft' field is required".to_string())
+        })?;
+
+        let revision = self.revision.ok_or_else(|| {
+            BuilderError::MissingField("'revision' field is required".to_string())
+        })?;
+
+        Ok(UpdateVersionAction {
+            version_id,
+            po_uid,
+            workflow_state,
+            is_draft,
+            revision,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct PayloadRevision {
+    revision_id: u64,
+    submitter: String,
+    created_at: u64,
+    order_xml_v3_4: String,
+}
+
+impl PayloadRevision {
+    pub fn revision_id(&self) -> u64 {
+        self.revision_id
+    }
+
+    pub fn submitter(&self) -> &str {
+        &self.submitter
+    }
+
+    pub fn created_at(&self) -> u64 {
+        self.created_at
+    }
+
+    pub fn order_xml_v3_4(&self) -> &str {
+        &self.order_xml_v3_4
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct PayloadRevisionBuilder {
+    revision_id: Option<u64>,
+    submitter: Option<String>,
+    created_at: Option<u64>,
+    order_xml_v3_4: Option<String>,
+}
+
+impl PayloadRevisionBuilder {
+    pub fn new() -> Self {
+        PayloadRevisionBuilder::default()
+    }
+
+    pub fn with_revision_id(mut self, value: u64) -> Self {
+        self.revision_id = Some(value);
+        self
+    }
+
+    pub fn with_submitter(mut self, value: String) -> Self {
+        self.submitter = Some(value);
+        self
+    }
+
+    pub fn with_created_at(mut self, value: u64) -> Self {
+        self.created_at = Some(value);
+        self
+    }
+
+    pub fn with_order_xml_v3_4(mut self, value: String) -> Self {
+        self.order_xml_v3_4 = Some(value);
+        self
+    }
+
+    pub fn build(self) -> Result<PayloadRevision, BuilderError> {
+        let revision_id = self.revision_id.ok_or_else(|| {
+            BuilderError::MissingField("'revision_id' field is required".to_string())
+        })?;
+
+        let submitter = self.submitter.ok_or_else(|| {
+            BuilderError::MissingField("'submitter' field is required".to_string())
+        })?;
+
+        let created_at = self.created_at.ok_or_else(|| {
+            BuilderError::MissingField("'created_at' field is required".to_string())
+        })?;
+
+        let order_xml_v3_4 = self.order_xml_v3_4.ok_or_else(|| {
+            BuilderError::MissingField("'order_xml_v3_4' field is required".to_string())
+        })?;
+
+        Ok(PayloadRevision {
+            revision_id,
+            submitter,
+            created_at,
+            order_xml_v3_4,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct PurchaseOrderAlternateId {
+    id_type: String,
+    id: String,
+    purchase_order_uid: String,
+}
+
+impl PurchaseOrderAlternateId {
+    pub fn new(purchase_order_uid: &str, alternate_id_type: &str, alternate_id: &str) -> Self {
+        Self {
+            purchase_order_uid: purchase_order_uid.to_string(),
+            id_type: alternate_id_type.to_string(),
+            id: alternate_id.to_string(),
+        }
+    }
+
+    pub fn id_type(&self) -> &str {
+        &self.id_type
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn purchase_order_uid(&self) -> &str {
+        &self.purchase_order_uid
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct PurchaseOrderAlternateIdBuilder {
+    id_type: Option<String>,
+    id: Option<String>,
+    purchase_order_uid: Option<String>,
+}
+
+impl PurchaseOrderAlternateIdBuilder {
+    pub fn new() -> Self {
+        PurchaseOrderAlternateIdBuilder::default()
+    }
+
+    pub fn with_id_type(mut self, id_type: String) -> Self {
+        self.id_type = Some(id_type);
+        self
+    }
+
+    pub fn with_id(mut self, id: String) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn with_purchase_order_uid(mut self, po_uid: String) -> Self {
+        self.purchase_order_uid = Some(po_uid);
+        self
+    }
+
+    pub fn build(self) -> Result<PurchaseOrderAlternateId, BuilderError> {
+        let id_type = self
+            .id_type
+            .ok_or_else(|| BuilderError::MissingField("'id_type' field is required".to_string()))?;
+
+        let id = self
+            .id
+            .ok_or_else(|| BuilderError::MissingField("'id' field is required".to_string()))?;
+
+        let purchase_order_uid = self.purchase_order_uid.ok_or_else(|| {
+            BuilderError::MissingField("'purchase_order_uid' field is required".to_string())
+        })?;
+
+        Ok(PurchaseOrderAlternateId {
+            id_type,
+            id,
+            purchase_order_uid,
+        })
+    }
+}

--- a/sdk/src/rest_api/resources/submit/v2/payloads/schema.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/schema.rs
@@ -1,0 +1,642 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::rest_api::resources::submit::v2::error::BuilderError;
+
+use std::error::Error as StdError;
+
+use super::TransactionPayload;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum SchemaAction {
+    CreateSchema(CreateSchemaAction),
+    UpdateSchema(UpdateSchemaAction),
+}
+
+impl SchemaAction {
+    pub fn into_inner(self) -> Box<dyn TransactionPayload> {
+        unimplemented!();
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct SchemaPayload {
+    action: SchemaAction,
+}
+
+impl SchemaPayload {
+    pub fn new(action: SchemaAction) -> Self {
+        Self { action }
+    }
+
+    pub fn action(&self) -> &SchemaAction {
+        &self.action
+    }
+
+    pub fn into_transaction_payload(self) -> Box<dyn TransactionPayload> {
+        self.action.into_inner()
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct CreateSchemaAction {
+    schema_name: String,
+    description: String,
+    properties: Vec<PropertyDefinition>,
+}
+
+impl CreateSchemaAction {
+    pub fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn properties(&self) -> &[PropertyDefinition] {
+        &self.properties
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct CreateSchemaBuilder {
+    schema_name: Option<String>,
+    description: Option<String>,
+    properties: Vec<PropertyDefinition>,
+}
+
+impl CreateSchemaBuilder {
+    pub fn new() -> Self {
+        CreateSchemaBuilder::default()
+    }
+
+    pub fn with_schema_name(mut self, schema_name: String) -> CreateSchemaBuilder {
+        self.schema_name = Some(schema_name);
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> CreateSchemaBuilder {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_properties(mut self, properties: Vec<PropertyDefinition>) -> CreateSchemaBuilder {
+        self.properties = properties;
+        self
+    }
+
+    pub fn build(self) -> Result<CreateSchemaAction, BuilderError> {
+        let schema_name = self.schema_name.ok_or_else(|| {
+            BuilderError::MissingField("'schema_name' field is required".to_string())
+        })?;
+
+        let description = self.description.unwrap_or_default();
+
+        let properties = {
+            if !self.properties.is_empty() {
+                self.properties
+            } else {
+                return Err(BuilderError::MissingField(
+                    "'properties' field is required".to_string(),
+                ));
+            }
+        };
+
+        Ok(CreateSchemaAction {
+            schema_name,
+            description,
+            properties,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct UpdateSchemaAction {
+    schema_name: String,
+    properties: Vec<PropertyDefinition>,
+}
+
+impl UpdateSchemaAction {
+    pub fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
+
+    pub fn properties(&self) -> &[PropertyDefinition] {
+        &self.properties
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct UpdateSchemaBuilder {
+    schema_name: Option<String>,
+    properties: Vec<PropertyDefinition>,
+}
+
+impl UpdateSchemaBuilder {
+    pub fn new() -> Self {
+        UpdateSchemaBuilder::default()
+    }
+
+    pub fn with_schema_name(mut self, schema_name: String) -> UpdateSchemaBuilder {
+        self.schema_name = Some(schema_name);
+        self
+    }
+
+    pub fn with_properties(mut self, properties: Vec<PropertyDefinition>) -> UpdateSchemaBuilder {
+        self.properties = properties;
+        self
+    }
+
+    pub fn build(self) -> Result<UpdateSchemaAction, BuilderError> {
+        let schema_name = self
+            .schema_name
+            .ok_or_else(|| BuilderError::MissingField("'schema field is required".to_string()))?;
+
+        let properties = {
+            if !self.properties.is_empty() {
+                self.properties
+            } else {
+                return Err(BuilderError::MissingField(
+                    "'properties' field is required".to_string(),
+                ));
+            }
+        };
+
+        Ok(UpdateSchemaAction {
+            schema_name,
+            properties,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct PropertyDefinition {
+    name: String,
+    data_type: DataType,
+    required: bool,
+    description: String,
+    number_exponent: i32,
+    enum_options: Vec<String>,
+    struct_properties: Vec<PropertyDefinition>,
+}
+
+impl PropertyDefinition {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    pub fn required(&self) -> &bool {
+        &self.required
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn number_exponent(&self) -> &i32 {
+        &self.number_exponent
+    }
+
+    pub fn enum_options(&self) -> &[String] {
+        &self.enum_options
+    }
+
+    pub fn struct_properties(&self) -> &[PropertyDefinition] {
+        &self.struct_properties
+    }
+}
+
+#[derive(Default, Clone, PartialEq)]
+pub struct PropertyDefinitionBuilder {
+    name: Option<String>,
+    data_type: Option<DataType>,
+    required: Option<bool>,
+    description: Option<String>,
+    number_exponent: Option<i32>,
+    enum_options: Vec<String>,
+    struct_properties: Vec<PropertyDefinition>,
+}
+
+impl PropertyDefinitionBuilder {
+    pub fn new() -> Self {
+        PropertyDefinitionBuilder::default()
+    }
+
+    pub fn with_name(mut self, name: String) -> PropertyDefinitionBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_data_type(mut self, data_type: DataType) -> PropertyDefinitionBuilder {
+        self.data_type = Some(data_type);
+        self
+    }
+
+    pub fn with_required(mut self, required: bool) -> PropertyDefinitionBuilder {
+        self.required = Some(required);
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> PropertyDefinitionBuilder {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_number_exponent(mut self, number_exponent: i32) -> PropertyDefinitionBuilder {
+        self.number_exponent = Some(number_exponent);
+        self
+    }
+
+    pub fn with_enum_options(mut self, enum_options: Vec<String>) -> PropertyDefinitionBuilder {
+        self.enum_options = enum_options;
+        self
+    }
+
+    pub fn with_struct_properties(
+        mut self,
+        struct_properties: Vec<PropertyDefinition>,
+    ) -> PropertyDefinitionBuilder {
+        self.struct_properties = struct_properties;
+        self
+    }
+
+    pub fn build(self) -> Result<PropertyDefinition, BuilderError> {
+        let name = self
+            .name
+            .ok_or_else(|| BuilderError::MissingField("'name' field is required".to_string()))?;
+
+        let data_type = self.data_type.ok_or_else(|| {
+            BuilderError::MissingField("'data_type' field is required".to_string())
+        })?;
+
+        let required = self.required.unwrap_or(false);
+        let description = self.description.unwrap_or_default();
+
+        let number_exponent = {
+            if data_type == DataType::Number {
+                self.number_exponent.ok_or_else(|| {
+                    BuilderError::MissingField("'number_exponent' field is required".to_string())
+                })?
+            } else {
+                0
+            }
+        };
+
+        let enum_options = {
+            if data_type == DataType::Enum {
+                if !self.enum_options.is_empty() {
+                    self.enum_options
+                } else {
+                    return Err(BuilderError::EmptyVec(
+                        "'enum_options' cannot be empty".to_string(),
+                    ));
+                }
+            } else {
+                self.enum_options
+            }
+        };
+
+        let struct_properties = {
+            if data_type == DataType::Struct {
+                if !self.struct_properties.is_empty() {
+                    self.struct_properties
+                } else {
+                    return Err(BuilderError::EmptyVec(
+                        "'struct_properties' cannot be empty".to_string(),
+                    ));
+                }
+            } else {
+                self.struct_properties
+            }
+        };
+
+        Ok(PropertyDefinition {
+            name,
+            data_type,
+            required,
+            description,
+            number_exponent,
+            enum_options,
+            struct_properties,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct PropertyValue {
+    name: String,
+    data_type: DataType,
+    bytes_value: Vec<u8>,
+    boolean_value: bool,
+    number_value: i64,
+    string_value: String,
+    enum_value: u32,
+    struct_values: Vec<PropertyValue>,
+    lat_long_value: LatLong,
+}
+
+impl PropertyValue {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    pub fn bytes_value(&self) -> &[u8] {
+        &self.bytes_value
+    }
+
+    pub fn boolean_value(&self) -> &bool {
+        &self.boolean_value
+    }
+
+    pub fn number_value(&self) -> &i64 {
+        &self.number_value
+    }
+
+    pub fn string_value(&self) -> &str {
+        &self.string_value
+    }
+
+    pub fn enum_value(&self) -> &u32 {
+        &self.enum_value
+    }
+
+    pub fn struct_values(&self) -> &[PropertyValue] {
+        &self.struct_values
+    }
+
+    pub fn lat_long_value(&self) -> &LatLong {
+        &self.lat_long_value
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct PropertyValueBuilder {
+    name: Option<String>,
+    data_type: Option<DataType>,
+    bytes_value: Option<Vec<u8>>,
+    boolean_value: Option<bool>,
+    number_value: Option<i64>,
+    string_value: Option<String>,
+    enum_value: Option<u32>,
+    struct_values: Vec<PropertyValue>,
+    lat_long_value: Option<LatLong>,
+}
+
+impl PropertyValueBuilder {
+    pub fn new() -> Self {
+        PropertyValueBuilder::default()
+    }
+
+    pub fn with_name(mut self, name: String) -> PropertyValueBuilder {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_data_type(mut self, data_type: DataType) -> PropertyValueBuilder {
+        self.data_type = Some(data_type);
+        self
+    }
+
+    pub fn with_bytes_value(mut self, bytes: Vec<u8>) -> PropertyValueBuilder {
+        self.bytes_value = Some(bytes);
+        self
+    }
+
+    pub fn with_boolean_value(mut self, boolean: bool) -> PropertyValueBuilder {
+        self.boolean_value = Some(boolean);
+        self
+    }
+
+    pub fn with_number_value(mut self, number: i64) -> PropertyValueBuilder {
+        self.number_value = Some(number);
+        self
+    }
+
+    pub fn with_enum_value(mut self, enum_value: u32) -> PropertyValueBuilder {
+        self.enum_value = Some(enum_value);
+        self
+    }
+
+    pub fn with_string_value(mut self, string: String) -> PropertyValueBuilder {
+        self.string_value = Some(string);
+        self
+    }
+
+    pub fn with_struct_values(mut self, struct_values: Vec<PropertyValue>) -> PropertyValueBuilder {
+        self.struct_values = struct_values;
+        self
+    }
+
+    pub fn with_lat_long_value(mut self, lat_long_value: LatLong) -> PropertyValueBuilder {
+        self.lat_long_value = Some(lat_long_value);
+        self
+    }
+
+    pub fn build(self) -> Result<PropertyValue, BuilderError> {
+        let name = self
+            .name
+            .ok_or_else(|| BuilderError::MissingField("'name' field is required".to_string()))?;
+
+        let data_type = self.data_type.ok_or_else(|| {
+            BuilderError::MissingField("'data_type' field is required".to_string())
+        })?;
+
+        let bytes_value = {
+            if data_type == DataType::Bytes {
+                self.bytes_value.ok_or_else(|| {
+                    BuilderError::MissingField("'bytes_value' field is required".to_string())
+                })?
+            } else {
+                vec![]
+            }
+        };
+
+        let boolean_value = {
+            if data_type == DataType::Boolean {
+                self.boolean_value.ok_or_else(|| {
+                    BuilderError::MissingField("'boolean_value' field is required".to_string())
+                })?
+            } else {
+                false
+            }
+        };
+
+        let number_value = {
+            if data_type == DataType::Number {
+                self.number_value.ok_or_else(|| {
+                    BuilderError::MissingField("'number_value' field is required".to_string())
+                })?
+            } else {
+                0
+            }
+        };
+
+        let string_value = {
+            if data_type == DataType::String {
+                self.string_value.ok_or_else(|| {
+                    BuilderError::MissingField("'string_value' field is required".to_string())
+                })?
+            } else {
+                "".to_string()
+            }
+        };
+
+        let enum_value = {
+            if data_type == DataType::Enum {
+                self.enum_value.ok_or_else(|| {
+                    BuilderError::MissingField("'enum_value' field is required".to_string())
+                })?
+            } else {
+                0
+            }
+        };
+
+        let struct_values = {
+            if data_type == DataType::Struct {
+                if !self.struct_values.is_empty() {
+                    self.struct_values
+                } else {
+                    return Err(BuilderError::MissingField(
+                        "'struct_values' cannot be empty".to_string(),
+                    ));
+                }
+            } else {
+                self.struct_values
+            }
+        };
+
+        let lat_long_value = {
+            if data_type == DataType::LatLong {
+                self.lat_long_value.ok_or_else(|| {
+                    BuilderError::MissingField("'lat_long_value' field is required".to_string())
+                })?
+            } else {
+                LatLong {
+                    latitude: 0,
+                    longitude: 0,
+                }
+            }
+        };
+
+        Ok(PropertyValue {
+            name,
+            data_type,
+            bytes_value,
+            boolean_value,
+            number_value,
+            string_value,
+            enum_value,
+            struct_values,
+            lat_long_value,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum DataType {
+    Bytes,
+    Boolean,
+    Number,
+    String,
+    Enum,
+    Struct,
+    LatLong,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct LatLong {
+    latitude: i64,
+    longitude: i64,
+}
+
+impl LatLong {
+    pub fn latitude(&self) -> &i64 {
+        &self.latitude
+    }
+
+    pub fn longitude(&self) -> &i64 {
+        &self.longitude
+    }
+}
+
+#[derive(Debug)]
+pub enum LatLongBuildError {
+    InvalidLatitude(i64),
+    InvalidLongitude(i64),
+}
+
+impl StdError for LatLongBuildError {}
+
+impl std::fmt::Display for LatLongBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            LatLongBuildError::InvalidLatitude(ref s) => write!(
+                f,
+                "Invalid latitude - must in the range of \
+                 -90000000 < lat < 90000000, but received: {}",
+                s
+            ),
+            LatLongBuildError::InvalidLongitude(ref s) => write!(
+                f,
+                "Invalid longitude - must in the range of \
+                 -180000000 < lat < 180000000, but received: {}",
+                s
+            ),
+        }
+    }
+}
+
+#[derive(Default, Clone, PartialEq)]
+pub struct LatLongBuilder {
+    latitude: i64,
+    longitude: i64,
+}
+
+impl LatLongBuilder {
+    pub fn new() -> Self {
+        LatLongBuilder::default()
+    }
+
+    pub fn with_lat_long(mut self, latitude: i64, longitude: i64) -> LatLongBuilder {
+        self.latitude = latitude;
+        self.longitude = longitude;
+        self
+    }
+
+    pub fn build(self) -> Result<LatLong, LatLongBuildError> {
+        let latitude = self.latitude;
+        let longitude = self.longitude;
+
+        if latitude < -90_000_000 || latitude > 90_000_000 {
+            Err(LatLongBuildError::InvalidLatitude(latitude))
+        } else if longitude < -180_000_000 || longitude > 180_000_000 {
+            Err(LatLongBuildError::InvalidLongitude(longitude))
+        } else {
+            Ok(LatLong {
+                latitude,
+                longitude,
+            })
+        }
+    }
+}


### PR DESCRIPTION
This adds a v2 to the `submit` module which contains structs used to deserialize REST API JSON requests into smart contract actions. Mainly, this adds the infrastructure needed to create Batches based on Grid's smart contracts.

A few specifics for deserializing: 
- Adds interim `DeserializableXPayload` structs for the Pike and Location modules. These structs assist in determining which action is specified in the JSON. 
- Updates the `CreateAgentAction` to be deserialized from the `CreateAgentActionBuilder`. This allows for errors relating to malformed actions to be more specific as to what is wrong with the payload, rather than attempting to deserialize directly into the `Action` itself. This generates the error from the builder's `build` method, rather than the JSON parsing.
- Adds tests for deserializing multiple JSON objects into the `Payload` enum, to verify the process of converting a list of JSON structs into the correct action.
- Adds tests for deserializing Pike actions for the individual actions and the top-level `Payload` object. 