### PR TITLE
Upgrade reqwest version to 0.11

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -38,7 +38,7 @@ log = { version = "0.4", optional = true }
 futures = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true }
 http = { version = "0.2", optional = true }
-reqwest = { version = "0.10.1", features = ["blocking", "json"], optional = true }
+reqwest = { version = "0.11", features = ["blocking", "json"], optional = true }
 protobuf = "2.19"
 regex = { version = "1", optional = true }
 sabre-sdk = { version = "0.5", optional = true }


### PR DESCRIPTION
0.11 removes an unnecessary trait bound on the post method that we would
otherwise need to implement in the upcoming submitted component.

Signed-off-by: Chris Eckhardt <eckhardt@bitwise.io>