### PR TITLE
Add `clean_stale_records` operation

### DIFF
--- a/sdk/src/batch_tracking/store/diesel/models.rs
+++ b/sdk/src/batch_tracking/store/diesel/models.rs
@@ -26,6 +26,19 @@ use crate::batch_tracking::store::error::BatchTrackingStoreError;
 #[derive(Identifiable, Insertable, Queryable, PartialEq, Debug, Clone)]
 #[table_name = "batches"]
 #[primary_key(service_id, batch_id)]
+pub struct NewBatchModel {
+    pub service_id: String,
+    pub batch_id: String,
+    pub data_change_id: Option<String>,
+    pub signer_public_key: String,
+    pub trace: bool,
+    pub serialized_batch: Vec<u8>,
+    pub submitted: bool,
+}
+
+#[derive(Identifiable, Insertable, Queryable, PartialEq, Debug, Clone)]
+#[table_name = "batches"]
+#[primary_key(service_id, batch_id)]
 pub struct BatchModel {
     pub service_id: String,
     pub batch_id: String,
@@ -490,10 +503,10 @@ impl
     }
 }
 
-pub fn make_batch_models(batches: &[TrackingBatch]) -> Vec<BatchModel> {
+pub fn make_new_batch_models(batches: &[TrackingBatch]) -> Vec<NewBatchModel> {
     let mut models = Vec::new();
     for batch in batches {
-        let model = BatchModel {
+        let model = NewBatchModel {
             service_id: batch.service_id().to_string(),
             batch_id: batch.batch_header().to_string(),
             data_change_id: batch.data_change_id().map(String::from),
@@ -501,7 +514,6 @@ pub fn make_batch_models(batches: &[TrackingBatch]) -> Vec<BatchModel> {
             trace: batch.trace(),
             serialized_batch: batch.serialized_batch().to_vec(),
             submitted: batch.submitted(),
-            created_at: batch.created_at(),
         };
 
         models.push(model)

--- a/sdk/src/batch_tracking/store/diesel/operations/add_batches.rs
+++ b/sdk/src/batch_tracking/store/diesel/operations/add_batches.rs
@@ -15,7 +15,7 @@
 use super::BatchTrackingStoreOperations;
 use crate::batch_tracking::store::{
     diesel::{
-        models::{make_batch_models, make_transaction_models},
+        models::{make_new_batch_models, make_transaction_models},
         schema::{batches, transactions},
     },
     BatchTrackingStoreError, TrackingBatch,
@@ -32,7 +32,7 @@ impl<'a> BatchTrackingStoreAddBatchesOperation
     for BatchTrackingStoreOperations<'a, diesel::pg::PgConnection>
 {
     fn add_batches(&self, batches: Vec<TrackingBatch>) -> Result<(), BatchTrackingStoreError> {
-        let batch_models = make_batch_models(&batches);
+        let batch_models = make_new_batch_models(&batches);
         let transaction_models = make_transaction_models(&batches);
         self.conn.transaction::<_, BatchTrackingStoreError, _>(|| {
             insert_into(batches::table)
@@ -57,7 +57,7 @@ impl<'a> BatchTrackingStoreAddBatchesOperation
     for BatchTrackingStoreOperations<'a, diesel::sqlite::SqliteConnection>
 {
     fn add_batches(&self, batches: Vec<TrackingBatch>) -> Result<(), BatchTrackingStoreError> {
-        let batch_models = make_batch_models(&batches);
+        let batch_models = make_new_batch_models(&batches);
         let transaction_models = make_transaction_models(&batches);
         self.conn.transaction::<_, BatchTrackingStoreError, _>(|| {
             insert_into(batches::table)

--- a/sdk/src/batch_tracking/store/diesel/operations/clean_stale_records.rs
+++ b/sdk/src/batch_tracking/store/diesel/operations/clean_stale_records.rs
@@ -1,0 +1,52 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::BatchTrackingStoreOperations;
+
+use crate::batch_tracking::store::diesel::schema::batches;
+
+use crate::batch_tracking::store::BatchTrackingStoreError;
+use diesel::{delete, prelude::*};
+
+pub(in crate::batch_tracking::store::diesel) trait BatchTrackingCleanStaleRecordsOperation {
+    fn clean_stale_records(&self, submitted_by: i64) -> Result<(), BatchTrackingStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> BatchTrackingCleanStaleRecordsOperation
+    for BatchTrackingStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn clean_stale_records(&self, submitted_by: i64) -> Result<(), BatchTrackingStoreError> {
+        self.conn.transaction::<_, BatchTrackingStoreError, _>(|| {
+            delete(batches::table.filter(batches::created_at.lt(&submitted_by)))
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> BatchTrackingCleanStaleRecordsOperation
+    for BatchTrackingStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn clean_stale_records(&self, submitted_by: i64) -> Result<(), BatchTrackingStoreError> {
+        self.conn.transaction::<_, BatchTrackingStoreError, _>(|| {
+            delete(batches::table.filter(batches::created_at.lt(&submitted_by)))
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}

--- a/sdk/src/batch_tracking/store/diesel/operations/mod.rs
+++ b/sdk/src/batch_tracking/store/diesel/operations/mod.rs
@@ -14,6 +14,7 @@
 
 pub(super) mod add_batches;
 pub(super) mod change_batch_to_submitted;
+pub(super) mod clean_stale_records;
 pub(super) mod get_batch;
 pub(super) mod get_batch_status;
 pub(super) mod get_failed_batches;

--- a/sdk/src/batch_tracking/store/mod.rs
+++ b/sdk/src/batch_tracking/store/mod.rs
@@ -478,7 +478,7 @@ impl TrackingBatchBuilder {
             ));
         };
 
-        if created_at <= 0 {
+        if created_at < 0 {
             return Err(BatchBuilderError::MissingRequiredField(
                 "created_at".to_string(),
             ));

--- a/sdk/src/batch_tracking/store/mod.rs
+++ b/sdk/src/batch_tracking/store/mod.rs
@@ -841,10 +841,7 @@ pub trait BatchTrackingStore {
     /// # Arguments
     ///
     ///  * `submitted_by` - The timestamp for which to delete records submitted before
-    fn clean_stale_records(
-        &self,
-        submitted_by: &str,
-    ) -> Result<TrackingBatchList, BatchTrackingStoreError>;
+    fn clean_stale_records(&self, submitted_by: i64) -> Result<(), BatchTrackingStoreError>;
 
     /// Gets batches that have not yet been submitted from the underlying storage
     fn get_unsubmitted_batches(&self) -> Result<TrackingBatchList, BatchTrackingStoreError>;
@@ -907,10 +904,7 @@ where
         unimplemented!();
     }
 
-    fn clean_stale_records(
-        &self,
-        _submitted_by: &str,
-    ) -> Result<TrackingBatchList, BatchTrackingStoreError> {
+    fn clean_stale_records(&self, _submitted_by: i64) -> Result<(), BatchTrackingStoreError> {
         unimplemented!();
     }
 


### PR DESCRIPTION
This adds an operation to clean batch tracking records that were created
    before a specified time. This works by removing batch records with a
    `created_at` value less than the specified timestamp. As the other
    batch tracking tables all use foreign keys derived from the batch_id and
    that use cascading deletes, this will remove the batch record and any
    associated "child" records.