### PR TITLE
Add REST API batch submission handler trait

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -127,6 +127,7 @@ experimental = [
     "proxy-client",
     "rest-api-actix-web-3",
     "rest-api-actix-web-3-run",
+    "rest-api-batch-submission-handler",
     "rest-api-resources-batch-tracking",
     "rest-api-endpoint-proxy",
     "rest-api-endpoint-record",
@@ -170,6 +171,7 @@ rest-api-actix-web-3 = [
     "url"
 ]
 rest-api-actix-web-3-run = ["rest-api-endpoint-submit"]
+rest-api-batch-submission-handler = ["rest-api-resources-batch-tracking"]
 rest-api-endpoint-agent = ["pike", "rest-api-resources-agent"]
 rest-api-endpoint-batches = ["backend", "rest-api-resources-batches"]
 rest-api-endpoint-location = ["location", "rest-api-resources-location"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -128,6 +128,7 @@ experimental = [
     "rest-api-actix-web-3",
     "rest-api-actix-web-3-run",
     "rest-api-batch-submission-handler",
+    "rest-api-batch-submission-handler-reqwest",
     "rest-api-resources-batch-tracking",
     "rest-api-endpoint-proxy",
     "rest-api-endpoint-record",
@@ -172,6 +173,12 @@ rest-api-actix-web-3 = [
 ]
 rest-api-actix-web-3-run = ["rest-api-endpoint-submit"]
 rest-api-batch-submission-handler = ["rest-api-resources-batch-tracking"]
+rest-api-batch-submission-handler-reqwest = [
+    "rest-api-batch-submission-handler",
+    "futures",
+    "url",
+    "reqwest",
+]
 rest-api-endpoint-agent = ["pike", "rest-api-resources-agent"]
 rest-api-endpoint-batches = ["backend", "rest-api-resources-batches"]
 rest-api-endpoint-location = ["location", "rest-api-resources-location"]

--- a/sdk/src/rest_api/resources/submit/v2/handler/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/handler/mod.rs
@@ -1,0 +1,77 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides an interface for submitting a `Batch` via a REST API
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::rest_api::resources::{
+    error::ErrorResponse, submit::v2::payloads::batch::BatchIdentifier,
+};
+
+/// Defines interactions for submitting a `Batch` via the REST API.
+pub trait BatchSubmissionHandler: Send + Sync + 'static {
+    // Submit a `Batch` to be persisted in state and submitted to the backend DLT.
+    fn submit_batches(self, submit_request: SerializedSubmitBatchRequest) -> SubmitBatchResponse;
+
+    fn cloned_box(&self) -> Box<dyn BatchSubmissionHandler>;
+}
+
+impl Clone for Box<dyn BatchSubmissionHandler> {
+    fn clone(&self) -> Box<dyn BatchSubmissionHandler> {
+        self.cloned_box()
+    }
+}
+
+/// Future which results in a list of `Batch`s that have been submitted
+pub type SubmitBatchResponse =
+    Pin<Box<dyn Future<Output = Result<BatchIdList, SubmitBatchErrorResponse>> + Send>>;
+
+/// Represents a list of Batch IDs of the persisted batches
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct BatchIdList {
+    pub batch_identifiers: Vec<BatchIdentifier>,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct SerializedSubmitBatchRequest {
+    // Represents the serialized bytes of a list of `TrackingBatchResource`s
+    pub body: Vec<u8>,
+}
+
+/// Represents errors encountered in the process of persisting a `Batch`
+#[derive(Default, Debug, Deserialize, Serialize, PartialEq)]
+pub struct SubmitBatchErrorResponse {
+    pub status: u16,
+    pub message: String,
+}
+
+impl SubmitBatchErrorResponse {
+    pub fn new(status: u16, message: &str) -> Self {
+        Self {
+            status,
+            message: message.to_string(),
+        }
+    }
+}
+
+impl From<ErrorResponse> for SubmitBatchErrorResponse {
+    fn from(err: ErrorResponse) -> Self {
+        Self {
+            status: err.status_code(),
+            message: err.message().to_string(),
+        }
+    }
+}

--- a/sdk/src/rest_api/resources/submit/v2/handler/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/handler/mod.rs
@@ -14,6 +14,12 @@
 
 //! Provides an interface for submitting a `Batch` via a REST API
 
+#[cfg(feature = "rest-api-batch-submission-handler-reqwest")]
+mod reqwest;
+
+#[cfg(feature = "rest-api-batch-submission-handler-reqwest")]
+pub use self::reqwest::ReqwestBatchSubmissionHandler;
+
 use std::future::Future;
 use std::pin::Pin;
 

--- a/sdk/src/rest_api/resources/submit/v2/handler/reqwest.rs
+++ b/sdk/src/rest_api/resources/submit/v2/handler/reqwest.rs
@@ -1,0 +1,200 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use futures::{prelude::future, FutureExt, TryFutureExt};
+use reqwest::{Client, StatusCode};
+use url::Url;
+
+use crate::rest_api::resources::error::ErrorResponse;
+use crate::rest_api::resources::submit::v2::handler::{
+    BatchIdList, BatchSubmissionHandler, SerializedSubmitBatchRequest, SubmitBatchErrorResponse,
+    SubmitBatchResponse,
+};
+
+#[derive(Clone)]
+pub struct ReqwestBatchSubmissionHandler {
+    submit_url: Url,
+}
+
+impl ReqwestBatchSubmissionHandler {
+    pub fn new(submit_url: Url) -> Self {
+        Self { submit_url }
+    }
+}
+
+impl BatchSubmissionHandler for ReqwestBatchSubmissionHandler {
+    fn submit_batches(self, submit_request: SerializedSubmitBatchRequest) -> SubmitBatchResponse {
+        let submit_url = self.submit_url;
+
+        let request = Client::new().post(submit_url).body(submit_request.body);
+
+        request
+            .send()
+            .map_err(|err| {
+                SubmitBatchErrorResponse::new(502, &format!("Failed to submit batch: {err}"))
+            })
+            .then(|client_resp| match client_resp {
+                Ok(resp) => future::join(
+                    future::ok(resp.status()),
+                    resp.bytes().map_err(|err| {
+                        SubmitBatchErrorResponse::new(
+                            502,
+                            &format!("Failed to retrieve response: {err}"),
+                        )
+                    }),
+                )
+                .boxed(),
+                Err(err) => {
+                    let error = SubmitBatchErrorResponse::new(502, "Failed to retrieve response");
+                    future::join(future::err(error), future::err(err)).boxed()
+                }
+            })
+            .map(|(status_res, body_res)| {
+                let bytes = body_res?.to_vec();
+                match status_res? {
+                    StatusCode::OK => {
+                        serde_json::from_slice::<BatchIdList>(&bytes).map_err(|err| {
+                            SubmitBatchErrorResponse::new(
+                                502,
+                                &format!("Got Ok, but received malformed response: {err}"),
+                            )
+                        })
+                    }
+                    status => {
+                        let error: ErrorResponse =
+                            serde_json::from_slice(&bytes).map_err(|err| {
+                                SubmitBatchErrorResponse::new(
+                                    502,
+                                    &format!(
+                                        "Received {} from upstream, but body was malformed: {err}",
+                                        status.as_u16()
+                                    ),
+                                )
+                            })?;
+                        Err(SubmitBatchErrorResponse::new(
+                            error.status_code(),
+                            &format!("Failed to submit batches: {}", error.message()),
+                        ))
+                    }
+                }
+            })
+            .boxed()
+    }
+
+    fn cloned_box(&self) -> Box<dyn BatchSubmissionHandler> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use mockito::{self, mock};
+
+    use crate::rest_api::resources::error::ErrorResponse;
+    use crate::rest_api::resources::submit::v2::payloads::batch::{
+        BatchIdentifier, SubmitBatchRequest, TrackingBatchResource,
+    };
+
+    const TEST_CIRCUIT_ID: &str = "z7499-QGFd3";
+    const TEST_SERVICE_ID: &str = "gsAA";
+    const TEST_BATCH_ID: &str = "one";
+    const TEST_DATA_CHANGE_ID: &str = "data_change_id::two";
+
+    #[actix_rt::test]
+    /// Validate the `ReqwestBatchSubmissionHandler` `submit_batches` method is able to return
+    /// an error from the backend, preserving the original error
+    async fn reqwest_batch_submission_handler_error() {
+        let error = ErrorResponse::new(408, "Request timed out");
+        let error_bytes = serde_json::to_vec(&error).expect("Unable to serialize error response");
+        let expected_error_response = SubmitBatchErrorResponse::new(
+            408,
+            &format!("Failed to submit batches: {}", error.message()),
+        );
+
+        let endpoint = mock("POST", "/batches")
+            .with_status(408)
+            .with_header("content-type", "application/octet-stream")
+            .with_body(error_bytes)
+            .create();
+
+        let response = setup_future_response().await;
+
+        endpoint.assert();
+
+        match response {
+            Ok(_) => panic!("Endpoint should have failed"),
+            Err(err) => assert_eq!(err, expected_error_response),
+        }
+    }
+
+    #[actix_rt::test]
+    /// Validate the `ReqwestBatchSubmissionHandler` `submit_batches` method is able to return
+    /// successfully with the expected response
+    async fn reqwest_batch_submission_handler_success() {
+        let expected_success_response = {
+            let batch_id = BatchIdentifier {
+                dlt_batch_id: TEST_BATCH_ID.to_string(),
+                data_change_id: Some(TEST_DATA_CHANGE_ID.to_string()),
+                service_id: Some(TEST_SERVICE_ID.to_string()),
+            };
+
+            BatchIdList {
+                batch_identifiers: vec![batch_id],
+            }
+        };
+        let response_body = serde_json::to_vec(&expected_success_response)
+            .expect("Unable to serialize batch ID list");
+
+        let endpoint = mock("POST", "/batches")
+            .with_status(200)
+            .with_header("content-type", "application/octet-stream")
+            .with_body(response_body)
+            .create();
+
+        let response = setup_future_response().await;
+
+        endpoint.assert();
+
+        match response {
+            Ok(batch_id_list) => assert_eq!(batch_id_list, expected_success_response),
+            Err(err) => panic!("Failed to submit batches, received response: {:?}", err),
+        }
+    }
+
+    fn make_submit_batch_request() -> SerializedSubmitBatchRequest {
+        let batch = TrackingBatchResource {
+            signed_batch: vec![],
+            data_change_id: Some(TEST_DATA_CHANGE_ID.to_string()),
+            service_id: Some(TEST_SERVICE_ID.to_string()),
+        };
+        let batch_request = SubmitBatchRequest {
+            batches: vec![batch],
+        };
+
+        let batch_bytes = serde_json::to_vec(&batch_request).expect("Unable to serialize batch");
+
+        SerializedSubmitBatchRequest { body: batch_bytes }
+    }
+
+    fn setup_future_response() -> SubmitBatchResponse {
+        let mut url =
+            Url::parse(&mockito::server_url()).expect("Unable to parse mockito server URL");
+        url = url
+            .join("/batches")
+            .expect("Unable to create `/batches` URL");
+        ReqwestBatchSubmissionHandler::new(url).submit_batches(make_submit_batch_request())
+    }
+}

--- a/sdk/src/rest_api/resources/submit/v2/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/mod.rs
@@ -13,4 +13,6 @@
 // limitations under the License.
 
 pub mod error;
+#[cfg(feature = "rest-api-batch-submission-handler")]
+pub mod handler;
 pub mod payloads;

--- a/sdk/src/rest_api/resources/submit/v2/payloads/batch.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/batch.rs
@@ -1,0 +1,37 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Serialize, Deserialize, PartialEq)]
+pub struct TrackingBatchResource {
+    pub signed_batch: BatchBytes,
+    pub service_id: Option<String>,
+    pub data_change_id: Option<String>,
+}
+
+/// A serialized `Batch`
+pub type BatchBytes = Vec<u8>;
+
+/// Represents a list of batches created from the REST API
+#[derive(Default, Serialize, Deserialize)]
+pub struct SubmitBatchRequest {
+    pub batches: Vec<TrackingBatchResource>,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq)]
+/// A batch's identifying information
+pub struct BatchIdentifier {
+    pub dlt_batch_id: String,
+    pub data_change_id: Option<String>,
+    pub service_id: Option<String>,
+}

--- a/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
@@ -14,7 +14,8 @@
 
 //! Provides native representations of smart contract actions used to deserialize from JSON
 
-mod batch;
+#[cfg(feature = "rest-api-batch-submission-handler")]
+pub mod batch;
 mod location;
 mod pike;
 mod product;

--- a/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
+++ b/sdk/src/rest_api/resources/submit/v2/payloads/mod.rs
@@ -14,6 +14,7 @@
 
 //! Provides native representations of smart contract actions used to deserialize from JSON
 
+mod batch;
 mod location;
 mod pike;
 mod product;


### PR DESCRIPTION
This adds a trait for a component of the REST API that submits batches. It will take in a generic bytes representation of the batch to be submitted (or batch list) and other information pertaining to the batch to be persisted by Grid. This will be used by endpoints that accept batches, in order to process generic `TransactionPayload`s to store them as batches in Grid's DB, or to send them to an upstream server for further handling. 