### PR TITLE
Use actix-rt library for testing actix async

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -70,7 +70,7 @@ glob = "0.3"
 cylinder = { version = "0.2" }
 mockito = "0.30"
 pretty_assertions = "1"
-tokio = { version = "0.2", features = ["macros"] }
+actix-rt = "1.1.1"
 
 [features]
 default = []

--- a/sdk/src/backend/splinter.rs
+++ b/sdk/src/backend/splinter.rs
@@ -307,7 +307,7 @@ mod tests {
         (mock_endpoint, response)
     }
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn splinter_backend_client_returns_useful_message_on_404() {
         let (endpoint, response) = setup_basic_request();
 
@@ -330,7 +330,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn splinter_backend_client_returns_correctly_on_200_success() {
         let (endpoint, response) = setup_basic_request();
 
@@ -349,7 +349,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn splinter_backend_client_returns_useful_message_on_200_deserialize_error() {
         let (endpoint, response) = setup_basic_request();
 
@@ -366,7 +366,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn splinter_backend_client_returns_useful_message_on_503_deserialize_error() {
         let (endpoint, response) = setup_basic_request();
 


### PR DESCRIPTION
Switch from tokio to actix-rt for actix async tests so the versions
don't clash with tokio's version.

Signed-off-by: Lee Bradley <bradley@bitwise.io>