### PR TITLE
Use `find` instead of `find_map`

### DIFF
--- a/daemon/src/splinter/app_auth_handler/mod.rs
+++ b/daemon/src/splinter/app_auth_handler/mod.rs
@@ -139,13 +139,12 @@ fn process_admin_event(
     debug!("Received the event at {}", event.timestamp);
     match event.admin_event {
         AdminServiceEvent::CircuitReady(msg_proposal) => {
-            let service = match msg_proposal.circuit.roster.iter().find_map(|service| {
-                if service.allowed_nodes.contains(&node_id.to_string()) {
-                    Some(service)
-                } else {
-                    None
-                }
-            }) {
+            let service = match msg_proposal
+                .circuit
+                .roster
+                .iter()
+                .find(|service| service.allowed_nodes.contains(&node_id.to_string()))
+            {
                 Some(service) => service,
                 None => {
                     debug!(


### PR DESCRIPTION
The `find` Iterator method takes a closure, which returns a boolean, and
the method then returns the first object that evaluates to true as an
Option, otherwise it returns None. Previously, we were doing this
specification manually in the `find_map` method.

This issue was caught by clippy, for more information on this lint,
see: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_find_map

Signed-off-by: Shannyn Telander <telander@bitwise.io>