### PR TITLE
Retire chenette and eloaverona

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @chenette @davececchi @dcmiddle @dnewh @dplumb94 @eloaverona @jsmitchell @leebradley @peterschwarz @rberg2 @rbuysse @RyanLassigBanks @shannynalayna @vaporos
+*       @agunde406 @davececchi @dcmiddle @dnewh @dplumb94 @jsmitchell @leebradley @peterschwarz @rberg2 @rbuysse @RyanLassigBanks @shannynalayna @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,12 +4,10 @@
 | Name | GitHub | RocketChat |
 | --- | --- | --- |
 | Andi Gunderson | agunde406 | agunde |
-| Anne Chenette | chenette | achenette |
 | Dan Middleton | dcmiddle | Dan |
 | Darian Plumb | dplumb94 | dplumb |
 | Dave Cecchi | davececchi | cecchi |
 | Davey Newhall | dnewh | newhall |
-| Eloá Franca Verona | eloaverona | eloafran |
 | James Mitchell | jsmitchell | jsmitchell |
 | Lee Bradley | leebradley | lbradley |
 | Peter Schwarz | peterschwarz | pschwarz |
@@ -22,4 +20,6 @@
 ### Retired Maintainers
 | Name | GitHub | RocketChat |
 | --- | --- | --- |
+| Anne Chenette | chenette | achenette |
 | Boyd Johnson | boydjohnson | boydjohnson |
+| Eloá Franca Verona | eloaverona | eloafran |


### PR DESCRIPTION
This change retires @chenette and @eloaverona as maintainers and
codeowners for Grid.

Signed-off-by: Shannyn Telander <telander@bitwise.io>