### PR TITLE
BACKPORT 0-3: Remove slack alerts from pull request workflows

### DIFF
--- a/.github/workflows/0-3-integration-tests.yaml
+++ b/.github/workflows/0-3-integration-tests.yaml
@@ -25,12 +25,3 @@ jobs:
 
       - name: Integration Tests
         run: just ci-test-integration
-
-      - name: Notify Slack of Failure
-        if: failure()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,author,job
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/0-3-lint-grid-ui.yaml
+++ b/.github/workflows/0-3-lint-grid-ui.yaml
@@ -25,12 +25,3 @@ jobs:
 
       - name: Lint Grid UI
         run: just ci-lint-ui
-
-      - name: Notify Slack of Failure
-        if: failure()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,author,job
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/0-3-lint-grid.yaml
+++ b/.github/workflows/0-3-lint-grid.yaml
@@ -25,12 +25,3 @@ jobs:
 
       - name: Run Lint/Clippy on Grid
         run: just ci-lint
-
-      - name: Notify Slack of Failure
-        if: failure()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,author,job
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/0-3-lint-openapi.yaml
+++ b/.github/workflows/0-3-lint-openapi.yaml
@@ -21,12 +21,3 @@ jobs:
 
       - name: Lint OpenAPI files
         run: just ci-lint-openapi
-
-      - name: Notify Slack of Failure
-        if: failure()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,author,job
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/0-3-test-grid-ui.yaml
+++ b/.github/workflows/0-3-test-grid-ui.yaml
@@ -25,12 +25,3 @@ jobs:
 
       - name: Grid UI Tests
         run: just ci-test-ui
-
-      - name: Notify Slack of Failure
-        if: failure()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,author,job
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/0-3-unit-test-grid.yaml
+++ b/.github/workflows/0-3-unit-test-grid.yaml
@@ -25,12 +25,3 @@ jobs:
 
       - name: Unit Test Grid
         run: just ci-test
-
-      - name: Notify Slack of Failure
-        if: failure()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,author,job
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
These were introduced inadvertently as a copy/paste error. Not only would
this behavior be undesired, but because the workflow runs in the context
of the forked repository there is no access to the secrets required.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>