### PR TITLE
Update Griddle to use builder pattern on start-up

### DIFF
--- a/examples/griddle/docker-compose-splinter.yaml
+++ b/examples/griddle/docker-compose-splinter.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Cargill Incorporated
+# Copyright 2018-2022 Cargill Incorporated
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ volumes:
   registry:
   gridd-alpha:
   gridd-beta:
-  gridd-gamma:
   templates-shared:
   cache-shared:
 
@@ -140,36 +139,42 @@ services:
       "
 
   generate-registry:
-    image: splintercommunity/splinter-cli:0.4
+    image: splintercommunity/splinter-cli:0.6
     volumes:
       - registry:/registry
+      - gridd-alpha:/gridd_alpha/keys
+      - gridd-beta:/gridd_beta/keys
+    depends_on:
+      - gridd-alpha
+      - gridd-beta
     command: |
       bash -c "
         if [ ! -f /registry/registry.yaml ]
         then
           # generate keys
-          splinter admin keygen alpha -d /registry
-          splinter admin keygen beta -d /registry
-          splinter admin keygen gamma -d /registry
+          splinter keygen alpha --key-dir /registry
+          splinter keygen beta --key-dir /registry
           # check if splinterd-alpha is available
-          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-alpha:8085/status) -ne 200 ]] ; do
-             >&2 echo \"splinterd alpha is unavailable - sleeping\"
+          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-alpha:8085/status) -ne 401 ]] ; do
+             >&2 echo \"splinterd is unavailable - sleeping\"
              sleep 1
           done
           # check if splinterd-beta is available
-          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-beta:8085/status) -ne 200 ]] ; do
-             >&2 echo \"splinterd beta is unavailable - sleeping\"
+          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-beta:8085/status) -ne 401 ]] ; do
+             >&2 echo \"splinterd is unavailable - sleeping\"
              sleep 1
           done
           # build the registry
           splinter registry build \
             http://splinterd-alpha:8085 \
             --file /registry/registry.yaml \
+            --key /gridd_alpha/keys/gridd.priv \
             --key-file /registry/alpha.pub \
             --metadata organization='Alpha'
           splinter registry build \
             http://splinterd-beta:8085 \
             --file /registry/registry.yaml \
+            --key /gridd_beta/keys/gridd.priv \
             --key-file /registry/beta.pub \
             --metadata organization='Beta'
         fi
@@ -229,24 +234,29 @@ services:
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv admin keygen --skip && \
         grid -vv keygen --skip --system && \
         grid -vv database migrate \
             -C postgres://grid:grid_example@db-alpha/grid &&
-        gridd -vv -b 0.0.0.0:8080 -k root -C splinter:http://splinterd-alpha:8085 \
+        gridd -vvv -b 0.0.0.0:8080 -k root -C splinter:http://splinterd-alpha:8085 \
             --database-url postgres://grid:grid_example@db-alpha/grid
       "
 
   scabbard-cli-alpha:
-    image: splintercommunity/scabbard-cli:0.4
+    image: splintercommunity/scabbard-cli:0.6
     container_name: scabbard-cli-alpha
     hostname: scabbard-cli-alpha
     volumes:
       - gridd-alpha:/root/.splinter/keys
+      - contracts-shared:/usr/share/scar
+      - registry:/registry
+    environment:
+      CYLINDER_PATH: /registry
+      CYLINDER_KEY_NAME: "alpha"
+      SPLINTER_REST_API_URL: http://splinterd-alpha:8085
     command: tail -f /dev/null
 
   splinterd-alpha:
-    image: splintercommunity/splinterd:0.4
+    image: splintercommunity/splinterd:0.6
     container_name: splinterd-alpha
     hostname: splinterd-alpha
     expose:
@@ -259,30 +269,39 @@ services:
       - contracts-shared:/usr/share/scar
       - registry:/registry
       - templates-shared:/usr/share/splinter/circuit-templates
+      - gridd-alpha:/etc/grid/keys
+    depends_on:
+      - gridd-alpha
+    environment:
+      CYLINDER_PATH: /registry
+      CYLINDER_KEY_NAME: "alpha"
+      SPLINTER_REST_API_URL: http://splinterd-alpha:8085
     entrypoint: |
       bash -c "
+        while [ ! -f /etc/grid/keys/gridd.pub ] ; do
+          >&2 echo \"Grid key file is unavailable - sleeping\"
+          sleep 1
+        done && \
+        if [ ! -s /etc/splinter/allow_keys ]
+        then
+          echo $$(cat /registry/alpha.pub) >> /etc/splinter/allow_keys
+          echo $$(cat /etc/grid/keys/gridd.pub) >> /etc/splinter/allow_keys
+        fi && \
         until PGPASSWORD=admin psql -h splinter-db-alpha -U admin -d splinter -c '\q'; do
           >&2 echo \"Database is unavailable - sleeping\"
           sleep 1
         done
-        if [ ! -f /etc/splinter/certs/private/server.key ]
-        then
-          splinter-cli cert generate --force
-        fi && \
+        splinter cert generate --skip && \
+        splinter keygen --system --skip && \
         splinter database migrate -C postgres://admin:admin@splinter-db-alpha:5432/splinter && \
+        splinter upgrade -C postgres://admin:admin@splinter-db-alpha:5432/splinter && \
         splinterd -vv \
         --registries http://registry-server:80/registry.yaml \
-        --rest-api-endpoint 0.0.0.0:8085 \
+        --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
         --advertised-endpoint tcps://splinterd-alpha:8044 \
         --node-id alpha-node-000 \
-        --service-endpoint tcp://0.0.0.0:8043 \
-        --storage yaml \
-        --tls-client-cert /etc/splinter/certs/client.crt \
-        --tls-client-key /etc/splinter/certs/private/client.key \
-        --tls-server-cert /etc/splinter/certs/server.crt \
-        --tls-server-key /etc/splinter/certs/private/server.key \
-        --enable-biome \
+        --enable-biome-credentials \
         --database postgres://admin:admin@splinter-db-alpha:5432/splinter \
         --tls-insecure
       "
@@ -308,21 +327,20 @@ services:
       dockerfile: griddle/Dockerfile
       args:
         - REPO_VERSION=${REPO_VERSION}
+        - CARGO_ARGS=--features experimental
     expose:
       - 8000
+    ports:
+      - "8000:8000"
+    hostname: griddle-alpha-0
     environment:
       GRIDDLE_KEY_DIR: griddle-alpha-0
       GRIDDLE_BIND: 0.0.0.0:8000
-      GRIDDLE_DATABASE_URL: postgres://grid:grid_example@db-alpha/grid
+      GRIDDLE_FORWARD_URL: http://gridd-alpha:8080
     entrypoint: |
       bash -c "
-        # we need to wait for the db to have started.
-        until PGPASSWORD=grid_example psql -h db-alpha -U grid -c '\q' > /dev/null 2>&1; do
-            >&2 echo \"Database alpha is unavailable - sleeping\"
-            sleep 1
-        done
-        grid -vv keygen --skip --system griddle-alpha-0
-        griddle -v --connect splinter:http://splinterd-alpha:8085
+        grid -vv keygen --skip griddle-alpha-0
+        griddle -vv --connect splinter:http://splinterd-alpha:8085
       "
 
   griddle-alpha-1:
@@ -333,20 +351,19 @@ services:
       dockerfile: griddle/Dockerfile
       args:
         - REPO_VERSION=${REPO_VERSION}
+        - CARGO_ARGS=--features experimental
+    ports:
+      - "8001:8000"
     expose:
       - 8000
+    hostname: griddle-alpha-0
     environment:
       GRIDDLE_KEY_DIR: griddle-alpha-1
       GRIDDLE_BIND: 0.0.0.0:8000
-      GRIDDLE_DATABASE_URL: postgres://grid:grid_example@db-alpha/grid
+      GRIDDLE_FORWARD_URL: http://gridd-alpha:8080
     entrypoint: |
       bash -c "
-        # we need to wait for the db to have started.
-        until PGPASSWORD=grid_example psql -h db-beta -U grid -c '\q' > /dev/null 2>&1; do
-            >&2 echo \"Database alpha is unavailable - sleeping\"
-            sleep 1
-        done
-        grid -vv keygen --skip --system griddle-alpha-1
+        grid -vv keygen --skip griddle-alpha-1
         griddle -v --connect splinter:http://splinterd-alpha:8085
       "
 
@@ -358,20 +375,19 @@ services:
       dockerfile: griddle/Dockerfile
       args:
         - REPO_VERSION=${REPO_VERSION}
+        - CARGO_ARGS=--features experimental
+    ports:
+      - "8002:8000"
     expose:
       - 8000
+    hostname: griddle-alpha-2
     environment:
       GRIDDLE_KEY_DIR: griddle-alpha-2
       GRIDDLE_BIND: 0.0.0.0:8000
-      GRIDDLE_DATABASE_URL: postgres://grid:grid_example@db-alpha/grid
+      GRIDDLE_FORWARD_URL: http://gridd-alpha:8080
     entrypoint: |
       bash -c "
-        # we need to wait for the db to have started.
-        until PGPASSWORD=grid_example psql -h db-alpha -U grid -c '\q' > /dev/null 2>&1; do
-            >&2 echo \"Database alpha is unavailable - sleeping\"
-            sleep 1
-        done
-        grid -vv keygen --skip --system griddle-alpha-2
+        grid -vv keygen --skip griddle-alpha-2
         griddle -v --connect splinter:http://splinterd-alpha:8085
       "
 
@@ -383,20 +399,19 @@ services:
       dockerfile: griddle/Dockerfile
       args:
         - REPO_VERSION=${REPO_VERSION}
+        - CARGO_ARGS=--features experimental
+    ports:
+      - "8003:8000"
     expose:
       - 8000
+    hostname: griddle-alpha-3
     environment:
       GRIDDLE_KEY_DIR: griddle-alpha-3
       GRIDDLE_BIND: 0.0.0.0:8000
-      GRIDDLE_DATABASE_URL: postgres://grid:grid_example@db-alpha/grid
+      GRIDDLE_FORWARD_URL: http://gridd-alpha:8080
     entrypoint: |
       bash -c "
-        # we need to wait for the db to have started.
-        until PGPASSWORD=grid_example psql -h db-alpha -U grid -c '\q' > /dev/null 2>&1; do
-            >&2 echo \"Database alpha is unavailable - sleeping\"
-            sleep 1
-        done
-        grid -vv keygen --skip --system griddle-alpha-3
+        grid -vv keygen --skip griddle-alpha-3
         griddle -v --connect splinter:http://splinterd-alpha:8085
       "
 
@@ -443,24 +458,29 @@ services:
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1
         done
-        grid -vv admin keygen --skip && \
-        grid -vv keygen --skip --system && \
+        grid -vv keygen --system --skip && \
         grid -vv database migrate \
             -C postgres://grid:grid_example@db-beta/grid &&
-        gridd -vv -k root -b 0.0.0.0:8080 -C splinter:http://splinterd-beta:8085 \
+        gridd -vvv -k root -b 0.0.0.0:8080 -C splinter:http://splinterd-beta:8085 \
             --database-url postgres://grid:grid_example@db-beta/grid
       "
 
   scabbard-cli-beta:
-    image: splintercommunity/scabbard-cli:0.4
+    image: splintercommunity/scabbard-cli:0.6
     container_name: scabbard-cli-beta
     hostname: scabbard-cli-beta
     volumes:
       - gridd-beta:/root/.splinter/keys
+      - contracts-shared:/usr/share/scar
+      - registry:/registry
+    environment:
+      CYLINDER_PATH: /registry
+      CYLINDER_KEY_NAME: "beta"
+      SPLINTER_REST_API_URL: http://splinterd-beta:8085
     command: tail -f /dev/null
 
   splinterd-beta:
-    image: splintercommunity/splinterd:0.4
+    image: splintercommunity/splinterd:0.6
     container_name: splinterd-beta
     hostname: splinterd-beta
     expose:
@@ -472,30 +492,39 @@ services:
       - contracts-shared:/usr/share/scar
       - registry:/registry
       - templates-shared:/usr/share/splinter/circuit-templates
+      - gridd-beta:/etc/grid/keys
+    depends_on:
+      - gridd-beta
+    environment:
+      CYLINDER_PATH: /registry
+      CYLINDER_KEY_NAME: "beta"
+      SPLINTER_REST_API_URL: http://splinterd-beta:8085
     entrypoint: |
       bash -c "
+        while [ ! -f /etc/grid/keys/gridd.pub ] ; do
+          >&2 echo \"Grid key file is unavailable - sleeping\"
+          sleep 1
+        done && \
+        if [ ! -s /etc/splinter/allow_keys ]
+        then
+          echo $$(cat /registry/beta.pub) >> /etc/splinter/allow_keys
+          echo $$(cat /etc/grid/keys/gridd.pub) >> /etc/splinter/allow_keys
+        fi && \
         until PGPASSWORD=admin psql -h splinter-db-beta -U admin -d splinter -c '\q'; do
           >&2 echo \"Database is unavailable - sleeping\"
           sleep 1
         done
-        if [ ! -f /etc/splinter/certs/private/server.key ]
-        then
-          splinter-cli cert generate --force
-        fi && \
+        splinter cert generate --skip && \
+        splinter keygen --system --skip && \
         splinter database migrate -C postgres://admin:admin@splinter-db-beta:5432/splinter && \
+        splinter upgrade -C postgres://admin:admin@splinter-db-beta:5432/splinter && \
         splinterd -vv \
         --registries http://registry-server:80/registry.yaml \
-        --rest-api-endpoint 0.0.0.0:8085 \
+        --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
         --advertised-endpoint tcps://splinterd-beta:8044 \
         --node-id beta-node-000 \
-        --service-endpoint tcp://0.0.0.0:8043 \
-        --storage yaml \
-        --tls-client-cert /etc/splinter/certs/client.crt \
-        --tls-client-key /etc/splinter/certs/private/client.key \
-        --tls-server-cert /etc/splinter/certs/server.crt \
-        --tls-server-key /etc/splinter/certs/private/server.key \
-        --enable-biome \
+        --enable-biome-credentials \
         --database postgres://admin:admin@splinter-db-beta:5432/splinter \
         --tls-insecure
       "
@@ -521,20 +550,18 @@ services:
       dockerfile: griddle/Dockerfile
       args:
         - REPO_VERSION=${REPO_VERSION}
+    ports:
+      - "8004:8000"
     expose:
       - 8000
+    hostname: griddle-beta-0
     environment:
       GRIDDLE_KEY_DIR: griddle-beta-0
       GRIDDLE_BIND: 0.0.0.0:8000
-      GRIDDLE_DATABASE_URL: postgres://grid:grid_example@db-beta/grid
+      GRIDDLE_FORWARD_URL: http://gridd-beta:8080
     entrypoint: |
       bash -c "
-        # we need to wait for the db to have started.
-        until PGPASSWORD=grid_example psql -h db-beta -U grid -c '\q' > /dev/null 2>&1; do
-            >&2 echo \"Database beta is unavailable - sleeping\"
-            sleep 1
-        done
-        grid -vv keygen --skip --system griddle-beta-0
+        grid -vv keygen --skip griddle-beta-0
         griddle -v --connect splinter:http://splinterd-beta:8085
       "
 
@@ -546,20 +573,19 @@ services:
       dockerfile: griddle/Dockerfile
       args:
         - REPO_VERSION=${REPO_VERSION}
+        - CARGO_ARGS=--features experimental
+    ports:
+      - "8005:8000"
     expose:
       - 8000
+    hostname: griddle-beta-1
     environment:
       GRIDDLE_KEY_DIR: griddle-beta-1
       GRIDDLE_BIND: 0.0.0.0:8000
-      GRIDDLE_DATABASE_URL: postgres://grid:grid_example@db-beta/grid
+      GRIDDLE_FORWARD_URL: http://gridd-beta:8080
     entrypoint: |
       bash -c "
-        # we need to wait for the db to have started.
-        until PGPASSWORD=grid_example psql -h db-beta -U grid -c '\q' > /dev/null 2>&1; do
-            >&2 echo \"Database beta is unavailable - sleeping\"
-            sleep 1
-        done
-        grid -vv keygen --skip --system griddle-beta-1
+        grid -vv keygen --skip griddle-beta-1
         griddle -v --connect splinter:http://splinterd-beta:8085
       "
 
@@ -571,20 +597,19 @@ services:
       dockerfile: griddle/Dockerfile
       args:
         - REPO_VERSION=${REPO_VERSION}
+        - CARGO_ARGS=--features experimental
+    ports:
+      - "8006:8000"
     expose:
       - 8000
+    hostname: griddle-beta-2
     environment:
       GRIDDLE_KEY_DIR: griddle-beta-2
       GRIDDLE_BIND: 0.0.0.0:8000
-      GRIDDLE_DATABASE_URL: postgres://grid:grid_example@db-beta/grid
+      GRIDDLE_FORWARD_URL: http://gridd-beta:8080
     entrypoint: |
       bash -c "
-        # we need to wait for the db to have started.
-        until PGPASSWORD=grid_example psql -h db-beta -U grid -c '\q' > /dev/null 2>&1; do
-            >&2 echo \"Database beta is unavailable - sleeping\"
-            sleep 1
-        done
-        grid -vv keygen --skip --system griddle-beta-2
+        grid -vv keygen --skip griddle-beta-2
         griddle -v --connect splinter:http://splinterd-beta:8085
       "
 
@@ -596,19 +621,18 @@ services:
       dockerfile: griddle/Dockerfile
       args:
         - REPO_VERSION=${REPO_VERSION}
+        - CARGO_ARGS=--features experimental
+    ports:
+      - "8007:8000"
     expose:
       - 8000
+    hostname: griddle-beta-3
     environment:
       GRIDDLE_KEY_DIR: griddle-beta-3
       GRIDDLE_BIND: 0.0.0.0:8000
-      GRIDDLE_DATABASE_URL: postgres://grid:grid_example@db-alpha/grid
+      GRIDDLE_FORWARD_URL: http://gridd-beta:8080
     entrypoint: |
       bash -c "
-        # we need to wait for the db to have started.
-        until PGPASSWORD=grid_example psql -h db-beta -U grid -c '\q' > /dev/null 2>&1; do
-            >&2 echo \"Database beta is unavailable - sleeping\"
-            sleep 1
-        done
-        grid -vv keygen --skip --system griddle-beta-3
+        grid -vv keygen --skip griddle-beta-3
         griddle -v --connect splinter:http://splinterd-beta:8085
       "

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -9,16 +9,17 @@ description = "Grid integration component"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = { version = "3", default-features = false }
+actix-web = { version = "4", default-features = false }
 clap = "2.33.3"
+cylinder = { version = "0.2.2", features = ["key-load", "jwt"], optional = true}
 diesel = { version = "1.0", features = ["r2d2"], optional = true }
 flexi_logger = "0.22"
+futures-0-3 = { package = "futures", version = "0.3", optional = true }
 log = "0.4"
 users = "0.11"
 
 [dependencies.grid-sdk]
 path = "../sdk"
-optional = true
 features = [
   "rest-api-actix-web-4",
   "rest-api-actix-web-4-run",
@@ -42,6 +43,7 @@ experimental = [
     "database-postgres",
     "database-sqlite",
     "proxy",
+    "rest-api",
 ]
 
 database-postgres = ["diesel", "grid-sdk/postgres"]
@@ -50,4 +52,9 @@ proxy = [
   "grid-sdk/proxy-run",
   "grid-sdk/proxy-client-reqwest",
   "grid-sdk/rest-api-endpoint-proxy",
+]
+rest-api = [
+  "cylinder",
+  "grid-sdk/lifecycle",
+  "futures-0-3",
 ]

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -44,6 +44,7 @@ experimental = [
     "database-sqlite",
     "proxy",
     "rest-api",
+    "rest-api-actix-web-4"
 ]
 
 database-postgres = ["diesel", "grid-sdk/postgres"]
@@ -57,4 +58,8 @@ rest-api = [
   "cylinder",
   "grid-sdk/lifecycle",
   "futures-0-3",
+]
+rest-api-actix-web-4 = [
+  "rest-api",
+  "grid-sdk/rest-api-actix-web-4",
 ]

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -25,6 +25,7 @@ description = "Grid integration component"
 [dependencies]
 actix-web = { version = "4", default-features = false }
 clap = "2.33.3"
+ctrlc = { version = "3.0", optional = true }
 cylinder = { version = "0.2.2", features = ["key-load", "jwt"], optional = true}
 dirs = { version = "4", optional = true }
 diesel = { version = "1.0", features = ["r2d2"], optional = true }
@@ -59,6 +60,7 @@ experimental = [
     "database-sqlite",
     "key-load",
     "griddle-builder",
+    "griddle-builder-run",
     "proxy",
     "rest-api",
     "rest-api-actix-web-4"
@@ -67,8 +69,14 @@ experimental = [
 database-postgres = ["diesel", "grid-sdk/postgres"]
 database-sqlite = ["diesel", "grid-sdk/sqlite"]
 griddle-builder = [
+  "ctrlc",
   "rest-api",
   "grid-sdk/lifecycle"
+]
+griddle-builder-run = [
+  "griddle-builder",
+  "key-load",
+  "rest-api",
 ]
 key-load = [
   "cylinder",

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -13,9 +13,18 @@ actix-web = { version = "3", default-features = false }
 clap = "2.33.3"
 diesel = { version = "1.0", features = ["r2d2"], optional = true }
 flexi_logger = "0.22"
-grid-sdk = { path = "../sdk", features = ["rest-api-actix-web-4", "rest-api-actix-web-4-run", "batch-processor"] }
 log = "0.4"
 users = "0.11"
+
+[dependencies.grid-sdk]
+path = "../sdk"
+optional = true
+features = [
+  "rest-api-actix-web-4",
+  "rest-api-actix-web-4-run",
+  "batch-processor",
+  "lifecycle"
+]
 
 [features]
 default = []

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -56,6 +56,7 @@ experimental = [
     # The following features are experimental:
     "database-postgres",
     "database-sqlite",
+    "griddle-builder",
     "proxy",
     "rest-api",
     "rest-api-actix-web-4"
@@ -63,6 +64,10 @@ experimental = [
 
 database-postgres = ["diesel", "grid-sdk/postgres"]
 database-sqlite = ["diesel", "grid-sdk/sqlite"]
+griddle-builder = [
+  "rest-api",
+  "grid-sdk/lifecycle"
+]
 proxy = [
   "grid-sdk/proxy-run",
   "grid-sdk/proxy-client-reqwest",

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -26,6 +26,7 @@ description = "Grid integration component"
 actix-web = { version = "4", default-features = false }
 clap = "2.33.3"
 cylinder = { version = "0.2.2", features = ["key-load", "jwt"], optional = true}
+dirs = { version = "4", optional = true }
 diesel = { version = "1.0", features = ["r2d2"], optional = true }
 flexi_logger = "0.22"
 futures-0-3 = { package = "futures", version = "0.3", optional = true }
@@ -56,6 +57,7 @@ experimental = [
     # The following features are experimental:
     "database-postgres",
     "database-sqlite",
+    "key-load",
     "griddle-builder",
     "proxy",
     "rest-api",
@@ -67,6 +69,10 @@ database-sqlite = ["diesel", "grid-sdk/sqlite"]
 griddle-builder = [
   "rest-api",
   "grid-sdk/lifecycle"
+]
+key-load = [
+  "cylinder",
+  "dirs"
 ]
 proxy = [
   "grid-sdk/proxy-run",

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -1,3 +1,17 @@
+# Copyright 2018-2022 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [package]
 name = "griddle"
 version = "0.4.1"

--- a/griddle/src/internals/builder.rs
+++ b/griddle/src/internals/builder.rs
@@ -1,0 +1,140 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "rest-api")]
+use cylinder::Signer;
+#[cfg(all(feature = "proxy", feature = "rest-api"))]
+use grid_sdk::proxy::ProxyClient;
+
+#[cfg(feature = "rest-api")]
+use crate::internals::RunnableGriddleRestApiVariant;
+use crate::internals::{DLTBackend, GriddleError, RunnableGriddle};
+#[cfg(feature = "rest-api-actix-web-4")]
+use crate::rest_api::actix_web_4::GriddleRestApiBuilder;
+
+#[derive(Default)]
+pub struct GriddleBuilder {
+    #[cfg(feature = "rest-api")]
+    /// Name of the private key file used for signing
+    signer: Option<Box<dyn Signer>>,
+    #[cfg(feature = "rest-api")]
+    /// REST API backend implementation
+    rest_api_variant: Option<GriddleRestApiVariant>,
+    #[cfg(feature = "rest-api")]
+    /// Address of the Griddle REST API
+    rest_api_endpoint: Option<String>,
+    #[cfg(all(feature = "proxy", feature = "rest-api"))]
+    /// Client used to proxy requests for Griddle
+    proxy_client: Option<Box<dyn ProxyClient>>,
+    /// Type of backend DLT used by Grid
+    dlt_backend: Option<DLTBackend>,
+}
+
+#[cfg(feature = "rest-api")]
+/// An enumeration of the various REST API backend implementations.
+pub enum GriddleRestApiVariant {
+    #[cfg(feature = "rest-api-actix-web-4")]
+    /// Actix Web 3 as the backend implementation
+    ActixWeb4,
+}
+
+impl GriddleBuilder {
+    #[cfg(feature = "rest-api")]
+    pub fn with_signer(mut self, signer: Box<dyn Signer>) -> Self {
+        self.signer = Some(signer);
+        self
+    }
+
+    #[cfg(feature = "rest-api")]
+    pub fn with_rest_api_variant(mut self, variant: GriddleRestApiVariant) -> Self {
+        self.rest_api_variant = Some(variant);
+        self
+    }
+
+    #[cfg(feature = "rest-api")]
+    pub fn with_rest_api_endpoint(mut self, url: String) -> Self {
+        self.rest_api_endpoint = Some(url);
+        self
+    }
+
+    #[cfg(all(feature = "proxy", feature = "rest-api"))]
+    pub fn with_proxy_client(mut self, proxy_client: Box<dyn ProxyClient>) -> Self {
+        self.proxy_client = Some(proxy_client);
+        self
+    }
+
+    pub fn with_dlt_backend(mut self, backend: DLTBackend) -> Self {
+        self.dlt_backend = Some(backend);
+        self
+    }
+
+    pub fn build(self) -> Result<RunnableGriddle, GriddleError> {
+        #[cfg(feature = "rest-api")]
+        let signer = self
+            .signer
+            .ok_or_else(|| GriddleError::MissingRequiredField("signer".to_string()))?;
+
+        #[cfg(feature = "rest-api")]
+        let rest_api_endpoint = self
+            .rest_api_endpoint
+            .ok_or_else(|| GriddleError::MissingRequiredField("rest_api_endpoint".to_string()))?;
+
+        #[cfg(feature = "rest-api")]
+        let builder_rest_api_variant = self
+            .rest_api_variant
+            .ok_or_else(|| GriddleError::MissingRequiredField("rest_api_variant".to_string()))?;
+
+        let dlt_backend = self
+            .dlt_backend
+            .ok_or_else(|| GriddleError::MissingRequiredField("dlt_backend".to_string()))?;
+
+        #[cfg(all(feature = "proxy", feature = "rest-api"))]
+        let proxy_client = self
+            .proxy_client
+            .ok_or_else(|| GriddleError::MissingRequiredField("proxy_client".to_string()))?;
+
+        #[cfg(feature = "rest-api")]
+        let rest_api_variant = match builder_rest_api_variant {
+            GriddleRestApiVariant::ActixWeb4 => {
+                let mut builder = GriddleRestApiBuilder::new()
+                    .with_bind(rest_api_endpoint.clone())
+                    .with_signer(signer.clone())
+                    .with_dlt_backend(dlt_backend.clone());
+
+                #[cfg(feature = "proxy")]
+                {
+                    builder = builder.with_proxy_client(proxy_client.clone());
+                }
+                // Need to create the resources in this arm
+                RunnableGriddleRestApiVariant::ActixWeb4(
+                    builder
+                        .build()
+                        .map_err(|err| GriddleError::InvalidArgumentError(err.to_string()))?,
+                )
+            }
+        };
+
+        Ok(RunnableGriddle {
+            #[cfg(feature = "rest-api")]
+            rest_api: rest_api_variant,
+            #[cfg(feature = "rest-api")]
+            rest_api_endpoint,
+            #[cfg(feature = "rest-api")]
+            signer,
+            #[cfg(all(feature = "proxy", feature = "rest-api"))]
+            proxy_client,
+            dlt_backend,
+        })
+    }
+}

--- a/griddle/src/internals/error.rs
+++ b/griddle/src/internals/error.rs
@@ -15,37 +15,23 @@
 use std::error;
 use std::fmt;
 
-#[cfg(feature = "griddle-builder")]
-use crate::internals::GriddleError;
-
 #[derive(Debug)]
-pub struct Error {
-    message: String,
+pub enum GriddleError {
+    InvalidArgumentError(String),
+    MissingRequiredField(String),
+    InternalError(String),
 }
 
-impl Error {
-    pub fn from_message(message: &str) -> Self {
-        Self {
-            message: message.to_string(),
-        }
-    }
-}
+impl error::Error for GriddleError {}
 
-impl error::Error for Error {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        None
-    }
-}
-
-impl fmt::Display for Error {
+impl fmt::Display for GriddleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-#[cfg(feature = "griddle-builder")]
-impl From<GriddleError> for Error {
-    fn from(griddle_err: GriddleError) -> Self {
-        Self::from_message(&griddle_err.to_string())
+        match self {
+            GriddleError::InvalidArgumentError(msg) => f.write_str(msg),
+            GriddleError::MissingRequiredField(msg) => {
+                write!(f, "missing required field: {}", msg)
+            }
+            GriddleError::InternalError(msg) => f.write_str(msg),
+        }
     }
 }

--- a/griddle/src/internals/mod.rs
+++ b/griddle/src/internals/mod.rs
@@ -19,6 +19,7 @@ mod running;
 
 pub use builder::GriddleBuilder;
 #[cfg(feature = "rest-api")]
+pub use builder::GriddleRestApiVariant;
 pub use error::GriddleError;
 pub use runnable::RunnableGriddle;
 #[cfg(feature = "rest-api")]

--- a/griddle/src/internals/mod.rs
+++ b/griddle/src/internals/mod.rs
@@ -15,6 +15,7 @@
 mod builder;
 mod error;
 mod runnable;
+mod running;
 
 pub use builder::GriddleBuilder;
 #[cfg(feature = "rest-api")]
@@ -22,6 +23,9 @@ pub use error::GriddleError;
 pub use runnable::RunnableGriddle;
 #[cfg(feature = "rest-api")]
 pub use runnable::RunnableGriddleRestApiVariant;
+pub use running::Griddle;
+#[cfg(feature = "rest-api")]
+pub use running::RunningGriddleRestApiVariant;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum DLTBackend {

--- a/griddle/src/internals/mod.rs
+++ b/griddle/src/internals/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod error;
+
+pub use error::GriddleError;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum DLTBackend {
+    Splinter,
+    Sawtooth,
+}

--- a/griddle/src/internals/mod.rs
+++ b/griddle/src/internals/mod.rs
@@ -12,9 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod builder;
 mod error;
+mod runnable;
 
+pub use builder::GriddleBuilder;
+#[cfg(feature = "rest-api")]
 pub use error::GriddleError;
+pub use runnable::RunnableGriddle;
+#[cfg(feature = "rest-api")]
+pub use runnable::RunnableGriddleRestApiVariant;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum DLTBackend {

--- a/griddle/src/internals/runnable.rs
+++ b/griddle/src/internals/runnable.rs
@@ -1,0 +1,43 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "rest-api")]
+use cylinder::Signer;
+#[cfg(all(feature = "proxy", feature = "rest-api"))]
+use grid_sdk::proxy::ProxyClient;
+
+use crate::internals::DLTBackend;
+#[cfg(feature = "rest-api-actix-web-4")]
+use crate::rest_api::actix_web_4::RunnableGriddleRestApi;
+
+#[cfg(feature = "rest-api")]
+pub enum RunnableGriddleRestApiVariant {
+    #[cfg(feature = "rest-api-actix-web-4")]
+    ActixWeb4(RunnableGriddleRestApi),
+}
+
+/// A fully configured and runnable version of Griddle
+pub struct RunnableGriddle {
+    #[cfg(feature = "rest-api")]
+    pub(super) rest_api: RunnableGriddleRestApiVariant,
+    #[cfg(feature = "rest-api")]
+    pub(super) rest_api_endpoint: String,
+    #[cfg(feature = "rest-api")]
+    pub(super) signer: Box<dyn Signer>,
+    #[cfg(all(feature = "proxy", feature = "rest-api"))]
+    /// Client used to proxy requests for Griddle
+    pub(super) proxy_client: Box<dyn ProxyClient>,
+    /// Type of backend DLT used by Grid
+    pub(super) dlt_backend: DLTBackend,
+}

--- a/griddle/src/internals/running.rs
+++ b/griddle/src/internals/running.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Cargill Incorporated
+// Copyright 2018-2022 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
 use cylinder::Signer;
 #[cfg(all(feature = "proxy", feature = "rest-api"))]
 use grid_sdk::proxy::ProxyClient;
+use grid_sdk::{error::InternalError, threading::lifecycle::ShutdownHandle};
 
-use crate::internals::DLTBackend;
+#[cfg(feature = "rest-api")]
+use crate::internals::GriddleRestApiVariant;
+use crate::internals::{DLTBackend, GriddleBuilder, GriddleError, RunnableGriddle};
 #[cfg(feature = "rest-api-actix-web-4")]
 use crate::rest_api::actix_web_4::GriddleRestApi;
 
@@ -39,4 +42,77 @@ pub struct Griddle {
     pub(super) proxy_client: Box<dyn ProxyClient>,
     /// Type of backend DLT used by Grid
     pub(super) dlt_backend: DLTBackend,
+}
+
+impl Griddle {
+    pub fn stop(mut self) -> Result<RunnableGriddle, GriddleError> {
+        self.signal_shutdown();
+
+        #[cfg(feature = "rest-api")]
+        let rest_api_variant = match self.rest_api {
+            #[cfg(feature = "rest-api-actix-web-4")]
+            RunningGriddleRestApiVariant::ActixWeb4(api) => {
+                api.wait_for_shutdown()
+                    .map_err(|err| GriddleError::InternalError(err.to_string()))?;
+
+                GriddleRestApiVariant::ActixWeb4
+            }
+        };
+
+        let mut griddle_builder = GriddleBuilder::default().with_dlt_backend(self.dlt_backend);
+
+        #[cfg(feature = "rest-api")]
+        {
+            griddle_builder = griddle_builder
+                .with_signer(self.signer)
+                .with_rest_api_variant(rest_api_variant)
+                .with_rest_api_endpoint(self.rest_api_endpoint);
+        }
+
+        #[cfg(feature = "proxy")]
+        {
+            griddle_builder = griddle_builder.with_proxy_client(self.proxy_client);
+        }
+
+        griddle_builder.build()
+    }
+}
+
+impl ShutdownHandle for Griddle {
+    fn signal_shutdown(&mut self) {
+        #[cfg(feature = "rest-api")]
+        match self.rest_api {
+            #[cfg(feature = "rest-api-actix-web-4")]
+            RunningGriddleRestApiVariant::ActixWeb4(ref mut rest_api) => {
+                rest_api.signal_shutdown();
+            }
+        }
+    }
+
+    fn wait_for_shutdown(self) -> Result<(), InternalError> {
+        let mut errors = vec![];
+
+        #[cfg(feature = "rest-api")]
+        match self.rest_api {
+            #[cfg(feature = "rest-api-actix-web-4")]
+            RunningGriddleRestApiVariant::ActixWeb4(rest_api) => {
+                if let Err(err) = rest_api.wait_for_shutdown() {
+                    errors.push(err);
+                }
+            }
+        }
+
+        match errors.len() {
+            0 => Ok(()),
+            1 => Err(errors.remove(0)),
+            _ => Err(InternalError::with_message(format!(
+                "Multiple errors occurred during shutdown: {}",
+                errors
+                    .into_iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))),
+        }
+    }
 }

--- a/griddle/src/internals/running.rs
+++ b/griddle/src/internals/running.rs
@@ -1,0 +1,42 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "rest-api")]
+use cylinder::Signer;
+#[cfg(all(feature = "proxy", feature = "rest-api"))]
+use grid_sdk::proxy::ProxyClient;
+
+use crate::internals::DLTBackend;
+#[cfg(feature = "rest-api-actix-web-4")]
+use crate::rest_api::actix_web_4::GriddleRestApi;
+
+#[cfg(feature = "rest-api")]
+pub enum RunningGriddleRestApiVariant {
+    #[cfg(feature = "rest-api-actix-web-4")]
+    ActixWeb4(GriddleRestApi),
+}
+
+pub struct Griddle {
+    #[cfg(feature = "rest-api")]
+    pub(super) rest_api: RunningGriddleRestApiVariant,
+    #[cfg(feature = "rest-api")]
+    pub(super) rest_api_endpoint: String,
+    #[cfg(feature = "rest-api")]
+    pub(super) signer: Box<dyn Signer>,
+    #[cfg(all(feature = "proxy", feature = "rest-api"))]
+    /// Client used to proxy requests for Griddle
+    pub(super) proxy_client: Box<dyn ProxyClient>,
+    /// Type of backend DLT used by Grid
+    pub(super) dlt_backend: DLTBackend,
+}

--- a/griddle/src/main.rs
+++ b/griddle/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 Cargill Incorporated
+// Copyright 2018-2022 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,37 +16,56 @@
 extern crate log;
 
 mod error;
-#[allow(dead_code)]
 #[cfg(feature = "griddle-builder")]
 pub mod internals;
-#[allow(dead_code)]
 #[cfg(feature = "rest-api")]
-mod rest_api;
+pub mod rest_api;
 #[cfg(feature = "key-load")]
-mod signing;
+pub mod signing;
 
 use std::env;
-#[cfg(any(feature = "database-postgres", feature = "database-sqlite"))]
+#[cfg(all(
+    any(feature = "database-postgres", feature = "database-sqlite"),
+    not(feature = "griddle-builder-run"),
+))]
 use std::str::FromStr;
+#[cfg(feature = "griddle-builder-run")]
+use std::sync::mpsc::channel;
+#[cfg(not(feature = "griddle-builder-run"))]
 use std::sync::Arc;
 
+#[cfg(feature = "griddle-builder-run")]
+use clap::ArgMatches;
 use clap::{App, Arg};
-#[cfg(feature = "diesel")]
+#[cfg(all(feature = "diesel", not(feature = "griddle-builder-run")))]
 use diesel::r2d2::{ConnectionManager, Pool};
 use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};
-#[cfg(feature = "proxy")]
-use grid_sdk::proxy::ReqwestProxyClient;
-#[cfg(any(feature = "database-postgres", feature = "database-sqlite"))]
+#[cfg(any(feature = "proxy", feature = "griddle-builder-run"))]
+use grid_sdk::proxy::{ProxyClient, ReqwestProxyClient};
+use grid_sdk::rest_api::actix_web_4::Endpoint;
+#[cfg(all(
+    any(feature = "database-postgres", feature = "database-sqlite"),
+    not(feature = "griddle-builder-run"),
+))]
 use grid_sdk::store::ConnectionUri;
+#[cfg(not(feature = "griddle-builder-run"))]
 use grid_sdk::{
     batch_processor::submitter::{
         BatchSubmitter, SawtoothBatchSubmitter, SawtoothConnection, SplinterBatchSubmitter,
     },
-    rest_api::actix_web_4::{self, Endpoint, KeyState, StoreState},
+    rest_api::actix_web_4::{self, KeyState, StoreState},
 };
+#[cfg(feature = "griddle-builder-run")]
+use grid_sdk::{rest_api::actix_web_4::Backend, threading::lifecycle::ShutdownHandle};
 use log::Record;
 use users::get_current_username;
 
+#[cfg(feature = "griddle-builder-run")]
+use crate::{
+    error::Error,
+    internals::{DLTBackend, GriddleBuilder, GriddleRestApiVariant},
+};
+#[cfg(not(feature = "griddle-builder-run"))]
 use error::Error;
 
 fn log_format(
@@ -57,14 +76,20 @@ fn log_format(
     write!(w, "{}", record.args(),)
 }
 
-#[cfg(not(any(feature = "database-postgres", feature = "database-sqlite")))]
+#[cfg(not(any(
+    feature = "database-postgres",
+    feature = "database-sqlite",
+    feature = "griddle-builder-run"
+)))]
 fn griddle_store_state(_db_url: &str) -> Result<StoreState, Error> {
     Err(Error::from_message(
         "no database feature was enabled during compilation",
     ))
 }
-
-#[cfg(any(feature = "database-postgres", feature = "database-sqlite"))]
+#[cfg(all(
+    any(feature = "database-postgres", feature = "database-sqlite"),
+    not(feature = "griddle-builder-run"),
+))]
 fn griddle_store_state(db_url: &str) -> Result<StoreState, Error> {
     let connection_url =
         ConnectionUri::from_str(db_url).map_err(|err| Error::from_message(&format!("{}", err)))?;
@@ -93,6 +118,7 @@ fn griddle_store_state(db_url: &str) -> Result<StoreState, Error> {
     })
 }
 
+#[cfg(not(feature = "griddle-builder-run"))]
 fn batch_submitter(endpoint: Endpoint) -> Arc<dyn BatchSubmitter> {
     if endpoint.is_sawtooth() {
         let connection = SawtoothConnection::new(&endpoint.url());
@@ -102,6 +128,7 @@ fn batch_submitter(endpoint: Endpoint) -> Arc<dyn BatchSubmitter> {
     }
 }
 
+#[cfg(not(feature = "griddle-builder-run"))]
 async fn run() -> Result<(), Error> {
     #[allow(unused_mut)]
     let mut app = App::new("griddle")
@@ -236,10 +263,166 @@ async fn run() -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(not(feature = "griddle-builder-run"))]
 #[actix_web::main]
 async fn main() {
     if let Err(e) = run().await {
         error!("{}", e);
         std::process::exit(1);
+    }
+}
+
+#[cfg(feature = "griddle-builder-run")]
+fn main() {
+    #[allow(unused_mut)]
+    let mut app = App::new("griddle")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author("Contributors to Hyperledger Grid")
+        .about("Grid Integration Component")
+        .arg(
+            Arg::with_name("verbose")
+                .short("v")
+                .multiple(true)
+                .global(true)
+                .help("Log verbosely"),
+        )
+        .arg(
+            Arg::with_name("quiet")
+                .short("q")
+                .long("quiet")
+                .global(true)
+                .conflicts_with("verbose")
+                .help("Do not display output"),
+        )
+        .arg(
+            Arg::with_name("bind")
+                .short("b")
+                .long("bind")
+                .takes_value(true)
+                .help("Connection endpoint for REST API"),
+        )
+        .arg(
+            Arg::with_name("connect")
+                .long("connect")
+                .short("C")
+                .takes_value(true)
+                .help("URL for splinter or sawtooth node to be used by griddle"),
+        )
+        .arg(
+            Arg::with_name("key")
+                .short("k")
+                .long("key")
+                .takes_value(true)
+                .help("Base name for private signing key file"),
+        );
+
+    #[cfg(feature = "proxy")]
+    {
+        app = app.arg(
+            Arg::with_name("forward_url")
+                .long("forward-url")
+                .takes_value(true)
+                .help("URL for Grid node to be used by griddle"),
+        );
+    }
+
+    if let Err(err) = start_griddle(app.get_matches()) {
+        error!("Failed to start Griddle, {}", err);
+        std::process::exit(1);
+    }
+}
+
+#[cfg(feature = "griddle-builder-run")]
+fn start_griddle(matches: ArgMatches) -> Result<(), Error> {
+    let log_level = if matches.is_present("quiet") {
+        log::LevelFilter::Error
+    } else {
+        match matches.occurrences_of("verbose") {
+            0 => log::LevelFilter::Info,
+            1 => log::LevelFilter::Debug,
+            _ => log::LevelFilter::Trace,
+        }
+    };
+    let mut log_spec_builder = LogSpecBuilder::new();
+    log_spec_builder.default(log_level);
+
+    Logger::with(log_spec_builder.build())
+        .format(crate::log_format)
+        .start()
+        .map_err(|_| Error::from_message("Failed to start logger"))?;
+
+    let key = matches
+        .value_of("key")
+        .map(String::from)
+        .or_else(|| env::var("GRIDDLE_KEY_DIR").ok())
+        .or_else(|| get_current_username().and_then(|os_str| os_str.into_string().ok()));
+    let signer = signing::load_signer(key)?;
+
+    let griddle_bind = matches
+        .value_of("bind")
+        .map(String::from)
+        .or_else(|| env::var("GRIDDLE_BIND").ok())
+        .unwrap_or_else(|| "localhost:8000".into());
+
+    let backend_connection = matches
+        .value_of("connect")
+        .map(String::from)
+        .or_else(|| env::var("CONNECT_URL").ok())
+        .unwrap_or_else(|| "http://localhost:8085".into());
+    let backend_endpoint = Endpoint::from(backend_connection.as_ref());
+
+    #[cfg(feature = "proxy")]
+    let forward_url = matches
+        .value_of("forward_url")
+        .map(String::from)
+        .or_else(|| env::var("GRIDDLE_FORWARD_URL").ok())
+        .unwrap_or_else(|| "http://localhost:8080".into());
+
+    #[cfg(feature = "proxy")]
+    let client = ReqwestProxyClient::new(&forward_url)
+        .map_err(|err| Error::from_message(&format!("Unable to create proxy client: {err}")))?;
+
+    let mut griddle_builder = GriddleBuilder::default()
+        .with_rest_api_variant(GriddleRestApiVariant::ActixWeb4)
+        .with_rest_api_endpoint(griddle_bind)
+        .with_dlt_backend(convert_endpoint_to_backend(backend_endpoint))
+        .with_signer(signer);
+
+    #[cfg(feature = "proxy")]
+    {
+        griddle_builder = griddle_builder.with_proxy_client(client.cloned_box());
+    }
+
+    let mut running_griddle = griddle_builder.build()?.run()?;
+
+    // Set the Ctrl-C handler to shut down Griddle
+    let (shutdown_tx, shutdown_rx) = channel();
+    ctrlc::set_handler(move || {
+        if shutdown_tx.send(()).is_err() {
+            // This was the second ctrl-c (as the receiver is dropped after the first one).
+            std::process::exit(0);
+        }
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    // recv that value, ignoring the result.
+    let _ = shutdown_rx.recv();
+    drop(shutdown_rx);
+    info!("Initiating graceful shutdown (press Ctrl+C again to force)");
+
+    running_griddle.signal_shutdown();
+
+    if let Err(err) = running_griddle.wait_for_shutdown() {
+        error!("Unable to cleanly shut down Griddle: {err}");
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "griddle-builder-run")]
+fn convert_endpoint_to_backend(backend_endpoint: Endpoint) -> DLTBackend {
+    match backend_endpoint.backend {
+        Backend::Sawtooth => DLTBackend::Sawtooth,
+        Backend::Splinter => DLTBackend::Splinter,
     }
 }

--- a/griddle/src/main.rs
+++ b/griddle/src/main.rs
@@ -16,6 +16,9 @@
 extern crate log;
 
 mod error;
+#[allow(dead_code)]
+#[cfg(feature = "rest-api")]
+mod rest_api;
 
 use std::env;
 #[cfg(any(feature = "database-postgres", feature = "database-sqlite"))]

--- a/griddle/src/main.rs
+++ b/griddle/src/main.rs
@@ -17,6 +17,9 @@ extern crate log;
 
 mod error;
 #[allow(dead_code)]
+#[cfg(feature = "griddle-builder")]
+pub mod internals;
+#[allow(dead_code)]
 #[cfg(feature = "rest-api")]
 mod rest_api;
 

--- a/griddle/src/main.rs
+++ b/griddle/src/main.rs
@@ -22,6 +22,8 @@ pub mod internals;
 #[allow(dead_code)]
 #[cfg(feature = "rest-api")]
 mod rest_api;
+#[cfg(feature = "key-load")]
+mod signing;
 
 use std::env;
 #[cfg(any(feature = "database-postgres", feature = "database-sqlite"))]

--- a/griddle/src/rest_api/actix_web_4/api.rs
+++ b/griddle/src/rest_api/actix_web_4/api.rs
@@ -1,0 +1,35 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{future::Future, net::SocketAddr, pin::Pin, thread::JoinHandle};
+
+use actix_web::dev::Server;
+
+/// Contains information about the ports to which the REST API is bound.
+#[derive(Debug)]
+pub struct GriddleBindAddress {
+    /// The SocketAddr which defines the bound port.
+    pub addr: SocketAddr,
+
+    /// The scheme (such as http) that is running on this port.
+    pub scheme: String,
+}
+
+/// A running instance of the REST API.
+pub struct GriddleRestApi {
+    bind_addresses: Vec<GriddleBindAddress>,
+    join_handle: Option<JoinHandle<()>>,
+    server: Server,
+    shutdown_future: Option<Pin<Box<dyn Future<Output = ()>>>>,
+}

--- a/griddle/src/rest_api/actix_web_4/api.rs
+++ b/griddle/src/rest_api/actix_web_4/api.rs
@@ -25,12 +25,11 @@ use actix_web::{dev::ServerHandle, middleware, rt::System, web, App, HttpServer}
 use cylinder::Signer;
 use futures_0_3::executor::block_on;
 
-use grid_sdk::{
-    error::InternalError, rest_api::actix_web_4::Endpoint, threading::lifecycle::ShutdownHandle,
-};
+use grid_sdk::{error::InternalError, threading::lifecycle::ShutdownHandle};
 #[cfg(feature = "proxy")]
 use grid_sdk::{proxy::ProxyClient, rest_api::actix_web_4::routes::proxy_get};
 
+use crate::internals::DLTBackend;
 use crate::rest_api::{actix_web_4::GriddleResourceProvider, error::GriddleRestApiServerError};
 
 /// Contains information about the ports to which the REST API is bound.
@@ -62,7 +61,7 @@ impl GriddleRestApi {
         resource_providers: Vec<Box<dyn GriddleResourceProvider>>,
         #[cfg(feature = "proxy")] proxy_client: Box<dyn ProxyClient>,
         signer: Box<dyn Signer>,
-        dlt_backend: Endpoint,
+        dlt_backend: DLTBackend,
     ) -> Result<Self, GriddleRestApiServerError> {
         let providers: Arc<Mutex<Vec<_>>> = Arc::new(Mutex::new(resource_providers));
         let (sender, receiver) = mpsc::channel();

--- a/griddle/src/rest_api/actix_web_4/api.rs
+++ b/griddle/src/rest_api/actix_web_4/api.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Cargill Incorporated
+// Copyright 2018-2022 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{future::Future, net::SocketAddr, pin::Pin, thread::JoinHandle};
+use std::{
+    future::Future,
+    io::Error as IoError,
+    net::SocketAddr,
+    pin::Pin,
+    sync::{mpsc, Arc, Mutex},
+    thread::{self, JoinHandle},
+};
 
-use actix_web::dev::Server;
+use actix_web::{dev::ServerHandle, middleware, rt::System, web, App, HttpServer};
+use cylinder::Signer;
+use futures_0_3::executor::block_on;
+
+use grid_sdk::{
+    error::InternalError, rest_api::actix_web_4::Endpoint, threading::lifecycle::ShutdownHandle,
+};
+#[cfg(feature = "proxy")]
+use grid_sdk::{proxy::ProxyClient, rest_api::actix_web_4::routes::proxy_get};
+
+use crate::rest_api::{actix_web_4::GriddleResourceProvider, error::GriddleRestApiServerError};
 
 /// Contains information about the ports to which the REST API is bound.
 #[derive(Debug)]
@@ -26,10 +43,149 @@ pub struct GriddleBindAddress {
     pub scheme: String,
 }
 
+enum FromThreadMessage {
+    IoError(IoError, String),
+    Running(ServerHandle, Vec<GriddleBindAddress>),
+}
+
 /// A running instance of the REST API.
 pub struct GriddleRestApi {
     bind_addresses: Vec<GriddleBindAddress>,
     join_handle: Option<JoinHandle<()>>,
-    server: Server,
+    server_handle: ServerHandle,
     shutdown_future: Option<Pin<Box<dyn Future<Output = ()>>>>,
+}
+
+impl GriddleRestApi {
+    pub(super) fn new(
+        bind_url: String,
+        resource_providers: Vec<Box<dyn GriddleResourceProvider>>,
+        #[cfg(feature = "proxy")] proxy_client: Box<dyn ProxyClient>,
+        signer: Box<dyn Signer>,
+        dlt_backend: Endpoint,
+    ) -> Result<Self, GriddleRestApiServerError> {
+        let providers: Arc<Mutex<Vec<_>>> = Arc::new(Mutex::new(resource_providers));
+        let (sender, receiver) = mpsc::channel();
+        let join_handle =
+            thread::Builder::new()
+                .name("GriddleRestApi".into())
+                .spawn(move || {
+                    let sys = System::new();
+                    let mut http_server = HttpServer::new(move || {
+                        let app = App::new();
+
+                        let mut app = app
+                            .wrap(middleware::Logger::default())
+                            .app_data(web::Data::new(signer.clone()))
+                            .app_data(web::Data::new(dlt_backend.clone()));
+
+                        for provider in providers.lock().unwrap().iter() {
+                            for resource in provider.resources() {
+                                app = app.service(resource)
+                            }
+                        }
+
+                        #[cfg(feature = "proxy")]
+                        {
+                            app = app
+                                .app_data(web::Data::new(proxy_client.cloned_box()))
+                                .default_service(web::get().to(proxy_get));
+                        }
+
+                        app
+                    });
+
+                    http_server = match http_server.bind(bind_url.clone()) {
+                        Ok(http_server) => http_server,
+                        Err(err1) => {
+                            let error_msg = format!("Bind to \"{}\" failed", bind_url);
+                            if let Err(err2) =
+                                sender.send(FromThreadMessage::IoError(err1, error_msg.clone()))
+                            {
+                                error!("{}", error_msg);
+                                error!("Failed to notify receiver of bind error: {}", err2);
+                            }
+                            return;
+                        }
+                    };
+
+                    let bind_addresses = http_server
+                        .addrs_with_scheme()
+                        .iter()
+                        .map(|(addr, scheme)| GriddleBindAddress {
+                            addr: *addr,
+                            scheme: scheme.to_string(),
+                        })
+                        .collect();
+
+                    let server = http_server.disable_signals().system_exit().run();
+                    let handle = server.handle();
+
+                    // Send the server and bind addresses to the parent thread
+                    if let Err(err) =
+                        sender.send(FromThreadMessage::Running(handle, bind_addresses))
+                    {
+                        error!("Unable to send running message to parent thread: {}", err);
+                        return;
+                    }
+
+                    match sys.block_on(server) {
+                        Ok(()) => info!("Griddle Rest API terminating"),
+                        Err(err) => error!("Griddle REST API unexpectedly exiting: {}", err),
+                    };
+                })?;
+
+        let (server_handle, bind_addresses) = loop {
+            match receiver.recv() {
+                Ok(FromThreadMessage::Running(server_handle, bind_address)) => {
+                    break (server_handle, bind_address);
+                }
+                Ok(FromThreadMessage::IoError(err, error_msg)) => {
+                    Err(GriddleRestApiServerError::StartUpError(format!(
+                        "Failed to start Griddle Rest API: {}: {}",
+                        error_msg, err
+                    )))
+                }
+                Err(err) => Err(GriddleRestApiServerError::StartUpError(format!(
+                    "Error receiving message from Griddle Rest Api thread: {}",
+                    err
+                ))),
+            }?;
+        };
+
+        Ok(GriddleRestApi {
+            bind_addresses,
+            join_handle: Some(join_handle),
+            server_handle,
+            shutdown_future: None,
+        })
+    }
+
+    /// Returns the list of addresses to which this REST API is bound.
+    pub fn bind_addresses(&self) -> &Vec<GriddleBindAddress> {
+        &self.bind_addresses
+    }
+}
+
+impl ShutdownHandle for GriddleRestApi {
+    fn signal_shutdown(&mut self) {
+        self.shutdown_future = Some(Box::pin(self.server_handle.stop(true)));
+    }
+
+    fn wait_for_shutdown(mut self) -> Result<(), InternalError> {
+        match (self.shutdown_future.take(), self.join_handle.take()) {
+            (Some(f), Some(join_handle)) => {
+                block_on(f);
+                join_handle.join().map_err(|_| {
+                    InternalError::with_message(
+                        "GriddleRestApi thread panicked, join() failed".to_string(),
+                    )
+                })?;
+                Ok(())
+            }
+            (_, _) => Err(InternalError::with_message(
+                "Called wait_for_shutdown() prior to signal_shutdown()".to_string(),
+            )),
+        }
+    }
 }

--- a/griddle/src/rest_api/actix_web_4/builder.rs
+++ b/griddle/src/rest_api/actix_web_4/builder.rs
@@ -16,10 +16,11 @@
 
 use cylinder::Signer;
 
+use grid_sdk::error::InvalidArgumentError;
 #[cfg(feature = "proxy")]
 use grid_sdk::proxy::ProxyClient;
-use grid_sdk::{error::InvalidArgumentError, rest_api::actix_web_4::Endpoint};
 
+use crate::internals::DLTBackend;
 use crate::rest_api::{
     actix_web_4::{GriddleResourceProvider, RunnableGriddleRestApi},
     error::GriddleRestApiServerError,
@@ -35,7 +36,7 @@ pub struct GriddleRestApiBuilder {
     #[cfg(feature = "proxy")]
     proxy_client: Option<Box<dyn ProxyClient>>,
     signer: Option<Box<dyn Signer>>,
-    dlt_backend_endpoint: Option<Endpoint>,
+    dlt_backend: Option<DLTBackend>,
 }
 
 impl GriddleRestApiBuilder {
@@ -68,8 +69,8 @@ impl GriddleRestApiBuilder {
         self
     }
 
-    pub fn with_dlt_backend_endpoint(mut self, endpoint: Endpoint) -> Self {
-        self.dlt_backend_endpoint = Some(endpoint);
+    pub fn with_dlt_backend(mut self, backend: DLTBackend) -> Self {
+        self.dlt_backend = Some(backend);
         self
     }
 
@@ -96,9 +97,9 @@ impl GriddleRestApiBuilder {
             ))
         })?;
 
-        let dlt_backend_endpoint = self.dlt_backend_endpoint.ok_or_else(|| {
+        let dlt_backend = self.dlt_backend.ok_or_else(|| {
             GriddleRestApiServerError::InvalidArgument(InvalidArgumentError::new(
-                "dlt_backend_endpoint".to_string(),
+                "dlt_backend".to_string(),
                 "Missing required field".to_string(),
             ))
         })?;
@@ -109,7 +110,7 @@ impl GriddleRestApiBuilder {
             #[cfg(feature = "proxy")]
             proxy_client,
             signer,
-            dlt_backend_endpoint,
+            dlt_backend,
         })
     }
 }

--- a/griddle/src/rest_api/actix_web_4/builder.rs
+++ b/griddle/src/rest_api/actix_web_4/builder.rs
@@ -1,0 +1,115 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains the implementation of `RestApiBuilder`
+
+use cylinder::Signer;
+
+#[cfg(feature = "proxy")]
+use grid_sdk::proxy::ProxyClient;
+use grid_sdk::{error::InvalidArgumentError, rest_api::actix_web_4::Endpoint};
+
+use crate::rest_api::{
+    actix_web_4::{GriddleResourceProvider, RunnableGriddleRestApi},
+    error::GriddleRestApiServerError,
+};
+
+/// Builds a `RunnableRestApi`.
+///
+/// This builder's primary function is to create the runnable REST API in a valid state.
+#[derive(Default)]
+pub struct GriddleRestApiBuilder {
+    resource_providers: Vec<Box<dyn GriddleResourceProvider>>,
+    bind: Option<String>,
+    #[cfg(feature = "proxy")]
+    proxy_client: Option<Box<dyn ProxyClient>>,
+    signer: Option<Box<dyn Signer>>,
+    dlt_backend_endpoint: Option<Endpoint>,
+}
+
+impl GriddleRestApiBuilder {
+    /// Construct a new `RestApiBuilder`
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_resource_provider(
+        mut self,
+        resource_provider: Box<dyn GriddleResourceProvider>,
+    ) -> Self {
+        self.resource_providers.push(resource_provider);
+        self
+    }
+
+    pub fn with_bind(mut self, value: String) -> Self {
+        self.bind = Some(value);
+        self
+    }
+
+    #[cfg(feature = "proxy")]
+    pub fn with_proxy_client(mut self, client: Box<dyn ProxyClient>) -> Self {
+        self.proxy_client = Some(client);
+        self
+    }
+
+    pub fn with_signer(mut self, signer: Box<dyn Signer>) -> Self {
+        self.signer = Some(signer);
+        self
+    }
+
+    pub fn with_dlt_backend_endpoint(mut self, endpoint: Endpoint) -> Self {
+        self.dlt_backend_endpoint = Some(endpoint);
+        self
+    }
+
+    pub fn build(self) -> Result<RunnableGriddleRestApi, GriddleRestApiServerError> {
+        let bind = self.bind.ok_or_else(|| {
+            GriddleRestApiServerError::InvalidArgument(InvalidArgumentError::new(
+                "bind".to_string(),
+                "Missing required field".to_string(),
+            ))
+        })?;
+
+        #[cfg(feature = "proxy")]
+        let proxy_client = self.proxy_client.ok_or_else(|| {
+            GriddleRestApiServerError::InvalidArgument(InvalidArgumentError::new(
+                "proxy_client".to_string(),
+                "Missing required field".to_string(),
+            ))
+        })?;
+
+        let signer = self.signer.ok_or_else(|| {
+            GriddleRestApiServerError::InvalidArgument(InvalidArgumentError::new(
+                "signer".to_string(),
+                "Missing required field".to_string(),
+            ))
+        })?;
+
+        let dlt_backend_endpoint = self.dlt_backend_endpoint.ok_or_else(|| {
+            GriddleRestApiServerError::InvalidArgument(InvalidArgumentError::new(
+                "dlt_backend_endpoint".to_string(),
+                "Missing required field".to_string(),
+            ))
+        })?;
+
+        Ok(RunnableGriddleRestApi {
+            bind,
+            resource_providers: self.resource_providers,
+            #[cfg(feature = "proxy")]
+            proxy_client,
+            signer,
+            dlt_backend_endpoint,
+        })
+    }
+}

--- a/griddle/src/rest_api/actix_web_4/mod.rs
+++ b/griddle/src/rest_api/actix_web_4/mod.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod builder;
+mod runnable;
+
+pub use builder::GriddleRestApiBuilder;
+pub use runnable::RunnableGriddleRestApi;
+
 use actix_web::Resource;
 
 /// A `ResourceProvider` provides a list of resources.

--- a/griddle/src/rest_api/actix_web_4/mod.rs
+++ b/griddle/src/rest_api/actix_web_4/mod.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod api;
 mod builder;
 mod runnable;
 
+pub use api::GriddleRestApi;
 pub use builder::GriddleRestApiBuilder;
 pub use runnable::RunnableGriddleRestApi;
 

--- a/griddle/src/rest_api/actix_web_4/mod.rs
+++ b/griddle/src/rest_api/actix_web_4/mod.rs
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "rest-api-actix-web-4")]
-pub mod actix_web_4;
-pub mod error;
+use actix_web::Resource;
+
+/// A `ResourceProvider` provides a list of resources.
+///
+/// This trait serves as a `Resource` factory, which allows dynamically building a REST API at
+/// runtime.
+pub trait GriddleResourceProvider: Send {
+    /// Returns a list of Actix `Resource`s.
+    fn resources(&self) -> Vec<Resource>;
+}

--- a/griddle/src/rest_api/actix_web_4/runnable.rs
+++ b/griddle/src/rest_api/actix_web_4/runnable.rs
@@ -19,7 +19,10 @@ use cylinder::Signer;
 use grid_sdk::proxy::ProxyClient;
 use grid_sdk::rest_api::actix_web_4::Endpoint;
 
-use crate::rest_api::actix_web_4::GriddleResourceProvider;
+use crate::rest_api::{
+    actix_web_4::{GriddleResourceProvider, GriddleRestApi},
+    error::GriddleRestApiServerError,
+};
 
 /// A configured REST API which may best started with `run` function.
 pub struct RunnableGriddleRestApi {
@@ -29,4 +32,15 @@ pub struct RunnableGriddleRestApi {
     pub(super) proxy_client: Box<dyn ProxyClient>,
     pub(super) signer: Box<dyn Signer>,
     pub(super) dlt_backend_endpoint: Endpoint,
+}
+
+impl RunnableGriddleRestApi {
+    /// Start the REST API and finish any necessary setup such as binding to ports, adding resource
+    /// endpoints, etc.
+    pub fn run(self) -> Result<GriddleRestApi, GriddleRestApiServerError> {
+        let RunnableGriddleRestApi { .. } = self;
+
+        // Build the running Griddle rest API
+        unimplemented!();
+    }
 }

--- a/griddle/src/rest_api/actix_web_4/runnable.rs
+++ b/griddle/src/rest_api/actix_web_4/runnable.rs
@@ -17,8 +17,8 @@
 use cylinder::Signer;
 #[cfg(feature = "proxy")]
 use grid_sdk::proxy::ProxyClient;
-use grid_sdk::rest_api::actix_web_4::Endpoint;
 
+use crate::internals::DLTBackend;
 use crate::rest_api::{
     actix_web_4::{GriddleResourceProvider, GriddleRestApi},
     error::GriddleRestApiServerError,
@@ -31,7 +31,7 @@ pub struct RunnableGriddleRestApi {
     #[cfg(feature = "proxy")]
     pub(super) proxy_client: Box<dyn ProxyClient>,
     pub(super) signer: Box<dyn Signer>,
-    pub(super) dlt_backend_endpoint: Endpoint,
+    pub(super) dlt_backend: DLTBackend,
 }
 
 impl RunnableGriddleRestApi {
@@ -44,7 +44,7 @@ impl RunnableGriddleRestApi {
             #[cfg(feature = "proxy")]
             proxy_client,
             signer,
-            dlt_backend_endpoint,
+            dlt_backend,
         } = self;
 
         GriddleRestApi::new(
@@ -53,7 +53,7 @@ impl RunnableGriddleRestApi {
             #[cfg(feature = "proxy")]
             proxy_client,
             signer,
-            dlt_backend_endpoint,
+            dlt_backend,
         )
     }
 }

--- a/griddle/src/rest_api/actix_web_4/runnable.rs
+++ b/griddle/src/rest_api/actix_web_4/runnable.rs
@@ -1,0 +1,32 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains the implementation of `RunnableRestApi`
+
+use cylinder::Signer;
+#[cfg(feature = "proxy")]
+use grid_sdk::proxy::ProxyClient;
+use grid_sdk::rest_api::actix_web_4::Endpoint;
+
+use crate::rest_api::actix_web_4::GriddleResourceProvider;
+
+/// A configured REST API which may best started with `run` function.
+pub struct RunnableGriddleRestApi {
+    pub(super) resource_providers: Vec<Box<dyn GriddleResourceProvider>>,
+    pub(super) bind: String,
+    #[cfg(feature = "proxy")]
+    pub(super) proxy_client: Box<dyn ProxyClient>,
+    pub(super) signer: Box<dyn Signer>,
+    pub(super) dlt_backend_endpoint: Endpoint,
+}

--- a/griddle/src/rest_api/actix_web_4/runnable.rs
+++ b/griddle/src/rest_api/actix_web_4/runnable.rs
@@ -38,9 +38,22 @@ impl RunnableGriddleRestApi {
     /// Start the REST API and finish any necessary setup such as binding to ports, adding resource
     /// endpoints, etc.
     pub fn run(self) -> Result<GriddleRestApi, GriddleRestApiServerError> {
-        let RunnableGriddleRestApi { .. } = self;
+        let RunnableGriddleRestApi {
+            resource_providers,
+            bind,
+            #[cfg(feature = "proxy")]
+            proxy_client,
+            signer,
+            dlt_backend_endpoint,
+        } = self;
 
-        // Build the running Griddle rest API
-        unimplemented!();
+        GriddleRestApi::new(
+            bind,
+            resource_providers,
+            #[cfg(feature = "proxy")]
+            proxy_client,
+            signer,
+            dlt_backend_endpoint,
+        )
     }
 }

--- a/griddle/src/rest_api/error.rs
+++ b/griddle/src/rest_api/error.rs
@@ -1,0 +1,62 @@
+// Copyright 2018-2022 Cargill, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use grid_sdk::error::{InternalError, InvalidArgumentError, InvalidStateError};
+
+#[derive(Debug)]
+pub enum GriddleRestApiServerError {
+    BindError(String),
+    StartUpError(String),
+    StdError(std::io::Error),
+    InternalError(InternalError),
+    InvalidArgument(InvalidArgumentError),
+    InvalidState(InvalidStateError),
+}
+
+impl From<std::io::Error> for GriddleRestApiServerError {
+    fn from(err: std::io::Error) -> GriddleRestApiServerError {
+        GriddleRestApiServerError::StdError(err)
+    }
+}
+
+impl Error for GriddleRestApiServerError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            GriddleRestApiServerError::BindError(_) => None,
+            GriddleRestApiServerError::StartUpError(_) => None,
+            GriddleRestApiServerError::StdError(err) => Some(err),
+            GriddleRestApiServerError::InternalError(err) => Some(err),
+            GriddleRestApiServerError::InvalidArgument(err) => Some(err),
+            GriddleRestApiServerError::InvalidState(err) => Some(err),
+        }
+    }
+}
+
+impl fmt::Display for GriddleRestApiServerError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            GriddleRestApiServerError::BindError(e) => write!(f, "Griddle Bind Error: {}", e),
+            GriddleRestApiServerError::StartUpError(e) => {
+                write!(f, "Griddle Start-up Error: {}", e)
+            }
+            GriddleRestApiServerError::StdError(e) => write!(f, "Std Error in Griddle: {}", e),
+            GriddleRestApiServerError::InternalError(e) => write!(f, "{}", e),
+            GriddleRestApiServerError::InvalidArgument(e) => write!(f, "{}", e),
+            GriddleRestApiServerError::InvalidState(e) => write!(f, "{}", e),
+        }
+    }
+}

--- a/griddle/src/rest_api/mod.rs
+++ b/griddle/src/rest_api/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod error;

--- a/griddle/src/signing.rs
+++ b/griddle/src/signing.rs
@@ -1,0 +1,88 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{env, path::Path, path::PathBuf};
+
+use cylinder::{
+    current_user_key_name, current_user_search_path, load_key, load_key_from_path,
+    secp256k1::Secp256k1Context, Context, PrivateKey, Signer,
+};
+
+use crate::error::Error;
+
+// If the `CYLINDER_PATH` environment variable is not set, add `$HOME/.grid/keys`
+// to the vector of paths to search. This is for backwards compatibility.
+fn grid_user_search_path() -> Vec<PathBuf> {
+    match env::var("CYLINDER_PATH") {
+        Ok(_) => current_user_search_path(),
+        Err(_) => {
+            let mut grid_path = match dirs::home_dir() {
+                Some(dir) => dir,
+                None => Path::new(".").to_path_buf(),
+            };
+            grid_path.push(".grid");
+            grid_path.push("keys");
+            let mut paths = current_user_search_path();
+            paths.push(grid_path);
+            paths
+        }
+    }
+}
+
+fn load_private_key(key_name: Option<String>) -> Result<PrivateKey, Error> {
+    let private_key = if let Some(key_name) = key_name {
+        if key_name.contains('/') {
+            load_key_from_path(Path::new(&*key_name))
+                .map_err(|err| Error::from_message(&err.to_string()))?
+        } else {
+            let path = grid_user_search_path();
+            load_key(&*key_name, &path)
+                .map_err(|err| Error::from_message(&err.to_string()))?
+                .ok_or_else(|| {
+                    Error::from_message({
+                        &format!(
+                            "No signing key found in {}. Either specify the --key argument or \
+                            generate the default key via grid keygen",
+                            path.iter()
+                                .map(|path| path.as_path().display().to_string())
+                                .collect::<Vec<String>>()
+                                .join(":")
+                        )
+                    })
+                })?
+        }
+    } else {
+        let path = grid_user_search_path();
+        load_key(&current_user_key_name(), &path)
+            .map_err(|err| Error::from_message(&err.to_string()))?
+            .ok_or_else(|| {
+                Error::from_message({
+                    &format!(
+                        "No signing key found in {}. Either specify the --key argument or \
+                        generate the default key via grid keygen",
+                        path.iter()
+                            .map(|path| path.as_path().display().to_string())
+                            .collect::<Vec<String>>()
+                            .join(":")
+                    )
+                })
+            })?
+    };
+
+    Ok(private_key)
+}
+
+pub fn load_signer(key_name: Option<String>) -> Result<Box<dyn Signer>, Error> {
+    Ok(Secp256k1Context::new().new_signer(load_private_key(key_name)?))
+}

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -136,7 +136,8 @@ experimental = [
     "rest-api-resources-batch-tracking",
     "rest-api-resources-submit",
     "rest-api-resources-track-and-trace",
-    "track-and-trace"
+    "track-and-trace",
+    "lifecycle"
 ]
 
 backend = ["base64", "futures", "url"]
@@ -209,3 +210,4 @@ rest-api-resources-submit = ["batch-store", "cylinder", "rest-api-resources", "s
 rest-api-resources-track-and-trace = ["rest-api-resources", "track-and-trace"]
 sqlite = ["chrono", "diesel/sqlite", "diesel_migrations", "log"]
 workflow = []
+lifecycle = []

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -67,6 +67,8 @@ pub mod rest_api;
 pub mod schema;
 pub mod scope_id;
 pub mod store;
+#[cfg(feature = "lifecycle")]
+pub mod threading;
 #[cfg(feature = "track-and-trace")]
 pub mod track_and_trace;
 #[cfg(feature = "workflow")]

--- a/sdk/src/threading/lifecycle.rs
+++ b/sdk/src/threading/lifecycle.rs
@@ -1,0 +1,43 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Traits and functions related to the lifecycle of components.
+
+use crate::error::InternalError;
+
+/// `ShutdownHandle` is a trait which defines an interface for shutting down components which have
+/// threads. It may also be used on non-threaded components which require cleanup at the end of
+/// their lifecycle.
+///
+/// Two functions are defined which correspond to a structured two-phase shutdown sequence. The
+/// first is `signal_shutdown` which instructs a component to begin the process of shutting down.
+/// The second is `wait_for_shutdown` which will wait for shutdown to be complete; this typically
+/// involves joining threads.
+///
+/// If multiple components are being shutdown, call `signal_shutdown` on all componets that can
+/// safely shutdown in parallel, then call `wait_for_shutdown` on all of the components. The length
+/// of time spent shutting down will be approximately the time of the slowest component.
+pub trait ShutdownHandle {
+    /// Instructs the component to begin shutting down.
+    ///
+    /// For components with threads, this should break out of any loops and ready the threads for
+    /// being joined.
+    fn signal_shutdown(&mut self);
+
+    /// Waits until the the component has completely shutdown.
+    ///
+    /// For components with threads, the threads should be joined during the call to
+    /// `wait_for_shutdown`.
+    fn wait_for_shutdown(self) -> Result<(), InternalError>;
+}

--- a/sdk/src/threading/mod.rs
+++ b/sdk/src/threading/mod.rs
@@ -1,0 +1,16 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module will contain components that will be used to support different threading models
+pub mod lifecycle;


### PR DESCRIPTION
Updates Griddle to be built and started using the builder pattern, employed throughout Grid and Splinter. This also updates the main function used to start Griddle, behind an experimental `griddle-builder-run` feature, to use the builder for set-up and tear-down. This also updates a few of the arguments passed to Griddle and removes any components that are not planned on being used for Grid v0.4 (i.e., the previous iterations of the batch processor/submitter, database access).


For testing:
1. Start the griddle docker-compose file: 
```
$ docker-compose -f examples/griddle/docker-compose-splinter.yaml up
```

2. Use the 0.4 documentation to create a splinter circuit, create an organization using the Grid container once the circuit is set-up. 

3. Attempt to hit the endpoint `http://localhost:8000/agent?service-id=01234-ABCDE::gsAA` and observe the response you see. You should see a list that contains your `alpha-agent` (or whatever key name used to submit Grid txns) with paging info and a 200 response. You should also see logs from griddle-alpha-Xs and gridd-alpha with the same responses. If you attempt to hit the endpoint `http://localhost:8080/agent?service_id=01234-ABCDE::gsAA`, you should see the same response received from griddle. This validates the rest api is running, and proxying requests as expected. 

4. Ctrl-c to shut down, observe griddle take its last breath. 