### PR TITLE
Fix clippy lint introduced in 1.62.0

### DIFF
--- a/cli/src/actions/agent.rs
+++ b/cli/src/actions/agent.rs
@@ -184,7 +184,8 @@ fn print_csv(column_names: Vec<&str>, row_values: Vec<Vec<String>>) {
     // print header row
     let mut header_row = "".to_owned();
     for column in &column_names {
-        header_row += &format!("\"{}\",", column);
+        let csv_cell = format!("\"{}\",", column);
+        header_row.push_str(&csv_cell);
     }
     header_row.pop();
     println!("{}", header_row);
@@ -193,7 +194,8 @@ fn print_csv(column_names: Vec<&str>, row_values: Vec<Vec<String>>) {
     for row in row_values {
         let mut print_row = "".to_owned();
         for cell in row.iter().take(column_names.len()) {
-            print_row += &format!("\"{}\",", cell);
+            let csv_cell = format!("\"{}\",", cell);
+            print_row.push_str(&csv_cell);
         }
         print_row.pop();
         println!("{}", print_row);
@@ -212,7 +214,8 @@ fn print_human_readable(column_names: Vec<&str>, row_values: Vec<Vec<String>>) {
     // print header row
     let mut header_row = "".to_owned();
     for i in 0..column_names.len() {
-        header_row += &format!("{:width$} ", column_names[i], width = widths[i]);
+        header_row.push_str(column_names[i]);
+        header_row.push_str(&" ".repeat(widths[i]));
     }
     println!("{}", header_row);
 
@@ -220,7 +223,8 @@ fn print_human_readable(column_names: Vec<&str>, row_values: Vec<Vec<String>>) {
     for row in row_values {
         let mut print_row = "".to_owned();
         for i in 0..column_names.len() {
-            print_row += &format!("{:width$} ", row[i], width = widths[i]);
+            print_row.push_str(&row[i]);
+            print_row.push_str(&" ".repeat(widths[i]));
         }
         println!("{}", print_row);
     }

--- a/cli/src/actions/organization.rs
+++ b/cli/src/actions/organization.rs
@@ -141,7 +141,8 @@ fn print_csv(column_names: Vec<String>, row_values: Vec<Vec<String>>) {
     // print header row
     let mut header_row = "".to_owned();
     for column in &column_names {
-        header_row += &format!("\"{}\",", column);
+        let cell = format!("\"{}\",", column);
+        header_row.push_str(&cell);
     }
     header_row.pop();
     println!("{}", header_row);
@@ -150,7 +151,8 @@ fn print_csv(column_names: Vec<String>, row_values: Vec<Vec<String>>) {
     for row in row_values {
         let mut print_row = "".to_owned();
         for cell in row.iter().take(column_names.len()) {
-            print_row += &format!("\"{}\",", cell);
+            let cell = format!("\"{}\",", cell);
+            print_row.push_str(&cell);
         }
         print_row.pop();
         println!("{}", print_row);
@@ -169,7 +171,8 @@ fn print_human_readable(column_names: Vec<String>, row_values: Vec<Vec<String>>)
     // print header row
     let mut header_row = "".to_owned();
     for i in 0..column_names.len() {
-        header_row += &format!("{:width$} ", column_names[i], width = widths[i]);
+        header_row.push_str(&column_names[i]);
+        header_row.push_str(&" ".repeat(widths[i]));
     }
     println!("{}", header_row);
 
@@ -177,7 +180,8 @@ fn print_human_readable(column_names: Vec<String>, row_values: Vec<Vec<String>>)
     for row in row_values {
         let mut print_row = "".to_owned();
         for i in 0..column_names.len() {
-            print_row += &format!("{:width$} ", row[i], width = widths[i]);
+            print_row.push_str(&row[i]);
+            print_row.push_str(&" ".repeat(widths[i]));
         }
         println!("{}", print_row);
     }
@@ -198,7 +202,8 @@ pub fn do_show_organization(
 fn print_organization(org: PikeOrganization) {
     let mut display_string = format!("Organization ID: {}\nName: {}\n", &org.org_id, &org.name);
     if let Some(service_id) = &org.service_id {
-        display_string += &format!("Service ID: {}\n", service_id);
+        let service_id_str = format!("Service ID: {}\n", service_id);
+        display_string.push_str(&service_id_str);
     }
     display_string += "Locations:";
     let locations = if org.locations.is_empty() {

--- a/cli/src/actions/purchase_order.rs
+++ b/cli/src/actions/purchase_order.rs
@@ -766,7 +766,8 @@ fn print_table<T: TableDisplay>(
     // print header row
     let mut header_row = "".to_owned();
     for i in 0..T::header().len() {
-        header_row += &format!("{:width$} ", T::header()[i], width = T::widths()[i]);
+        header_row.push_str(T::header()[i]);
+        header_row.push_str(&" ".repeat(T::widths()[i]));
     }
     println!("{}", header_row);
 
@@ -776,7 +777,8 @@ fn print_table<T: TableDisplay>(
             Ok(res) => {
                 let mut print_row = "".to_owned();
                 for i in 0..T::header().len() {
-                    print_row += &format!("{:width$} ", res.details()[i], width = T::widths()[i]);
+                    print_row.push_str(&res.details()[i]);
+                    print_row.push_str(&" ".repeat(T::widths()[i]));
                 }
                 println!("{}", print_row);
             }

--- a/sdk/src/client/reqwest/mod.rs
+++ b/sdk/src/client/reqwest/mod.rs
@@ -332,11 +332,13 @@ pub fn post_batches(
 
     let mut wait_time = wait;
 
-    let mut url = format!("{}/batches", url);
-
-    if let Some(service_id) = service_id {
-        url.push_str(&format!("?service_id={}", service_id));
-    }
+    let url = {
+        if let Some(service_id) = service_id {
+            format!("{url}/batches?service_id={service_id}")
+        } else {
+            format!("{url}/batches")
+        }
+    };
 
     let client = BlockingClient::new();
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::extra_unused_lifetimes)]
+
 // Copyright 2019 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This makes several changes necessary to remove all Clippy lint warnings introduced in the 1.62.0 rust release. The two main changes are: 

1. Allowing unused lifetimes in Diesel macros. 
2. Remove unnecessary allocations made when appending to an existing string