### PR TITLE
Add REST API module to griddle

### DIFF
--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -63,6 +63,7 @@ experimental = [
     "database-sqlite",
     "proxy",
     "rest-api",
+    "rest-api-actix-web-4"
 ]
 
 config = []
@@ -81,4 +82,8 @@ rest-api = [
   "cylinder",
   "futures-0-3",
   "grid-sdk/lifecycle",
+]
+rest-api-actix-web-4 = [
+  "rest-api",
+  "grid-sdk/rest-api-actix-web-4",
 ]

--- a/griddle/Cargo.toml
+++ b/griddle/Cargo.toml
@@ -23,13 +23,23 @@ description = "Grid integration component"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = { version = "3", default-features = false }
+actix-web = { version = "4", default-features = false }
 clap = "2.33.3"
+cylinder = { version = "0.2.2", features = ["key-load", "jwt"], optional = true}
 diesel = { version = "1.0", features = ["r2d2"], optional = true }
 flexi_logger = "0.22"
-grid-sdk = { path = "../sdk", features = ["rest-api-actix-web-4", "rest-api-actix-web-4-run", "batch-processor"] }
+futures-0-3 = { package = "futures", version = "0.3", optional = true }
 log = "0.4"
 users = "0.11"
+
+[dependencies.grid-sdk]
+path = "../sdk"
+features = [
+  "rest-api-actix-web-4",
+  "rest-api-actix-web-4-run",
+  "batch-processor",
+  "lifecycle"
+]
 
 [features]
 default = []
@@ -52,6 +62,7 @@ experimental = [
     "database-postgres",
     "database-sqlite",
     "proxy",
+    "rest-api",
 ]
 
 config = []
@@ -65,4 +76,9 @@ proxy = [
   "grid-sdk/proxy-run",
   "grid-sdk/proxy-client-reqwest",
   "grid-sdk/rest-api-endpoint-proxy",
+]
+rest-api = [
+  "cylinder",
+  "futures-0-3",
+  "grid-sdk/lifecycle",
 ]

--- a/griddle/src/main.rs
+++ b/griddle/src/main.rs
@@ -19,6 +19,9 @@ extern crate log;
 #[cfg(feature = "config")]
 mod config;
 mod error;
+#[allow(dead_code)]
+#[cfg(feature = "rest-api")]
+mod rest_api;
 
 use std::env;
 #[cfg(any(feature = "database-postgres", feature = "database-sqlite"))]

--- a/griddle/src/rest_api/actix_web_4/api.rs
+++ b/griddle/src/rest_api/actix_web_4/api.rs
@@ -1,0 +1,44 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation for the running of the REST API, the `GriddleRestApi` handles the startup and
+//! shutdown of Griddle's REST API.
+
+use std::{future::Future, net::SocketAddr, pin::Pin, thread::JoinHandle};
+
+use actix_web::dev::ServerHandle;
+
+/// Contains information about the ports to which the REST API is bound.
+#[derive(Debug)]
+pub struct GriddleBindAddress {
+    /// The SocketAddr which defines the bound port.
+    pub addr: SocketAddr,
+
+    /// The scheme (such as http) that is running on this port.
+    pub scheme: PortScheme,
+}
+
+/// Indicates the scheme used by a port
+#[derive(Debug)]
+pub enum PortScheme {
+    Http,
+}
+
+/// A running instance of the Griddle REST API.
+pub struct GriddleRestApi {
+    bind_addresses: Vec<GriddleBindAddress>,
+    join_handle: Option<JoinHandle<()>>,
+    server_handle: ServerHandle,
+    shutdown_future: Option<Pin<Box<dyn Future<Output = ()>>>>,
+}

--- a/griddle/src/rest_api/actix_web_4/api.rs
+++ b/griddle/src/rest_api/actix_web_4/api.rs
@@ -15,9 +15,24 @@
 //! Implementation for the running of the REST API, the `GriddleRestApi` handles the startup and
 //! shutdown of Griddle's REST API.
 
-use std::{future::Future, net::SocketAddr, pin::Pin, thread::JoinHandle};
+use std::{
+    future::Future,
+    io::Error as IoError,
+    net::SocketAddr,
+    pin::Pin,
+    sync::{mpsc, Arc, Mutex},
+    thread::{self, JoinHandle},
+};
 
-use actix_web::dev::ServerHandle;
+use actix_web::{dev::ServerHandle, middleware, rt::System, web, App, HttpServer};
+use cylinder::Signer;
+use futures_0_3::executor::block_on;
+
+use grid_sdk::{error::InternalError, threading::lifecycle::ShutdownHandle};
+#[cfg(feature = "proxy")]
+use grid_sdk::{proxy::ProxyClient, rest_api::actix_web_4::routes::proxy_get};
+
+use crate::rest_api::{actix_web_4::GriddleResourceProvider, GriddleRestApiServerError, Scope};
 
 /// Contains information about the ports to which the REST API is bound.
 #[derive(Debug)]
@@ -35,10 +50,160 @@ pub enum PortScheme {
     Http,
 }
 
+// Convert the scheme string slice from Actix's `HttpServer` into a `PortScheme` variant.
+// Defaults to 'PortScheme::Http'.
+impl From<&str> for PortScheme {
+    fn from(scheme: &str) -> Self {
+        match scheme.to_lowercase().as_str() {
+            "http" => PortScheme::Http,
+            _ => PortScheme::Http,
+        }
+    }
+}
+
+enum FromThreadMessage {
+    IoError(IoError, String),
+    Running(ServerHandle, Vec<GriddleBindAddress>),
+}
+
 /// A running instance of the Griddle REST API.
 pub struct GriddleRestApi {
     bind_addresses: Vec<GriddleBindAddress>,
     join_handle: Option<JoinHandle<()>>,
     server_handle: ServerHandle,
     shutdown_future: Option<Pin<Box<dyn Future<Output = ()>>>>,
+}
+
+impl GriddleRestApi {
+    pub(super) fn new(
+        bind_url: String,
+        resource_providers: Vec<Box<dyn GriddleResourceProvider>>,
+        #[cfg(feature = "proxy")] proxy_client: Box<dyn ProxyClient>,
+        signer: Box<dyn Signer>,
+        scope: Scope,
+    ) -> Result<Self, GriddleRestApiServerError> {
+        let providers: Arc<Mutex<Vec<_>>> = Arc::new(Mutex::new(resource_providers));
+        let (sender, receiver) = mpsc::channel();
+        let join_handle =
+            thread::Builder::new()
+                .name("GriddleRestApi".into())
+                .spawn(move || {
+                    let sys = System::new();
+                    let mut http_server = HttpServer::new(move || {
+                        let app = App::new();
+
+                        let mut app = app
+                            .wrap(middleware::Logger::default())
+                            .app_data(web::Data::new(signer.clone()))
+                            .app_data(web::Data::new(scope.clone()));
+
+                        for provider in providers.lock().unwrap().iter() {
+                            for resource in provider.resources() {
+                                app = app.service(resource)
+                            }
+                        }
+
+                        #[cfg(feature = "proxy")]
+                        {
+                            app = app
+                                .app_data(web::Data::new(proxy_client.cloned_box()))
+                                .default_service(web::get().to(proxy_get));
+                        }
+
+                        app
+                    });
+
+                    http_server = match http_server.bind(bind_url.clone()) {
+                        Ok(http_server) => http_server,
+                        Err(err1) => {
+                            let error_msg = format!("Bind to \"{}\" failed", bind_url);
+                            if let Err(err2) =
+                                sender.send(FromThreadMessage::IoError(err1, error_msg.clone()))
+                            {
+                                error!("{}", error_msg);
+                                error!("Failed to notify receiver of bind error: {}", err2);
+                            }
+                            return;
+                        }
+                    };
+
+                    let bind_addresses = http_server
+                        .addrs_with_scheme()
+                        .iter()
+                        .map(|(addr, scheme)| GriddleBindAddress {
+                            addr: *addr,
+                            scheme: PortScheme::from(*scheme),
+                        })
+                        .collect();
+
+                    let server = http_server.disable_signals().system_exit().run();
+                    let handle = server.handle();
+
+                    // Send the server and bind addresses to the parent thread
+                    if let Err(err) =
+                        sender.send(FromThreadMessage::Running(handle, bind_addresses))
+                    {
+                        error!("Unable to send running message to parent thread: {}", err);
+                        return;
+                    }
+
+                    match sys.block_on(server) {
+                        Ok(()) => info!("Griddle Rest API terminating"),
+                        Err(err) => error!("Griddle REST API unexpectedly exiting: {}", err),
+                    };
+                })?;
+
+        let (server_handle, bind_addresses) = loop {
+            match receiver.recv() {
+                Ok(FromThreadMessage::Running(server_handle, bind_address)) => {
+                    break (server_handle, bind_address);
+                }
+                Ok(FromThreadMessage::IoError(err, error_msg)) => {
+                    Err(GriddleRestApiServerError::StartUpError(format!(
+                        "Failed to start Griddle Rest API: {}: {}",
+                        error_msg, err
+                    )))
+                }
+                Err(err) => Err(GriddleRestApiServerError::StartUpError(format!(
+                    "Error receiving message from Griddle Rest Api thread: {}",
+                    err
+                ))),
+            }?;
+        };
+
+        Ok(GriddleRestApi {
+            bind_addresses,
+            join_handle: Some(join_handle),
+            server_handle,
+            shutdown_future: None,
+        })
+    }
+
+    /// Returns the list of addresses to which this REST API is bound.
+    pub fn bind_addresses(&self) -> &Vec<GriddleBindAddress> {
+        &self.bind_addresses
+    }
+}
+
+impl ShutdownHandle for GriddleRestApi {
+    fn signal_shutdown(&mut self) {
+        self.shutdown_future = Some(Box::pin(self.server_handle.stop(true)));
+    }
+
+    fn wait_for_shutdown(mut self) -> Result<(), InternalError> {
+        match (self.shutdown_future.take(), self.join_handle.take()) {
+            (Some(f), Some(join_handle)) => {
+                block_on(f);
+                join_handle.join().map_err(|_| {
+                    InternalError::with_message(
+                        "GriddleRestApi thread panicked, join() failed".to_string(),
+                    )
+                })?;
+                Ok(())
+            }
+            (_, _) => Err(InternalError::with_message(
+                "Called wait_for_shutdown() prior to signal_shutdown()".to_string(),
+            )),
+        }
+    }
 }

--- a/griddle/src/rest_api/actix_web_4/builder.rs
+++ b/griddle/src/rest_api/actix_web_4/builder.rs
@@ -1,0 +1,115 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains the implementation of `GriddleRestApiBuilder`
+
+use cylinder::Signer;
+
+use grid_sdk::error::InvalidArgumentError;
+#[cfg(feature = "proxy")]
+use grid_sdk::proxy::ProxyClient;
+
+use crate::rest_api::{
+    actix_web_4::{GriddleResourceProvider, RunnableGriddleRestApi},
+    GriddleRestApiServerError, Scope,
+};
+
+/// Builds a `RunnableGriddleRestApi`.
+///
+/// This builder's primary function is to create the runnable Griddle REST API in a valid state.
+#[derive(Default)]
+pub struct GriddleRestApiBuilder {
+    resource_providers: Vec<Box<dyn GriddleResourceProvider>>,
+    bind: Option<String>,
+    #[cfg(feature = "proxy")]
+    proxy_client: Option<Box<dyn ProxyClient>>,
+    signer: Option<Box<dyn Signer>>,
+    scope: Option<Scope>,
+}
+
+impl GriddleRestApiBuilder {
+    /// Construct a new `GriddleRestApiBuilder`
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_resource_provider(
+        mut self,
+        resource_provider: Box<dyn GriddleResourceProvider>,
+    ) -> Self {
+        self.resource_providers.push(resource_provider);
+        self
+    }
+
+    pub fn with_bind(mut self, value: String) -> Self {
+        self.bind = Some(value);
+        self
+    }
+
+    #[cfg(feature = "proxy")]
+    pub fn with_proxy_client(mut self, client: Box<dyn ProxyClient>) -> Self {
+        self.proxy_client = Some(client);
+        self
+    }
+
+    pub fn with_signer(mut self, signer: Box<dyn Signer>) -> Self {
+        self.signer = Some(signer);
+        self
+    }
+
+    pub fn with_scope(mut self, service_scope: Scope) -> Self {
+        self.scope = Some(service_scope);
+        self
+    }
+
+    pub fn build(self) -> Result<RunnableGriddleRestApi, GriddleRestApiServerError> {
+        let bind = self.bind.ok_or_else(|| {
+            GriddleRestApiServerError::InvalidArgument(InvalidArgumentError::new(
+                "bind".to_string(),
+                "Missing required field".to_string(),
+            ))
+        })?;
+
+        #[cfg(feature = "proxy")]
+        let proxy_client = self.proxy_client.ok_or_else(|| {
+            GriddleRestApiServerError::InvalidArgument(InvalidArgumentError::new(
+                "proxy_client".to_string(),
+                "Missing required field".to_string(),
+            ))
+        })?;
+
+        let signer = self.signer.ok_or_else(|| {
+            GriddleRestApiServerError::InvalidArgument(InvalidArgumentError::new(
+                "signer".to_string(),
+                "Missing required field".to_string(),
+            ))
+        })?;
+
+        let scope = self.scope.ok_or_else(|| {
+            GriddleRestApiServerError::InvalidArgument(InvalidArgumentError::new(
+                "service_scope".to_string(),
+                "Missing required field".to_string(),
+            ))
+        })?;
+
+        Ok(RunnableGriddleRestApi {
+            bind,
+            resource_providers: self.resource_providers,
+            #[cfg(feature = "proxy")]
+            proxy_client,
+            signer,
+            scope,
+        })
+    }
+}

--- a/griddle/src/rest_api/actix_web_4/mod.rs
+++ b/griddle/src/rest_api/actix_web_4/mod.rs
@@ -15,9 +15,11 @@
 //! Implementation of the components necessary to run Griddle's REST API,
 //! backed by [Actix Web 4](https://crates.io/crates/actix-web).
 
+mod api;
 mod builder;
 mod runnable;
 
+pub use api::GriddleRestApi;
 pub use builder::GriddleRestApiBuilder;
 pub use runnable::RunnableGriddleRestApi;
 

--- a/griddle/src/rest_api/actix_web_4/mod.rs
+++ b/griddle/src/rest_api/actix_web_4/mod.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "rest-api-actix-web-4")]
-pub mod actix_web_4;
-mod error;
+//! Implementation of the components necessary to run Griddle's REST API,
+//! backed by [Actix Web 4](https://crates.io/crates/actix-web).
 
-pub use error::GriddleRestApiServerError;
+use actix_web::Resource;
 
-#[derive(Clone, Debug, PartialEq)]
-/// Indicates the service scope intended for incoming requests and is used by the REST API to
-/// validate requests.
-pub enum Scope {
-    Global,
-    Service,
+/// A `GriddleResourceProvider` provides a list of resources to a Griddle instance.
+///
+/// This trait serves as a `Resource` factory, which allows dynamically building a REST API at
+/// runtime.
+pub trait GriddleResourceProvider: Send {
+    /// Returns a list of Actix `Resource`s.
+    fn resources(&self) -> Vec<Resource>;
 }

--- a/griddle/src/rest_api/actix_web_4/runnable.rs
+++ b/griddle/src/rest_api/actix_web_4/runnable.rs
@@ -36,9 +36,22 @@ pub struct RunnableGriddleRestApi {
 impl RunnableGriddleRestApi {
     /// Start Griddle's REST API and return the running version.
     pub fn run(self) -> Result<GriddleRestApi, GriddleRestApiServerError> {
-        let RunnableGriddleRestApi { .. } = self;
+        let RunnableGriddleRestApi {
+            resource_providers,
+            bind,
+            #[cfg(feature = "proxy")]
+            proxy_client,
+            signer,
+            scope,
+        } = self;
 
-        // Build the running Griddle rest API
-        unimplemented!();
+        GriddleRestApi::new(
+            bind,
+            resource_providers,
+            #[cfg(feature = "proxy")]
+            proxy_client,
+            signer,
+            scope,
+        )
     }
 }

--- a/griddle/src/rest_api/actix_web_4/runnable.rs
+++ b/griddle/src/rest_api/actix_web_4/runnable.rs
@@ -18,7 +18,10 @@ use cylinder::Signer;
 #[cfg(feature = "proxy")]
 use grid_sdk::proxy::ProxyClient;
 
-use crate::rest_api::{actix_web_4::GriddleResourceProvider, Scope};
+use crate::rest_api::{
+    actix_web_4::{GriddleResourceProvider, GriddleRestApi},
+    GriddleRestApiServerError, Scope,
+};
 
 /// A configured REST API for Griddle which may best started with `run` function.
 pub struct RunnableGriddleRestApi {
@@ -28,4 +31,14 @@ pub struct RunnableGriddleRestApi {
     pub(super) proxy_client: Box<dyn ProxyClient>,
     pub(super) signer: Box<dyn Signer>,
     pub(super) scope: Scope,
+}
+
+impl RunnableGriddleRestApi {
+    /// Start Griddle's REST API and return the running version.
+    pub fn run(self) -> Result<GriddleRestApi, GriddleRestApiServerError> {
+        let RunnableGriddleRestApi { .. } = self;
+
+        // Build the running Griddle rest API
+        unimplemented!();
+    }
 }

--- a/griddle/src/rest_api/actix_web_4/runnable.rs
+++ b/griddle/src/rest_api/actix_web_4/runnable.rs
@@ -12,22 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Implementation of the components necessary to run Griddle's REST API,
-//! backed by [Actix Web 4](https://crates.io/crates/actix-web).
+//! Contains the implementation of `RunnableGriddleRestApi`
 
-mod builder;
-mod runnable;
+use cylinder::Signer;
+#[cfg(feature = "proxy")]
+use grid_sdk::proxy::ProxyClient;
 
-pub use builder::GriddleRestApiBuilder;
-pub use runnable::RunnableGriddleRestApi;
+use crate::rest_api::{actix_web_4::GriddleResourceProvider, Scope};
 
-use actix_web::Resource;
-
-/// A `GriddleResourceProvider` provides a list of resources to a Griddle instance.
-///
-/// This trait serves as a `Resource` factory, which allows dynamically building a REST API at
-/// runtime.
-pub trait GriddleResourceProvider: Send {
-    /// Returns a list of Actix `Resource`s.
-    fn resources(&self) -> Vec<Resource>;
+/// A configured REST API for Griddle which may best started with `run` function.
+pub struct RunnableGriddleRestApi {
+    pub(super) resource_providers: Vec<Box<dyn GriddleResourceProvider>>,
+    pub(super) bind: String,
+    #[cfg(feature = "proxy")]
+    pub(super) proxy_client: Box<dyn ProxyClient>,
+    pub(super) signer: Box<dyn Signer>,
+    pub(super) scope: Scope,
 }

--- a/griddle/src/rest_api/error.rs
+++ b/griddle/src/rest_api/error.rs
@@ -1,0 +1,62 @@
+// Copyright 2018-2022 Cargill, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use grid_sdk::error::{InternalError, InvalidArgumentError, InvalidStateError};
+
+#[derive(Debug)]
+pub enum GriddleRestApiServerError {
+    BindError(String),
+    StartUpError(String),
+    StdError(std::io::Error),
+    InternalError(InternalError),
+    InvalidArgument(InvalidArgumentError),
+    InvalidState(InvalidStateError),
+}
+
+impl From<std::io::Error> for GriddleRestApiServerError {
+    fn from(err: std::io::Error) -> GriddleRestApiServerError {
+        GriddleRestApiServerError::StdError(err)
+    }
+}
+
+impl Error for GriddleRestApiServerError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            GriddleRestApiServerError::BindError(_) => None,
+            GriddleRestApiServerError::StartUpError(_) => None,
+            GriddleRestApiServerError::StdError(err) => Some(err),
+            GriddleRestApiServerError::InternalError(err) => Some(err),
+            GriddleRestApiServerError::InvalidArgument(err) => Some(err),
+            GriddleRestApiServerError::InvalidState(err) => Some(err),
+        }
+    }
+}
+
+impl fmt::Display for GriddleRestApiServerError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            GriddleRestApiServerError::BindError(e) => write!(f, "Griddle Bind Error: {}", e),
+            GriddleRestApiServerError::StartUpError(e) => {
+                write!(f, "Griddle Start-up Error: {}", e)
+            }
+            GriddleRestApiServerError::StdError(e) => write!(f, "Std Error in Griddle: {}", e),
+            GriddleRestApiServerError::InternalError(e) => write!(f, "{}", e),
+            GriddleRestApiServerError::InvalidArgument(e) => write!(f, "{}", e),
+            GriddleRestApiServerError::InvalidState(e) => write!(f, "{}", e),
+        }
+    }
+}

--- a/griddle/src/rest_api/mod.rs
+++ b/griddle/src/rest_api/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod error;
+
+pub use error::GriddleRestApiServerError;

--- a/griddle/src/rest_api/mod.rs
+++ b/griddle/src/rest_api/mod.rs
@@ -15,3 +15,11 @@
 mod error;
 
 pub use error::GriddleRestApiServerError;
+
+#[derive(Clone, Debug, PartialEq)]
+/// Indicates the service scope intended for incoming requests and is used by the REST API to
+/// validate requests.
+pub enum Scope {
+    Global,
+    Service,
+}


### PR DESCRIPTION
This adds a rest api with a builder, runnable, and running instances. This allows for the rest api to be stood up and taken down more easily. The running instance of the rest api implements the `ShutdownHandle` trait from the threading::lifecycle module.  

Technically, this also updates Griddle to use actix web 4. The rest api module is behind the experimental `rest-api` feature. 