### PR TITLE
Update ci-test just recipe so unit-tests pass in GHA

### DIFF
--- a/justfile
+++ b/justfile
@@ -92,8 +92,13 @@ ci-lint-ui: ci-build-ui-test-deps
     docker run --rm --env CI=true product-sapling:$ISOLATION_ID just lint-product-sapling
 
 ci-test:
-    #!/usr/bin/env sh
+    #!/usr/bin/env bash
     set -e
+    if [[ $GITHUB_ACTIONS ]] && [[ $RUNNER_OS == "Linux" ]]; then
+        echo "Github Actions is running this workflow."
+        docker rmi $(docker images -qa)
+        sudo rm -rf /usr/local/lib/android/
+    fi
     docker-compose -f docker/compose/grid-tests.yaml build --force-rm
     docker-compose -f docker/compose/grid-tests.yaml up --abort-on-container-exit --exit-code-from grid_tests
 


### PR DESCRIPTION
The GHA provided runners have limited free space so after building Docker
images necessary for the test they can easily run out of disk, causing the
test to fail. Removing unecessary prepopulated Docker images and some
large android libraries ensures there's plenty of headroom for our builds.

Link to list of pre-installed software:
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>