### PR TITLE
Upgrade sabre image version in sawtooth example

### DIFF
--- a/examples/sawtooth/docker-compose.yaml
+++ b/examples/sawtooth/docker-compose.yaml
@@ -223,7 +223,7 @@ services:
     stop_signal: SIGKILL
 
   sabre-tp:
-    image: hyperledger/sawtooth-sabre-tp:0.5
+    image: hyperledger/sawtooth-sabre-tp:0.8
     container_name: sawtooth-sabre-tp
     depends_on:
       - sawtooth-validator


### PR DESCRIPTION
Updates the sawtooth example sabre image version to match the version
used in Grid contracts.

Signed-off-by: Chris Eckhardt <eckhardt@bitwise.io>